### PR TITLE
add benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ services:
 #   hipchat: [api token]@[room id or name]
 env:
     global:
+      - JAVA_OPTS="-XX:MaxPermSize=256m"
       - COMPOSE_VERSION: 1.4.2
       - CTIA_STORE_ES_DEFAULT_HOST=127.0.0.1
       - CTIA_STORE_ES_DEFAULT_INDEXNAME=elasticsearch

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ production, unless you ensure access to the NREPL port is restricted.
 
 This will start up with non-persistent in-memory storage only.
 
+**Remark**:
+if you use java 1.7, you might need to add `-XX:MaxPermSize=256m`
+to java options.
+
 ### Packaging and running as standalone jar
 
 This is the proper way to run this in production.

--- a/benchmarks/ctia/http/routes/actor_bench.clj
+++ b/benchmarks/ctia/http/routes/actor_bench.clj
@@ -1,12 +1,11 @@
 (ns ctia.http.routes.actor-bench
-  (:refer-clojure :exclude [get])
-  (:require [perforate.core :refer :all]
-            [ctia.init :refer [start-ctia!]]
-            [ctia.http.server :as http-server]
-            [ctia.flows.hooks :as hooks]
-            [ctia.events :as events]
-            [ctia.test-helpers.es :as esh]
-            [ctia.test-helpers.core :refer [get post put delete] :as helpers]))
+  (:require [ctia.test-helpers
+             [benchmark :refer [cleanup-ctia!
+                                setup-ctia-atom-store!
+                                setup-ctia-es-store!
+                                setup-ctia-es-store-native!]]
+             [core :as helpers :refer [delete post]]]
+            [perforate.core :refer :all]))
 
 (def small-actor
   {:title "actor"
@@ -38,36 +37,28 @@
    :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
                 :end_time "2016-07-11T00:40:48.212-00:00"}})
 
-;; -----------------------------------------------------------------------------
 (defgoal create-actor "Create Actor"
-  :setup (fn []
-           (let [http-port (helpers/available-port)]
-             (println "Default: Launch CTIA on port" http-port)
-             (helpers/fixture-properties:clean
-              (fn []
-                (helpers/with-properties ["ctia.http.enabled" true
-                                          "ctia.http.port" http-port
-                                          "ctia.http.show.port" http-port]
-                  (start-ctia! :join? false))))))
-  :cleanup (fn []
-             (http-server/stop!)
-             (hooks/shutdown!)
-             (events/shutdown!)))
+  :setup (fn [] [true])
+  :cleanup (fn [_]))
 
