### PR TITLE
Fix the ES issue on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 #     only:
 #         - master
 before_script:
-    - cp test/resources/ctia-test.properties.ci test/resources/ctia-test.properties
+    - cp test/resources/ctia-test.properties.ci resources/ctia-default.properties
     # Wait ES
     - until curl http://localhost:9200/; do sleep 1; done
 services:


### PR DESCRIPTION
Apparently the test suite doesn't uses `test/resources/ctia-test.properties` at least for the `es-store` tests.

This is a simple hot fix for the travis check to success. But we should take a look on how we could force the test suite to use the test properties file.

Closes #168