### PR TITLE
Updated to clj-momo 0.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,13 +19,14 @@
                  [com.taoensso/carmine "2.12.2"]
                  [org.clojure/tools.cli "0.3.5"]
                  [pandect "0.6.0"]
-                 [threatgrid/clj-momo "0.2.0"]
+                 [threatgrid/clj-momo "0.2.1"]
 
                  ;; Schemas
                  [prismatic/schema "1.0.5"]
                  [metosin/schema-tools "0.7.0"
                   :exclusions [prismatic/schema]]
-                 [threatgrid/ctim "0.1.6"]
+                 [threatgrid/ctim "0.1.6"
+                  :exclusions [threatgrid/clj-momo]]
 
                  ;; Web server
                  [metosin/compojure-api "1.0.0"]

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -1,5 +1,5 @@
 (ns ctia.test-helpers.http
-  (:require [clj-momo.test-helpers.http :as mthh]
+  (:require [clj-momo.test-helpers.http-assert-1 :as mthh]
             [ctia.test-helpers.core :as th]))
 
 (def api-key "45c1f5e3f05d0")


### PR DESCRIPTION
Namespace change for the HTTP assertion helpers.

Related to threatgrid/clj-momo#4