### PR TITLE
Store ES data in a host volume.

### DIFF
--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -22,6 +22,8 @@ services:
   elasticsearch:
     image: elasticsearch:2.3
     command: elasticsearch -Des.network.host=0.0.0.0
+    volumes:
+      - ./elasticsearch/data:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
Closes #259 

When deploying this in an environment (such as alpha.ctia) that already has an ES container running, you can use "docker cp" to copy the data directory out of the container and into your host filesystem, like so:

    $ docker cp 23debcf88ef7:/usr/share/elasticsearch/data ./data

It's a good idea to inspect the data before you stop and remove the container.