### PR TITLE
added verdict ES store, verdict by observable http lookup route

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [prismatic/schema "1.0.5"]
                  [metosin/schema-tools "0.7.0"
                   :exclusions [prismatic/schema]]
-                 [threatgrid/ctim "0.1.1"]
+                 [threatgrid/ctim "0.1.2"]
 
                  ;; Web server
                  [metosin/compojure-api "1.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [prismatic/schema "1.0.5"]
                  [metosin/schema-tools "0.7.0"
                   :exclusions [prismatic/schema]]
-                 [threatgrid/ctim "0.1.2"]
+                 [threatgrid/ctim "0.1.3"]
 
                  ;; Web server
                  [metosin/compojure-api "1.0.0"]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -28,7 +28,7 @@ ctia.store.indicator=es
 ctia.store.judgement=es
 ctia.store.sighting=es
 ctia.store.ttp=es
-ctia.store.verdict=atom
+ctia.store.verdict=es
 
 ctia.store.es.actor.indexname=ctia_actor
 ctia.store.es.campaign.indexname=ctia_campaign

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -113,6 +113,7 @@
      (assoc new-verdict
             :id id
             :owner login
+            :version schema-version
             :created now))))
 
 (s/defn realize-sighting :- StoredSighting

--- a/src/ctia/http/routes/verdict.clj
+++ b/src/ctia/http/routes/verdict.clj
@@ -5,20 +5,24 @@
             [ctia.store :refer :all]
             [ctim.schemas
              [vocabularies :refer [ObservableType]]
-             [verdict :refer [Verdict]]]))
+             [verdict :refer [StoredVerdict]]]))
 
 (defroutes verdict-routes
   (GET "/:observable_type/:observable_value/verdict" []
     :tags ["Verdict"]
     :path-params [observable_type :- ObservableType
                   observable_value :- s/Str]
-    :return (s/maybe Verdict)
+    :return (s/maybe StoredVerdict)
     :summary "Returns the current Verdict associated with the specified observable."
     :header-params [api_key :- (s/maybe s/Str)]
     :capabilities :read-verdict
-    (if-let [d (read-store :judgement
-                           (fn [store]
-                             (calculate-verdict store {:type observable_type
-                                                       :value observable_value})))]
+    (if-let [d (-> (read-store :verdict list-verdicts
+                               {[:observable :type] observable_type
+                                [:observable :value] observable_value} {:sort_by :created
+                                                                        :sort_order :desc
+                                                                        :limit 1})
+                   :data
+                   first)]
+
       (ok d)
       (not-found))))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -89,7 +89,8 @@
               (ss/->JudgementStore))}
 
    :verdict
-   {:atom as/->VerdictStore}
+   {:atom as/->VerdictStore
+    :es es-store/->VerdictStore}
 
    :sighting
    {:atom as/->SightingStore

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -19,7 +19,8 @@
 (defprotocol IVerdictStore
   (create-verdict [this new-verdict])
   (read-verdict [this id])
-  (delete-verdict [this id]))
+  (delete-verdict [this id])
+  (list-verdicts [this filter-map params]))
 
 (defprotocol IIndicatorStore
   (create-indicator [this new-indicator])

--- a/src/ctia/stores/atom/common.clj
+++ b/src/ctia/stores/atom/common.clj
@@ -92,8 +92,6 @@
                               filter-map))
                     (vals (deref state)))))))
 
-
-
 (defn list-handler [Model]
   (s/fn :- (list-response-schema Model)
     ([state :- (s/atom {s/Str Model})

--- a/src/ctia/stores/atom/judgement.clj
+++ b/src/ctia/stores/atom/judgement.clj
@@ -41,6 +41,7 @@
   {:type "verdict"
    :disposition (:disposition judgement)
    :judgement_id (:id judgement)
+   :observable (:observable judgement)
    :disposition_name (get c/disposition-map (:disposition judgement))})
 
 (s/defn handle-calculate-verdict :- (s/maybe Verdict)

--- a/src/ctia/stores/atom/store.clj
+++ b/src/ctia/stores/atom/store.clj
@@ -136,7 +136,9 @@
   (read-verdict [_ id]
     (verdict/handle-read state id))
   (delete-verdict [_ id]
-    (verdict/handle-delete state id)))
+    (verdict/handle-delete state id))
+  (list-verdicts [_ filter-map params]
+    (verdict/handle-list state filter-map params)))
 
 (defrecord SightingStore [state]
   ISightingStore

--- a/src/ctia/stores/atom/verdict.clj
+++ b/src/ctia/stores/atom/verdict.clj
@@ -5,3 +5,4 @@
 (def handle-create (mc/create-handler-from-realized StoredVerdict))
 (def handle-read (mc/read-handler StoredVerdict))
 (def handle-delete (mc/delete-handler StoredVerdict))
+(def handle-list (mc/list-handler StoredVerdict))

--- a/src/ctia/stores/es/judgement.clj
+++ b/src/ctia/stores/es/judgement.clj
@@ -72,6 +72,7 @@
   {:type "verdict"
    :disposition (:disposition judgement)
    :judgement_id (:id judgement)
+   :observable (:observable judgement)
    :disposition_name (get disposition-map (:disposition judgement))})
 
 (s/defn handle-calculate-verdict :- (s/maybe Verdict)

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -298,6 +298,21 @@
      :created ts
      :modified ts}}})
 
