### PR TITLE
Refactor capabilities to require all and remove :admin capability

### DIFF
--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -2,9 +2,10 @@
 
 (defprotocol IIdentity
   (authenticated? [this])
+  (admin? [this])
   (login [this])
   (allowed-capabilities [this])
-  (allowed-capability? [this capability]))
+  (capable? [this capabilities]))
 
 (defprotocol IAuth
   (require-login? [this])
@@ -12,24 +13,85 @@
 
 (defonce auth-service (atom nil))
 
+(def all-capabilities
+  #{;; Actor
+    :create-actor
+    :read-actor
+    :delete-actor
+
+    ;; Campaign
+    :create-campaign
+    :read-campaign
+    :delete-campaign
+
+    ;; COA
+    :create-coa
+    :read-coa
+    :delete-coa
+
+    ;; Exploit-Target
+    :create-exploit-target
+    :read-exploit-target
+    :delete-exploit-target
+
+    ;; Feedback
+    :create-feedback
+    :read-feedback
+    :delete-feedback
+
+    ;; Incident
+    :create-incident
+    :read-incident
+    :delete-incident
+
+    ;; Indicator
+    :read-indicator
+    :list-indicators
+    :create-indicator
+
+    ;; Judgement
+    :create-judgement
+    :read-judgement
+    :list-judgements
+    :delete-judgement
+
+    ;; Sighting
+    :create-sighting
+    :read-sighting
+    :list-sightings
+    :delete-sighting
+
+    ;; TTP
+    :create-ttp
+    :read-ttp
+    :delete-ttp
+
+    ;; Verdict
+    :read-verdict
+
+    ;; Other
+    :developer
+    })
+
 (def default-capabilities
   {:user
-   #{:read-judgement
-     :list-judgements-by-observable
-     :list-judgements-by-indicator
-     :read-indicator
-     :list-indicators-by-title
-     :read-feedback
-     :reat-ttp
-     :read-campaign
+   #{;; Actor
      :read-actor
-     :read-exploit-target
+     :read-campaign
      :read-coa
-     :read-sighting
+     :read-exploit-target
+     :read-feedback
      :read-incident
-     :read-relation}
+     :read-indicator
+     :list-indicators
+     :read-judgement
+     :list-judgements
+     :read-sighting
+     :list-sightings
+     :read-ttp
+     :read-verdict}
    :admin
-   #{:admin}})
+   all-capabilities})
 
 (def not-logged-in-owner "Unknown")
 
@@ -37,11 +99,13 @@
   IIdentity
   (authenticated? [_]
     false)
+  (admin? [_]
+    false)
   (login [_]
     not-logged-in-owner)
   (allowed-capabilities [_]
     #{})
-  (allowed-capability? [_ _]
+  (capable? [_ _]
     false))
 
 (def denied-identity-singleton (->DeniedIdentity))

--- a/src/ctia/auth/allow_all.clj
+++ b/src/ctia/auth/allow_all.clj
@@ -1,7 +1,8 @@
 (ns ctia.auth.allow-all
   (:require [ctia.auth
              :refer [IIdentity IAuth]
-             :as auth]))
+             :as auth]
+            [ctia.lib.set :refer [as-set]]))
 
 (defrecord Identity []
   IIdentity
@@ -10,8 +11,8 @@
   (login [_]
     auth/not-logged-in-owner)
   (allowed-capabilities [_]
-    (get auth/default-capabilities :admin))
-  (allowed-capability? [_ _]
+    auth/all-capabilities)
+  (capable? [_ _]
     true))
 
 (def identity-singleton

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -14,16 +14,16 @@
                   :login (auth/login id))
            (assoc-in [:headers "api_key"] api_key))))))
 
