### PR TITLE
added ES Store and Producer HTTP Support

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -9,6 +9,7 @@ ctia.store.es.host=127.0.0.1
 ctia.store.es.port=9300
 ctia.store.es.clustername=ctia_dev
 ctia.store.es.indexname=ctia_dev
+ctia.producer.es.uri=http://127.0.0.1:9200
 ctia.producer.es.host=127.0.0.1
 ctia.producer.es.port=9300
 ctia.producer.es.clustername=ctia_dev

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -4,6 +4,7 @@ ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false
 ctia.store.sql.db.delimiters=
+ctia.store.es.uri=http://localhost:9200
 ctia.store.es.host=127.0.0.1
 ctia.store.es.port=9300
 ctia.store.es.clustername=ctia_dev

--- a/src/ctia/events/producers/es/producer.clj
+++ b/src/ctia/events/producers/es/producer.clj
@@ -25,15 +25,13 @@
   "given a conn state and an event write the event to ES"
   [state :- ESConnState
    event :- Event]
-
   (->> event
        transform-fields
        ((create-doc-fn (:conn state))
         (:conn state)
         (:index state)
         "event")
-
-       :id))
+       :_id))
 
 (defrecord EventProducer [state]
   IEventProducer

--- a/src/ctia/events/producers/es/producer.clj
+++ b/src/ctia/events/producers/es/producer.clj
@@ -1,7 +1,8 @@
 (ns ctia.events.producers.es.producer
   (:require
    [schema.core :as s]
-   [clojurewerkz.elastisch.native.document :as document]
+   [clojurewerkz.elastisch.native.document :as native-document]
+   [clojurewerkz.elastisch.rest.document :as rest-document]
    [ctia.lib.es.index :refer [ESConnState]]
    [ctia.events.schemas :refer [Event]]
    [ctia.events.producer :refer [IEventProducer]]))
@@ -13,8 +14,12 @@
            (map #(hash-map :field (first %)
                            :action (second %)
                            :change (last %)) fields))
-
     e))
+
+(defn create-doc-fn [conn]
+  (if (:uri conn)
+    rest-document/create
+    native-document/create))
 
 (s/defn handle-produce-event :- s/Str
   "given a conn state and an event write the event to ES"
@@ -23,9 +28,10 @@
 
   (->> event
        transform-fields
-       (document/create (:conn state)
-                        (:index state)
-                        "event")
+       ((create-doc-fn (:conn state))
+        (:conn state)
+        (:index state)
+        "event")
 
        :id))
 

--- a/src/ctia/lib/es/index.clj
+++ b/src/ctia/lib/es/index.clj
@@ -63,8 +63,7 @@
   (let [props (read-producer-index-spec)]
     {:index (:indexname props)
      :mapping producer-mappings
-     :conn (n/connect [[(:host props) (Integer. (:port props))]]
-                      {"cluster.name" (:clustername props)})}))
+     :conn (connect props)}))
 
 (defn delete!
   "delete an index, abort if non existant"

--- a/src/ctia/lib/es/index.clj
+++ b/src/ctia/lib/es/index.clj
@@ -2,7 +2,9 @@
   (:require
    [schema.core :as s]
    [clojurewerkz.elastisch.native :as n]
-   [clojurewerkz.elastisch.native.index :as idx]
+   [clojurewerkz.elastisch.rest :as h]
+   [clojurewerkz.elastisch.native.index :as native-index]
+   [clojurewerkz.elastisch.rest.index :as rest-index]
    [ctia.stores.es.mapping :refer [store-mappings]]
    [ctia.events.producers.es.mapping :refer [producer-mappings]]
    [ctia.properties :refer [properties]]))
@@ -10,7 +12,27 @@
 (s/defschema ESConnState
   {:index s/Str
    :mapping {s/Any s/Any}
-   :conn org.elasticsearch.client.transport.TransportClient})
+   :conn (s/either
+          clojurewerkz.elastisch.rest.Connection
+          org.elasticsearch.client.transport.TransportClient)})
+
+(defn native-conn? [conn]
+  (not (:uri conn)))
+
+(defn index-exists?-fn [conn]
+  (if (native-conn? conn)
+    native-index/exists?
+    rest-index/exists?))
+
+(defn index-create-fn [conn]
+  (if (native-conn? conn)
+    native-index/create
+    rest-index/create))
+
+(defn index-delete-fn [conn]
+  (if (native-conn? conn)
+    native-index/delete
+    rest-index/delete))
 
 (defn read-store-index-spec []
   "read es store index config properties, returns an option map"
@@ -20,15 +42,20 @@
   "read es producer index config properties, returns an option map"
   (get-in @properties [:ctia :producer :es]))
 