-(defn play-big []
+(defn play-big [port]
   (let [{:keys [status parsed_body]}
         (post "ctia/actor"
               :body big-actor
+              :port port
               :headers {"api_key" "45c1f5e3f05d0"})]
     (if (= 201 status)
       (delete (str "ctia/actor" (:id parsed_body)))
       (prn "play-big: " status))))
 
-(defcase create-actor :big-actor-atom-store []
-  (helpers/fixture-properties:atom-store play-big))
+(defcase* create-actor :big-actor-atom-store
+  (fn [_] (let [port (setup-ctia-atom-store!)]
+           [#(play-big port) cleanup-ctia!])))
 
-(defcase create-actor :big-actor-es-store []
-  (esh/fixture-properties:es-store play-big))
+(defcase* create-actor :big-actor-es-store
+  (fn [_] (let [port (setup-ctia-es-store!)]
+           [#(play-big port) cleanup-ctia!])))
 
-(defcase create-actor :big-actor-es-store-native []
-  (esh/fixture-properties:es-store-native play-big))
+(defcase* create-actor :big-actor-es-store-native
+  (fn [_] (let [port (setup-ctia-es-store-native!)]
+           [#(play-big port) cleanup-ctia!])))

--- a/benchmarks/ctia/http/routes/actor_bench.clj
+++ b/benchmarks/ctia/http/routes/actor_bench.clj
@@ -1,0 +1,73 @@
+(ns ctia.http.routes.actor-bench
+  (:refer-clojure :exclude [get])
+  (:require [perforate.core :refer :all]
+            [ctia.init :refer [start-ctia!]]
+            [ctia.http.server :as http-server]
+            [ctia.flows.hooks :as hooks]
+            [ctia.events :as events]
+            [ctia.test-helpers.es :as esh]
+            [ctia.test-helpers.core :refer [get post put delete] :as helpers]))
+
+(def small-actor
+  {:title "actor"
+   :description "description"
+   :actor_type "Hacker"
+   :source "a source"
+   :confidence "High"
+   :associated_actors [{:actor_id "actor-123"}
+                       {:actor_id "actor-456"}]
+   :associated_campaigns [{:campaign_id "campaign-444"}
+                          {:campaign_id "campaign-555"}]
+   :observed_TTPs [{:ttp_id "ttp-333"}
+                   {:ttp_id "ttp-999"}]
+   :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
+                :end_time "2016-07-11T00:40:48.212-00:00"}})
+
+(defn gen [n k pref]
+  (map (fn [i] {k (str pref "-" i)}) (range n)))
+
+(def big-actor
+  {:title "actor"
+   :description "description"
+   :actor_type "Hacker"
+   :source "a source"
+   :confidence "High"
+   :associated_actors (gen 100 :actor_id "actor")
+   :associated_campaigns (gen 100 :campaign_id "campaign")
+   :observed_TTPs (gen 100 :ttp_id "ttp")
+   :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
+                :end_time "2016-07-11T00:40:48.212-00:00"}})
+
+;; -----------------------------------------------------------------------------
+(defgoal create-actor "Create Actor"
+  :setup (fn []
+           (let [http-port (helpers/available-port)]
+             (println "Default: Launch CTIA on port" http-port)
+             (helpers/fixture-properties:clean
+              (fn []
+                (helpers/with-properties ["ctia.http.enabled" true
+                                          "ctia.http.port" http-port
+                                          "ctia.http.show.port" http-port]
+                  (start-ctia! :join? false))))))
+  :cleanup (fn []
+             (http-server/stop!)
+             (hooks/shutdown!)
+             (events/shutdown!)))
+
+(defn play-big []
+  (let [{:keys [status parsed_body]}
+        (post "ctia/actor"
+              :body big-actor
+              :headers {"api_key" "45c1f5e3f05d0"})]
+    (if (= 201 status)
+      (delete (str "ctia/actor" (:id parsed_body)))
+      (prn "play-big: " status))))
+
+(defcase create-actor :big-actor-atom-store []
+  (helpers/fixture-properties:atom-store play-big))
+
+(defcase create-actor :big-actor-es-store []
+  (esh/fixture-properties:es-store play-big))
+
+(defcase create-actor :big-actor-es-store-native []
+  (esh/fixture-properties:es-store-native play-big))

--- a/benchmarks/ctia/http/routes/campaign_bench.clj
+++ b/benchmarks/ctia/http/routes/campaign_bench.clj
@@ -1,0 +1,85 @@
+(ns ctia.http.routes.campaign-bench
+  (:refer-clojure :exclude [get])
+  (:require [perforate.core :refer :all]
+            [ctia.init :refer [start-ctia!]]
+            [ctia.http.server :as http-server]
+            [ctia.flows.hooks :as hooks]
+            [ctia.events :as events]
+            [ctia.test-helpers.es :as esh]
+            [ctia.test-helpers.core :refer [get post put delete] :as helpers]))
+
+(def small-campaign
+  {:title "campaign"
+   :description "description"
+   :tlp "red"
+   :campaign_type "anything goes here"
+   :intended_effect ["Theft"]
+   :indicators [{:indicator_id "indicator-foo"}
+                {:indicator_id "indicator-bar"}]
+   :attribution [{:confidence "High"
+                  :source "source"
+                  :relationship "relationship"
+                  :actor_id "actor-123"}]
+   :related_incidents [{:confidence "High"
+                        :source "source"
+                        :relationship "relationship"
+                        :incident_id "incident-222"}]
+   :related_TTPs [{:confidence "High"
+                   :source "source"
+                   :relationship "relationship"
+                   :ttp_id "ttp-999"}]
+   :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
+                :end_time "2016-07-11T00:40:48.212-00:00"}})
+
+(defn gen [n k pref]
+  (map (fn [i] {k (str pref "-" i)}) (range n)))
+
+(def big-campaign
+  {:title "campaign"
+   :description "description"
+   :tlp "red"
+   :campaign_type "anything goes here"
+   :intended_effect ["Theft"]
+   :indicators (gen 100 :indicator_id "indicator")
+   :attribution [{:confidence "High"
+                  :source "source"
+                  :relationship "relationship"
+                  :actor_id "actor-123"}]
+   :related_incidents (gen 100 :incident_id "incident")
+   :related_TTPs      (gen 100 :ttp_id "ttp")
+   :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
+                :end_time "2016-07-11T00:40:48.212-00:00"}})
+
+;; -----------------------------------------------------------------------------
+(defgoal create-campaign "Create Campaign"
+  :setup (fn []
+           (let [http-port (helpers/available-port)]
+             (println "Default: Launch CTIA on port" http-port)
+             (helpers/fixture-properties:clean
+              (fn []
+                (helpers/with-properties ["ctia.http.enabled" true
+                                          "ctia.http.port" http-port
+                                          "ctia.http.show.port" http-port]
+                  (start-ctia! :join? false))))))
+  :cleanup (fn []
+             (http-server/stop!)
+             (hooks/shutdown!)
+             (events/shutdown!)))
+
+(defn play-big []
+  (let [{:keys [status parsed_body]}
+        (post "ctia/campaign"
+              :body big-campaign
+              :headers {"api_key" "45c1f5e3f05d0"})]
+    (if (= 201 status)
+      (delete (str "ctia/campaign" (:id parsed_body)))
+      (prn "play-big: " status))))
+
+(defcase create-campaign :big-campaign-atom-store []
+  (helpers/fixture-properties:atom-store play-big))
+
+(defcase create-campaign :big-campaign-es-store []
+  (esh/fixture-properties:es-store play-big))
+
+(defcase create-campaign :big-campaign-es-store-native []
+  (esh/fixture-properties:es-store-native play-big))

--- a/project.clj
+++ b/project.clj
@@ -124,10 +124,23 @@
                                      "test/resources/hooks/hook-example-0.1.0-SNAPSHOT.jar"]}
              :prepush {:plugins [[yogsototh/lein-kibit "0.1.6-SNAPSHOT"]
                                  [lein-bikeshed "0.3.0"]]}}
+  :perforate {:environments [{:name :actor
+                              :namespaces [ctia.http.routes.actor-bench]}
+                             {:name :campaign
+                              :namespaces [ctia.http.routes.campaign-bench]}]}
   :plugins [[lein-shell "0.5.0"]
             [perforate "0.3.4"]]
   :aliases {"kibit" ["with-profile" "prepush" "kibit"]
             "bikeshed" ["with-profile" "prepush" "bikeshed" "-m" "100"]
-            "prepush" ["shell" "scripts/pre-push-check.sh"]
-            "bench" ["with-profile" "test" "perforate"]
-            "init-properties" ["shell" "scripts/init-properties-for-docker.sh"]})
+
+            "prepush" ^{:doc "Check code quality before pushing"}
+            ["shell" "scripts/pre-push-check.sh"]
+
+            "bench" ^{:doc (str "Launch benchmarks"
+                                "; use `lein bench actor` to only launch"
+                                " actor related benchmarks")}
+            ["with-profile" "test" "perforate"]
+
+            "init-properties" ^{:doc (str "create an initial `ctia.properties`"
+                                          " using docker machine ip")}
+            ["shell" "scripts/init-properties-for-docker.sh"]})

--- a/project.clj
+++ b/project.clj
@@ -93,6 +93,7 @@
                                   [com.h2database/h2 "1.4.191"]
                                   [org.clojure/test.check "0.9.0"]
                                   [com.gfredericks/test.chuck "0.2.6"]
+                                  [perforate "0.3.4"]
                                   [prismatic/schema-generators "0.1.0"
                                    :exclusions [prismatic/schema]]]
                    :resource-paths ["model"
@@ -123,7 +124,8 @@
                                      "test/resources/hooks/hook-example-0.1.0-SNAPSHOT.jar"]}
              :prepush {:plugins [[yogsototh/lein-kibit "0.1.6-SNAPSHOT"]
                                  [lein-bikeshed "0.3.0"]]}}