-(defn require-capability! [granting-capabilities id]
-  (if (and granting-capabilities
+(defn require-capability! [required-capability id]
+  (if (and required-capability
            (auth/require-login? @auth/auth-service))
     (cond
       (not (auth/authenticated? id))
       (http-response/forbidden! {:message "Only authenticated users allowed"})
 
-      (not (auth/allowed-capability? id granting-capabilities))
+      (not (auth/capable? id required-capability))
       (http-response/unauthorized! {:message "Missing capability"
-                                    :capabilities granting-capabilities
+                                    :capabilities required-capability
                                     :owner (auth/login id)}))))
 
 

--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -14,7 +14,7 @@
       :body [actor NewActor {:description "a new Actor"}]
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Adds a new Actor"
-      :capabilities #{:create-actor :admin}
+      :capabilities :create-actor
       :login login
       (ok (flows/create-flow :entity-type :actor
                              :realize-fn realize-actor
@@ -27,7 +27,7 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Updates an Actor"
       :path-params [id :- s/Str]
-      :capabilities #{:create-actor :admin}
+      :capabilities :create-actor
       :login login
       (ok (flows/update-flow :entity-type :actor
                              :get-fn #(read-actor @actor-store %)
@@ -41,7 +41,7 @@
       :summary "Gets an Actor by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-actor :admin}
+      :capabilities :read-actor
       (if-let [d (read-actor @actor-store id)]
         (ok d)
         (not-found)))
@@ -50,7 +50,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes an Actor"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-actor :admin}
+      :capabilities :delete-actor
       :login login
       (if (flows/delete-flow :entity-type :actor
                              :get-fn #(read-actor @actor-store %)

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -14,7 +14,7 @@
       :body [campaign NewCampaign {:description "a new campaign"}]
       :summary "Adds a new Campaign"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-campaign :admin}
+      :capabilities :create-campaign
       :login login
       (ok (flows/create-flow :realize-fn realize-campaign
                              :store-fn #(create-campaign @campaign-store %)
@@ -27,7 +27,7 @@
       :summary "Updates a Campaign"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-campaign :admin}
+      :capabilities :create-campaign
       :login login
       (ok (flows/update-flow :get-fn #(read-campaign @campaign-store %)
                              :realize-fn realize-campaign
@@ -41,7 +41,7 @@
       :summary "Gets a Campaign by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-campaign :admin}
+      :capabilities :read-campaign
       (if-let [d (read-campaign @campaign-store id)]
         (ok d)
         (not-found)))
@@ -50,7 +50,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes a Campaign"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-campaign :admin}
+      :capabilities :delete-campaign
       :login login
       (if (flows/delete-flow :get-fn #(read-campaign @campaign-store %)
                              :delete-fn #(delete-campaign @campaign-store %)

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -14,7 +14,7 @@
       :body [coa NewCOA {:description "a new COA"}]
       :summary "Adds a new COA"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-coa :admin}
+      :capabilities :create-coa
       :login login
       (ok (flows/create-flow :realize-fn realize-coa
                              :store-fn #(create-coa @coa-store %)
@@ -27,7 +27,7 @@
       :summary "Updates a COA"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-coa :admin}
+      :capabilities :create-coa
       :login login
       (ok (flows/update-flow :get-fn #(read-coa @coa-store %)
                              :realize-fn realize-coa
@@ -41,7 +41,7 @@
       :summary "Gets a COA by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-coa :admin}
+      :capabilities :read-coa
       (if-let [d (read-coa @coa-store id)]
         (ok d)
         (not-found)))
@@ -50,7 +50,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes a COA"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-coa :admin}
+      :capabilities :delete-coa
       :login login
       (if (flows/delete-flow :get-fn #(read-coa @coa-store %)
                              :delete-fn #(delete-coa @coa-store %)

--- a/src/ctia/http/routes/event.clj
+++ b/src/ctia/http/routes/event.clj
@@ -11,5 +11,5 @@
     (GET "/log" []
       :return [ModelEventBase]
       :summary "Recent Event log"
-      :capabilities #{:admin}
+      :capabilities :developer
       (ok (recent-events)))))

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -16,7 +16,7 @@
       :body [exploit-target NewExploitTarget {:description "a new ExploitTarget"}]
       :summary "Adds a new ExploitTarget"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-exploit-target :admin}
+      :capabilities :create-exploit-target
       :login login
       (ok (flows/create-flow :realize-fn realize-exploit-target
                              :store-fn #(create-exploit-target @exploit-target-store %)
@@ -31,7 +31,7 @@
       :summary "Updates an ExploitTarget"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-exploit-target :admin}
+      :capabilities :create-exploit-target
       :login login
       (ok (flows/update-flow :get-fn #(read-exploit-target @exploit-target-store %)
                              :realize-fn realize-exploit-target
@@ -45,7 +45,7 @@
       :summary "Gets an ExploitTarget by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-exploit-target :admin}
+      :capabilities :read-exploit-target
       (if-let [d (read-exploit-target @exploit-target-store id)]
         (ok d)
         (not-found)))
@@ -54,7 +54,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes an ExploitTarget"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-exploit-target :admin}
+      :capabilities :delete-exploit-target
       :login login
       (if (flows/delete-flow :get-fn #(read-exploit-target @exploit-target-store %)
                              :delete-fn #(delete-exploit-target @exploit-target-store %)

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -24,7 +24,7 @@
       :body [feedback NewFeedback {:description "a new Feedback on an entity"}]
       :summary "Adds a new Feedback"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-feedback :admin}
+      :capabilities :create-feedback
       :login login
       (ok (flows/create-flow :realize-fn realize-feedback
                              :store-fn #(create-feedback @feedback-store %)
@@ -36,7 +36,7 @@
       :query [params FeedbackQueryParams]
       :summary "Search Feedback"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:list-feedback :admin}
+      :capabilities :read-feedback
 
       (paginated-ok
        (list-feedback @feedback-store
@@ -47,7 +47,7 @@
       :summary "Gets a Feedback by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-feedback :admin}
+      :capabilities :read-feedback
       (if-let [d (read-feedback @feedback-store id)]
         (ok d)
         (not-found)))
@@ -56,7 +56,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes a feedback"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-feedback :admin}
+      :capabilities :delete-feedback
       :login login
       (if (flows/delete-flow :get-fn #(read-feedback @feedback-store %)
                              :delete-fn #(delete-feedback @feedback-store %)

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -17,7 +17,7 @@
       :body [incident NewIncident {:description "a new incident"}]
       :summary "Adds a new Incident"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-incident :admin}
+      :capabilities :create-incident
       :login login
       (ok (flows/create-flow :realize-fn realize-incident
                              :store-fn #(create-incident @incident-store %)
@@ -30,7 +30,7 @@
       :summary "Updates an Incident"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-incident :admin}
+      :capabilities :create-incident
       :login login
       (ok (flows/update-flow :get-fn #(read-incident @incident-store %)
                              :realize-fn realize-incident
@@ -53,7 +53,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes an Incident"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-incident :admin}
+      :capabilities :delete-incident
       :login login
       (if (flows/delete-flow :get-fn #(read-incident @incident-store %)
                              :delete-fn #(delete-incident @incident-store %)

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -51,7 +51,7 @@
       :body [indicator NewIndicator {:description "a new Indicator"}]
       :summary "Adds a new Indicator"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-indicator :admin}
+      :capabilities :create-indicator
       :login login
       (ok (flows/create-flow :realize-fn realize-indicator
                              :store-fn #(create-indicator @indicator-store %)
@@ -64,7 +64,7 @@
       :summary "Updates an Indicator"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-indicator :admin}
+      :capabilities :create-indicator
       :login login
       (ok (flows/update-flow :get-fn #(read-indicator @indicator-store %)
                              :realize-fn realize-indicator
@@ -78,7 +78,7 @@
       :summary "Gets an Indicator by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-indicator :admin}
+      :capabilities :read-indicator
       (if-let [d (read-indicator @indicator-store id)]
         (ok d)
         (not-found)))
@@ -87,6 +87,7 @@
       :path-params [id :- s/Str]
       :query [params SightingsByIndicatorQueryParams]
       :summary "Gets all Sightings associated with the Indicator"
+      :capabilities #{:read-indicator :list-sightings}
       (if-let [indicator (read-indicator @indicator-store id)]
         (if-let [sightings (list-sightings-by-indicators @sighting-store [indicator] params)]
           (paginated-ok sightings)
@@ -98,7 +99,7 @@
       :query [params IndicatorsByTitleQueryParams]
       :path-params [title :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:list-indicators-by-title :admin}
+      :capabilities :read-indicator
       (paginated-ok
        (list-indicators @indicator-store {:title title} params))))
   (GET "/judgement/:id/indicators" []
@@ -108,7 +109,7 @@
     :query [params IndicatorsListQueryParams]
     :path-params [id :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-title :admin}
+    :capabilities :list-indicators
     (paginated-ok
      (list-indicators @indicator-store
                       {:judgements #{{:judgement_id (->long-id :judgement id)}}}
@@ -120,7 +121,7 @@
     :query [params IndicatorsListQueryParams]
     :path-params [id :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-title :admin}
+    :capabilities :list-indicators
     (paginated-ok
      (list-indicators @indicator-store
                       {:related_campaigns #{{:campaign_id (->long-id :campaign id)}}}
@@ -132,7 +133,7 @@
     :query [params IndicatorsListQueryParams]
     :path-params [id :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-title :admin}
+    :capabilities :list-indicators
     (paginated-ok
      (list-indicators @indicator-store
                       {:related_COAs #{{:COA_id (->long-id :coa id)}}}
@@ -144,7 +145,7 @@
     :query [params IndicatorsListQueryParams]
     :path-params [id :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-title :admin}
+    :capabilities :list-indicators
     (paginated-ok
      (list-indicators @indicator-store
                       {:indicated_TTP #{{:ttp_id (->long-id :ttp id)}}}
@@ -156,7 +157,7 @@
     :query [params IndicatorsListQueryParams]
     :path-params [id :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-title :admin}
+    :capabilities :list-indicators
     (paginated-ok
      (list-indicators @indicator-store
                       {:related_indicators #{{:indicator_id (->long-id :indicator id)}}}

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -30,7 +30,7 @@
       :body [judgement NewJudgement {:description "a new Judgement"}]
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Adds a new Judgement"
-      :capabilities #{:create-judgement :admin}
+      :capabilities :create-judgement
       :login login
       (ok (flows/create-flow :realize-fn realize-judgement
                              :store-fn #(create-judgement @judgement-store %)
@@ -43,7 +43,7 @@
       :body [indicator-relationship rel/RelatedIndicator]
       :header-params [api_key :- s/Str]
       :summary "Adds an Indicator to a Judgement"
-      :capabilities #{:create-judgement-indicator}
+      :capabilities :create-judgement
       (if-let [d (add-indicator-to-judgement @judgement-store
                                              judgement-id
                                              indicator-relationship)]
@@ -54,7 +54,7 @@
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Gets a Judgement by ID"
-      :capabilities #{:read-judgement :admin}
+      :capabilities :read-judgement
       (if-let [d (read-judgement @judgement-store id)]
         (ok d)
         (not-found)))
@@ -63,7 +63,7 @@
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Deletes a Judgement"
-      :capabilities #{:delete-judgement :admin}
+      :capabilities :delete-judgement
       :login login
       (if (flows/delete-flow :get-fn #(read-judgement @judgement-store %)
                              :delete-fn #(delete-judgement @judgement-store %)

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -41,7 +41,7 @@
     :return (s/maybe [StoredJudgement])
     :summary "Returns all the Judgements associated with the specified observable."
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-judgements-by-observable :admin}
+    :capabilities :list-judgements
     (paginated-ok (list-judgements-by-observable @judgement-store
                                                  {:type observable_type
                                                   :value observable_value} params)))
@@ -54,7 +54,7 @@
     :return (s/maybe [StoredIndicator])
     :summary "Returns all the Indicators associated with the specified observable."
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-indicators-by-observable :admin}
+    :capabilities #{:list-judgements :list-indicators}
     (paginated-ok
      (as-> {:type observable_type
             :value observable_value} $
@@ -68,7 +68,7 @@
     :path-params [observable_type :- ObservableType
                   observable_value :- s/Str]
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:list-sightings-by-observable :admin}
+    :capabilities :list-sightings
     :return (s/maybe [StoredSighting])
     :summary "Returns all the Sightings associated with the specified observable."
     (paginated-ok (list-sightings-by-observables @sighting-store

--- a/src/ctia/http/routes/properties.clj
+++ b/src/ctia/http/routes/properties.clj
@@ -8,7 +8,7 @@
   (context "/properties" []
            :tags ["Properties"]
            :summary "The currently running properties"
-           :capabilities :admin
+           :capabilities :developer
            :header-params [api_key :- (s/maybe s/Str)]
            (GET "/" []
                 (ok @properties))))

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -16,7 +16,7 @@
       :body [sighting NewSighting {:description "A new Sighting"}]
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Adds a new Sighting"
-      :capabilities #{:create-sighting :admin}
+      :capabilities :create-sighting
       :login login
       (if (check-new-sighting sighting)
         (ok (flows/create-flow :realize-fn realize-sighting
@@ -31,7 +31,7 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :summary "Updates a Sighting"
       :path-params [id :- s/Str]
-      :capabilities #{:create-sighting :admin}
+      :capabilities :create-sighting
       :login login
       (if (check-new-sighting sighting)
         (ok (flows/update-flow :get-fn #(read-sighting @sighting-store %)
@@ -47,7 +47,7 @@
       :summary "Gets a Sighting by ID"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-sighting :admin}
+      :capabilities :read-sighting
       (if-let [d (read-sighting @sighting-store id)]
         (ok d)
         (not-found)))
@@ -55,7 +55,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes a Sighting"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-sighting :admin}
+      :capabilities :delete-sighting
       (if (delete-sighting @sighting-store id)
         (no-content)
         (not-found)))))

--- a/src/ctia/http/routes/ttp.clj
+++ b/src/ctia/http/routes/ttp.clj
@@ -14,7 +14,7 @@
       :body [ttp NewTTP {:description "a new TTP"}]
       :summary "Adds a new TTP"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-ttp :admin}
+      :capabilities :create-ttp
       :login login
       (ok (flows/create-flow :realize-fn realize-ttp
                              :store-fn #(create-ttp @ttp-store %)
@@ -27,7 +27,7 @@
       :summary "Updates a TTP"
       :path-params [id :- s/Str]
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:create-ttp :admin}
+      :capabilities :create-ttp
       :login login
       (ok (flows/update-flow :get-fn #(read-ttp @ttp-store %)
                              :realize-fn realize-ttp
@@ -40,7 +40,7 @@
       :return (s/maybe StoredTTP)
       :summary "Gets a TTP by ID"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:read-ttp :admin}
+      :capabilities :read-ttp
       :path-params [id :- s/Str]
       (if-let [d (read-ttp @ttp-store id)]
         (ok d)
@@ -50,7 +50,7 @@
       :path-params [id :- s/Str]
       :summary "Deletes a TTP"
       :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities #{:delete-ttp :admin}
+      :capabilities :delete-ttp
       :login login
       (if (flows/delete-flow :get-fn #(read-ttp @ttp-store %)
                              :delete-fn #(delete-ttp @ttp-store %)

--- a/src/ctia/http/routes/verdict.clj
+++ b/src/ctia/http/routes/verdict.clj
@@ -14,9 +14,8 @@
     :return (s/maybe Verdict)
     :summary "Returns the current Verdict associated with the specified observable."
     :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities #{:get-verdict :admin}
+    :capabilities :read-verdict
     (if-let [d (calculate-verdict @judgement-store {:type observable_type
                                                     :value observable_value})]
       (ok d)
       (not-found))))
-

--- a/src/ctia/lib/set.clj
+++ b/src/ctia/lib/set.clj
@@ -1,0 +1,6 @@
+(ns ctia.lib.set)
+
+(defn as-set [x]
+  (cond (set? x) x
+        (keyword? x) #{x}
+        (sequential? x) (set x)))

--- a/src/ctia/schemas/identity.clj
+++ b/src/ctia/schemas/identity.clj
@@ -1,92 +1,11 @@
 (ns ctia.schemas.identity
-  (:require [ctia.schemas.common :as c]
+  (:require [ctia.auth :refer [all-capabilities]]
+            [ctia.schemas.common :as c]
             [schema.core :as s]
             [schema-tools.core :as st]))
 
-(def capabilities
-  [:admin
-   :get-verdict
-
-   ;; judgements
-   :create-judgement
-   :read-judgement
-   :delete-judgement
-   :list-judgements-by-observable
-   :list-judgements-by-indicator
-   :create-judgement-indicator
-
-   ;; indicators
-   :create-indicator
-   :read-indicator
-   ;;:read-indicator-implementation
-   :delete-indicator
-   :list-indicators
-   :list-indicators-by-observable
-   :list-indicators-by-title
-
-   :create-sightings
-   :read-sightings
-   :delete-sightings
-   :list-sightings
-
-   ;; feedback
-   :create-feedback
-   :read-feedback
-   :delete-feedback
-   :list-feedback
-
-   ;; threats
-   :create-ttp
-   :delete-ttp
-   :read-ttp
-   :list-ttps
-
-   :create-campaign
-   :delete-campaign
-   :read-campaign
-   :list-campaigns
-
-   :create-actor
-   :delete-actor
-   :read-actor
-   :list-actors
-
-   :create-exploit-target
-   :read-exploit-target
-   :delete-exploit-target
-   :list-exploit-targets
-
-   :create-coa
-   :read-coa
-   :delete-coa
-   :list-coas
-
-
-   ;; sightings
-   :create-sighting
-   :delete-sighting
-   :read-sighting
-   :list-sightings-by-observable
-   :list-sightings
-
-   ;; incidents
-   :create-incident
-   :delete-incident
-   :read-incident
-   :list-incidents-by-observable
-   :list-incidents-by-indicator
-   :list-incidents
-
-   ;; relations
-   :create-relation
-   :delete-relation
-   :read-relation
-   :list-relations
-
-   ])
-
 (def Capability
-  (apply s/enum capabilities))
+  (apply s/enum all-capabilities))
 
 (def Role s/Str)
 

--- a/test/ctia/http/routes/judgement_test.clj
+++ b/test/ctia/http/routes/judgement_test.clj
@@ -142,7 +142,7 @@
                      :headers {"api_key" "2222222222222"})]
             (is (= 401 status))
             (is (= {:message "Missing capability",
-                    :capabilities #{:admin :read-judgement},
+                    :capabilities :read-judgement,
                     :owner "baruser"}
                    body)))))
 

--- a/test/ctia/test_helpers/auth.clj
+++ b/test/ctia/test_helpers/auth.clj
@@ -1,20 +1,4 @@
 (ns ctia.test-helpers.auth)
 
-(def all-capabilities
-  #{:create-actor :read-actor :delete-actor
-    :create-campaign :read-campaign :delete-campaign
-    :create-exploit-target :read-exploit-target :delete-exploit-target
-    :create-coa :read-coa :delete-coa
-    :create-incident :read-incident :delete-incident
-    :create-judgement :read-judgement :delete-judgement
-    :create-judgement-indicator
-    :create-feedback :read-feedback :list-feedback :delete-feedback
-    :create-sighting :read-sighting :delete-sighting
-    :create-indicator :read-indicator
-    :list-indicators-by-title
-    :create-ttp :read-ttp :delete-ttp
-    :list-judgements-by-observable
-    :list-judgements-by-indicator
-    :list-indicators-by-observable
-    :list-sightings-by-observable
-    :get-verdict})
+;; Deprecated - prefer to use directly
+(def all-capabilities ctia.auth/all-capabilities)


### PR DESCRIPTION
Refactored auth to require the user to have all the capabilities for a particular route. Admin and allow-all auth mode gets all capabilities rather than the special :admin capability.

Closes #108