### PR TITLE
CTIM PR #61 Support - Bundle Changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.1.9"]
+                 [threatgrid/ctim "0.1.10-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -740,6 +740,7 @@
      :sightings {:type "object" :enabled false}
      :ttps {:type "object" :enabled false}
      :verdicts {:type "object" :enabled false}
+     :others {:type "object" :enabled false}
 
      :actor_refs string
      :campaign_refs string
@@ -751,7 +752,9 @@
      :judgement_refs string
      :sighting_refs string
      :ttp_refs string
-     :verdict_refs string}}})
+     :verdict_refs string
+     :other_refs string}}})
+
 (def store-mappings
   (merge {}
          judgement-mapping

--- a/test/ctia/http/routes/bundle_test.clj
+++ b/test/ctia/http/routes/bundle_test.clj
@@ -70,14 +70,14 @@
           ttps (repeat 10 ttp)
           new-bundle {:valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                    :end_time #inst "2016-07-11T00:40:48.212-00:00"}
-                      :ttps ttps
                       :source "iroh"
                       :schema_version schema-version
                       :type "bundle"
-                      :judgements judgements
-                      :indicators indicators
-                      :actor_refs actor-refs
-                      :verdict_refs verdict-refs}
+                      :judgements (set judgements)
+                      :indicators (set indicators)
+                      :ttps (set ttps)
+                      :actor_refs (set actor-refs)
+                      :verdict_refs (set verdict-refs)}
 
           response (post "ctia/bundle"
                          :body new-bundle


### PR DESCRIPTION
This PR holds the necessary changes to make it work with CTIM Bundle latest changes.

- Updated ES Mapping
- ring-swagger seems to translates `set` container as `vector`, added a custom bundle spec with a coercion before validation
- updated bundle tests