-  :plugins [[lein-shell "0.5.0"]]
+  :plugins [[lein-shell "0.5.0"]
+            [perforate "0.3.4"]]
   :aliases {"kibit" ["with-profile" "prepush" "kibit"]
             "bikeshed" ["with-profile" "prepush" "bikeshed" "-m" "100"]
             "prepush" ["shell" "scripts/pre-push-check.sh"]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
   :jvm-opts [ "-Xmx4g" ;; On some OSX VMs, this is needed to increase available memory
              "-Djava.awt.headless=true"
              "-Dlog.console.threshold=INFO"
-             "-XX:MaxPermSize=256m" ;; recommended permgen size
              "-server"]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [clj-time "0.9.0"] ; required due to bug in lein-ring
@@ -98,6 +97,17 @@
                                    :exclusions [prismatic/schema]]]
                    :resource-paths ["model"
                                     "test/resources"]}
+             :jmx {:jvm-opts ["-Dcom.sun.management.jmxremote"
+                              "-Dcom.sun.management.jmxremote.port=9010"
+                              "-Dcom.sun.management.jmxremote.local.only=false"
+                              "-Dcom.sun.management.jmxremote.authenticate=false"
+                              "-Dcom.sun.management.jmxremote.ssl=false"]}
+             :bench {:dependencies [[cheshire "5.6.1"]
+                                    [perforate "0.3.4"]
+                                    [com.h2database/h2 "1.4.191"]
+                                    [org.clojure/test.check "0.9.0"]
+                                    [com.gfredericks/test.chuck "0.2.6"]
+                                    [prismatic/schema-generators "0.1.0"]]}
              :test {:jvm-opts ["-Dlog.console.threshold=WARN"]
                     :dependencies [[cheshire "5.6.1"]
                                    [com.h2database/h2 "1.4.191"]
@@ -117,4 +127,5 @@
   :aliases {"kibit" ["with-profile" "prepush" "kibit"]
             "bikeshed" ["with-profile" "prepush" "bikeshed" "-m" "100"]
             "prepush" ["shell" "scripts/pre-push-check.sh"]
+            "bench" ["with-profile" "test" "perforate"]
             "init-properties" ["shell" "scripts/init-properties-for-docker.sh"]})

--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -17,12 +17,12 @@
       :summary "Adds a new Actor"
       :capabilities :create-actor
       :identity identity
-      (ok (flows/create-flow :entity-type :actor
-                             :realize-fn realize-actor
-                             :store-fn #(write-store :actor create-actor %)
-                             :entity-type :actor
-                             :identity identity
-                             :entity actor)))
+      (created (flows/create-flow :entity-type :actor
+                                  :realize-fn realize-actor
+                                  :store-fn #(write-store :actor create-actor %)
+                                  :entity-type :actor
+                                  :identity identity
+                                  :entity actor)))
     (PUT "/:id" []
       :return StoredActor
       :body [actor NewActor {:description "an updated Actor"}]

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -129,7 +129,7 @@
       :identity login
       (if (> (bulk-size bulk) (get-bulk-max-size))
         (bad-request (str "Bulk max nb of entities: " (get-bulk-max-size)))
-        (ok (gen-bulk-from-fn create-entities bulk login))))
+        (created (gen-bulk-from-fn create-entities bulk login))))
     (GET "/" []
       :return (s/maybe StoredBulk)
       :summary "Gets many entities at once"

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -17,11 +17,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-campaign
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-campaign
-                             :store-fn #(write-store :campaign create-campaign %)
-                             :entity-type :campaign
-                             :identity identity
-                             :entity campaign)))
+      (created (flows/create-flow :realize-fn realize-campaign
+                                  :store-fn #(write-store :campaign create-campaign %)
+                                  :entity-type :campaign
+                                  :identity identity
+                                  :entity campaign)))
     (PUT "/:id" []
       :return StoredCampaign
       :body [campaign NewCampaign {:description "an updated campaign"}]

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -17,11 +17,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-coa
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-coa
-                             :store-fn #(write-store :coa create-coa %)
-                             :entity-type :coa
-                             :identity identity
-                             :entity coa)))
+      (created (flows/create-flow :realize-fn realize-coa
+                                  :store-fn #(write-store :coa create-coa %)
+                                  :entity-type :coa
+                                  :identity identity
+                                  :entity coa)))
     (PUT "/:id" []
       :return StoredCOA
       :body [coa NewCOA {:description "an updated COA"}]

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -18,11 +18,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-exploit-target
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-exploit-target
-                             :store-fn #(write-store :exploit-target create-exploit-target %)
-                             :entity-type :exploit-target
-                             :identity identity
-                             :entity exploit-target)))
+      (created (flows/create-flow :realize-fn realize-exploit-target
+                                  :store-fn #(write-store :exploit-target create-exploit-target %)
+                                  :entity-type :exploit-target
+                                  :identity identity
+                                  :entity exploit-target)))
     (PUT "/:id" []
       :return StoredExploitTarget
       :body [exploit-target

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -26,7 +26,7 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-feedback
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-feedback
+      (created (flows/create-flow :realize-fn realize-feedback
                              :store-fn #(write-store :feedback create-feedback %)
                              :entity-type :feedback
                              :identity identity

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -19,11 +19,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-incident
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-incident
-                             :store-fn #(write-store :incident create-incident %)
-                             :entity-type :incident
-                             :identity identity
-                             :entity incident)))
+      (created (flows/create-flow :realize-fn realize-incident
+                                  :store-fn #(write-store :incident create-incident %)
+                                  :entity-type :incident
+                                  :identity identity
+                                  :entity incident)))
     (PUT "/:id" []
       :return StoredIncident
       :body [incident NewIncident {:description "an updated incident"}]

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -47,11 +47,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-indicator
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-indicator
-                             :store-fn #(write-store :indicator create-indicator %)
-                             :entity-type :indicator
-                             :identity identity
-                             :entity indicator)))
+      (created (flows/create-flow :realize-fn realize-indicator
+                                  :store-fn #(write-store :indicator create-indicator %)
+                                  :entity-type :indicator
+                                  :identity identity
+                                  :entity indicator)))
     (PUT "/:id" []
       :return StoredIndicator
       :body [indicator NewIndicator {:description "an updated Indicator"}]

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -34,11 +34,11 @@
       :summary "Adds a new Judgement"
       :capabilities :create-judgement
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-judgement
-                             :store-fn #(write-store :judgement create-judgement %)
-                             :entity-type :judgement
-                             :identity identity
-                             :entity judgement)))
+      (created (flows/create-flow :realize-fn realize-judgement
+                                  :store-fn #(write-store :judgement create-judgement %)
+                                  :entity-type :judgement
+                                  :identity identity
+                                  :entity judgement)))
     (POST "/:judgement-id/indicator" []
       :return (s/maybe rel/RelatedIndicator)
       :path-params [judgement-id :- s/Str]

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -19,11 +19,11 @@
       :capabilities :create-sighting
       :identity identity
       (if (check-new-sighting sighting)
-        (ok (flows/create-flow :realize-fn realize-sighting
-                               :store-fn #(write-store :sighting create-sighting %)
-                               :entity-type :sighting
-                               :identity identity
-                               :entity sighting))
+        (created (flows/create-flow :realize-fn realize-sighting
+                                    :store-fn #(write-store :sighting create-sighting %)
+                                    :entity-type :sighting
+                                    :identity identity
+                                    :entity sighting))
         (unprocessable-entity)))
     (PUT "/:id" []
       :return StoredSighting

--- a/src/ctia/http/routes/ttp.clj
+++ b/src/ctia/http/routes/ttp.clj
@@ -18,11 +18,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :create-ttp
       :identity identity
-      (ok (flows/create-flow :realize-fn realize-ttp
-                             :store-fn #(write-store :ttp create-ttp %)
-                             :entity-type :ttp
-                             :identity identity
-                             :entity ttp)))
+      (created (flows/create-flow :realize-fn realize-ttp
+                                  :store-fn #(write-store :ttp create-ttp %)
+                                  :entity-type :ttp
+                                  :identity identity
+                                  :entity ttp)))
     (PUT "/:id" []
       :return StoredTTP
       :body [ttp NewTTP {:description "an updated TTP"}]

--- a/test/ctia/flows/hooks/es_event_hook_test.clj
+++ b/test/ctia/flows/hooks/es_event_hook_test.clj
@@ -71,9 +71,9 @@
                        :confidence "Low"
                        :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})]
 
