### PR TITLE
remove a warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -52,6 +52,7 @@
                                      (:es-producer %))}
 
   :java-source-paths ["hooks/ctia"]
+  :javac-options  ["-proc:none"] ;; remove a warning
   :profiles {:dev {:dependencies [[cheshire "5.5.0"]
                                   [com.h2database/h2 "1.4.191"]
                                   [org.clojure/test.check "0.9.0"]]


### PR DESCRIPTION
Closes #235

> javac enables annotation processors by default. If you are not using them, and wish to suppress warnings, you need to pass the -proc:none command line flag to javac when you compile your code.

source: https://github.com/antlr/antlr4/issues/487

Apparently it isn't useful for leiningen