### PR TITLE
Restructured the web specific code (handlers, middleware, and routes)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [hiccup "1.0.5"]]
 
   :resource-paths ["resources" "doc"]
-  :ring {:handler ctia.web.handler/app
+  :ring {:handler ctia.http.handler/app
          :init ctia.init/init!
          :nrepl {:start? true}}
   :uberjar-name "server.jar"

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -1,4 +1,4 @@
-(ns ctia.web.handler
+(ns ctia.http.handler
   (:require [ctia.printers :refer :all]
             [ctia.schemas.actor :refer [NewActor StoredActor]]
             [ctia.schemas.campaign :refer [NewCampaign StoredCampaign]]
@@ -27,8 +27,8 @@
             [ring.util.http-response :refer :all]
             [schema.core :as s]
             [ctia.schemas.relationships :as rel]
-            [ctia.web.middleware.auth :as auth]
-            [ctia.web.routes.documentation :refer [documentation-routes]]))
+            [ctia.http.middleware.auth :as auth]
+            [ctia.http.routes.documentation :refer [documentation-routes]]))
 
 (def JudgementSort
   "A sort ordering"

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -1,4 +1,4 @@
-(ns ctia.web.middleware.auth
+(ns ctia.http.middleware.auth
   (:require [ctia.auth :as auth :refer [auth-service]]
             [compojure.api.meta :as meta]
             [ring.util.http-response :as http-response]))

--- a/src/ctia/http/routes/documentation.clj
+++ b/src/ctia/http/routes/documentation.clj
@@ -1,4 +1,4 @@
-(ns ctia.web.routes.documentation
+(ns ctia.http.routes.documentation
   (:require
    [compojure.api.sweet :refer :all]
    [ring.util.http-response :refer :all]

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -1,7 +1,7 @@
-(ns ctia.web.handler.allow-all-test
+(ns ctia.http.handler.allow-all-test
   (:refer-clojure :exclude [get])
   (:require [ctia.auth :as auth]
-            [ctia.web.handler :as handler]
+            [ctia.http.handler :as handler]
             [ctia.test-helpers.core :as helpers :refer [post get]]
             [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]))
 

--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -1,6 +1,6 @@
-(ns ctia.web.handler-test
+(ns ctia.http.handler-test
   (:refer-clojure :exclude [get])
-  (:require [ctia.web.handler :as handler]
+  (:require [ctia.http.handler :as handler]
             [ctia.test-helpers.core :refer [delete get post put] :as helpers]
             [ctia.test-helpers.db :as db-helpers]
             [ctia.test-helpers.index :as index-helpers]


### PR DESCRIPTION
Creates a new "web" ns and moves handler.clj, middleware, and routes underneath.  We've talked about breaking up handler.clj, and this gives us a place to put it.  Also I will be adding another PR for STIX format support that adds new handlers and routes, and I need a nice place to put the new code.
