### PR TITLE
TG Feed Importer

### DIFF
--- a/src/ctia/import/threatgrid/feed.clj
+++ b/src/ctia/import/threatgrid/feed.clj
@@ -1,0 +1,129 @@
+(ns ctia.import.threatgrid.feed
+  (:require [cheshire.core :as cjson]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clj-time.core :refer [date-time days]]
+            [clj-time.format :refer [unparse formatter]]
+            [ctia.lib.time :refer [date-range] :as ctime]
+            [ctia.import.threatgrid.feed.indicators :as fi]
+            [ctia.import.threatgrid.feed.sightings :as fs]
+            [ctia.import.threatgrid.feed.judgements :as fj]
+            [clj-http.client :as http]
+            [clj-http.conn-mgr :as conn]))
+
+(defn tg-feed-names []
+  [;;"autorun-registry" ;; always empty
+   "banking-dns"
+   "dll-hijacking-dns"
+   "doc-net-com-dns"
+   "downloaded-pe-dns"
+   "dynamic-dns"
+   "irc-dns"
+   "modified-hosts-dns"
+   "parked-dns"
+   "public-ip-check-dns"
+   "rat-dns"
+   ;;"scheduled-tasks" ;; always empty
+   "sinkholed-ip-dns"
+   "stolen-cert-dns"])
+
+(defn dates
+  []
+  (mapv
+   (fn [dt] (unparse (formatter "yyyy-MM-dd") dt))
+   (date-range (date-time 2016 03 01)
+               (date-time 2016 03 02)
+               (days 1))))
+
+(defn tg-uri [feed-file-name & {:keys [api-key]
+                                :or {api-key nil}}]
+  (str
+   "https://panacea.threatgrid.com/api/v3/feeds/"
+   feed-file-name
+   (if api-key (str "?api_key=" api-key))))
+
+;; get feed data via direct http call
+(defn feed-file-names [feed-names dates]
+  (for [feed-name feed-names
+        date-str dates]
+    (str feed-name "_" date-str ".json")))
+
+(defn body-empty? [body]
+  (or (empty? body)
+      (= "[]" body)))
+
+(defn file-path [s]
+  (str "/var/tg-feeds/" s))
+
+(defn dump-file [file-name file-contents]
+  (with-open [wrtr (io/writer file-name)]
+    (.write wrtr file-contents)))
+
+(defn download-feeds []
+  (let [api-key (or (System/getenv "APIKEY") "")
+        tg-feed-uri "https://panacea.threatgrid.com/api/v3/feeds/"]
+    (doseq [feed-file-name (filter #(not (.exists (io/as-file (file-path %))))
+                                   (feed-file-names (tg-feed-names) (dates)))]
+      (Thread/sleep 1000) ;; a courtesy
+      (let [body (:body (http/get (tg-uri feed-file-name :api-key api-key)))]
+        (if (not (body-empty? body))
+          (dump-file (file-path feed-file-name) body))))))
+
+(defn retry
+  [retries f & args]
+  (let [res (try {:value (apply f args)}
+                 (catch Exception e
+                   (if (= 0 retries)
+                     (throw e)
+                     {:exception e})))]
+    (if (:exception res)
+      (do
+        (recur (dec retries) f args))
+            (:value res))))
+
+(defn post-to-ctia
+  [expressions xtype ctia-uri conn-mgr]
+  (let [target-uri (str ctia-uri "/ctia/" xtype)]
+    (doall
+     (map (fn [expression]
+            (let [options {:connection-manager conn-mgr
+                           :content-type :edn
+                           :accept :edn
+                           :throw-exceptions false
+                           :body (pr-str expression)
+                           :query-params {"api_key" "importer"}}
+                  response (try
+                             (retry 5 http/post target-uri options)
+                             (catch java.net.SocketTimeoutException e
+                               (println "Socket timed out after 5 retries.")))]
+              response))
+          expressions))))
+
+(comment
+  (let [indicators (atom {})]
+    (doseq [date (dates)
+            name (tg-feed-names)
+            file-name (filter #(.exists (io/as-file (file-path %)))
+                              (feed-file-names [name] [date]))]
+      (println "Start loading " file-name)
+      (let [uri (tg-uri file-name)
+            entries (cjson/parse-string (slurp (file-path file-name)) true)
+            description (-> entries first :description)
+            ctia-uri "http://localhost:3000"
+            conn-mgr (conn/make-reusable-conn-manager {:timeout 5 :threads 8})
+            indicator (fi/feed-indicator name description ctia-uri indicators)
+            feed {:title name
+                  :description description
+                  :source file-name
+                  :source-uri uri
+                  :indicator indicator
+                  :observable {:type "domain" :field :domain}
+                  :entries entries}]
+        (let [judgements (fj/feed->judgements feed)]
+          (println "Posting" (count judgements) "judgements to ctia")
+          (post-to-ctia judgements "judgement" ctia-uri conn-mgr))
+        (let [sightings (fs/feed->sightings feed)]
+          (println "Posting" (count sightings) "sightings to ctia")
+          (post-to-ctia sightings "sighting" ctia-uri conn-mgr)))
+      (println "Done loading " file-name))))

