### PR TITLE
Fix search sightings by indicator and other short/long id issues

### DIFF
--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -41,7 +41,7 @@
   (id/long-id
    (id/short-id->id id-type
                     short-id
-                    #(get-in @properties [:ctia :http :show]))))
+                    (get-in @properties [:ctia :http :show]))))
 
 (defroutes indicator-routes
   (context "/indicator" []
@@ -89,9 +89,9 @@
       :summary "Gets all Sightings associated with the Indicator"
       :capabilities #{:read-indicator :list-sightings}
       (if-let [indicator (read-indicator @indicator-store id)]
-        (if-let [sightings (list-sightings-by-indicators @sighting-store [indicator] params)]
-          (paginated-ok sightings)
-          (not-found))
+        (paginated-ok (list-sightings @sighting-store
+                                      {:indicators #{{:indicator_id (->long-id :indicator id)}}}
+                                      params))
         (not-found)))
     (GET "/title/:title" []
       :return (s/maybe [StoredIndicator])

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -1,9 +1,10 @@
 (ns ctia.http.routes.observable
   (:require
    [compojure.api.sweet :refer :all]
+   [ctia.lib.pagination :as pag]
    [ctia.http.routes.common :refer [paginated-ok PagingParams]]
    [ctia.schemas
-    [indicator :refer [StoredIndicator]]
+    [common :as c]
     [judgement :refer [StoredJudgement]]
     [sighting :refer [StoredSighting]]
     [vocabularies :refer [ObservableType]]]
@@ -21,16 +22,13 @@
                                :severity
                                :confidence)}))
 
-(s/defschema IndicatorsByObservableQueryParams
-  (st/merge
-   PagingParams
-   {(s/optional-key :sort_by) (s/enum :id :title)}))
+(s/defschema IndicatorRefsByObservableQueryParams
+  (st/dissoc PagingParams :sort_by :sort_order))
 
 (s/defschema SightingsByObservableQueryParams
   (st/merge
    PagingParams
    {(s/optional-key :sort_by) (s/enum :id :timestamp :confidence)}))
-
 
 (defroutes observable-routes
   (GET "/:observable_type/:observable_value/judgements" []
@@ -48,19 +46,28 @@
 
   (GET "/:observable_type/:observable_value/indicators" []
     :tags ["Indicator"]
-    :query [params IndicatorsByObservableQueryParams]
+    :query [params IndicatorRefsByObservableQueryParams]
     :path-params [observable_type :- ObservableType
                   observable_value :- s/Str]
-    :return (s/maybe [StoredIndicator])
-    :summary "Returns all the Indicators associated with the specified observable."
+    :return (s/maybe [c/Reference])
+    :summary "Returns all the Indicator References associated with the specified observable."
     :header-params [api_key :- (s/maybe s/Str)]
     :capabilities #{:list-judgements :list-indicators}
     (paginated-ok
-     (as-> {:type observable_type
-            :value observable_value} $
-       (list-judgements-by-observable @judgement-store $ nil)
-       (:data $ [])
-       (list-indicators-by-judgements @indicator-store $ params))))
+     (let [res (->> (list-judgements-by-observable @judgement-store
+                                                   {:type observable_type
+                                                    :value observable_value}
+                                                   nil)
+                    :data
+                    (mapcat :indicators)
+                    (map :indicator_id)
+                    distinct
+                    sort)]
+       (-> res
+           (pag/paginate params)
+           (pag/response (:offset params)
+                         (:limit params)
+                         (count res))))))
 
   (GET "/:observable_type/:observable_value/sightings" []
     :tags ["Sighting"]

--- a/src/ctia/lib/pagination.clj
+++ b/src/ctia/lib/pagination.clj
@@ -27,3 +27,16 @@
               {:total-hits hits}
               (when previous? previous)
               (when next? next))}))