-      (is (= 200 judgement-1-status))
-      (is (= 200 judgement-2-status))
-      (is (= 200 judgement-3-status))
+      (is (= 201 judgement-1-status))
+      (is (= 201 judgement-2-status))
+      (is (= 201 judgement-3-status))
 
       (let [{:keys [index conn props]} (init-producer-conn)]
         ((index/refresh-fn conn) conn index)

--- a/test/ctia/flows/hooks/redis_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redis_event_hook_test.clj
@@ -69,9 +69,9 @@
                          :confidence "Low"
                          :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})]
 
-        (is (= 200 judgement-1-status))
-        (is (= 200 judgement-2-status))
-        (is (= 200 judgement-3-status))
+        (is (= 201 judgement-1-status))
+        (is (= 201 judgement-2-status))
+        (is (= 201 judgement-3-status))
 
         (is (.await finish-signal 10 TimeUnit/SECONDS)
             "Unexpected timeout waiting for subscriptions")

--- a/test/ctia/http/generative/specs.clj
+++ b/test/ctia/http/generative/specs.clj
@@ -10,6 +10,16 @@
             [ctim.generators.schemas :as gen]
             [ctim.generators.schemas.sighting-generators :as gs]))
 
+(defn assert-successfully-created
+  ([status]
+   (assert (= 201 status)
+           (format "status %s was not 201" status)))
+  ([status body]
+   (assert (empty? (:errors body))
+           (format (str "Errors in the body: " (:errors body))))
+   (assert (= 201 status)
+           (format "Status %s was not 201" status))))
+
 (defn assert-successful
   ([status]
    (assert (= 200 status)
@@ -35,11 +45,8 @@
               get-entity# :parsed-body}
              (get (str "ctia/" ~model-type "/" (encode id#)))]
 
-         (assert-successful post-status# post-entity#)
+         (assert-successfully-created post-status# post-entity#)
          (assert-successful get-status# get-entity#)
-         ;;(println "NEW" new-entity#)
-         ;;(println "POST:" post-entity#)
-         ;;(println "GET:" get-entity#)
          (if-not (empty? (keys new-entity#))
            (common= new-entity#
                     (normalize post-entity#)
@@ -84,9 +91,9 @@
                (map :id)
                set)]
 
-      (assert-successful post-status)
+      (assert-successfully-created post-status)
       (doseq [{status :status} stored-sighting-responses]
-        (assert-successful status))
+        (assert-successfully-created status))
       (assert-successful get-indicator-status)
       (assert-successful search-result-status)
 

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -29,7 +29,7 @@
                        :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
                                     :end_time "2016-03-11T00:00:00.000-00:00"}
                        :indicators [{:indicator_id "indicator-123"}]})]
-      (is (= 200 status))
+      (is (= 201 status))
       (is (deep=
            {:type "judgement"
             :observable {:value "1.2.3.4"

--- a/test/ctia/http/routes/actor_test.clj
+++ b/test/ctia/http/routes/actor_test.clj
@@ -36,7 +36,7 @@
                                              :end_time "2016-07-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           actor (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "actor"
             :description "description",

--- a/test/ctia/http/routes/bulk_test.clj
+++ b/test/ctia/http/routes/bulk_test.clj
@@ -180,7 +180,7 @@
                          :body new-bulk
                          :headers {"api_key" "45c1f5e3f05d0"})
           bulk-ids (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (doseq [type (keys new-bulk)]
         (testing (str "number of created " (name type))
           (is (= (count (get-in new-bulk [type]))
@@ -248,7 +248,7 @@
                                              :headers {"api_key" "45c1f5e3f05d0"})]
     (testing "POST of right size bulk are accepted"
       (is (empty? (:errors response-ok)) "No errors")
-      (is (= 200 status-ok)))
+      (is (= 201 status-ok)))
     (testing "POST of too big bulks are rejected"
       (is (empty? (:errors response-too-big)) "No errors")
       (is (= 400 status-too-big)))))

--- a/test/ctia/http/routes/campaign_test.clj
+++ b/test/ctia/http/routes/campaign_test.clj
@@ -44,7 +44,7 @@
                                              :end_time "2016-07-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           campaign (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "campaign"
             :title "campaign"

--- a/test/ctia/http/routes/coa_test.clj
+++ b/test/ctia/http/routes/coa_test.clj
@@ -28,7 +28,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           coa (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "COA"
             :title "coa"

--- a/test/ctia/http/routes/exploit_target_test.clj
+++ b/test/ctia/http/routes/exploit_target_test.clj
@@ -34,7 +34,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           exploit-target (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "exploit-target"
             :title "exploit-target"

--- a/test/ctia/http/routes/feedback_test.clj
+++ b/test/ctia/http/routes/feedback_test.clj
@@ -33,7 +33,7 @@
                        :reason "false positive"
                        :tlp "green"}
                 :headers {"api_key" "45c1f5e3f05d0"})]
-      (is (= 200 status))
+      (is (= 201 status))
       (is (deep=
            {:feedback -1,
             :entity_id "judgement-123"

--- a/test/ctia/http/routes/incident_test.clj
+++ b/test/ctia/http/routes/incident_test.clj
@@ -37,7 +37,7 @@
                                                     {:incident_id "indicent-789"}]}
                          :headers {"api_key" "45c1f5e3f05d0"})
           incident (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "incident"
             :title "incident"

--- a/test/ctia/http/routes/indicator_test.clj
+++ b/test/ctia/http/routes/indicator_test.clj
@@ -42,8 +42,7 @@
                                                 :COA_id "coa-123"}]}
                          :headers {"api_key" "45c1f5e3f05d0"})
           indicator (:parsed-body response)]
-
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "indicator"
             :title "indicator-title"

--- a/test/ctia/http/routes/judgement_test.clj
+++ b/test/ctia/http/routes/judgement_test.clj
@@ -44,7 +44,7 @@
           judgement-id (id/short-id->id :judgement
                                         (:id judgement)
                                         (get-in @properties [:ctia :http :show]))]
-      (is (= 200 status))
+      (is (= 201 status))
       (is (deep=
            {:type "judgement"
             :observable {:value "1.2.3.4"
@@ -186,7 +186,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "judgement"
             :observable {:value "1.2.3.4"
@@ -218,7 +218,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "judgement"
             :observable {:value "1.2.3.4"
@@ -249,7 +249,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "judgement"
             :observable {:value "1.2.3.4"
@@ -312,7 +312,7 @@
                        :confidence "Low"
                        :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                 :headers {"api_key" "45c1f5e3f05d0"})]
-      (assert (= 200 status)
+      (assert (= 201 status)
               (format "Expected status to be 200 but was %s on loop %s" status n))))
 
   (pagination-test

--- a/test/ctia/http/routes/observable_test.clj
+++ b/test/ctia/http/routes/observable_test.clj
@@ -189,19 +189,19 @@
               :headers {"api_key" "45c1f5e3f05d0"})]
 
     (testing "With successful test setup"
-      (is (= 200 judgement-1-status))
-      (is (= 200 sighting-1-status))
-      (is (= 200 sighting-2-status))
-      (is (= 200 indicator-1-status))
+      (is (= 201 judgement-1-status))
+      (is (= 201 sighting-1-status))
+      (is (= 201 sighting-2-status))
+      (is (= 201 indicator-1-status))
       (is (= 200 judgement-1-update-status))
-      (is (= 200 judgement-2-status))
-      (is (= 200 sighting-3-status))
-      (is (= 200 indicator-2-status))
+      (is (= 201 judgement-2-status))
+      (is (= 201 sighting-3-status))
+      (is (= 201 indicator-2-status))
       (is (= 200 judgement-2-update-status))
-      (is (= 200 judgement-3-status))
-      (is (= 200 sighting-4-status))
-      (is (= 200 sighting-5-status))
-      (is (= 200 indicator-3-status))
+      (is (= 201 judgement-3-status))
+      (is (= 201 sighting-4-status))
+      (is (= 201 sighting-5-status))
+      (is (= 201 indicator-3-status))
       (is (= 200 judgement-3-update-status)))
 
     (testing "GET /ctia/:observable_type/:observable_value/judgements"

--- a/test/ctia/http/routes/sighting_test.clj
+++ b/test/ctia/http/routes/sighting_test.clj
@@ -72,7 +72,7 @@
                        :indicators [{:indicator_id "indicator-22334455"}]}
                 :headers {"api_key" api-key})]
       (is (empty? (:errors sighting)) "No errors when")
-      (is (= 200 status))
+      (is (= 201 status))
 
       (testing "GET /ctia/sighting/:id"
         (let [{status :status
@@ -176,5 +176,5 @@
                       :sensor "endpoint.sensor"
                       :confidence "High"}
                :headers {"api_key" api-key})]
-      (is (= 200 post-status))
+      (is (= 201 post-status))
       (is (= 422 put-status)))))

--- a/test/ctia/http/routes/ttp_test.clj
+++ b/test/ctia/http/routes/ttp_test.clj
@@ -32,7 +32,7 @@
                                              :end_time "2016-07-11T00:40:48.212-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           ttp (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
       (is (deep=
            {:type "ttp"
             :title "ttp"

--- a/test/ctia/http/routes/verdict_test.clj
+++ b/test/ctia/http/routes/verdict_test.clj
@@ -36,7 +36,7 @@
                                 :confidence "Low"
                                 :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})]
-      (is (= 200 (:status response)))))
+      (is (= 201 (:status response)))))
 
   (testing "test setup: create a judgement (2)"
     ;; Lower priority
@@ -50,7 +50,7 @@
                                 :confidence "Low"
                                 :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})]
