### PR TITLE
[Issue-86] Add configs for deployment in Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: lein ring server-headless

--- a/project.clj
+++ b/project.clj
@@ -19,6 +19,7 @@
          :init cia.init/init!
          :nrepl {:start? true}}
   :uberjar-name "server.jar"
+  :min-lein-version "2.4.0"
   :test-selectors {:es-store #(.contains (name (:name %)) "-es-store")
                    :default #(not (or (.contains (name (:name %)) "-es-store")
                                       (:integration %)

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=1.8


### PR DESCRIPTION
Adds a Procfile and system.properties file needed for deploying compojure-api
apps to Heroku.  Allows Heroku to start a headless ring server.  Also adds a
minimum clojure version to the project.clj, to help Heroku build and launch.

See http://islandofatlas.net/2013/08/15/deploying-clj-compojure-in-heroku.html
for more details.

This addresses https://github.com/threatgrid/cia/issues/86
