### PR TITLE
get rid of the nested documents on sighting

### DIFF
--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -583,7 +583,8 @@
      :source_device string
      :reference string
      :confidence string
-     :observables (assoc observable :type "nested")
+     :observables observable
+     :observables_hash string
      :indicators related-indicators
      :incidents related-incidents
      :relations observed-relation

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -8,14 +8,25 @@
             [schema.core :as s]))
 
 (s/defschema ESStoredSighting
-  (st/merge StoredSighting
-            {:observables_hash [s/Str]}))
+  (st/assoc StoredSighting :observables_hash [s/Str]))
 
+(def ESStoredSightingList (list-response-schema ESStoredSighting))
+(def StoredSightingList (list-response-schema StoredSighting))
 (def es-coerce! (crud/coerce-to-fn [(s/maybe ESStoredSighting)]))
+(def create-fn (crud/handle-create :sighting ESStoredSighting))
+(def read-fn (crud/handle-read :sighting ESStoredSighting))
+(def update-fn (crud/handle-update :sighting ESStoredSighting))
+(def list-fn (crud/handle-find :sighting ESStoredSighting))
 
 (s/defn observable->observable-hash :- s/Str
-  [{:keys [type value] :as obsrvable :- Observable}]
+  "transform an observable to a hash"
+  [{:keys [type value] :as o :- Observable}]
   (str type ":" value))
+
+(s/defn obs->hashes :- [s/Str]
+  "transform a list of observables into hashes"
+  [observables :- [Observable]]
+  (map #(observable->observable-hash %) observables))
 
 (s/defn stored-sighting->es-stored-sighting :- (s/maybe ESStoredSighting)
   "adds an observables hash to a sighting"
@@ -31,44 +42,37 @@
 
 (s/defn handle-create-sighting :- StoredSighting
   [state realized]
-  (let [create-fn (crud/handle-create :sighting ESStoredSighting)
-        transformed (stored-sighting->es-stored-sighting realized)]
-    (-> (create-fn state transformed)
-        es-stored-sighting->stored-sighting)))
+  (->> (stored-sighting->es-stored-sighting realized)
+       (create-fn state)
+       es-stored-sighting->stored-sighting))
 
 (s/defn handle-read-sighting :- (s/maybe StoredSighting)
   [state id]
-  (let [read-fn (crud/handle-read :sighting ESStoredSighting)]
-    (-> (read-fn state id)
-        es-stored-sighting->stored-sighting)))
+  (es-stored-sighting->stored-sighting
+   (read-fn state id)))
 
 (s/defn handle-update-sighting :- StoredSighting
   [state id realized]
-  (let [update-fn (crud/handle-update :sighting ESStoredSighting)
-        transformed (stored-sighting->es-stored-sighting realized)]
-    (-> (update-fn state id transformed)
-        es-stored-sighting->stored-sighting)))
+  (->> (stored-sighting->es-stored-sighting realized)
+       (update-fn state id)
+       es-stored-sighting->stored-sighting))
 
 (def handle-delete-sighting (crud/handle-delete :sighting StoredSighting))
 