+(defn connect [props]
+  "instantiate an ES conn from props"
+  (if (:uri props)
+    (h/connect (:uri props))
+    (n/connect [[(:host props) (Integer. (:port props))]]
+               {"cluster.name" (:clustername props)})))
+
 (s/defn init-store-conn :- ESConnState []
   "initiate an ES store connection returns a map containing transport,
    mapping, and the configured index name"
-
   (let [props (read-store-index-spec)]
     {:index (:indexname props)
      :mapping store-mappings
-     :conn (n/connect [[(:host props) (Integer. (:port props))]]
-                      {"cluster.name" (:clustername props)})}))
+     :conn (connect props)}))
 
 (s/defn init-producer-conn :- ESConnState []
   "initiate an ES producer connection returns a map containing transport,
@@ -42,11 +69,11 @@
 (defn delete!
   "delete an index, abort if non existant"
   [conn index-name]
-  (when (idx/exists? conn index-name)
-    (idx/delete conn index-name)))
+  (when ((index-exists?-fn conn) conn index-name)
+    ((index-delete-fn conn) conn index-name)))
 
 (defn create!
   "create an index, abort if already exists"
   [conn index-name mappings]
-  (when-not (idx/exists? conn index-name)
-    (idx/create conn index-name :mappings mappings)))
+  (when-not ((index-exists?-fn conn) conn index-name)
+    ((index-create-fn conn) conn index-name :mappings mappings)))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -38,6 +38,7 @@
    (s/optional-key "ctia.store.es.port") s/Int
    (s/optional-key "ctia.store.es.clustername") s/Str
    (s/optional-key "ctia.store.es.indexname") s/Str
+   (s/optional-key "ctia.producer.es.uri") s/Str
    (s/optional-key "ctia.producer.es.host") s/Str
    (s/optional-key "ctia.producer.es.port") s/Int
    (s/optional-key "ctia.producer.es.clustername") s/Str

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -33,6 +33,7 @@
    (s/optional-key "ctia.store.sql.db.subprotocol") s/Str
    (s/optional-key "ctia.store.sql.db.subname") s/Str
    (s/optional-key "ctia.store.sql.db.delimiters") s/Str
+   (s/optional-key "ctia.store.es.uri") s/Str
    (s/optional-key "ctia.store.es.host") s/Str
    (s/optional-key "ctia.store.es.port") s/Int
    (s/optional-key "ctia.store.es.clustername") s/Str

