### PR TITLE
Fixing bugs in properties code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,14 +2,17 @@
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [clj-time "0.9.0"] ; required due to bug in lein-ring
-                 [metosin/schema-tools "0.7.0"]
+                 [prismatic/schema "1.1.0"]
+                 [metosin/schema-tools "0.7.0"
+                  :exclusions [prismatic/schema]]
                  [com.rpl/specter "0.9.2"]
                  [org.clojure/core.async "0.2.374"]
                  [clj-http "2.0.1"]
                  [org.clojure/core.memoize "0.5.8"]
 
                  ;; Web server
-                 [metosin/compojure-api "1.0.0"]
+                 [metosin/compojure-api "1.0.0"
+                  :exclusions [prismatic/schema]]
                  [ring-middleware-format "0.7.0"]
 
                  ;; Database

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -1,4 +1,4 @@
-auth.service=allow-all
+auth.service.name=allow-all
 auth.service.threatgrid.url=https://panacea.threatgrid.com/api/v3/session/whoami
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -1,4 +1,4 @@
-auth.service.name=allow-all
+auth.service.type=allow-all
 auth.service.threatgrid.url=https://panacea.threatgrid.com/api/v3/session/whoami
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -19,7 +19,7 @@
             [ctia.stores.memory.ttp :as mt]))
 
 (defn init-auth-service! []
-  (let [auth-service-name (get-in @properties/properties [:auth :service])]
+  (let [auth-service-name (get-in @properties/properties [:auth :service :name])]
     (case auth-service-name
       "allow-all" (reset! auth/auth-service (allow-all/->AuthService))
       "threatgrid" (reset! auth/auth-service (threatgrid/make-auth-service

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -19,8 +19,8 @@
             [ctia.stores.memory.ttp :as mt]))
 
 (defn init-auth-service! []
-  (let [auth-service-name (get-in @properties/properties [:auth :service :name])]
-    {case auth-service-name
+  (let [auth-service-type (get-in @properties/properties [:auth :service :type])]
+    {case auth-service-type
       :allow-all (reset! auth/auth-service (allow-all/->AuthService))
       :threatgrid (reset! auth/auth-service (threatgrid/make-auth-service
                                               (threatgrid/make-whoami-service)))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -20,13 +20,13 @@
 
 (defn init-auth-service! []
   (let [auth-service-name (get-in @properties/properties [:auth :service :name])]
-    (case auth-service-name
-      "allow-all" (reset! auth/auth-service (allow-all/->AuthService))
-      "threatgrid" (reset! auth/auth-service (threatgrid/make-auth-service
+    {case auth-service-name
+      :allow-all (reset! auth/auth-service (allow-all/->AuthService))
+      :threatgrid (reset! auth/auth-service (threatgrid/make-auth-service
                                               (threatgrid/make-whoami-service)))
       (throw (ex-info "Auth service not configured"
                       {:message "Unknown service"
-                       :requested-service auth-service-name})))))
+                       :requested-service auth-service-name}))}))
 
 (defn init-mem-store! []
   (let [store-impls {store/actor-store     ma/->ActorStore

--- a/src/ctia/lib/map.clj
+++ b/src/ctia/lib/map.clj
@@ -1,0 +1,7 @@
+(ns ctia.lib.map)
+
+(defn rmerge
+  [& vals]
+  (if (every? map? vals)
+    (apply merge-with rmerge vals)
+    (last vals)))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -1,14 +1,51 @@
-(ns ctia.properties
+(ns ^{:doc "Properties (aka configuration) of the application.
+            Properties are stored in property files.  There is a
+            default file which can be overridden by placing an
+            alternative properties file on the classpath, or by
+            setting system properties."}
+    ctia.properties
   (:refer-clojure :exclude [load])
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
-            [ctia.lib.map :as map])
+            [ctia.lib.map :as map]
+            [schema.coerce :as c]
+            [schema.core :as s]
+            [clj-time.coerce :as coerce])
   (:import java.util.Properties))
 
-(def property-files ["ctia.properties"
-                     "ctia-default.properties"])
+(def property-files
+  "Property file names, in order of preference"
+  ["ctia.properties"
+   "ctia-default.properties"])
 
-(defonce properties (atom {}))
+(defonce properties
+  (atom {}))
+
+(s/defschema PropertiesSchema
+  "This is the schema used for value type coercion.  It is also used
+   for validating the properties that are read in so that required
+   properties must be present.  Only the following properties may be
+   set.  This is also used for selecting system properties to merge
+   with the properties file."
+  {(s/required-key "auth.service.type") s/Keyword
+   (s/optional-key "auth.service.threatgrid.url") s/Str
+   (s/optional-key "ctia.store.sql.db.classname") s/Str
+   (s/optional-key "ctia.store.sql.db.subprotocol") s/Str
+   (s/optional-key "ctia.store.sql.db.subname") s/Str
+   (s/optional-key "ctia.store.sql.db.delimiters") s/Str
+   (s/optional-key "ctia.store.es.host") s/Str
+   (s/optional-key "ctia.store.es.port") s/Int
+   (s/optional-key "ctia.store.es.clustername") s/Str
+   (s/optional-key "ctia.store.es.indexname") s/Str})
+
+(def configurable-properties
+  "String keys from PropertiesSchema, used to select system properties."
+  (map #(or (:k %) %) (keys PropertiesSchema)))
+
+(def coerce-properties
+  "Fn used to coerce property values using PropertiesSchema"
+  (c/coercer! PropertiesSchema
+              c/string-coercion-matcher))
 
 (defn- read-property-file []
   (->> property-files
@@ -33,10 +70,15 @@
           {}
           properties))
 
-(defn init! []
-  (reset! properties
-          (transform
-           (let [properties-from-file (read-property-file)]
-             (merge properties-from-file
-                    (select-keys (System/getProperties)
-                                 (keys properties-from-file)))))))
+(defn init!
+  "Read a properties file, merge it with system properties, coerce and
+   validate it, transform it into a nested map with keyword keys, and
+   then store it in memory."
+  []
+  (->> (let [properties-from-file (read-property-file)]
+         (merge properties-from-file
+                (select-keys (System/getProperties)
+                             configurable-properties)))
+       coerce-properties
+       transform
+       (reset! properties)))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -11,16 +11,14 @@
 (defonce properties (atom {}))
 
 (defn- read-property-file []
-  (->>
-   (loop [[file & more-files] property-files]
-     (if file
-       (if-let [reader (some-> file io/resource io/reader)]
-         (try
-           (doto (Properties.)
-             (.load reader))
-           (finally (.close reader)))
-         (recur more-files))))
-   (into {})))
+  (->> property-files
+       (keep (fn [file]
+               (when-let [rdr (some-> file io/resource io/reader)]
+                 (with-open [rdr rdr]
+                   (doto (Properties.)
+                     (.load rdr))))))
+       first
+       (into {})))
 
 (defn- transform [properties]
   (reduce (fn [accum [k v]]

--- a/src/ctia/stores/es/index.clj
+++ b/src/ctia/stores/es/index.clj
@@ -15,7 +15,7 @@
 
   (let [props (read-index-spec)]
     {:index (:indexname props)
-     :conn (n/connect [[(:host props) (Integer. (:port props))]]
+     :conn (n/connect [[(:host props) (:port props)]]
                       {"cluster.name" (:clustername props)})}))
 
 (defn delete!

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -37,7 +37,8 @@
                         :expected '~form, :actual nil})))))
 
 (defn fixture-properties [f]
-  (props/init! "ctia-test.properties")
+  (with-redefs [props/property-files ["ctia-test.properties"]]
+    (props/init!))
   (f))
 
 

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -1,4 +1,4 @@
-auth.service.name=threatgrid
+auth.service.type=threatgrid
 auth.service.threatgrid.url=
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -1,4 +1,4 @@
-auth.service=threatgrid
+auth.service.name=threatgrid
 auth.service.threatgrid.url=
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2


### PR DESCRIPTION
Properties that are read from a properties file may be overridden with system properties of the same name (note that only overrides are kept; properties not defined in the file that are defined as system properties are ignored).  Also fixed a bug in transform (using rmerge instead of assoc-in).

Closes #116

Another improvement is that this version closes the properties file correctly after reading it.