-(s/defn es-paginated-list->paginated-list :- (list-response-schema StoredSighting)
-  [paginated-list :- (list-response-schema ESStoredSighting)]
+(s/defn es-paginated-list->paginated-list :- StoredSightingList
+  [paginated-list :- ESStoredSightingList]
   (update-in paginated-list
              [:data]
              #(map es-stored-sighting->stored-sighting (es-coerce! %))))
 
-(defn handle-list-sightings
+(s/defn handle-list-sightings :- StoredSightingList
   [state filter-map params]
+  (es-paginated-list->paginated-list
+   (list-fn state filter-map params)))
 
-  (let [list-fn (crud/handle-find :sighting ESStoredSighting)
-        res (list-fn state filter-map params)]
-
-    (es-paginated-list->paginated-list res)))
-
-(def ^{:private true} mapping "sighting")
-
-(defn handle-list-sightings-by-observables
-  [state observables params]
-
-  (let [hashes (map #(observable->observable-hash %) observables)]
-    (handle-list-sightings state {:observables_hash hashes} params)))
+(s/defn handle-list-sightings-by-observables :- StoredSightingList
+  [state observables :- [Observable] params]
+  (handle-list-sightings state
+                         {:observables_hash
+                          (obs->hashes observables)}
+                         params))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -1,28 +1,70 @@
 (ns ctia.stores.es.sighting
-  (:require
-   [schema.core :as s]
-   [ctia.stores.es.crud :as crud]
-   [ctia.stores.es.query :refer [sightings-by-observables-query]]
-   [ctim.schemas.sighting :refer [Sighting
-                                  NewSighting
-                                  StoredSighting]]
-   [ctim.schemas.indicator :refer [Indicator]]
-   [ctia.lib.es.document :refer [search-docs]]))
+  (:require [ctia.stores.es.crud :as crud]
+            [ctim.schemas
+             [common :refer [Observable]]
+             [sighting :refer [StoredSighting]]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
 
+(s/defschema ESStoredSighting
+  (st/merge StoredSighting
+            {:observables_hash [s/Str]}))
 
-(def handle-create-sighting (crud/handle-create :sighting StoredSighting))
-(def handle-read-sighting (crud/handle-read :sighting StoredSighting))
-(def handle-update-sighting (crud/handle-update :sighting StoredSighting))
+(def es-coerce! (crud/coerce-to-fn [(s/maybe ESStoredSighting)]))
+
+(s/defn observable->observable-hash :- s/Str
+  [{:keys [type value] :as obsrvable :- Observable}]
+  (str (name type) ":" value))
+
+(s/defn stored-sighting->es-stored-sighting :- (s/maybe ESStoredSighting)
+  "adds an observables hash to a sighting"
+  [{:keys [observables] :as s :- (s/maybe StoredSighting)}]
+  (when s
+    (assoc s :observables_hash
+           (map #(observable->observable-hash %) observables))))
+
+(s/defn es-stored-sighting->stored-sighting :- (s/maybe StoredSighting)
+  "remove the computed observables hash from a sighting"
+  [s :- (s/maybe ESStoredSighting)]
+  (when s (dissoc s :observables_hash)))
+
+(s/defn handle-create-sighting [state realized] :- StoredSighting
+  (let [create-fn (crud/handle-create :sighting ESStoredSighting)
+        transformed (stored-sighting->es-stored-sighting realized)]
+    (-> (create-fn state transformed)
+        es-stored-sighting->stored-sighting)))
+
+(s/defn handle-read-sighting [state id] :- StoredSighting
+  (let [read-fn (crud/handle-read :sighting ESStoredSighting)]
+    (-> (read-fn state id)
+        es-stored-sighting->stored-sighting)))
+
+(s/defn handle-update-sighting :- StoredSighting
+  [state id realized]
+  (let [update-fn (crud/handle-update :sighting ESStoredSighting)
+        transformed (stored-sighting->es-stored-sighting realized)]
+    (-> (update-fn state id transformed)
+        es-stored-sighting->stored-sighting)))
+
 (def handle-delete-sighting (crud/handle-delete :sighting StoredSighting))
-(def handle-list-sightings (crud/handle-find :sighting StoredSighting))
+
+(defn es-paginated-list->paginated-list [paginated-list]
+  (update-in paginated-list
+             [:data]
+             #(map es-stored-sighting->stored-sighting (es-coerce! %))))
+
+(defn handle-list-sightings
+  [state filter-map params]
+
+  (let [list-fn (crud/handle-find :sighting ESStoredSighting)
+        res (list-fn state filter-map params)]
+
+    (es-paginated-list->paginated-list res)))
 
 (def ^{:private true} mapping "sighting")
 
 (defn handle-list-sightings-by-observables
-  [{:keys [conn index]}  observables params]
+  [state observables params]
 
-  (search-docs conn
-               index
-               mapping
-               nil
-               (assoc params :query (sightings-by-observables-query observables))))
+  (let [hashes (map #(observable->observable-hash %) observables)]
+    (handle-list-sightings state {:observables_hash hashes} params)))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -26,14 +26,14 @@
 (s/defn obs->hashes :- [s/Str]
   "transform a list of observables into hashes"
   [observables :- [Observable]]
-  (map #(observable->observable-hash %) observables))
+  (map observable->observable-hash observables))
 
 (s/defn stored-sighting->es-stored-sighting :- (s/maybe ESStoredSighting)
   "adds an observables hash to a sighting"
   [{:keys [observables] :as s :- (s/maybe StoredSighting)}]
   (when s
     (assoc s :observables_hash
-           (map #(observable->observable-hash %) observables))))
+           (map observable->observable-hash observables))))
 
 (s/defn es-stored-sighting->stored-sighting :- (s/maybe StoredSighting)
   "remove the computed observables hash from a sighting"


### PR DESCRIPTION
closes https://github.com/threatgrid/ctim/issues/21

This enables us to get rid of ES nested objects for sighting observables by computing an observable hashes list just before ES document storage and clearing it at retrieval.

I would have used something like https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-transform.html
but it is now deprecated so I do it from CTIA.