### PR TITLE
Remove clj-time coercion.

### DIFF
--- a/doc/data_structures.md
+++ b/doc/data_structures.md
@@ -722,7 +722,7 @@ string
 <a name="time"/>
 ### Time
 
-Time is stored internally as a Joda DateTime object, serialized as a
+Time is stored internally as a java.util.Date object, serialized as a
 string the field should follow the rules of the ISO8601 standard.
 
 <a name="time_structure"/>


### PR DESCRIPTION
This removes the coercion to joda time and then back to date time
or sql-time, in favor of direct coercion mechanisms.  All new Date
objects use UTC implicitly.  This resolves issue #140