+(def verdict-mapping
+  {"verdict"
+   {:dynamic "strict"
+    :include_in_all false
+    :properties
+    {:id string
+     :type string
+     :version string
+     :judgement_id string
+     :observable observable
+     :disposition {:type "long"}
+     :disposition_name string
+     :owner string
+     :created ts}}})
+
 (def feedback-mapping
   {"feedback"
    {:dynamic "strict"
@@ -579,6 +594,7 @@
 (def store-mappings
   (merge {}
          judgement-mapping
+         verdict-mapping
          indicator-mapping
          ttp-mapping
          feedback-mapping

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -11,6 +11,7 @@
              [incident :as inc]
              [indicator :as in]
              [judgement :as ju]
+             [verdict :as ve]
              [mapping :refer [store-mappings]]
              [sighting :as sig]
              [ttp :as ttp]]
@@ -23,6 +24,7 @@
                                 IIncidentStore
                                 IIndicatorStore
                                 IJudgementStore
+                                IVerdictStore
                                 ISightingStore
                                 ITTPStore]]))
 
@@ -61,6 +63,17 @@
                                       [:observable :value] (:value observable)} params))
   (calculate-verdict [_ observable]
     (ju/handle-calculate-verdict state observable)))
+
+(defrecord VerdictStore [state]
+  IVerdictStore
+  (create-verdict [_ new-verdict]
+    (ve/handle-create-verdict state new-verdict))
+  (read-verdict [_ id]
+    (ve/handle-read-verdict state id))
+  (delete-verdict [_ id]
+    (ve/handle-delete-verdict state id))
+  (list-verdicts [_ filter-map params]
+    (ve/handle-list-verdicts state filter-map params)))
 
 (defrecord FeedbackStore [state]
   IFeedbackStore

--- a/src/ctia/stores/es/verdict.clj
+++ b/src/ctia/stores/es/verdict.clj
@@ -1,0 +1,8 @@
+(ns ctia.stores.es.verdict
+  (:require [ctia.stores.es.crud :as crud]
+            [ctim.schemas.verdict :refer [StoredVerdict]]))
+
+(def handle-create-verdict (crud/handle-create :verdict StoredVerdict))
+(def handle-read-verdict (crud/handle-read :verdict StoredVerdict))
+(def handle-delete-verdict (crud/handle-delete :verdict StoredVerdict))
+(def handle-list-verdicts (crud/handle-find :verdict StoredVerdict))

--- a/src/ctia/stores/sql/judgement.clj
+++ b/src/ctia/stores/sql/judgement.clj
@@ -1,5 +1,6 @@
 (ns ctia.stores.sql.judgement
-  (:require [ctia.lib.pagination :as pagination]
+  (:require [clojure.tools.logging :as log]
+            [ctia.lib.pagination :as pagination]
             [ctia.lib.specter.paths :as path]
             [ctia.lib.time :as time]
             [ctia.stores.sql.common :as c]
@@ -56,7 +57,6 @@
 
 (defn sort-select
   [sort_by sort_order judgements]
-
   (let [sorted (sort-by sort_by judgements)]
     (if (= :desc sort_order)
       (reverse sorted)
@@ -127,7 +127,7 @@
                     (k/where {:judgement_id id})))]
      (pos? num-rows-deleted))))
 
-(defn calculate-verdict [{:keys [type value] :as _observable_}]
+(defn calculate-verdict [{:keys [type value] :as observable}]
   (some-> (k/select @judgement
                     (k/fields :disposition [:id :judgement_id] :disposition_name)
                     (k/where {:observable_type type
@@ -139,7 +139,8 @@
                     (k/order :valid_time_start_time)
                     (k/limit 1))
           first
-          (merge {:type "verdict"})))
+          (merge {:type "verdict"
+                  :observable observable})))
 
 (defn create-judgement-indicator [judgement-id indicator-rel]
   (when (seq (k/select @judgement (k/where {:id judgement-id})))

--- a/test/ctia/http/routes/verdict_test.clj
+++ b/test/ctia/http/routes/verdict_test.clj
@@ -1,18 +1,17 @@
 (ns ctia.http.routes.verdict-test
   (:refer-clojure :exclude [get])
-  (:require
-   [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
-   [ctia.test-helpers.core :refer [delete get post put] :as helpers]
-   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-   [ctia.test-helpers.store :refer [deftest-for-each-store]]
-   [ctia.test-helpers.auth :refer [all-capabilities]]))
+  (:require [clojure.test :refer [is join-fixtures testing use-fixtures]]
+            [ctia.test-helpers
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [get post]]
+             [fake-whoami-service :as whoami-helpers]
+             [store :refer [deftest-for-each-store]]]))
 
 (use-fixtures :once (join-fixtures [helpers/fixture-schema-validation
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
-
 
 (deftest-for-each-store test-observable-verdict-route
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -105,7 +104,7 @@
                   :disposition 2
                   :disposition_name "Malicious"
                   :judgement_id (:id judgement-1)}
-                 (dissoc verdict :id :observable :owner :created))))))))
+                 (dissoc verdict :id :observable :owner :created :version))))))))
 
 (deftest-for-each-store test-observable-verdict-route-2
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -156,5 +155,5 @@
                     :disposition 2
                     :disposition_name "Malicious"
                     :judgement_id (:id judgement)}
