### PR TITLE
Configure HTTP & nREPL servers via properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ WORKDIR /usr/src/app
 COPY project.clj /usr/src/app/
 RUN lein deps
 COPY . /usr/src/app
-RUN lein ring uberjar
+RUN lein uberjar
 CMD ["java", "-jar", "target/server.jar"]
 EXPOSE 3000

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,13 @@
 
                  ;; Web server
                  [metosin/compojure-api "1.0.0"]
+                 [ring/ring-jetty-adapter "1.4.0"]
+                 [javax.servlet/servlet-api "2.5"]
                  [ring-middleware-format "0.7.0"]
+
+                 ;; nREPL server
+                 [org.clojure/tools.nrepl "0.2.12"]
+                 [cider/cider-nrepl "0.11.0"]
 
                  ;; Database
                  [clojurewerkz/elastisch "2.2.1"]
@@ -25,9 +31,7 @@
                  [hiccup "1.0.5"]]
 
   :resource-paths ["resources" "doc"]
-  :ring {:handler ctia.http.handler/app
-         :init ctia.init/init!
-         :nrepl {:start? true}}
+  :main ctia.main
   :uberjar-name "server.jar"
   :min-lein-version "2.4.0"
   :test-selectors {:atom-store :atom-store
@@ -43,8 +47,6 @@
                                      (:es-producer %))}
 
   :profiles {:dev {:dependencies [[cheshire "5.5.0"]
-                                  [javax.servlet/servlet-api "2.5"]
-                                  [ring/ring-jetty-adapter "1.4.0"]
                                   [com.h2database/h2 "1.4.191"]
                                   [org.clojure/test.check "0.9.0"]]
                    :plugins [[lein-ring "0.9.6"]]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
                  [ring/ring-jetty-adapter "1.4.0"]
                  [javax.servlet/servlet-api "2.5"]
                  [ring-middleware-format "0.7.0"]
+                 [ring/ring-devel "1.4.0"]
 
                  ;; nREPL server
                  [org.clojure/tools.nrepl "0.2.12"]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -1,4 +1,9 @@
 auth.service.type=allow-all
+ctia.http.port=3000
+ctia.http.min-threads=10
+ctia.http.max-threads=100
+ctia.nrepl.port=3001
+ctia.nrepl.enabled=true
 ctia.store.default=memory
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -1,0 +1,22 @@
+(ns ctia.http.server
+  (:require [ctia.http.handler :as handler]
+            [ctia.properties :refer [properties]]
+            [ring.adapter.jetty :as jetty])
+  (:import org.eclipse.jetty.server.Server))
+
+(defonce server (atom nil))
+
+(defn start! [& {:keys [join?]
+                 :or {join? true}}]
+  (let [{:keys [min-threads max-threads port]} (get-in @properties [:ctia :http])]
+    (reset! server (jetty/run-jetty handler/app
+                                    {:port port
+                                     :min-threads min-threads
+                                     :max-threads max-threads
+                                     :join? join?}))))
+
+(defn stop! []
+  (swap! server
+         (fn [^Server s]
+           (when s (.stop s))
+           nil)))

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -1,15 +1,19 @@
 (ns ctia.http.server
   (:require [ctia.http.handler :as handler]
             [ctia.properties :refer [properties]]
-            [ring.adapter.jetty :as jetty])
+            [ring.adapter.jetty :as jetty]
+            [ring.middleware.reload :refer [wrap-reload]])
   (:import org.eclipse.jetty.server.Server))
 
 (defonce server (atom nil))
 
 (defn start! [& {:keys [join?]
                  :or {join? true}}]
-  (let [{:keys [min-threads max-threads port]} (get-in @properties [:ctia :http])]
-    (reset! server (jetty/run-jetty handler/app
+  (let [{:keys [dev-reload min-threads max-threads port]} (get-in @properties [:ctia :http])
+        handler (if dev-reload
+                  (wrap-reload handler/app)
+                  handler/app)]
+    (reset! server (jetty/run-jetty handler
                                     {:port port
                                      :min-threads min-threads
                                      :max-threads max-threads

--- a/src/ctia/main.clj
+++ b/src/ctia/main.clj
@@ -1,0 +1,22 @@
+(ns ctia.main
+  (:gen-class)
+  (:require [ctia.init :refer [init!]]
+            [ctia.http.server :as http-server]
+            [ctia.properties :refer [properties]]
+            [clojure.tools.nrepl.server :as nrepl-server]
+            [cider.nrepl :refer [cider-nrepl-handler]]
+            [ring.adapter.jetty :as jetty]))
+
+(defn -main
+  "Application entry point"
+  [& args]
+  (init!)
+  (let [{nrepl-port :port
+         enabled? :enabled} (get-in @properties [:ctia :nrepl])]
+    (when (and enabled? nrepl-port)
+      (println (str "Starting nREPL server on port " nrepl-port))
+      (nrepl-server/start-server :port nrepl-port
+                                 :handler cider-nrepl-handler)))
+  (let [http-port (get-in @properties [:ctia :http :port])]
+    (println (str "Starting HTTP server on port " http-port))
+    (http-server/start!)))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -28,7 +28,12 @@
    set.  This is also used for selecting system properties to merge
    with the properties file."
   {(s/required-key "auth.service.type") s/Keyword
+   (s/required-key "ctia.http.port") s/Int
+   (s/required-key "ctia.http.min-threads") s/Int
+   (s/required-key "ctia.http.max-threads") s/Int
+   (s/required-key "ctia.nrepl.enabled") s/Bool
    (s/optional-key "auth.service.threatgrid.url") s/Str
+   (s/optional-key "ctia.nrepl.port") s/Int
    (s/optional-key "ctia.store.default") s/Keyword
    (s/optional-key "ctia.store.sql.db.classname") s/Str
    (s/optional-key "ctia.store.sql.db.subprotocol") s/Str

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -32,6 +32,7 @@
    (s/required-key "ctia.http.port") s/Int
    (s/required-key "ctia.http.min-threads") s/Int
    (s/required-key "ctia.http.max-threads") s/Int
+   (s/optional-key "ctia.http.dev-reload") s/Bool
    (s/required-key "ctia.nrepl.enabled") s/Bool
    (s/optional-key "auth.service.threatgrid.url") s/Str
    (s/optional-key "ctia.nrepl.port") s/Int

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -7,7 +7,7 @@
 
 (use-fixtures :once helpers/fixture-properties)
 
-(use-fixtures :each (join-fixtures [(helpers/fixture-server handler/app)
+(use-fixtures :each (join-fixtures [helpers/fixture-http-server
                                     helpers/fixture-schema-validation
                                     helpers/fixture-allow-all-auth
                                     helpers/fixture-atom-store]))

--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -31,7 +31,7 @@
                                     db-helpers/fixture-init-db
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each (join-fixtures [(helpers/fixture-server handler/app)
+(use-fixtures :each (join-fixtures [helpers/fixture-http-server
                                     helpers/fixture-schema-validation
                                     whoami-helpers/fixture-reset-state]))
 

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -4,7 +4,6 @@ ctia.http.min-threads=9
 ctia.http.max-threads=10
 ctia.nrepl.enabled=false
 ctia.store.default=memory
-auth.service.threatgrid.url=
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false

--- a/test/resources/ctia-test.properties
+++ b/test/resources/ctia-test.properties
@@ -1,4 +1,8 @@
 auth.service.type=allow-all
+ctia.http.port=3000
+ctia.http.min-threads=9
+ctia.http.max-threads=10
+ctia.nrepl.enabled=false
 ctia.store.default=memory
 auth.service.threatgrid.url=
 ctia.store.sql.db.classname=org.h2.Driver

--- a/test/resources/ctia-test.properties.ci
+++ b/test/resources/ctia-test.properties.ci
@@ -1,5 +1,8 @@
 auth.service.type=threatgrid
-auth.service.threatgrid.url=
+ctia.http.port=3000
+ctia.http.min-threads=9
+ctia.http.max-threads=10
+ctia.nrepl.enabled=false
 ctia.store.sql.db.classname=org.h2.Driver
 ctia.store.sql.db.subprotocol=h2
 ctia.store.sql.db.subname=/tmp/ctia-h2-db;DATABASE_TO_UPPER=false


### PR DESCRIPTION
Removes the lein-ring plugin and explicitly starts the jetty server.  We lose some automatic features, but gain control.  (Please let me know if you are missing a feature from lein-ring and I can add it).

Server is started with "lein run".

Closes #186 

I'm adding this so that we can use the configured port in URL IDs.