### PR TITLE
Add CLI to feed importer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,6 +18,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [leiningen-core "2.6.1"] ;; For accessing project configuration
                  [com.taoensso/carmine "2.12.2"]
+                 [org.clojure/tools.cli "0.3.5"]
 
                  ;; Schemas
                  [prismatic/schema "1.0.5"]

--- a/src/ctia/import/threatgrid/feed.clj
+++ b/src/ctia/import/threatgrid/feed.clj
@@ -1,16 +1,16 @@
 (ns ctia.import.threatgrid.feed
   (:require [cheshire.core :as cjson]
-            [clojure.data.json :as json]
             [clojure.java.io :as io]
+            [clojure.data.json :as json]
             [clojure.string :as str]
-            [clj-time.core :refer [date-time days]]
-            [clj-time.format :refer [unparse formatter]]
-            [ctia.lib.time :refer [date-range] :as ctime]
+            [clj-time.core :refer [date-time days now] :as time]
+            [clj-time.format :refer [parse unparse formatter] :as tf]
+            [ctia.lib.time :refer [date-range after?] :as ctime]
+            [ctia.import.threatgrid.http :as http]
             [ctia.import.threatgrid.feed.indicators :as fi]
             [ctia.import.threatgrid.feed.sightings :as fs]
             [ctia.import.threatgrid.feed.judgements :as fj]
-            [clj-http.client :as http]
-            [clj-http.conn-mgr :as conn]))
+            [clojure.tools.cli :refer [parse-opts]]))
 
 (defn tg-feed-names []
   [;;"autorun-registry" ;; always empty
@@ -28,102 +28,169 @@
    "sinkholed-ip-dns"
    "stolen-cert-dns"])
 
-(defn dates
-  []
-  (mapv
-   (fn [dt] (unparse (formatter "yyyy-MM-dd") dt))
-   (date-range (date-time 2016 03 01)
-               (date-time 2016 03 02)
-               (days 1))))
+(defn date->str [dt]
+  (unparse (formatter "yyyy-MM-dd") dt))
 
-(defn tg-uri [feed-file-name & {:keys [api-key]
-                                :or {api-key nil}}]
-  (str
-   "https://panacea.threatgrid.com/api/v3/feeds/"
-   feed-file-name
-   (if api-key (str "?api_key=" api-key))))
+(defn dates-in-range [sdate edate]
+  (mapv date->str (date-range sdate edate (days 1))))
 
-;; get feed data via direct http call
-(defn feed-file-names [feed-names dates]
-  (for [feed-name feed-names
-        date-str dates]
-    (str feed-name "_" date-str ".json")))
+(defn post-judgements-to-ctia [feed ctia-uri]
+  (let [judgements (fj/feed->judgements feed)]
+    (println "Posting" (count judgements) "judgements to ctia")
+    (http/post-to-ctia judgements :judgements ctia-uri)))
 
-(defn body-empty? [body]
-  (or (empty? body)
-      (= "[]" body)))
+(defn post-sightings-to-ctia [feed ctia-uri]
+  (let [sightings (fs/feed->sightings feed)]
+    (println "Posting" (count sightings) "sightings to ctia")
+    (http/post-to-ctia sightings :sightings ctia-uri)))
 
