### PR TITLE
Setting fixtures to only enable ES during ES tests

### DIFF
--- a/test/ctia/flows/hooks/redis_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redis_event_hook_test.clj
@@ -9,6 +9,7 @@
 (use-fixtures :once test-helpers/fixture-schema-validation)
 
 (use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
+                                    test-helpers/fixture-properties:atom-store
                                     test-helpers/fixture-properties:redis-hook
                                     test-helpers/fixture-ctia
                                     test-helpers/fixture-allow-all-auth]))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -65,6 +65,8 @@
                     "ctia.http.min-threads" 9
                     "ctia.http.max-threads" 10
                     "ctia.nrepl.enabled" false
+                    "ctia.hook.es.enabled" false
+                    "ctia.hook.redis.enabled" false
                     "ctia.hook.redis.channel-name" "events-test"]
     ;; run tests
     (f)))


### PR DESCRIPTION
fixes #278 