--- a/src/ctia/import/threatgrid/feed/indicators.clj
+++ b/src/ctia/import/threatgrid/feed/indicators.clj
@@ -1,0 +1,54 @@
+(ns ctia.import.threatgrid.feed.indicators
+  (:require [ctia.schemas.indicator :as si]
+            [schema.core :as s]
+            [clj-http.client :as http]
+            [cheshire.core :as cjson]
+            [clojure.edn :as edn]))
+
+(defn http-options []
+  {:content-type :edn
+   :accept :edn
+   :throw-exceptions false
+   :socket-timeout 10000
+   :conn-timeout 10000})
+
+(defn stored-ctia-indicator [title ctia-uri]
+  (let [target-url (str ctia-uri "/ctia/indicator/title/" title)
+        result (http/get target-url (http-options))]
+    (cond
+      (= 200 (:status result)) (-> result
+                                   :body
+                                   edn/read-string
+                                   first)
+      (= 400 (:status result)) nil)))
+
+(defn make-ctia-indicator
+  [title description ctia-uri]
+  (let [indicator {:title (str "tg-feed-" title)
+                   :type "indicator"
+                   :short_description (str "ThreatGrid " title " Feed.")
+                   :description (str description)
+                   :confidence "High"
+                   ;; :severity 100
+                   :tags []
+                   :producer "ThreatGrid"}
+        target-url (str ctia-uri "/ctia/indicator")
+        options (assoc (http-options) :body (pr-str indicator))
+        response (http/post target-url options)
+        result (-> response
+                   :body
+                   edn/read-string)]
+    (println "Created" (:id result))
+    result))
+
+(defn init-ctia-indicator
+  [title description ctia-uri indicators]
+  (let [ctia-indicator (or (stored-ctia-indicator title ctia-uri)
+                           (make-ctia-indicator title description ctia-uri))]
+    (swap! indicators assoc title ctia-indicator)
+    ctia-indicator))
+
+(defn feed-indicator
+  [title description ctia-uri indicators]
+  (or (get-in @indicators [title])
+      (init-ctia-indicator title description ctia-uri indicators)))

--- a/src/ctia/import/threatgrid/feed/sightings.clj
+++ b/src/ctia/import/threatgrid/feed/sightings.clj
@@ -1,0 +1,82 @@
+(ns ctia.import.threatgrid.feed.sightings
+  (:require [ctia.import.threatgrid.feed.indicators :as fi]
+            [ctia.schemas.sighting :as ss]
+            [ctia.lib.time :as time]
+            [schema.core :as s]
+            [clj-http.client :as http]
+            [cheshire.core :as json]
+            [clojure.edn :as edn]))
+
+(defn make-feed-sighting
+  [description feed-uri timestamp observable indicator]
+  (let [sighting {:description description
+                  :type "sighting"
+                  :source "ThreatGrid Feed"
+                  :source_uri feed-uri
+                  :tlp "green"
+                  :confidence "High"
+                  :timestamp timestamp
+                  :observables [observable]
+                  :indicators [indicator]}]))
+
+(defn transform
+  [entries
+   observable-type
+   observable-value
+   indicator-id
+   indicator-source
+   source-uri & {:keys [tlp confidence]
+                 :or {tlp "green"
+                      confidence "High"}}]
+  (map
+   (fn [entry]
+     (let [{:keys [description timestamp]} entry]
+       {:description description
+        :type "sighting"
+        :source "ThreatGrid"
+        :source_uri source-uri
+        :tlp tlp
+        :confidence confidence
+        :timestamp timestamp
+        :observables [{:type observable-type
+                       :value (observable-value entry)}]
+        :indicators [{:confidence "High"
+                      :source indicator-source
+                      :indicator_id indicator-id}]}))
+   entries))
+
+(defn entries->sightings
+  [entries observable-type observable-field
+   indicator-id indicator-source source-uri & {:as options}]
+  (apply transform entries observable-type observable-field
+         indicator-id indicator-source source-uri options))
+
+(defn feed->sightings
+  [feed]
+  (let [{:keys [entries source-uri title]
+         {observable-type :type
+          observable-field :field} :observable
+         {indicator-id :id
+          indicator-source :title} :indicator} feed
+        sighting-source (str "ThreatGrid " title " Feed")]
+    (entries->sightings entries
+                        observable-type
+                        observable-field
+                        indicator-id
+                        indicator-source
+                        source-uri)))
+
+(defn feed-file->sightings
+  [feed-name file observable-type observable-field ctia-uri source-uri & {:as options}]
+  (let [entries (json/parse-string (slurp file) true)
+        description (-> entries first :description)
+        indicator (fi/feed-indicator feed-name description ctia-uri)
+        indicator-id (:id indicator)
+        indicator-source (:title indicator)]
+    (entries->sightings entries
+                        observable-type
+                        observable-field
+                        indicator-id
+                        indicator-source
+                        source-uri
+                        options)))

--- a/src/ctia/lib/time.clj
+++ b/src/ctia/lib/time.clj
@@ -2,7 +2,8 @@
     ctia.lib.time
   (:require [clj-time.core :as time]
             [clj-time.format :as time-format]
-            [clj-time.coerce :as time-coerce])
+            [clj-time.coerce :as time-coerce]
+            [clj-time.periodic :refer [periodic-seq] :as periodic])
   (:import [java.sql Time Timestamp]
            [java.util Date]
            [org.joda.time DateTime DateTimeZone]))
@@ -99,3 +100,8 @@
           :year   (time/date-time year))
 
         (time-coerce/to-date))))
+
+(defn date-range [start end step]
+  (let [inf-range (periodic-seq start step)
+        below-end? (fn [t] (time/within? (time/interval start end) t))]
+    (take-while below-end? inf-range)))


### PR DESCRIPTION
Creates indicators, judgements, and sightings from TG Feeds. Includes
utilities for downloading feeds between date ranges, then processing
and importing expressions to CTIA.

Closes #289 