--- a/src/ctia/stores/es/document.clj
+++ b/src/ctia/stores/es/document.clj
@@ -2,59 +2,100 @@
   (:require
    [clojure.string :as str]
    [ctia.stores.es.query :refer :all]
-   [clojurewerkz.elastisch.native.document :as document]
-   [clojurewerkz.elastisch.native.response :refer :all]))
+   [clojurewerkz.elastisch.native.document :as native-document]
+   [clojurewerkz.elastisch.rest.document :as rest-document]
+   [clojurewerkz.elastisch.native.response :as native-response]
+   [clojurewerkz.elastisch.rest.response :as rest-response]))
+
+(defn native-conn? [conn]
+  (not (:uri conn)))
+
+(defn get-doc-fn [conn]
+  (if (native-conn? conn)
+    native-document/get
+    rest-document/get))
+
+(defn create-doc-fn [conn]
+  (if (native-conn? conn)
+    native-document/create
+    rest-document/create))
+
+(defn update-doc-fn [conn]
+  (if (native-conn? conn)
+    native-document/update-with-partial-doc
+    rest-document/update-with-partial-doc))
+
+(defn delete-doc-fn [conn]
+  (if (native-conn? conn)
+    native-document/delete
+    rest-document/delete))
+
+(defn search-doc-fn [conn]
+  (if (native-conn? conn)
+    native-document/search
+    rest-document/search))
+
+(defn hits-from-fn [conn]
+  (if (native-conn? conn)
+    native-response/hits-from
+    rest-response/hits-from))
 
 (defn get-doc
   "get a document on es and return only the source"
   [conn index-name mapping id]
-  (-> (document/get conn
-                    index-name
-                    mapping
-                    id)
-      :source))
+
+  (:_source ((get-doc-fn conn)
+             conn
+             index-name
+             mapping
+             id)))
 
 (defn create-doc
   "create a document on es return the created document"
   [conn index-name mapping doc]
-
-  (document/create conn
-                   index-name
-                   mapping
-                   doc
-                   :id (:id doc)
-                   :refresh true)
+  ((create-doc-fn conn)
+   conn
+   index-name
+   mapping
+   doc
+   :id (:id doc)
+   :refresh true)
   doc)
 
 (defn update-doc
   "update a document on es return the updated document"
   [conn index-name mapping id doc]
 
-  (get-in (document/update-with-partial-doc conn
-                                            index-name
-                                            mapping
-                                            id
-                                            doc
-                                            {:refresh true
-                                             :fields "_source"})
-          [:get-result :source]))
+  (let [res ((update-doc-fn conn)
+             conn
+             index-name
+             mapping
+             id
+             doc
+             {:refresh true
+              :fields "_source"})]
+    (or (get-in res [:get-result :source])
+        (get-in res [:get :_source]))))
 
 (defn delete-doc
   "delete a document on es and return nil if ok"
   [conn index-name mapping id]
-  (:found?
-   (document/delete conn
-                    index-name
-                    mapping
-                    id)))
+
+  (:found
+   ((delete-doc-fn conn)
+    conn
+    index-name
+    mapping
+    id)))
 
 (defn raw-search-docs [conn index-name mapping query sort]
-  (->> (document/search conn
-                        index-name
-                        mapping
-                        :query query
-                        :sort sort)
-       hits-from
+  (->> ((search-doc-fn conn)
+        conn
+        index-name
+        mapping
+        :query query
+        :sort sort)
+       ((hits-from-fn conn))
        (map :_source)))
 
 (defn search-docs
@@ -62,10 +103,11 @@
   [conn index-name mapping filter-map]
 
   (let [filters (filter-map->terms-query filter-map)
-        res (document/search conn
-                             index-name
-                             mapping
-                             :query filters)]
+        res ((search-doc-fn conn)
+             conn
+             index-name
+             mapping
+             :query filters)]
     (->> res
-         hits-from
+         ((hits-from-fn conn))
          (map :_source))))

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -4,6 +4,7 @@ ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false
 ctia.store.sql.db.delimiters=
+ctia.store.es.uri=http://127.0.0.1:9200
 ctia.store.es.host=127.0.0.1
 ctia.store.es.port=9300
 ctia.store.es.clustername=ctia_dev

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -4,11 +4,12 @@ ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false
 ctia.store.sql.db.delimiters=
-ctia.store.es.uri=http://127.0.0.1:9200
+ctia.store.es.uri=http://127.0.0.1:9300
 ctia.store.es.host=127.0.0.1
 ctia.store.es.port=9300
 ctia.store.es.clustername=ctia_dev
 ctia.store.es.indexname=ctia_dev
+ctia.producer.es.uri=http://127.0.0.1:9200
 ctia.producer.es.host=127.0.0.1
 ctia.producer.es.port=9300
 ctia.producer.es.clustername=ctia_dev

--- a/test/resources/ctia-test.properties.ci
+++ b/test/resources/ctia-test.properties.ci
@@ -4,10 +4,12 @@ ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false
 ctia.store.sql.db.delimiters=
+ctia.store.es.uri=http://127.0.0.1:9200
 ctia.store.es.host=127.0.0.1
 ctia.store.es.port=9300
 ctia.store.es.clustername=elasticsearch
 ctia.store.es.indexname=elasticsearch
+ctia.producer.es.uri=http://127.0.0.1:9200
 ctia.producer.es.host=127.0.0.1
 ctia.producer.es.port=9300
 ctia.producer.es.clustername=elasticsearch


### PR DESCRIPTION
- Added ES HTTP Transport support
- new property: ctia.store.es.uri=http://127.0.0.1:9200 (has precedence)
- all tests still working on both modes