-(defn file-path [s]
-  (str "/var/tg-feeds/" s))
-
-(defn dump-file [file-name file-contents]
-  (with-open [wrtr (io/writer file-name)]
-    (.write wrtr file-contents)))
-
-(defn download-feeds []
-  (let [api-key (or (System/getenv "APIKEY") "")
-        tg-feed-uri "https://panacea.threatgrid.com/api/v3/feeds/"]
-    (doseq [feed-file-name (filter #(not (.exists (io/as-file (file-path %))))
-                                   (feed-file-names (tg-feed-names) (dates)))]
-      (Thread/sleep 1000) ;; a courtesy
-      (let [body (:body (http/get (tg-uri feed-file-name :api-key api-key)))]
-        (if (not (body-empty? body))
-          (dump-file (file-path feed-file-name) body))))))
-
-(defn retry
-  [retries f & args]
-  (let [res (try {:value (apply f args)}
-                 (catch Exception e
-                   (if (= 0 retries)
-                     (throw e)
-                     {:exception e})))]
-    (if (:exception res)
-      (do
-        (recur (dec retries) f args))
-            (:value res))))
-
-(defn post-to-ctia
-  [expressions xtype ctia-uri conn-mgr]
-  (let [target-uri (str ctia-uri "/ctia/" xtype)]
-    (doall
-     (map (fn [expression]
-            (let [options {:connection-manager conn-mgr
-                           :content-type :edn
-                           :accept :edn
-                           :throw-exceptions false
-                           :body (pr-str expression)
-                           :query-params {"api_key" "importer"}}
-                  response (try
-                             (retry 5 http/post target-uri options)
-                             (catch java.net.SocketTimeoutException e
-                               (println "Socket timed out after 5 retries.")))]
-              response))
-          expressions))))
+(defn file->feed [indicators feed-path feed-name file-name ctia-uri]
+  (let [uri (http/tg-uri file-name)
+        entries (cjson/parse-string (slurp (str feed-path "/" file-name)) true)
+        description (-> entries first :description)
+        indicator (fi/feed-indicator feed-name description ctia-uri indicators)
+        feed {:title feed-name
+              :description description
+              :source file-name
+              :source_uri uri
+              :indicator indicator
+              :observable {:type "domain" :field :domain}
+              :entries entries}]
+    feed))
 
 (comment
+  (let [indicators (atom {})
+        feed-path "/var/tg-feeds"
+        feed-name "rat-dns"
+        file-name "rat-dns_2016-03-01.json"
+        ctia-uri "http://localhost:3000"
+        feed (file->feed indicators
+                         feed-path
+                         feed-name
+                         file-name
+                         ctia-uri)]
+    (post-sightings-to-ctia feed ctia-uri)))
+
+(defn load-feed-to-ctia [{:keys [source] :as feed} ctia-uri]
+  (println "Start loading " source)
+  (post-judgements-to-ctia feed ctia-uri)
+  (post-sightings-to-ctia feed ctia-uri)
+  (println "Done loading " source))
+
+(defn process-feeds
+  [{:keys [feed-path
+           feed-names
+           dates
+           ctia-uri] :as options}]
   (let [indicators (atom {})]
-    (doseq [date (dates)
-            name (tg-feed-names)
-            file-name (filter #(.exists (io/as-file (file-path %)))
-                              (feed-file-names [name] [date]))]
-      (println "Start loading " file-name)
-      (let [uri (tg-uri file-name)
-            entries (cjson/parse-string (slurp (file-path file-name)) true)
-            description (-> entries first :description)
-            ctia-uri "http://localhost:3000"
-            conn-mgr (conn/make-reusable-conn-manager {:timeout 5 :threads 8})
-            indicator (fi/feed-indicator name description ctia-uri indicators)
-            feed {:title name
-                  :description description
-                  :source file-name
-                  :source-uri uri
-                  :indicator indicator
-                  :observable {:type "domain" :field :domain}
-                  :entries entries}]
-        (let [judgements (fj/feed->judgements feed)]
-          (println "Posting" (count judgements) "judgements to ctia")
-          (post-to-ctia judgements "judgement" ctia-uri conn-mgr))
-        (let [sightings (fs/feed->sightings feed)]
-          (println "Posting" (count sightings) "sightings to ctia")
-          (post-to-ctia sightings "sighting" ctia-uri conn-mgr)))
-      (println "Done loading " file-name))))
+    (doseq [date dates
+            feed-name feed-names
+            file-name (filter #(.exists (io/as-file (str feed-path "/" %)))
+                              (http/feed-file-names [feed-name] [date]))]
+      (let [feed (file->feed indicators feed-path feed-name file-name ctia-uri)]
+        (load-feed-to-ctia feed ctia-uri)))))
+
+(def cli-options
+  [["-h" "--help" "Print help menu"
+    :default false]
+   [nil "--feed-name STRING" "Name of feed. "
+    :default nil
+    :validate [#(.contains (tg-feed-names) %)
+               "Invalid feed name.  See --help for list of valid feed names."]]
+   [nil "--ctia-uri STRING" (str "URI for the CTIA server. ")
+    :default "http://localhost:3000"]
+   ["-d" "--download" (str "Download feeds from Threat Grid. "
+                           "Skips feeds that are empty or already downloaded. "
+                           "Requires --tg-api-key or \"APIKEY\" env variable")
+    :default false
+    :required false]
+   [nil "--tg-api-key STRING" (str "Threat Grid API key. "
+                                   "Required when downloading feeds from "
+                                   "Threat Grid, unless \"APIKEY\" environment "
+                                   "variable is set.")
+    :default nil]
+   ["-s" "--start-date STRING" (str "Date string representing start of date range. "
+                                    "Must be in \"yyyy-MM-dd\" format. ")
+    :default (date->str (now))]
+   ["-e" "--end-date STRING" (str "Date string representing end of date range. "
+                                  "Must be in \"yyyy-MM-dd\" format. "
+                                  "Defaults to one day after :start-date")
+    :default nil]
+   ["-a" "--all" (str "Perform action on all known feeds.")
+    :default false
+    :required false]
+   [nil "--feed-path STRING" (str "Absolute path to local directory "
+                                  "containing feed files. ")
+    :default "/var/tg-feeds"
+    :validate [#(.isDirectory (io/file %))
+               "Directory does not exist."]]])
+
+(defn usage [options-summary]
+  (str "Import Threat Grid feeds into CTIA.
+
+Usage: lein run -m ctia.import.threatgrid.feed [options]
+
+Options:
+"
+       options-summary
+"
+
+Valid Feed Names:
+  banking-dns
+  dll-hijacking-dns
+  doc-net-com-dns
+  downloaded-pe-dns
+  dynamic-dns
+  irc-dns
+  modified-hosts-dns
+  parked-dns
+  public-ip-check-dns
+  rat-dns
+  sinkholed-ip-dns
+  stolen-cert-dns"))
+
+(defn exit [status msg]
+  (println msg)
+  (System/exit status))
+
+(defn error-msg [errors]
+  (str "The following errors occurred while parsing your command:\n\n"
+              (str/join \newline errors)))
+
+(defn -main [& args]
+  (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    ;; Handle help and error conditions
+    (cond
+      (:help options) (exit 0 (usage summary))
+      errors (exit 1 (error-msg errors)))
+    ;; Post-parse assertions
+    (try (assert (or (:feed-name options)
+                     (:all options))
+                 (str "Either --feed-name OR --all option must be specified." options))
+         (assert (or (:tg-api-key options)
+                     (System/getenv "APIKEY")
+                     (not (:download options)))
+                 (str "If --download is true, either --tg-api-key "
+                      "or \"APIKEY\" environment variable is required."))
+         (catch java.lang.AssertionError e (exit 1 (error-msg [e]))))
+    (let [date-formatter (formatter "yyyy-MM-dd")
+          sdate (parse date-formatter (:start-date options))
+          end-date (if (empty? (:end-date options))
+                     (date->str (time/plus sdate (time/days 1)))
+                     (:end-date options))
+          edate (parse date-formatter end-date)
+          feed-names (if (:all options)
+                       (tg-feed-names)
+                       [(:feed-name options)])
+          tg-api-key (or (:tg-api-key options)
+                         (System/getenv "APIKEY"))
+          dates (dates-in-range sdate edate)
+          options (assoc options
+                         :end-date end-date
+                         :dates dates
+                         :feed-names feed-names
+                         :tg-api-key tg-api-key)]
+      (println "Executing with options:" options)
+      (if (:download options)
+        (http/download-feeds options))
+      (process-feeds options))))

--- a/src/ctia/import/threatgrid/feed/indicators.clj
+++ b/src/ctia/import/threatgrid/feed/indicators.clj
@@ -13,7 +13,7 @@
    :conn-timeout 10000})
 
 (defn stored-ctia-indicator [title ctia-uri]
-  (let [target-url (str ctia-uri "/ctia/indicator/title/" title)
+  (let [target-url (str ctia-uri "/ctia/indicator/title/tg-feed-" title)
         result (http/get target-url (http-options))]
     (cond
       (= 200 (:status result)) (-> result
@@ -38,7 +38,9 @@
         result (-> response
                    :body
                    edn/read-string)]
-    (println "Created" (:id result))
+    (if (= (:status response) 200)
+      (println "Created" (:id result))
+      (println response))
     result))
 
 (defn init-ctia-indicator

--- a/src/ctia/import/threatgrid/feed/sightings.clj
+++ b/src/ctia/import/threatgrid/feed/sightings.clj
@@ -7,76 +7,54 @@
             [cheshire.core :as json]
             [clojure.edn :as edn]))
 
-(defn make-feed-sighting
-  [description feed-uri timestamp observable indicator]
-  (let [sighting {:description description
-                  :type "sighting"
-                  :source "ThreatGrid Feed"
-                  :source_uri feed-uri
-                  :tlp "green"
-                  :confidence "High"
-                  :timestamp timestamp
-                  :observables [observable]
-                  :indicators [indicator]}]))
+(defn entry->relations
+  [feed entry source-observable relation-type related-type related-key]
+  (mapv (fn [related-value]
+          {:origin (:source feed)
+           :origin_uri (:source_uri feed)
+           :source source-observable
+           :relation relation-type
+           :related {:value related-value
+                     :type related-type}})
+        (related-key entry)))
 
 (defn transform
-  [entries
-   observable-type
-   observable-value
-   indicator-id
-   indicator-source
-   source-uri & {:keys [tlp confidence]
+  [{:keys [title description entries]
+    indicator-source :source
+    source-uri :source_uri
+    {observable-type :type
+     observable-field :field
+     :as observable} :observable
+    {indicator-id :id
+     :as indicator} :indicator
+    :as feed} & {:keys [tlp confidence]
                  :or {tlp "green"
                       confidence "High"}}]
   (map
    (fn [entry]
-     (let [{:keys [description timestamp]} entry]
+     (let [{:keys [description timestamp]} entry
+           observable {:type observable-type
+                       :value (observable-field entry)}
+           feed-meta (dissoc feed :entries)]
        {:description description
         :type "sighting"
-        :source "ThreatGrid"
+        :source (str "Threat Grid " title " feed")
         :source_uri source-uri
         :tlp tlp
         :confidence confidence
         :timestamp timestamp
-        :observables [{:type observable-type
-                       :value (observable-value entry)}]
+        :observables [observable]
         :indicators [{:confidence "High"
                       :source indicator-source
-                      :indicator_id indicator-id}]}))
+                      :indicator_id indicator-id}]
+        :relations (entry->relations feed-meta
+                                     entry
+                                     observable
+                                     "Resolved_To"
+                                     "ip"
+                                     :ips)}))
    entries))
 