+
+(defn paginate
+  [data {:keys [sort_by sort_order offset limit]
+         :or {sort_by :id
+              sort_order :asc
+              offset 0
+              limit default-limit}}]
+  (as-> data $
+    (sort-by sort_by $)
+    (if (= :desc sort_order)
+      (reverse $) $)
+    (drop offset $)
+    (take limit $)))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -64,7 +64,6 @@
   (update-sighting [this id sighting])
   (delete-sighting [this id])
   (list-sightings [this filtermap params])
-  (list-sightings-by-indicators [this indicators params])
   (list-sightings-by-observables [this observable params]))
 
 (defprotocol IIncidentStore

--- a/src/ctia/stores/atom/common.clj
+++ b/src/ctia/stores/atom/common.clj
@@ -5,6 +5,7 @@
             [clojure.set :as set]
             [ctia.lib.pagination :refer [default-limit
                                          list-response-schema
+                                         paginate
                                          response]]))
 
 (defn random-id [prefix]
@@ -91,18 +92,7 @@
                               filter-map))
                     (vals (deref state)))))))
 
-(defn paginate
-  [data {:keys [sort_by sort_order offset limit]
-         :or {sort_by :id
-              sort_order :asc
-              offset 0
-              limit default-limit}}]
-  (as-> data $
-    (sort-by sort_by $)
-    (if (= :desc sort_order)
-      (reverse $) $)
-    (drop offset $)
-    (take limit $)))
+
 
 (defn list-handler [Model]
   (s/fn :- (list-response-schema Model)

--- a/src/ctia/stores/atom/indicator.clj
+++ b/src/ctia/stores/atom/indicator.clj
@@ -1,10 +1,15 @@
 (ns ctia.stores.atom.indicator
-  (:require [ctia.schemas
+  (:require [ctia.domain.id :as id]
+            [ctia.lib.pagination :refer [list-response-schema]]
+            [ctia.properties :refer [properties]]
+            [ctia.schemas
              [indicator :refer [StoredIndicator]]
              [judgement :refer [StoredJudgement]]]
-            [ctia.lib.pagination :refer [list-response-schema]]
             [ctia.stores.atom.common :as mc]
             [schema.core :as s]))
+
+(defn long-id->short-id [long-id]
+  (id/short-id (id/long-id->id long-id)))
 
 (def handle-create-indicator (mc/create-handler-from-realized StoredIndicator))
 (def handle-read-indicator (mc/read-handler StoredIndicator))
@@ -18,6 +23,6 @@
    params]
   (let [indicator-ids (some->> (map :indicators judgements)
                                (mapcat #(map :indicator_id %))
+                               (map #(long-id->short-id %))
                                set)]
-
     (handle-list-indicators indicator-state {:id indicator-ids} params)))

--- a/src/ctia/stores/atom/sighting.clj
+++ b/src/ctia/stores/atom/sighting.clj
@@ -14,16 +14,6 @@
 (def handle-delete-sighting (mc/delete-handler StoredSighting))
 (def handle-list-sightings (mc/list-handler StoredSighting))
 
-(s/defn handle-list-sightings-by-indicators :- (list-response-schema StoredSighting)
-  [sightings-state :- (s/atom {s/Str StoredSighting})
-   indicators :- (s/maybe [StoredIndicator])
-   params]
-
-  (let [indicators-set (set (map (fn [ind] {:indicator_id (:id ind)})
-                                 indicators))]
-    (handle-list-sightings sightings-state
-                           {:indicators indicators-set} params)))
-
 (s/defn handle-list-sightings-by-observables :- (list-response-schema StoredSighting)
   [sightings-state :- (s/atom {s/Str StoredSighting})
    observables :- (s/maybe [c/Observable])

--- a/src/ctia/stores/atom/store.clj
+++ b/src/ctia/stores/atom/store.clj
@@ -140,8 +140,6 @@
     (sighting/handle-delete-sighting state id))
   (list-sightings [_ filter-map params]
     (sighting/handle-list-sightings state filter-map params))
-  (list-sightings-by-indicators [_ indicators params]
-    (sighting/handle-list-sightings-by-indicators state indicators params))
   (list-sightings-by-observables [_ observables params]
     (sighting/handle-list-sightings-by-observables state observables params)))
 

--- a/src/ctia/stores/es/indicator.clj
+++ b/src/ctia/stores/es/indicator.clj
@@ -1,15 +1,8 @@
 (ns ctia.stores.es.indicator
-  (:import java.util.UUID)
-  (:require
-   [schema.core :as s]
-   [ctia.stores.es.crud :as crud]
-   [ctia.schemas.common :refer [Observable]]
-   [ctia.schemas.indicator :refer [Indicator
-                                   NewIndicator
-                                   StoredIndicator
-                                   realize-indicator]]
-   [ctia.stores.es.query :refer [indicators-by-judgements-query]]
-   [ctia.lib.es.document :refer [search-docs]]))
+  (:require [ctia.domain.id :as id]
+            [ctia.lib.es.document :refer [search-docs]]
+            [ctia.schemas.indicator :refer [StoredIndicator]]
+            [ctia.stores.es.crud :as crud]))
 
 (def handle-create-indicator (crud/handle-create :indicator StoredIndicator))
 (def handle-read-indicator (crud/handle-read :indicator StoredIndicator))
@@ -19,12 +12,12 @@
 
 (def ^{:private true} mapping "indicator")
 
-
 (defn handle-list-indicators-by-judgements
   [state judgements params]
   (let [ids (some->> judgements
                      (map :indicators)
                      (mapcat #(map :indicator_id %))
+                     (map #(id/str->short-id %))
                      set)]
     (when ids
       (search-docs (:conn state)

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -19,13 +19,6 @@
 
 (def ^{:private true} mapping "sighting")
 
-(defn handle-list-sightings-by-indicators
-  [state indicators params]
-  (let [indicator-ids (mapv :id indicators)]
-    (handle-list-sightings state {:type "sighting"
-                                  [:indicators :indicator_id]
-                                  indicator-ids} params)))
-
 (defn handle-list-sightings-by-observables
   [{:keys [conn index]}  observables params]
 

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -197,7 +197,5 @@
     (sig/handle-delete-sighting state id))
   (list-sightings [_ filter-map params]
     (sig/handle-list-sightings state filter-map params))
-  (list-sightings-by-indicators [_ indicators params]
-    (sig/handle-list-sightings-by-indicators state indicators params))
   (list-sightings-by-observables [_ observables params]
     (sig/handle-list-sightings-by-observables state observables params)))

--- a/test/ctia/http/generative/specs.clj
+++ b/test/ctia/http/generative/specs.clj
@@ -37,50 +37,49 @@
 (def-property spec-coa-routes 'coa)
 (def-property spec-exploit-target-routes 'exploit-target)
 
-(def-property spec-indicator-routes 'indicator)
-#_(def spec-indicator-routes
-    (for-all [[new-indicator new-sightings] gen/gen-new-indicator-with-new-sightings]
-             (let [{post-status :status
-                    {id :id, :as post-indicator} :parsed-body}
-                   (post "ctia/indicator"
-                         :body new-indicator)
+(def spec-indicator-routes
+  (for-all [[new-indicator new-sightings] gen/gen-new-indicator-with-new-sightings]
+    (let [{post-status :status
+           {id :id, :as post-indicator} :parsed-body}
+          (post "ctia/indicator"
+                :body new-indicator)
 
-                   {get-indicator-status :status
-                    get-indicator :parsed-body}
-                   (get (str "ctia/indicator/" (encode id)))
+          {get-indicator-status :status
+           get-indicator :parsed-body}
+          (get (str "ctia/indicator/" (encode id)))
 
-                   stored-sighting-responses
-                   (map #(post "ctia/sighting"
-                               :body %)
-                        new-sightings)
+          stored-sighting-responses
+          (map #(post "ctia/sighting"
+                      :body %)
+               new-sightings)
 
-                   stored-sighting-ids
-                   (->> stored-sighting-responses
-                        (map (comp :id :parsed-body))
-                        set)
+          stored-sighting-ids
+          (->> stored-sighting-responses
+               (map (comp :id :parsed-body))
+               set)
 
-                   {search-result-status :status
-                    search-results :parsed-body
-                    :as search-response}
-                   (get (str "ctia/indicator/" (encode id) "/sightings"))
+          {search-result-status :status
+           search-results :parsed-body
+           :as search-response}
+          (get (str "ctia/indicator/" (encode id) "/sightings"))
 
-                   search-result-ids
-                   (->> search-results
-                        (map :id)
-                        set)]
+          search-result-ids
+          (->> search-results
+               (map :id)
+               set)]
 
-               (assert-successful post-status)
-               (doseq [{status :status} stored-sighting-responses]
-                 (assert-successful status))
-               (assert-successful get-indicator-status)
-               (assert-successful search-result-status)
+      (assert-successful post-status)
+      (doseq [{status :status} stored-sighting-responses]
+        (assert-successful status))
+      (assert-successful get-indicator-status)
+      (assert-successful search-result-status)
 
-               (and
-                (= stored-sighting-ids
-                   search-result-ids)
-                (common= new-indicator
-                         (normalize post-indicator)
-                         (normalize get-indicator))))))
+      (and
+       (= stored-sighting-ids
+          search-result-ids)
+       (common= new-indicator
+                (normalize post-indicator)
+                (normalize get-indicator))))))
 
 (def-property spec-feedback-routes 'feedback)
 (def-property spec-incident-routes 'incident)

--- a/test/ctia/http/routes/observable_test.clj
+++ b/test/ctia/http/routes/observable_test.clj
@@ -1,12 +1,12 @@
 (ns ctia.http.routes.observable-test
   (:refer-clojure :exclude [get])
-  (:require
-    [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
-    [ctia.lib.url :as url]
-    [ctia.test-helpers.core :refer [delete get post put] :as helpers]
-    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-    [ctia.test-helpers.store :refer [deftest-for-each-store]]
-    [ctia.test-helpers.auth :refer [all-capabilities]]))
+  (:require [clojure.test :refer [is join-fixtures testing use-fixtures]]
+            [ctia.http.routes.indicator :refer [->long-id]]
+            [ctia.test-helpers
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [get post]]
+             [fake-whoami-service :as whoami-helpers]
+             [store :refer [deftest-for-each-store]]]))
 
 (use-fixtures :once (join-fixtures [helpers/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -43,6 +43,7 @@
                      :valid_time {:end_time "2016-02-12T00:00:00.000-00:00"}
                      :tlp "red"}
               :headers {"api_key" "45c1f5e3f05d0"})
+        long-indicator-1-id (->long-id :indicator indicator-1-id)
 
         {sighting-1-status :status
          {sighting-1-id :id} :parsed-body}
@@ -51,7 +52,7 @@
                      :source "foo"
                      :confidence "Medium"
                      :description "sighting 1"
-                     :indicators [{:indicator_id indicator-1-id}]
+                     :indicators [{:indicator_id long-indicator-1-id}]
                      :observables [{:value "1.2.3.4"
                                      :type "ip"}]
                      :tlp "red"}
@@ -64,7 +65,7 @@
                      :source "bar"
                      :confidence "High"
                      :description "sighting 2"
-                     :indicators [{:indicator_id indicator-1-id}]
+                     :indicators [{:indicator_id long-indicator-1-id}]
                      :observables [{:value "1.2.3.4"
                                      :type "ip"}]
                      :tlp "red"}
@@ -101,6 +102,7 @@
                                   :end_time "2016-02-12T00:00:00.000-00:00"}
                      :tlp "red"}
               :headers {"api_key" "45c1f5e3f05d0"})
+        long-indicator-2-id (->long-id :indicator indicator-2-id)
 
         {sighting-3-status :status
          {sighting-3-id :id} :parsed-body}
@@ -109,7 +111,7 @@
                      :source "spam"
                      :confidence "None"
                      :description "sighting 3"
-                     :indicators [{:indicator_id indicator-2-id}]
+                     :indicators [{:indicator_id long-indicator-2-id}]
                      :observables [{:value "10.0.0.1"
                                      :type "ip"}]
                      :tlp "red"}
@@ -117,7 +119,7 @@
 
         {judgement-2-update-status :status}
         (post (str "ctia/judgement/" judgement-2-id "/indicator")
-              :body {:indicator_id indicator-2-id}
+              :body {:indicator_id long-indicator-2-id}
               :headers {"api_key" "45c1f5e3f05d0"})
 
         {{judgement-3-id :id} :parsed-body
@@ -146,6 +148,7 @@
                                   :end_time "2016-02-11T00:00:00.000-00:00"}
                      :tlp "red"}
               :headers {"api_key" "45c1f5e3f05d0"})
+        long-indicator-3-id (->long-id :indicator indicator-3-id)
 
         {sighting-4-status :status
          {sighting-4-id :id} :parsed-body}
@@ -154,7 +157,7 @@
                      :source "foo"
                      :confidence "High"
                      :description "sighting 4"
-                     :indicators [{:indicator_id indicator-3-id}]
+                     :indicators [{:indicator_id long-indicator-3-id}]
                      :observables [{:value "10.0.0.1"
                                      :type "ip"}]
                      :tlp "red"}
@@ -167,7 +170,7 @@
                      :source "bar"
                      :confidence "Low"
                      :description "sighting 5"
-                     :indicators [{:indicator_id indicator-3-id}]
+                     :indicators [{:indicator_id long-indicator-3-id}]
                      :observables [{:value "10.0.0.1"
                                      :type "ip"}]
                      :tlp "red"}