-      (is (= 200 (:status response)))))
+      (is (= 201 (:status response)))))
 
   (testing "test setup: create a judgement (3)"
     ;; Wrong disposition
@@ -64,7 +64,7 @@
                                 :confidence "Low"
                                 :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})]
-      (is (= 200 (:status response)))))
+      (is (= 201 (:status response)))))
 
   (testing "test setup: create a judgement (4)"
     ;; Loses a tie because of its timestamp being later
@@ -79,7 +79,7 @@
                                 :valid_time {:start_time "2016-02-12T00:01:00.000-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement-1 (:parsed-body response)]
-      (is (= 200 (:status response)))))
+      (is (= 201 (:status response)))))
 
   (testing "with a highest-priority judgement"
     (let [response (post "ctia/judgement"
@@ -93,7 +93,7 @@
                                 :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement-1 (:parsed-body response)]
-      (is (= 200 (:status response))) ;; success creating judgement
+      (is (= 201 (:status response))) ;; success creating judgement
 
       (testing "GET /ctia/:observable_type/:observable_value/verdict"
         (let [response (get "ctia/ip/10.0.0.1/verdict"
@@ -127,7 +127,7 @@
                                              :end_time "2016-02-12T14:56:26.719-00:00"}
                                 :confidence "Medium"}
                          :headers {"api_key" "45c1f5e3f05d0"})]
-      (is (= 200 (:status response)))))
+      (is (= 201 (:status response)))))
   (testing "with a verdict judgement"
     (let [response (post "ctia/judgement"
                          :body {:observable {:value "10.0.0.1",
@@ -143,7 +143,7 @@
                                 :confidence "Medium"}
                          :headers {"api_key" "45c1f5e3f05d0"})
           judgement (:parsed-body response)]
-      (is (= 200 (:status response)))
+      (is (= 201 (:status response)))
 
       (testing "GET /ctia/:observable_type/:observable_value/verdict"
         (with-redefs [ctia.lib.time/now (constantly (ctia.lib.time/timestamp "2016-02-12T15:42:58.232-00:00"))]

--- a/test/ctia/test_helpers/benchmark.clj
+++ b/test/ctia/test_helpers/benchmark.clj
@@ -1,0 +1,35 @@
+(ns ctia.test-helpers.benchmark
+  (:require [ctia
+             [events :as events]
+             [init :refer [start-ctia!]]]
+            [ctia.flows.hooks :as hooks]
+            [ctia.http.server :as http-server]
+            [ctia.test-helpers
+             [core :as helpers]
+             [es :as esh]]))
+
+(defn setup-ctia! [fixture]
+  (let [http-port (helpers/available-port)]
+    (println "Default: Launch CTIA on port" http-port)
+    (fixture (fn [] (helpers/fixture-properties:clean
+                    #(helpers/with-properties ["ctia.store.es.default.refresh" false
+                                               "ctia.http.enabled" true
+                                               "ctia.http.port" http-port
+                                               "ctia.http.show.port" http-port]
+                       (start-ctia! :join? false)))))
+    http-port))
+
+
+(defn setup-ctia-atom-store! []
+  (setup-ctia! helpers/fixture-properties:atom-store))
+
+(defn setup-ctia-es-store! []
+  (setup-ctia! esh/fixture-properties:es-store))
+
+(defn setup-ctia-es-store-native! []
+  (setup-ctia! esh/fixture-properties:es-store-native))
+
+(defn cleanup-ctia! [_]
+  (http-server/stop!)
+  (hooks/shutdown!)
+  (events/shutdown!))

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -24,8 +24,8 @@
       (log/error message))
     (when errors
       (log/error errors))
-    (is (= 200 status))
-    (when (= 200 status)
+    (is (= 201 status))
+    (when (= 201 status)
       (is (= new-entity
              result))
       result)))
@@ -41,8 +41,8 @@
         (post path
               :body new-entity
               :headers {"api_key" api-key})]
