### PR TITLE
updated swagger api description documentation link

### DIFF
--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -64,7 +64,7 @@
   priority, than Clean disposition has priority over all others, then
   Malicious disposition, and so on down to Unknown.
 
-  <a href='/doc/data_structures.md'>Data structures documentation</a>")
+  <a href='/doc/README.md'>CTIA Documentation</a>")
 
 (defapi api-handler
   {:exceptions

--- a/src/ctia/http/routes/documentation.clj
+++ b/src/ctia/http/routes/documentation.clj
@@ -83,7 +83,7 @@
 (def render-request-with-cache
   "request cache wrapper"
   (memo/ttl
-   render-request 
+   render-request
    :ttl/threshold cache-ttl-ms))
 
 (defroutes documentation-routes


### PR DESCRIPTION
as the documentation changed, the CTIM docs is no longer on the CTIA project, this changes the link so that it points to the README.