### PR TITLE
ES Producer Hook tests rewrite

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -54,15 +54,11 @@
                    :sql-store :sql-store
                    :es-store :es-store
                    :disabled :disabled
-                   :es-producer #{:es-producer
-                                   :es-producer-filtered-alias
-                                   :es-producer-aliased-index}
                    :default #(not= :disabled %)
-                   :integration #{:es-store
-                                   :integration
-                                   :es-producer
-                                   :es-producer-filtered-alias
-                                   :es-producer-aliased-index}
+                   :integration #(or (:es-store %)
+                                     (:integration %)
+                                     (:es-filtered-alias %)
+                                     (:es-aliased-index %))
                    :all #(not (:disabled %))}
 
   :java-source-paths ["hooks/ctia"]

--- a/src/ctia/events/producers/es/producer.clj
+++ b/src/ctia/events/producers/es/producer.clj
@@ -1,14 +1,12 @@
 (ns ctia.events.producers.es.producer
-  (:require
-   [schema.core :as s]
-   [ctia.properties :refer [properties]]
-   [ctia.lib.es.index :refer [ESConnState connect]]
-   [ctia.lib.es.document :refer [create-doc-fn]]
-   [ctia.events.producers.es.mapping :refer [producer-mappings]]
-   [ctia.lib.es.slice :refer [SliceProperties
-                              ensure-slice-created!
-                              get-slice-props]]
-   [ctia.events.schemas :refer [Event UpdateTriple]]))
+  (:require [ctia.events.producers.es.mapping :refer [producer-mappings]]
+            [ctia.events.schemas :refer [Event UpdateTriple]]
+            [ctia.lib.es
+             [document :refer [create-doc-fn]]
+             [index :refer [connect ESConnState]]
+             [slice :refer [ensure-slice-created! get-slice-props SliceProperties]]]
+            [ctia.properties :refer [properties]]
+            [schema.core :as s]))
 
 (s/defn init-producer-conn :- (s/maybe ESConnState) []
   "initiate an ES producer connection returns a map containing transport,

--- a/src/ctia/lib/es/index.clj
+++ b/src/ctia/lib/es/index.clj
@@ -42,6 +42,11 @@
     native-index/update-aliases
     rest-index/update-aliases))
 
