### PR TITLE
Added ES refresh property boolean, use it only on tests

### DIFF
--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -54,19 +54,19 @@
 
 (defn create-doc
   "create a document on es return the created document"
-  [conn index-name mapping doc]
+  [conn index-name mapping doc refresh?]
   ((create-doc-fn conn)
    conn
    index-name
    mapping
    doc
    :id (:id doc)
-   :refresh true)
+   :refresh refresh?)
   doc)
 
 (defn update-doc
   "update a document on es return the updated document"
-  [conn index-name mapping id doc]
+  [conn index-name mapping id doc refresh?]
 
   (let [res ((update-doc-fn conn)
              conn
@@ -74,14 +74,14 @@
              mapping
              id
              doc
-             {:refresh true
+             {:refresh refresh?
               :fields "_source"})]
     (or (get-in res [:get-result :source])
         (get-in res [:get :_source]))))
 
 (defn delete-doc
   "delete a document on es and return nil if ok"
-  [conn index-name mapping id]
+  [conn index-name mapping id refresh?]
 
   (:found
    ((delete-doc-fn conn)
@@ -89,7 +89,7 @@
     index-name
     mapping
     id
-    :refresh true)))
+    :refresh refresh?)))
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit]

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -71,6 +71,7 @@
                       "ctia.store.es.port" s/Int
                       "ctia.store.es.clustername" s/Str
                       "ctia.store.es.indexname" s/Str
+                      "ctia.store.es.refresh" s/Bool
 
                       "ctia.hook.redis.uri" s/Str
                       "ctia.hook.redis.host" s/Str

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -24,7 +24,8 @@
       (-> (create-doc (:conn state)
                       (:index state)
                       (name mapping)
-                      realized)
+                      realized
+                      (get-in state [:props :refresh] false))
           coerce!))))
 
 (defn handle-update
@@ -39,7 +40,8 @@
                       (:index state)
                       (name mapping)
                       id
-                      realized)
+                      realized
+                      (get-in state [:props :refresh] false))
           coerce!))))
 
 (defn handle-read
@@ -65,7 +67,8 @@
     (delete-doc (:conn state)
                 (:index state)
                 (name mapping)
-                id)))
+                id
+                (get-in state [:props :refresh] false))))
 
 (defn handle-find
   "Generate an ES find/list handler using some mapping and schema"

--- a/src/ctia/stores/es/identity.clj
+++ b/src/ctia/stores/es/identity.clj
@@ -28,7 +28,8 @@
         res (create-doc (:conn state)
                         (:index state)
                         mapping
-                        transformed)]
+                        transformed
+                        (get-in state [:props :refresh] false))]
     (-> res
         (update-in [:capabilities] capabilities->capabilities-set)
         (dissoc :id))))

--- a/src/ctia/stores/es/judgement.clj
+++ b/src/ctia/stores/es/judgement.clj
@@ -44,7 +44,8 @@
                 (:index state)
                 mapping
                 judgement-id
-                updated)
+                updated
+                (get-in state [:props :refresh] false))
     indicator-rel))
 
 

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -49,6 +49,7 @@
                       "ctia.store.judgement" "es"
                       "ctia.store.sighting" "es"
                       "ctia.store.ttp" "es"
+                      "ctia.store.es.refresh" true
                       "ctia.store.es.uri" "http://192.168.99.100:9200"
                       "ctia.store.es.clustername" "elasticsearch"
                       "ctia.store.es.indexname" "test_ctia"]


### PR DESCRIPTION
closes #298 

This adds a boolean parameter to enable ES Index refresh on each operation involving writes.
This is disabled by default and only enabled on ES Store test fixtures.