### PR TITLE
Issue 305 bulk insert

### DIFF
--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -3,6 +3,7 @@
             [ctia.http.middleware.auth :as auth]
             [ctia.http.routes
              [actor :refer [actor-routes]]
+             [bulk :refer [bulk-routes]]
              [campaign :refer [campaign-routes]]
              [coa :refer [coa-routes]]
              [documentation :refer [documentation-routes]]
@@ -87,6 +88,7 @@
   (context "/ctia" []
     version-routes
     actor-routes
+    bulk-routes
     campaign-routes
     exploit-target-routes
     coa-routes

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -1,0 +1,162 @@
+(ns ctia.http.routes.bulk
+  (:require [compojure.api.sweet :refer :all]
+            [clojure.string :as str]
+            [ctia.flows.crud :as flows]
+            [ctia.domain.entities :as ent]
+            [ctia.schemas
+             [bulk :refer [BulkRefs NewBulk StoredBulk]]]
+            [ctim.schemas.common :as c]
+            [ctia.store :refer :all]
+            [ring.util.http-response :refer :all]
+            [schema.core :as s]
+            [clojure.tools.logging :as log]))
+
+(defn singular [k]
+  "remove the last s of a keyword see test for an example."
+  (-> k
+      name
+      (str/replace #"s$" "")
+      keyword))
+
+(defn realize [k]
+  "return the realize function provided an entity key name"
+  (condp = k
+    :actor          ent/realize-actor
+    :campaign       ent/realize-campaign
+    :coa            ent/realize-coa
+    :exploit-target ent/realize-exploit-target
+    :feedback       ent/realize-feedback
+    :incident       ent/realize-incident
+    :indicator      ent/realize-indicator
+    :judgement      ent/realize-judgement
+    :sighting       ent/realize-sighting
+    :ttp            ent/realize-ttp))
+
+(defn create-fn [k]
+  "return the create function provided an entity key name"
+  (condp = k
+    :actor          #(create-actor @actor-store %)
+    :campaign       #(create-campaign @campaign-store %)
+    :coa            #(create-coa @coa-store %)
+    :exploit-target #(create-exploit-target @exploit-target-store %)
+    :feedback       #(create-feedback @feedback-store %)
+    :incident       #(create-incident @incident-store %)
+    :indicator      #(create-indicator @indicator-store %)
+    :judgement      #(create-judgement @judgement-store %)
+    :sighting       #(create-sighting @sighting-store %)
+    :ttp            #(create-ttp @ttp-store %)))
+
+(defn read-fn [k]
+  "return the create function provided an entity key name"
+  (condp = k
+    :actor          #(read-actor @actor-store %)
+    :campaign       #(read-campaign @campaign-store %)
+    :coa            #(read-coa @coa-store %)
+    :exploit-target #(read-exploit-target @exploit-target-store %)
+    :feedback       #(read-feedback @feedback-store %)
+    :incident       #(read-incident @incident-store %)
+    :indicator      #(read-indicator @indicator-store %)
+    :judgement      #(read-judgement @judgement-store %)
+    :sighting       #(read-sighting @sighting-store %)
+    :ttp            #(read-ttp @ttp-store %)))
+
+(defn create-entities
+  "Create many entities provided their type and returns a list of ids"
+  [entities entity-type login]
+  (->> entities
+       (map #(try (flows/create-flow
+                   :entity-type entity-type
+                   :realize-fn (realize entity-type)
+                   :store-fn (create-fn entity-type)
+                   :identity login
+                   :entity %)
+                  (catch Exception e
+                    (do (log/error (pr-str e))
+                        nil))))
+       (map :id)))
+
+(defn read-entities
+  "Retrieve many entities of the same type provided their ids and common type"
+  [ids entity-type]
+  (let [read-entity (read-fn entity-type)]
+    (->> ids
+         (map (fn [id] (try (read-entity id)
+                            (catch Exception e
+                              (do (log/error (pr-str e))
+                                  nil))))))))
+
+(defn gen-bulk-from-fn
+  "Kind of fmap but adapted for bulk
+
+  ~~~~.clojure
+  (gen-bulk-from-fn f {k [v1 ... vn]} args)
+  ===> {k (map #(apply f % (singular k) args) [v1 ... vn])}
+  ~~~~
+  "
+  [func bulk & args]
+  (reduce (fn [acc entity-type]
+            (assoc acc
+                   entity-type
+                   (apply func
+                          (get bulk entity-type)
+                          (singular entity-type)
+                          args)))
+          {}
+          (keys bulk)))
+
+(defroutes bulk-routes
+  (context "/bulk" []
+    :tags ["Bulk"]
+    (POST "/" []
+      :return BulkRefs
+      :body [bulk NewBulk {:description "a new Bulk object"}]
+      :header-params [api_key :- (s/maybe s/Str)]
+      :summary "Adds a lot of new entities in only one HTTP call"
+      :capabilities #{:create-actor
+                      :create-campaign
+                      :create-coa
+                      :create-exploit-target
+                      :create-feedback
+                      :create-incident
+                      :create-indicator
+                      :create-judgement
+                      :create-sighting
+                      :create-ttp}
+      :identity login
+      (ok (gen-bulk-from-fn create-entities bulk login)))
+    (GET "/" []
+      :return (s/maybe StoredBulk)
+      :summary "Gets many entities at once"
+      :query-params [{actors          :- [c/Reference] []}
+                     {campaigns       :- [c/Reference] []}
+                     {coas            :- [c/Reference] []}
+                     {exploit-targets :- [c/Reference] []}
+                     {feedbacks       :- [c/Reference] []}
+                     {incidents       :- [c/Reference] []}
+                     {indicators      :- [c/Reference] []}
+                     {judgements      :- [c/Reference] []}
+                     {sightings       :- [c/Reference] []}
+                     {ttps            :- [c/Reference] []}]
+      :header-params [api_key :- (s/maybe s/Str)]
+      :capabilities #{:read-actor
+                      :read-campaign
+                      :read-coa
+                      :read-exploit-target
+                      :read-feedback
+                      :read-incident
+                      :read-indicator
+                      :read-judgement
+                      :read-sighting
+                      :read-ttp}
+      (let [bulk (into {} (filter (comp not empty? second)
+                                  {:actors          actors
+                                   :campaigns       campaigns
+                                   :coas            coas
+                                   :exploit-targets exploit-targets
+                                   :feedbacks       feedbacks
+                                   :incidents       incidents
+                                   :indicators      indicators
+                                   :judgements      judgements
+                                   :sightings       sightings
+                                   :ttps            ttps}))]
+        (ok (gen-bulk-from-fn read-entities bulk))))))

--- a/src/ctia/schemas/bulk.clj
+++ b/src/ctia/schemas/bulk.clj
@@ -1,0 +1,54 @@
+(ns ctia.schemas.bulk
+  (:require [ctim.schemas
+             [actor :as actor]
+             [campaign :as campaign]
+             [coa :as coa]
+             [common :as c]
+             [exploit-target :as et]
+             [feedback :as feedback]
+             [incident :as incident]
+             [indicator :as indicator]
+             [judgement :as judgement]
+             [sighting :as sighting]
+             [ttp :as ttp]]
+            [schema.core :as s]
+            [schema-tools.core :as st]))
+
+(s/defschema StoredBulk
+  (st/optional-keys
+   {:actors          [(s/maybe actor/StoredActor)]
+    :campaigns       [(s/maybe campaign/StoredCampaign)]
+    :coas            [(s/maybe coa/StoredCOA)]
+    :exploit-targets [(s/maybe et/StoredExploitTarget)]
+    :feedbacks       [(s/maybe feedback/StoredFeedback)]
+    :incidents       [(s/maybe incident/StoredIncident)]
+    :indicators      [(s/maybe indicator/StoredIndicator)]
+    :judgements      [(s/maybe judgement/StoredJudgement)]
+    :sightings       [(s/maybe sighting/StoredSighting)]
+    :ttps            [(s/maybe ttp/StoredTTP)]}))
+
+(s/defschema BulkRefs
+  (st/optional-keys
+   {:actors          [(s/maybe c/Reference)]
+    :campaigns       [(s/maybe c/Reference)]
+    :coas            [(s/maybe c/Reference)]
+    :exploit-targets [(s/maybe c/Reference)]
+    :feedbacks       [(s/maybe c/Reference)]
+    :incidents       [(s/maybe c/Reference)]
+    :indicators      [(s/maybe c/Reference)]
+    :judgements      [(s/maybe c/Reference)]
+    :sightings       [(s/maybe c/Reference)]
+    :ttps            [(s/maybe c/Reference)]}))
+
+(s/defschema NewBulk
+  (st/optional-keys
+   {:actors          [actor/NewActor]
+    :campaigns       [campaign/NewCampaign]
+    :coas            [coa/NewCOA]
+    :exploit-targets [et/NewExploitTarget]
+    :feedbacks       [feedback/NewFeedback]
+    :incidents       [incident/NewIncident]
+    :indicators      [indicator/NewIndicator]
+    :judgements      [judgement/NewJudgement]
+    :sightings       [sighting/NewSighting]
+    :ttps            [ttp/NewTTP]}))

--- a/test/ctia/http/routes/bulk_test.clj
+++ b/test/ctia/http/routes/bulk_test.clj
@@ -1,0 +1,201 @@
+(ns ctia.http.routes.bulk-test
+  (:refer-clojure :exclude [get])
+  (:require
+   [ctia.lib.url :refer [encode]]
+   [ctia.http.routes.bulk :refer [singular gen-bulk-from-fn]]
+   [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
+   [ctia.test-helpers.core :refer [delete get post put] :as helpers]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.store :refer [deftest-for-each-store]]
+   [ctia.auth :refer [all-capabilities]]
+   [clojure.string :as str]))
+
+
+(use-fixtures :once (join-fixtures [helpers/fixture-schema-validation
+                                    helpers/fixture-properties:clean
+                                    whoami-helpers/fixture-server]))
+
+(use-fixtures :each whoami-helpers/fixture-reset-state)
+
+(deftest testing-singular
+  (is (= :actor (singular :actors)))
+  (is (= :campaign (singular :campaigns)))
+  (is (= :coa (singular :coas)))
+  (is (= :exploit-target (singular :exploit-targets)))
+  (is (= :feedback (singular :feedbacks)))
+  (is (= :incident (singular :incidents)))
+  (is (= :indicator (singular :indicators)))
+  (is (= :judgement (singular :judgements)))
+  (is (= :sighting (singular :sightings)))
+  (is (= :ttp (singular :ttps))))
+
+
+(defn mk-new-actor [n]
+  {:title (str "actor-" n)
+   :description (str "description: actor-" n)
+   :actor_type "Hacker"
+   :source "a source"
+   :confidence "High"
+   :associated_actors [{:actor_id "actor-123"}
+                       {:actor_id "actor-456"}]
+   :associated_campaigns [{:campaign_id "campaign-444"}
+                          {:campaign_id "campaign-555"}]
+   :observed_TTPs [{:ttp_id "ttp-333"}
+                   {:ttp_id "ttp-999"}]
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
+(defn mk-new-campaign [n]
+  {:title (str "campaign" n)
+   :description "description"
+   :campaign_type "anything goes here"
+   :intended_effect ["Theft"]
+   :indicators [{:indicator_id "indicator-foo"}
+                {:indicator_id "indicator-bar"}]
+   :attribution [{:confidence "High"
+                  :source "source"
+                  :relationship "relationship"
+                  :actor_id "actor-123"}]
+   :related_incidents [{:confidence "High"
+                        :source "source"
+                        :relationship "relationship"
+                        :incident_id "incident-222"}]
+   :related_TTPs [{:confidence "High"
+                   :source "source"
+                   :relationship "relationship"
+                   :ttp_id "ttp-999"}]
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
+(defn mk-new-coa [n]
+  {:title (str "coa-" n)
+   :description (str "description: coa-" n)
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
+(defn mk-new-exploi-target [n]
+  {:title (str "exploi-target-" n)
+   :description (str "description: exploi-target-" n)
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
+(defn mk-new-feedback [n]
+  {:entity_id (str "judgement-" n)
+   :feedback -1
+   :reason "false positive"})
+
+(defn mk-new-incident [n]
+  {:title (str "incident-" n)
+   :description (str "description: incident-" n)
+   :confidence "Low"
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
+(defn mk-new-indicator [n]
+  {:title (str "indicator-" n)
+   :description (str "description: indicator-" n)
+   :producer "producer"
+   :indicator_type ["C2" "IP Watchlist"]
+   :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}
+   :judgements [{:judgement_id "judgement-1234"}
+                {:judgement_id "judgement-5678"}]})
+
+(defn mk-new-judgement [n]
+  {:valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}
+   :observable {:value (str "10.0.0." n)
+                :type "ip"}
+   :disposition 2
+   :source "test"
+   :priority 100
+   :severity 100
+   :confidence "Low"
+   :indicators [{:confidence "High"
+                 :source "source"
+                 :relationship "relationship"
+                 :indicator_id "indicator-123"}]})
+
+(defn mk-new-sighting [n]
+  {:description (str "description: sighting-" n)
+   :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :source "source"
+   :source_device "endpoint.sensor"
+   :confidence "High"
+   :indicators [{:indicator_id "indicator-22334455"}]})
+
+(defn mk-new-ttp [n]
+  {:title (str "ttp-" n)
+   :description (str "description: ttp-" n)
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}
+   :ttp_type "foo"
+   :indicators [{:indicator_id "indicator-1"}
+                {:indicator_id "indicator-2"}]
+   :exploit_targets [{:exploit_target_id "exploit-target-123"}
+                     {:exploit_target_id "exploit-target-234"}]})
+
+(deftest testing-gen-bulk-from-fn
+  (let [new-bulk {:actors (map mk-new-actor (range 6))
+                  :campaigns (map mk-new-campaign (range 6))}]
+    (testing "testing gen-bulk-from-fn with 2 args"
+      (is (= (gen-bulk-from-fn (fn [lst _] (map (fn [_] :s) lst))
+                               new-bulk)
+             {:actors [:s :s :s :s :s :s]
+              :campaigns [:s :s :s :s :s :s]})))
+    (testing "testing gen-bulk-from-fn with 3 args"
+      (is (= (gen-bulk-from-fn (fn [lst _ x] (map (fn [_] x) lst))
+                               new-bulk
+                               :x)
+             {:actors [:x :x :x :x :x :x]
+              :campaigns [:x :x :x :x :x :x]})))))
+
+(def tst-bulk{:actors (map #(str "actor-" %) (range 6))
+              :campaigns (map #(str "campaign-" %) (range 6))})
+
+(defn make-get-query-str-from-bulkrefs
+  "Given a BulkRefs returns the string of query-params"
+  [bulk-ids]
+  (str/join "&"
+            (map
+             (fn [type]
+               (str/join "&"
+                         (map (fn [id] (str (encode (name type)) "=" (encode id)))
+                              (get-in bulk-ids [type]))))
+             (keys bulk-ids))))
+
+(deftest-for-each-store test-bulk-routes
+  (helpers/set-capabilities! "foouser" "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "user")
+  (testing "POST /ctia/bulk"
+    (let [nb 10
+          new-bulk {:actors (map mk-new-actor (range nb))
+                    :campaigns (map mk-new-campaign (range nb))
+                    :coas (map mk-new-coa (range nb))
+                    :exploit-targets (map mk-new-exploi-target (range nb))
+                    :feedbacks (map mk-new-feedback (range nb))
+                    :incidents (map mk-new-incident (range nb))
+                    :indicators (map mk-new-indicator (range nb))
+                    :judgements (map mk-new-judgement (range nb))
+                    :sightings (map mk-new-sighting (range nb))
+                    :ttps (map mk-new-ttp (range nb))
+                    }
+          response (post "ctia/bulk"
+                         :body new-bulk
+                         :headers {"api_key" "45c1f5e3f05d0"})
+          bulk-ids (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (doseq [type (keys new-bulk)]
+        (testing (str "number of created " (name type))
+          (is (= (count (get-in new-bulk [type]))
+                 (count (get-in bulk-ids [type]))))))
+      (testing "GET /ctia/bulk"
+        (let [resp (get (str "ctia/bulk?"
+                             (make-get-query-str-from-bulkrefs bulk-ids))
+                        :headers {"api_key" "45c1f5e3f05d0"})]
+          (is (= 200 (:status resp)))
+          (doseq [k (keys new-bulk)]
+            (testing (str "retrieved " (name k))
+              (is (= (get-in new-bulk [k])
+                     (map #(dissoc % :created :id :type :modified :owner :tlp :version :disposition_name)
+                          (get-in (:parsed-body resp) [k])))))))))))


### PR DESCRIPTION
I made one commit per route, tell me if you prefer only one big squashed commit.

Also, I'm not fond of the route naming I choose. For now, it is: `/:entity/multi`

I didn't want to call the route `bulk` because the current implementation focus on reducing the number of HTTP request not really on being able to handle big volume of insertions, yet.

Closes #305
Closes #304 