+(defn refresh-fn [conn]
+  (if (native-conn? conn)
+    native-index/refresh
+    rest-index/refresh))
+
 (defn connect [props]
   "instantiate an ES conn from props"
   (if (:uri props)

--- a/test/ctia/flows/hooks/es_event_hook_test.clj
+++ b/test/ctia/flows/hooks/es_event_hook_test.clj
@@ -1,0 +1,140 @@
+(ns ctia.flows.hooks.es-event-hook-test
+  (:require [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.events.producers.es.producer :refer [init-producer-conn]]
+            [ctia.lib.es
+             [document :as document]
+             [index :as index]]
+            [ctia.test-helpers
+             [core :as test-helpers :refer [post deftest-for-each-fixture]]
+             [es :as es-helpers]]))
+
+(use-fixtures :once test-helpers/fixture-schema-validation)
+
+(deftest-for-each-fixture test-events-es
+
+  {:filtered-alias (join-fixtures [test-helpers/fixture-properties:clean
+                                   test-helpers/fixture-properties:atom-store
+                                   test-helpers/fixture-properties:es-hook-filtered-alias
+                                   test-helpers/fixture-ctia
+                                   test-helpers/fixture-allow-all-auth
+                                   es-helpers/fixture-purge-producer-indexes])
+
+   :aliased-index (join-fixtures [test-helpers/fixture-properties:clean
+                                  test-helpers/fixture-properties:atom-store
+                                  test-helpers/fixture-properties:es-hook-aliased-index
+                                  test-helpers/fixture-ctia
+                                  test-helpers/fixture-allow-all-auth
+                                  es-helpers/fixture-purge-producer-indexes])}
+
+  (testing "Events are published to es"
+    (let [{{judgement-1-id :id} :parsed-body
+           judgement-1-status :status
+           :as judgement-1}
+          (post "ctia/judgement"
+                :body {:observable {:value "1.2.3.4"
+                                    :type "ip"}
+                       :disposition 1
+                       :source "source"
+                       :tlp "green"
+                       :priority 100
+                       :severity 100
+                       :confidence "Low"
+                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})
+
+          {{judgement-2-id :id} :parsed-body
+           judgement-2-status :status
+           :as judgement-2}
+          (post "ctia/judgement"
+                :body {:observable {:value "1.2.3.4"
+                                    :type "ip"}
+                       :disposition 2
+                       :source "source"
+                       :tlp "green"
+                       :priority 100
+                       :severity 100
+                       :confidence "Low"
+                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})
+
+          {{judgement-3-id :id} :parsed-body
+           judgement-3-status :status
+           :as judgement-3}
+          (post "ctia/judgement"
+                :body {:observable {:value "1.2.3.4"
+                                    :type "ip"}
+                       :disposition 3
+                       :source "source"
+                       :tlp "green"
+                       :priority 100
+                       :severity 100
+                       :confidence "Low"
+                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})]
+
+      (is (= 200 judgement-1-status))
+      (is (= 200 judgement-2-status))
+      (is (= 200 judgement-3-status))
+
+      (let [{:keys [index conn props]} (init-producer-conn)]
+
+        ((index/refresh-fn conn) conn)
+
+        (is (= [{:owner "Unknown"
+                 :entity {:valid_time
+                          {:start_time "2016-02-11T00:40:48.212Z"
+                           :end_time "2525-01-01T00:00:00.000Z"}
+                          :observable {:value "1.2.3.4" :type "ip"},
+                          :type "judgement"
+                          :source "source"
+                          :tlp "green"
+                          :disposition 1
+                          :disposition_name "Clean"
+                          :priority 100
+                          :id judgement-1-id
+                          :severity 100
+                          :confidence "Low"
+                          :owner "Unknown"}
+                 :id judgement-1-id
+                 :type "CreatedModel"}
+                {:owner "Unknown"
+                 :entity {:valid_time
+                          {:start_time "2016-02-11T00:40:48.212Z"
+                           :end_time "2525-01-01T00:00:00.000Z"}
+                          :observable {:value "1.2.3.4" :type "ip"},
+                          :type "judgement"
+                          :source "source"
+                          :tlp "green"
+                          :disposition 2
+                          :disposition_name "Malicious"
+                          :priority 100
+                          :id judgement-2-id
+                          :severity 100
+                          :confidence "Low"
+                          :owner "Unknown"}
+                 :id judgement-2-id
+                 :type "CreatedModel"}
+                {:owner "Unknown"
+                 :entity {:valid_time
+                          {:start_time "2016-02-11T00:40:48.212Z"
+                           :end_time "2525-01-01T00:00:00.000Z"}
+                          :observable {:value "1.2.3.4" :type "ip"},
+                          :type "judgement"
+                          :source "source"
+                          :tlp "green"
+                          :disposition 3
+                          :disposition_name "Suspicious"
+                          :priority 100
+                          :id judgement-3-id
+                          :severity 100
+                          :confidence "Low"
+                          :owner "Unknown"}
+                 :id judgement-3-id
+                 :type "CreatedModel"}]
+               (->> (document/search-docs conn
+                                          index
+                                          "event"
+                                          nil
+                                          {:sort_by "timestamp"
+                                           :sort_order "asc"
+                                           :query {"match_all" {}}})
+                    :data
+                    (map #(dissoc % :timestamp :http-params))
+                    (map #(update % :entity dissoc :created)))))))))

--- a/test/ctia/flows/hooks/es_event_hook_test.clj
+++ b/test/ctia/flows/hooks/es_event_hook_test.clj
@@ -10,21 +10,21 @@
 
 (use-fixtures :once test-helpers/fixture-schema-validation)
 
-(deftest-for-each-fixture test-events-es
+(deftest-for-each-fixture test-event-producer
 
-  {:filtered-alias (join-fixtures [test-helpers/fixture-properties:clean
-                                   test-helpers/fixture-properties:atom-store
-                                   test-helpers/fixture-properties:es-hook-filtered-alias
-                                   test-helpers/fixture-ctia
-                                   test-helpers/fixture-allow-all-auth
-                                   es-helpers/fixture-purge-producer-indexes])
+  {:es-filtered-alias (join-fixtures [test-helpers/fixture-properties:clean
+                                      test-helpers/fixture-properties:atom-store
+                                      test-helpers/fixture-properties:es-hook-filtered-alias
+                                      test-helpers/fixture-ctia
+                                      test-helpers/fixture-allow-all-auth
+                                      es-helpers/fixture-purge-producer-indexes])
 
-   :aliased-index (join-fixtures [test-helpers/fixture-properties:clean
-                                  test-helpers/fixture-properties:atom-store
-                                  test-helpers/fixture-properties:es-hook-aliased-index
-                                  test-helpers/fixture-ctia
-                                  test-helpers/fixture-allow-all-auth
-                                  es-helpers/fixture-purge-producer-indexes])}
+   :es-aliased-index (join-fixtures [test-helpers/fixture-properties:clean
+                                     test-helpers/fixture-properties:atom-store
+                                     test-helpers/fixture-properties:es-hook-aliased-index
+                                     test-helpers/fixture-ctia
+                                     test-helpers/fixture-allow-all-auth
+                                     es-helpers/fixture-purge-producer-indexes])}
 
   (testing "Events are published to es"
     (let [{{judgement-1-id :id} :parsed-body

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -1,24 +1,27 @@
 (ns ctia.test-helpers.core
   (:refer-clojure :exclude [get])
-  (:require [com.rpl.specter :refer [transform]]
-            [ctia.auth :as auth]
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clojure
+             [data :as cd]
+             [edn :as edn]
+             [string :as str]
+             [test :as ct]]
+            [com.rpl.specter :refer [transform]]
+            [ctia
+             [auth :as auth]
+             [events :as events]
+             [init :as init]
+             [properties :as props]
+             [store :as store]]
             [ctia.auth.allow-all :as aa]
-            [ctia.events :as events]
             [ctia.flows.hooks :as hooks]
             [ctia.http.server :as http-server]
-            [ctia.init :as init]
-            [ctia.lib.map :as map]
+            [ctia.lib
+             [map :as map]
+             [time :as time]
+             [url :as url]]
             [ctia.lib.specter.paths :as path]
-            [ctia.lib.time :as time]
-            [ctia.lib.url :as url]
-            [ctia.properties :as props]
-            [ctia.store :as store]
-            [cheshire.core :as json]
-            [clj-http.client :as http]
-            [clojure.data :as cd]
-            [clojure.edn :as edn]
-            [clojure.string :as str]
-            [clojure.test :as ct]
             [schema.core :as schema])
   (:import java.net.ServerSocket))
 
@@ -98,6 +101,16 @@
 
 (defn fixture-properties:redis-hook [f]
   (with-properties ["ctia.hook.redis.enabled" true]
+    (f)))
+
+(defn fixture-properties:es-hook-aliased-index [f]
+  (with-properties ["ctia.hook.es.enabled" true
+                    "ctia.hook.es.slicing.strategy" :aliased-index]
+    (f)))
+
+(defn fixture-properties:es-hook-filtered-alias [f]
+  (with-properties ["ctia.hook.es.enabled" true
+                    "ctia.hook.es.slicing.strategy" :filtered-alias]
     (f)))
 
 (defn fixture-properties:hook-classes [f]


### PR DESCRIPTION
closes #271 

- Tests the ES producer hook on both slicing strategies
- also had to change test selectors, see my comment for more details.