-    (when (not= 200 status)
-      (throw (ex-info (str "Expected status to be 200 but was " status
+    (when (not= 201 status)
+      (throw (ex-info (str "Expected status to be 201 but was " status
                            " for " path ":\n"
                            (with-out-str (clojure.pprint/pprint response)))
                       {:path path


### PR DESCRIPTION
Added a benchmark system.

To launch it

~~~
lein perforate
~~~

It will start a CTIA server and benchmark actor creation between small and big actor entity.
It takes a _very_ long time (about 2 min) to finish. But in the end you'll have a resume like this:

~~~
Goal:  Create Actor
-----
Case:  :small-actor
Evaluation count : 23580 in 60 samples of 393 calls.
             Execution time mean : 2.545941 ms
    Execution time std-deviation : 86.434541 µs
   Execution time lower quantile : 2.482845 ms ( 2.5%)
   Execution time upper quantile : 2.787981 ms (97.5%)

Found 2 outliers in 60 samples (3.3333 %)
	low-severe	 2 (3.3333 %)
 Variance from outliers : 20.6060 % Variance is moderately inflated by outliers

Case:  :big-actor
Evaluation count : 5280 in 60 samples of 88 calls.
             Execution time mean : 11.069992 ms
    Execution time std-deviation : 519.617484 µs
   Execution time lower quantile : 10.623136 ms ( 2.5%)
   Execution time upper quantile : 12.150540 ms (97.5%)

Found 2 outliers in 60 samples (3.3333 %)
	low-severe	 1 (1.6667 %)
	low-mild	 1 (1.6667 %)
 Variance from outliers : 33.5521 % Variance is moderately inflated by outliers
~~~

I'm not familiar with this library, apparently we can also use fixtures. But I believe that using the `setup` and `cleanup` helps not counting the start and shutdown of the server in the tests time.