@@ -175,7 +178,7 @@
 
         {judgement-3-update-status :status}
         (post (str "ctia/judgement/" judgement-3-id "/indicator")
-              :body {:indicator_id indicator-3-id}
+              :body {:indicator_id long-indicator-3-id}
               :headers {"api_key" "45c1f5e3f05d0"})]
 
     (testing "With successful test setup"
@@ -211,7 +214,7 @@
                 :priority 100
                 :severity 100
                 :confidence "High"
-                :indicators [{:indicator_id indicator-2-id}]
+                :indicators [{:indicator_id long-indicator-2-id}]
                 :valid_time {:start_time #inst "2016-02-01T00:00:00.000-00:00"
                              :end_time #inst "2525-01-01T00:00:00.000-00:00"}
                 :tlp "red"
@@ -226,7 +229,7 @@
                 :priority 100
                 :severity 100
                 :confidence "Low"
-                :indicators [{:indicator_id indicator-3-id}]
+                :indicators [{:indicator_id long-indicator-3-id}]
                 :valid_time {:start_time #inst "2016-02-01T00:00:00.000-00:00"
                              :end_time #inst "2525-01-01T00:00:00.000-00:00"}
                 :tlp "red"
@@ -241,30 +244,8 @@
             indicators (:parsed-body response)]
         (is (= 200 (:status response)))
 
-        (is (deep=
-             #{{:id indicator-2-id
-                :type "indicator"
-                :title "indicator"
-                :description "indicator 2"
-                :producer "producer"
-                :indicator_type ["C2" "IP Watchlist"]
-                :valid_time {:start_time #inst "2016-01-12T00:00:00.000-00:00"
-                             :end_time #inst "2016-02-12T00:00:00.000-00:00"}
-                :owner "foouser"
-                :tlp "red"}
-               {:id indicator-3-id
-                :type "indicator"
-                :title "indicator"
-                :description "indicator 3"
-                :producer "producer"
-                :indicator_type ["C2" "IP Watchlist"]
-                :valid_time {:start_time #inst "2016-01-11T00:00:00.000-00:00"
-                             :end_time #inst "2016-02-11T00:00:00.000-00:00"}
-                :owner "foouser"
-                :tlp "red"}}
-             (->> indicators
-                  (map #(dissoc % :created :modified))
-                  set)))))
+        (is (= #{long-indicator-2-id long-indicator-3-id}
+               (set indicators)))))
 
     (testing "GET /ctia/:observable_type/:observable_value/sightings"
       (let [{status :status
@@ -280,7 +261,7 @@
                 :source "spam"
                 :confidence "None"
                 :description "sighting 3"
-                :indicators [{:indicator_id indicator-2-id}]
+                :indicators [{:indicator_id long-indicator-2-id}]
                 :observables [{:value "10.0.0.1"
                                :type "ip"}]
                 :owner "foouser"
@@ -291,7 +272,7 @@
                 :source "foo"
                 :confidence "High"
                 :description "sighting 4"
-                :indicators [{:indicator_id indicator-3-id}]
+                :indicators [{:indicator_id long-indicator-3-id}]
                 :observables [{:value "10.0.0.1"
                                :type "ip"}]
                 :owner "foouser"
@@ -302,7 +283,7 @@
                 :source "bar"
                 :confidence "Low"
                 :description "sighting 5"
-                :indicators [{:indicator_id indicator-3-id}]
+                :indicators [{:indicator_id long-indicator-3-id}]
                 :observables [{:value "10.0.0.1"
                                :type "ip"}]
                 :owner "foouser"

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -1,12 +1,15 @@
 (ns ctia.http.routes.pagination-test
   (:refer-clojure :exclude [get])
   (:require [clojure.test :refer [join-fixtures testing use-fixtures]]
+            [ctia.properties :refer [properties]]
             [ctia.test-helpers
              [core :as helpers]
              [fake-whoami-service :as whoami-helpers]
              [http :refer [assert-post]]
-             [pagination :refer [pagination-test]]
+             [pagination :refer [pagination-test
+                                 pagination-test-no-sort]]
              [store :refer [deftest-for-each-store]]]
+            [ctia.http.routes.indicator :refer [->long-id]]
             [ctia.test-helpers.generators.schemas :as gs]
             [ring.util.codec :refer [url-encode]]
             [ctia.lib.url :as url]))
@@ -23,7 +26,8 @@
           indicators (->> (gs/sample-by-kw 5 :new-indicator)
                           (map #(assoc % :title "test")))
           created-indicators (map #(assert-post "ctia/indicator" %) indicators)
-          indicator-rels (map (fn [{:keys [id]}] {:indicator_id id}) created-indicators)
+          indicator-rels (map (fn [{:keys [id]}] {:indicator_id (->long-id :indicator id)})
+                              created-indicators)
           judgements (->> (gs/sample-by-kw 5 :new-judgement)
                           (map #(assoc %
                                        :observable observable
@@ -41,9 +45,9 @@
         (assert-post "ctia/judgement" judgement))
 
       (testing "test paginated lists responses"
-        (pagination-test (str route-pref "/indicators")
-                         {"api_key" "45c1f5e3f05d0"}
-                         [:id :title])
+        (pagination-test-no-sort (str route-pref "/indicators")
+                                 {"api_key" "45c1f5e3f05d0"}
+                                 [])
         (pagination-test (str "/ctia/indicator/title/"
                               (-> indicators first :title))
                          {"api_key" "45c1f5e3f05d0"}

--- a/test/ctia/stores/atom/sighting_test.clj
+++ b/test/ctia/stores/atom/sighting_test.clj
@@ -7,21 +7,6 @@
             [ctia.test-helpers.generators.schemas :as gen]
             [ctia.test-helpers.generators.schemas.sighting-generators :as sg]))
 
-(defspec spec-handle-list-sightings-by-indicators
-  (for-all [[indicator sightings] gen/gen-indicator-with-sightings]
-           (let [store (->> sightings
-                            (map (fn [x] [(:id x) x]))
-                            (into {})
-                            atom)]
-             (and
-              ;; Empty search
-              (empty? (:data (sut/handle-list-sightings-by-indicators store [] {})))
-              ;; Basic search
-              (= (set (vals @store))
-                 (-> (sut/handle-list-sightings-by-indicators store [indicator] {})
-                     :data
-                     set))))))
-
 (def gen-observable-and-sightings
   (tcg/let [observable (gen/gen-entity :observable)
             different-observables (tcg/vector

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -72,10 +72,15 @@
   (with-properties ["ctia.http.dev-reload" false
                     "ctia.http.min-threads" 9
                     "ctia.http.max-threads" 10
+                    "ctia.http.show.protocol"    "http"
+                    "ctia.http.show.hostname"    "localhost"
+                    "ctia.http.show.port"        "57254"
+                    "ctia.http.show.path-prefix" ""
                     "ctia.nrepl.enabled" false
                     "ctia.hook.es.enabled" false
                     "ctia.hook.redis.enabled" false
-                    "ctia.hook.redis.channel-name" "events-test"]
+                    "ctia.hook.redis.channel-name" "events-test"
+                    ]
     ;; run tests
     (f)))
 

--- a/test/ctia/test_helpers/generators/schemas.clj
+++ b/test/ctia/test_helpers/generators/schemas.clj
@@ -1,8 +1,9 @@
 (ns ctia.test-helpers.generators.schemas
   (:require [clojure.test.check.generators :as gen]
+            [ctia.domain.id :as id]
+            [ctia.properties :refer [properties]]
             [ctia.schemas
              [common :refer [Observable]]
-             [feedback :refer [Feedback]]
              [identity :refer [Identity]]
              [verdict :refer [Verdict]]]
             [ctia.test-helpers.generators.common :refer [generate-entity]]
@@ -18,16 +19,21 @@
              [sighting-generators :as sg]
              [ttp-generators :as tg]]))
 
+(def ->indicator-long-id
+  (id/long-id-factory :indicator
+                      #(get-in @properties [:ctia :http :show])))
+
+
 (def gen-new-indicator-with-new-sightings
   (gen/fmap
    (fn [[indicator sightings]]
      [indicator
       (map (fn [sighting]
              (assoc sighting :indicators
-                    [{:indicator_id (:id indicator)}]))
+                    [{:indicator_id (->indicator-long-id (:id indicator))}]))
            sightings)])
    (gen/tuple ng/gen-new-indicator-with-id
-              (gen/vector sg/gen-new-sighting 1 10))))
+              (gen/vector sg/gen-new-sighting 1 1))))
 
 (def gen-indicator-with-sightings
   (gen/fmap
@@ -35,7 +41,7 @@
      [indicator
       (map (fn [sighting]
              (assoc sighting :indicators
-                    [{:indicator_id (:id indicator)}]))
+                    [{:indicator_id (->indicator-long-id (:id indicator))}]))
            sightings)])
    (gen/tuple ng/gen-indicator
               (gen/vector sg/gen-sighting 1 10))))

--- a/test/ctia/test_helpers/pagination.clj
+++ b/test/ctia/test_helpers/pagination.clj
@@ -122,7 +122,14 @@
 
 (defn pagination-test [route headers sort-fields]
   "all pagination related tests for a list route"
-  (do (limit-test route headers)
-      (offset-test route headers)
-      (sort-test route headers sort-fields)
-      (edge-cases-test route headers)))
+  (testing (str "paginations tests for: " route)
+    (do (limit-test route headers)
+        (offset-test route headers)
+        (sort-test route headers sort-fields)
+        (edge-cases-test route headers))))
+
+(defn pagination-test-no-sort [route headers sort-fields]
+  "all pagination related tests for a list route"
+  (testing (str "paginations tests for: " route)
+    (do (limit-test route headers)
+        (offset-test route headers))))


### PR DESCRIPTION
This PR should fix many bugs related to new short/long ids.

About this route: `/observable/:type/:value/indicators`
It currently works by listing all judgements related to an observable and from that list of judgements, retrieve all related indicators. 

Since each Judgement could reference external indicators, we might not want to keep this route for the same reason we deleted routes on issue #19.

Also, slightly related to this, do you think it would be a good idea to transform all short-ids provided in relationships to URLs at creation/update (maybe at realization)?