-                   (dissoc verdict :id :observable :owner :created)))))))))
+                   (dissoc verdict :id :observable :owner :created :version)))))))))
 

--- a/test/ctia/http/routes/verdict_test.clj
+++ b/test/ctia/http/routes/verdict_test.clj
@@ -105,7 +105,7 @@
                   :disposition 2
                   :disposition_name "Malicious"
                   :judgement_id (:id judgement-1)}
-                 verdict)))))))
+                 (dissoc verdict :id :observable :owner :created))))))))
 
 (deftest-for-each-store test-observable-verdict-route-2
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -156,5 +156,5 @@
                     :disposition 2
                     :disposition_name "Malicious"
                     :judgement_id (:id judgement)}
-                   verdict))))))))
+                   (dissoc verdict :id :observable :owner :created)))))))))
 

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -104,6 +104,7 @@
                     "ctia.store.incident" "atom"
                     "ctia.store.indicator" "atom"
                     "ctia.store.judgement" "atom"
+                    "ctia.store.verdict" "atom"
                     "ctia.store.sighting" "atom"
                     "ctia.store.ttp" "atom"]
     (f)))
@@ -128,6 +129,7 @@
                     "ctia.store.incident" "atom,es"
                     "ctia.store.indicator" "atom,es"
                     "ctia.store.judgement" "atom,es,sql"
+                    "ctia.store.verdict"  "atom,es"
                     "ctia.store.sighting" "atom,es"
                     "ctia.store.ttp" "atom,es"]
     (f)))

--- a/test/ctia/test_helpers/db.clj
+++ b/test/ctia/test_helpers/db.clj
@@ -53,6 +53,7 @@
      "ctia.store.incident" "atom"
      "ctia.store.indicator" "atom"
      "ctia.store.judgement" "sql"
+     "ctia.store.verdict" "atom"
      "ctia.store.sighting" "atom"
      "ctia.store.ttp" "atom"
      "ctia.store.sql.judgement.classname"    "org.h2.Driver"

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -48,6 +48,7 @@
                       "ctia.store.incident" "es"
                       "ctia.store.indicator" "es"
                       "ctia.store.judgement" "es"
+                      "ctia.store.verdict" "es"
                       "ctia.store.sighting" "es"
                       "ctia.store.ttp" "es"]
     (test)))


### PR DESCRIPTION
closes #356 

depends on 
https://github.com/threatgrid/ctim/pull/19 https://github.com/threatgrid/ctim/pull/20

- Added verdict ES Store
- Updated verdict route to lookup verdicts by observables through the Verdict Store
- Updated Verdict Store tests to run on all store implementations