-(defn entries->sightings
-  [entries observable-type observable-field
-   indicator-id indicator-source source-uri & {:as options}]
-  (apply transform entries observable-type observable-field
-         indicator-id indicator-source source-uri options))
-
 (defn feed->sightings
-  [feed]
-  (let [{:keys [entries source-uri title]
-         {observable-type :type
-          observable-field :field} :observable
-         {indicator-id :id
-          indicator-source :title} :indicator} feed
-        sighting-source (str "ThreatGrid " title " Feed")]
-    (entries->sightings entries
-                        observable-type
-                        observable-field
-                        indicator-id
-                        indicator-source
-                        source-uri)))
-
-(defn feed-file->sightings
-  [feed-name file observable-type observable-field ctia-uri source-uri & {:as options}]
-  (let [entries (json/parse-string (slurp file) true)
-        description (-> entries first :description)
-        indicator (fi/feed-indicator feed-name description ctia-uri)
-        indicator-id (:id indicator)
-        indicator-source (:title indicator)]
-    (entries->sightings entries
-                        observable-type
-                        observable-field
-                        indicator-id
-                        indicator-source
-                        source-uri
-                        options)))
+  [feed & {:as options}]
+  (apply transform feed options))

--- a/src/ctia/import/threatgrid/http.clj
+++ b/src/ctia/import/threatgrid/http.clj
@@ -1,0 +1,65 @@
+(ns ctia.import.threatgrid.http
+  (:require [clj-http.client :as http]
+            [clj-http.conn-mgr :as conn]
+            [clojure.core.async :as async]
+            [clojure.java.io :as io]))
+
+(defn tg-uri [feed-file-name]
+  (str "https://panacea.threatgrid.com/api/v3/feeds/" feed-file-name))
+
+;; get feed data via direct http call
+(defn feed-file-names [feed-names dates]
+  (for [feed-name feed-names
+        date-str dates]
+    (str feed-name "_" date-str ".json")))
+
+(defn body-empty? [body]
+  (or (empty? body)
+      (= "[]" body)))
+
+(defn download-feeds
+  [{:keys [feed-path feed-names dates tg-api-key] :as cli-options}]
+  (let [options {:query-params {"api_key" tg-api-key}}]
+    ;; don't download a feed if we already have it
+    (doseq [feed-file-name (filter #(not (.exists (io/as-file (str feed-path "/" %))))
+                                   (feed-file-names feed-names dates))]
+      (Thread/sleep 1000) ;; a courtesy
+      (let [body (:body (http/get (tg-uri feed-file-name) options))]
+        (if (not (body-empty? body))
+          (let [file-path (str feed-path "/" feed-file-name)]
+            (println "Downloading" file-path)
+            (with-open [wrtr (io/writer file-path)]
+              (.write wrtr body)))
+          (println feed-file-name "is empty."))))))
+
+(defn retry
+  [retries f & args]
+  (let [res (try {:value (apply f args)}
+                 (catch Exception e
+                   (if (= 0 retries)
+                     (throw e)
+                     {:exception e})))]
+    (if (:exception res)
+      (recur (dec retries) f args)
+      (:value res))))
+
+(defn post-to-ctia
+  [expressions xtype ctia-uri]
+  (let [target-uri (str ctia-uri "/ctia/bulk")
+        conn-mgr (conn/make-reusable-conn-manager {:timeout 5
+                                                   :threads 16
+                                                   :default-per-route 16})]
+    (doall
+     (pmap (fn [entities]
+            (let [options {:connection-manager conn-mgr
+                           :content-type :edn
+                           :accept :edn
+                           :throw-exceptions false
+                           :body (pr-str {xtype entities})
+                           :query-params {"api_key" "importer"}}
+                  results (try
+                            (retry 5 http/post target-uri options)
+                            (catch java.net.SocketTimeoutException e
+                              (println "Socket timed out after 5 retries.")))]
+              (get-in results [:body :id])))
+           (partition-all 1000 expressions)))))


### PR DESCRIPTION
Adds command line interface for the threatgrid feed import tools,
allowing us to run the importer from the alpha.ctia server without
access to the NREPL.  Also adds support for relations to the sightings.

Closes #323