### PR TITLE
Improve bulk insert performance

### DIFF
--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -1,14 +1,36 @@
 (ns ctia.flows.crud
   "This namespace handle all necessary flows for creating, updating and deleting entities."
   (:import java.util.UUID)
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.core.async :as a]
+            [clojure.core.async.impl.protocols :as ap]
+            [clojure.tools.logging :as log]
             [ctia.auth :as auth]
             [ctia.flows.hooks :as h]
+            [ctia.lib.async :as la]
             [ctim.events.obj-to-event :refer [to-create-event
                                               to-update-event
                                               to-delete-event]]
             [ctim.domain.id :as id]
-            [ring.util.http-response :as http-response]))
+            [ring.util.http-response :as http-response]
+            [schema.core :as s]))
+
+(def FlowMap
+  "Parameters that are common across multiple fns below"
+  {:create-event-fn (s/pred fn?)
+   (s/optional-key :delete-chan) (s/protocol ap/Channel)
+   :entity {s/Keyword s/Any}
+   (s/optional-key :entity-chan) (s/protocol ap/Channel)
+   (s/optional-key :entity-id) s/Str
+   :entity-type s/Keyword
+   (s/optional-key :event-chan) (s/protocol ap/Channel)
+   :flow-type (s/enum :create :update :delete)
+   :identity (s/protocol auth/IIdentity)
+   :login s/Str
+   (s/optional-key :prev-entity) (s/maybe {s/Keyword s/Any})
+   (s/optional-key :realize-fn) (s/pred fn?)
+   (s/optional-key :result-chan) (s/protocol ap/Channel)
+   (s/optional-key :side-effect-chans) [(s/protocol ap/Channel)]
+   :store-fn (s/pred fn?)})
 
 (defn- find-id
   "Lookup an ID in a given entity.  Parse it, because it might be a
@@ -22,64 +44,147 @@
   [entity-type]
   (str (name entity-type) "-" (UUID/randomUUID)))
 
-(defn- find-entity-id [identity entity-type entity prev-entity]
-  (or (find-id prev-entity)
-      (when-let [entity-id (find-id entity)]
-        (when-not (auth/capable? identity :specify-id)
-          (throw (http-response/bad-request!
-                  {:error "Missing capability to specify entity ID"
-                   :entity entity})))
-        (if (id/valid-short-id? entity-id)
-          entity-id
-          (throw (http-response/bad-request!
-                  {:error (format "Invalid entity ID: %s" entity-id)
-                   :entity entity}))))
-      (make-id entity-type)))
+(s/defn ^:private find-entity-id :- FlowMap
+  [{:keys [entity entity-id entity-type identity prev-entity] :as fm} :- FlowMap]
+  (assoc fm
+         :entity-id
+         (or entity-id
+             (find-id prev-entity)
+             (when-let [entity-id (find-id entity)]
+               (when-not (auth/capable? identity :specify-id)
+                 (throw (http-response/bad-request!
+                         {:error "Missing capability to specify entity ID"
+                          :entity entity})))
+               (if (id/valid-short-id? entity-id)
+                 entity-id
+                 (throw (http-response/bad-request!
+                         {:error (format "Invalid entity ID: %s" entity-id)
+                          :entity entity}))))
+             (make-id entity-type))))
 
-(defn- handle-flow
-  [& {:keys [flow-type
-             entity-type
-             entity
-             prev-entity
-             identity
-             realize-fn
-             store-fn
-             create-event-fn]}]
-  (let [login (auth/login identity)
-        entity-id (find-entity-id identity entity-type entity prev-entity)
-        realized (h/apply-hooks :entity (case flow-type
-                                          :create (realize-fn entity entity-id login)
-                                          :update (realize-fn entity entity-id login prev-entity)
-                                          :delete entity)
-                                :prev-entity prev-entity
-                                :hook-type (case flow-type
-                                             :create :before-create
-                                             :update :before-update
-                                             :delete :before-delete)
-                                :read-only? (= flow-type :delete))
-        event (try
-                (if (= :update flow-type)
-                  (create-event-fn realized prev-entity)
-                  (create-event-fn realized))
-                (catch Throwable e
-                  (log/error "Could not create event" e)
-                  (throw (ex-info "Could not create event"
-                                  {:flow-type flow-type
-                                   :login login
-                                   :entity realized
-                                   :prev-entity prev-entity}))))
-        result (if (= :delete flow-type)
-                 (store-fn entity-id)
-                 (store-fn realized))]
-    (h/apply-event-hooks event)
-    (h/apply-hooks :entity realized
-                   :prev-entity prev-entity
-                   :hook-type (case flow-type
-                                :create :after-create
-                                :update :after-update
-                                :delete :after-delete)
-                   :read-only? true)
-    result))
+(s/defn ^:private realize-entity :- FlowMap
+  [{:keys [realize-fn flow-type entity prev-entity login entity-id] :as fm} :- FlowMap]
+  (assoc fm
+         :entity-chan
+         (la/on-chan
+          (case flow-type
+            :create (realize-fn entity entity-id login)
+            :update (realize-fn entity entity-id login prev-entity)
+            :delete entity))))
+
+(defn- apply-create-event-fn
+  [create-event-fn realized prev-entity flow-type login]
+  (try
+    (if (= :update flow-type)
+      (create-event-fn realized prev-entity)
+      (create-event-fn realized))
+    (catch Throwable e
+      (log/error "Could not create event" e)
+      (throw (ex-info "Could not create event"
+                      {:flow-type flow-type
+                       :login login
+                       :entity realized
+                       :prev-entity prev-entity})))))
+
+(s/defn ^:private create-event-xf :- (s/pred fn?)
+  [{:keys [create-event-fn prev-entity flow-type login]} :- FlowMap]
+  (fn [rf]
+    (fn
+      ([] (rf))
+      ([result] (rf result))
+      ([result entity]
+       (let [event (apply-create-event-fn create-event-fn
+                                          entity
+                                          prev-entity
+                                          flow-type
+                                          login)]
+         (rf result event))))))
+
+(s/defn ^:private make-event-chan :- FlowMap
+  "Take an entity-chan and, using a mult, clone it to a new
+  entity-chan and an event-chan.  The event chan uses an event
+  producing transducer."
+  [{:keys [entity-chan] :as fm} :- FlowMap]
+
+  (let [m-chan (a/chan)
+        mult (a/mult m-chan)
+        new-entity-chan (a/chan)
+        new-event-chan (a/chan 1 ; must be >0
+                               (create-event-xf fm)
+                               la/throwable)]
+    (a/tap mult new-event-chan)
+    (a/tap mult new-entity-chan)
+    ;; Have to pipe after taps to avoid race
+    (a/pipe entity-chan m-chan)
+    (assoc fm
+           :entity-chan new-entity-chan
+           :event-chan new-event-chan)))
+
+(s/defn ^:private apply-before-hooks :- FlowMap
+  [{:keys [prev-entity entity-chan flow-type] :as fm} :- FlowMap]
+  (assoc fm
+         :entity-chan
+         (h/apply-hooks :entity-chan entity-chan
+                        :prev-entity prev-entity
+                        :hook-type (case flow-type
+                                     :create :before-create
+                                     :update :before-update
+                                     :delete :before-delete)
+                        :read-only? (= flow-type :delete))))
+
+(s/defn ^:private apply-event-hooks :- FlowMap
+  [{:keys [event-chan] :as fm} :- FlowMap]
+  (assoc fm
+         :event-chan
+         (h/apply-event-hooks event-chan)))
+
+(s/defn ^:private apply-after-hooks :- FlowMap
+  [{:keys [prev-entity entity-chan flow-type] :as fm} :- FlowMap]
+  (assoc fm
+         :entity-chan
+         (h/apply-hooks :entity-chan entity-chan
+                        :prev-entity prev-entity
+                        :hook-type (case flow-type
+                                     :create :after-create
+                                     :update :after-update
+                                     :delete :after-delete)
+                        :read-only? true)))
+
+(s/defn ^:private apply-store-fn :- FlowMap
+  [{:keys [entity-chan store-fn] :as fm} :- FlowMap]
+  (assoc fm
+         :entity-chan
+         (store-fn entity-chan)))
+
+(s/defn ^:private apply-delete-fn :- FlowMap
+  [{:keys [entity-id store-fn] :as fm} :- FlowMap]
+  (assoc fm
+         :delete-chan
+         (store-fn (doto (a/promise-chan)
+                     (a/>!! entity-id)))))
+
+(s/defn ^:private result-chan :- FlowMap
+  [fm :- FlowMap
+   fm-key :- s/Keyword]
+  (-> fm
+      (assoc :result-chan (get fm fm-key))
+      (dissoc fm-key)))
+
+(s/defn ^:private side-effects-chan :- FlowMap
+  [fm :- FlowMap
+   fm-key :- s/Keyword]
+  (-> fm
+      (update :side-effect-chans conj (get fm fm-key))
+      (dissoc fm-key)))
+
+(s/defn pop-result :- (s/conditional map? {s/Keyword s/Any}
+                                     :else s/Bool)
+  "Takes a FlowMap and waits on all of the side-effect-chans
+   and the result-chan, returning the latter's output."
+  [{:keys [result-chan side-effect-chans]} :- FlowMap]
+  (doseq [c side-effect-chans]
+    (la/<!! c))
+  (la/<!! result-chan))
 
 (defn create-flow
   "This function centralizes the create workflow.
@@ -93,13 +198,23 @@
              store-fn
              identity
              entity]}]
-  (handle-flow :flow-type :create
-               :entity-type entity-type
-               :entity entity
-               :identity identity
-               :realize-fn realize-fn
-               :store-fn store-fn
-               :create-event-fn to-create-event))
+  (-> {:create-event-fn to-create-event
+       :flow-type :create
+       :entity entity
+       :entity-type entity-type
+       :identity identity
+       :login (auth/login identity)
+       :realize-fn realize-fn
+       :store-fn store-fn}
+      find-entity-id
+      realize-entity
+      apply-before-hooks
+      make-event-chan
+      apply-store-fn
+      apply-event-hooks
+      (side-effects-chan :event-chan)
+      apply-after-hooks
+      (result-chan :entity-chan)))
 
 (defn update-flow
   "This function centralize the update workflow.
@@ -115,15 +230,24 @@
              entity-id
              identity
              entity]}]
-  (let [prev-entity (get-fn entity-id)]
-    (handle-flow :flow-type :update
-                 :entity-type entity-type
-                 :entity entity
-                 :prev-entity prev-entity
-                 :identity identity
-                 :realize-fn realize-fn
-                 :store-fn update-fn
-                 :create-event-fn to-update-event)))
+  (-> {:create-event-fn to-update-event
+       :flow-type :update
+       :entity entity
+       :entity-type entity-type
+       :identity identity
+       :login (auth/login identity)
+       :prev-entity (get-fn entity-id)
+       :realize-fn realize-fn
+       :store-fn update-fn}
+      find-entity-id
+      realize-entity
+      apply-before-hooks
+      make-event-chan
+      apply-store-fn
+      apply-event-hooks
+      (side-effects-chan :event-chan)
+      apply-after-hooks
+      (result-chan :entity-chan)))
 
 (defn delete-flow
   "This function centralize the deletion workflow.
@@ -139,10 +263,21 @@
              entity-id
              identity]}]
   (let [entity (get-fn entity-id)]
-    (handle-flow :flow-type :delete
-                 :entity-type entity-type
-                 :entity entity
-                 :prev-entity entity
-                 :identity identity
-                 :store-fn delete-fn
-                 :create-event-fn to-delete-event)))
+    (-> {:create-event-fn to-delete-event
+         :entity entity
+         :entity-chan (la/on-chan entity)
+         :entity-type entity-type
+         :flow-type :delete
+         :identity identity
+         :login (auth/login identity)
+         :prev-entity entity
+         :store-fn delete-fn}
+        find-entity-id
+        apply-before-hooks
+        make-event-chan
+        apply-delete-fn
+        apply-event-hooks
+        (side-effects-chan :event-chan)
+        apply-after-hooks
+        (side-effects-chan :entity-chan)
+        (result-chan :delete-chan))))

--- a/src/ctia/flows/hooks.clj
+++ b/src/ctia/flows/hooks.clj
@@ -1,36 +1,51 @@
 (ns ctia.flows.hooks
   "Handle hooks ([Cf. #159](https://github.com/threatgrid/ctia/issues/159))."
-  (:require [ctia.flows.autoload :as auto-hooks]
+  (:require [clojure.core.async :as a]
+            [ctia.flows
+             [autoload :as auto-hooks]
+             [hooks-pipe :as fhp]]
+            [ctia.flows.hooks.after-hooks :as after-hooks]
             [ctia.flows.hooks.event-hooks :as event-hooks]
-            [ctia.flows.hook-protocol
-             :refer [Hook] :as prot]
+            [ctia.flows
+             [hooks-pipe :as fhp]
+             [hook-protocol
+              :refer [Hook]
+              :as prot]]
+            [ctia.lib.async :as la]
             [ctia.shutdown :as shutdown]))
 
 (defn- doc-list [& s]
   (with-meta [] {:doc (apply str s)}))
 
 (def empty-hooks
-  {:before-create (doc-list "`before-create` hooks are triggered on"
-                            " create routes before the entity is saved in the DB.")
+  {:before-create (doc-list "`before-create` hooks are triggered on create "
+                            "routes before the entity is saved in the DB.")
 
-   :after-create (doc-list "`after-create` hooks are called after an entity was created.")
+   :after-create (doc-list "`after-create` hooks are called after an entity was"
+                           " created.")
 
    :before-update (doc-list "`before-update` hooks are triggered on"
-                            " update routes before the entity is saved in the DB.")
+                            " update routes before the entity is saved in the "
+                            "DB.")
 
-   :after-update (doc-list "`after-update` hooks are called after an entity was updated.")
+   :after-update (doc-list "`after-update` hooks are called after an entity was "
+                           "updated.")
 
-   :before-delete (doc-list "`before-delete` hooks are called before an entity is deleted.")
+   :before-delete (doc-list "`before-delete` hooks are called before an entity "
+                            "is deleted.")
 
-   :after-delete (doc-list "`after-delete` hooks are called after an entity is deleted.")
+   :after-delete (doc-list "`after-delete` hooks are called after an entity is "
+                           "deleted.")
 
-   :event (doc-list "`event` hooks are called with an event during any CRUD activity.")})
+   :event (doc-list "`event` hooks are called with an event during any CRUD "
+                    "activity.")})
 
 (defonce hooks (atom empty-hooks))
 
 (defn reset-hooks! []
   (reset! hooks
           (-> empty-hooks
+              after-hooks/register-hooks
               event-hooks/register-hooks
               auto-hooks/register-hooks)))
 
@@ -53,7 +68,7 @@
   @hooks)
 
 (defn destroy-hooks!
-  "Should call all destructor for each hook in reverse order."
+  "Should call all destructors for each hook in reverse order."
   []
   (doseq [hook-list (vals @hooks)
           hook (reverse hook-list)]
@@ -61,26 +76,28 @@
 
 (defn apply-hooks
   "Apply the registered hooks for a given hook-type to the passed in data.
-   Data may be an entity (or an event) and a previous entity.  Accepts
-  read-only?, in which case the result of the hooks do not change the result.
-  In any hook returns nil, the result is ignored and the input entity is kept."
-  [& {:keys [hook-type
-             entity
-             prev-entity
-             read-only?]}]
-  (loop [[hook & more-hooks :as hooks] (get @hooks hook-type)
-         result entity]
-    (if (empty? hooks)
-      result
-      (let [handle-result (prot/handle hook result prev-entity)]
-        (if (or read-only?
-                (nil? handle-result))
-          (recur more-hooks result)
-          (recur more-hooks handle-result))))))
 
-(defn apply-event-hooks [event]
+  Data may be an entity (or an event) and a previous entity (the
+  entity is read from the passed in entity-chan channel).  Accepts
+  read-only?, in which case the result of the hooks do not change the
+  result.  If any hook returns nil, the result is ignored and the
+  previous result is preserved.
+
+  Application is done on one of the hooks-pipe threads (asynchronous)."
+  [& {:keys [hook-type
+             entity-chan
+             prev-entity
+             read-only?] :as args}]
+  (if-let [hooks (seq (get @hooks hook-type))]
+    (fhp/apply-hooks {:entity-chan entity-chan
+                      :hooks hooks
+                      :prev-entity prev-entity
+                      :read-only? read-only?})
+    entity-chan))
+
+(defn apply-event-hooks [event-chan]
   (apply-hooks :hook-type :event
-               :entity event
+               :entity-chan event-chan
                :read-only? true))
 
 (defn shutdown!
@@ -92,4 +109,5 @@
 (defn init! []
   (reset-hooks!)
   (init-hooks!)
+  (fhp/init-hooks-pipe!)
   (shutdown/register-hook! :flows.hooks shutdown!))

--- a/src/ctia/flows/hooks/after_hooks.clj
+++ b/src/ctia/flows/hooks/after_hooks.clj
@@ -1,0 +1,48 @@
+(ns ctia.flows.hooks.after-hooks
+  (:require [clojure.string :as str]
+            [ctia.domain.entities :as entities]
+            [ctia.flows.hook-protocol :refer [Hook]]
+            [ctia.lib.async :as la]
+            [ctia.schemas.core :refer [StoredJudgement StoredVerdict Verdict]]
+            [ctia.store :as store]
+            [schema.core :as s]))
+
+(defn- judgement? [{:keys [type]}]
+  (= type "judgement"))
+
+(def ^:private judgement-prefix "judgement-")
+
+(s/defn ^:private verdict-id :- s/Str
+  [j-id :- s/Str]
+  (str "verdict-" (subs j-id
+                        (count judgement-prefix))))
+
+(s/defn realize-verdict-wrapper :- StoredVerdict
+  [verdict :- Verdict
+   {id :id, :as judgement} :- StoredJudgement
+   owner :- s/Str]
+  (if (str/starts-with? id judgement-prefix)
+    (entities/realize-verdict verdict (verdict-id id) owner)
+    (entities/realize-verdict verdict owner)))
+
+(defrecord VerdictGenerator []
+  Hook
+  (init [_] :nothing)
+  (destroy [_] :nothing)
+  (handle [_ {:keys [observable owner] :as entity} _]
+    (when (judgement? entity)
+      (when-let [new-verdict (some->
+                              (store/read-store :judgement
+                                                store/calculate-verdict
+                                                observable)
+                              (realize-verdict-wrapper entity owner))]
+        (la/<!!
+         (store/write-store :verdict
+                            store/create-verdict
+                            (la/on-chan new-verdict)))))))
+
+(s/defn register-hooks :- {s/Keyword [(s/protocol Hook)]}
+  [hooks-m :- {s/Keyword [(s/protocol Hook)]}]
+  (cond-> hooks-m
+    :always (update :after-create #(conj % (->VerdictGenerator)))
+    :always (update :after-update #(conj % (->VerdictGenerator)))))

--- a/src/ctia/flows/hooks_pipe.clj
+++ b/src/ctia/flows/hooks_pipe.clj
@@ -23,18 +23,9 @@
   lp/WorkHandler
   (make-worker [this]
     (a/thread
-      (let [[msg port] (a/alts!! [work-chan (a/timeout worker-max-sleep-ms)]
-                                 :priority true)]
-        (cond
-          ;; timed out while waiting
-          (not= port work-chan) (recur)
-
-          ;; the work-chan closed; terminate
-          (nil? msg) nil
-
-          ;; do some work
-          :else (do (lp/do-some-work this msg)
-                    (recur))))))
+      (when-let [msg (la/<!! work-chan)]
+        (lp/do-some-work this msg)
+        (recur))))
 
   (do-some-work [_ {:keys [result-chan entity-chan hooks prev-entity read-only?]}]
     (try

--- a/src/ctia/flows/hooks_pipe.clj
+++ b/src/ctia/flows/hooks_pipe.clj
@@ -1,0 +1,75 @@
+(ns ctia.flows.hooks-pipe
+  (:require [clojure.core.async :as a]
+            [clojure.core.async.impl.protocols :as ap]
+            [ctia.flows.hook-protocol :as fhp]
+            [ctia.lib.async :as la]
+            [ctia.lib.pipes :as lp]
+            [ctia.shutdown :as shutdown]
+            [schema.core :as s]))
+
+(def pipe (atom nil))
+
+(defrecord HooksPipe [work-chan worker-max-sleep-ms]
+  lp/AsyncPipe
+  (start-workers [this num-workers]
+    (lp/do-start-workers this num-workers))
+
+  (shutdown! [_]
+    (a/close! work-chan))
+
+  (add-job [_ job]
+    (a/>!! work-chan job))
+
+  lp/WorkHandler
+  (make-worker [this]
+    (a/thread
+      (let [[msg port] (a/alts!! [work-chan (a/timeout worker-max-sleep-ms)]
+                                 :priority true)]
+        (cond
+          ;; timed out while waiting
+          (not= port work-chan) (recur)
+
+          ;; the work-chan closed; terminate
+          (nil? msg) nil
+
+          ;; do some work
+          :else (do (lp/do-some-work this msg)
+                    (recur))))))
+
+  (do-some-work [_ {:keys [result-chan entity-chan hooks prev-entity read-only?]}]
+    (try
+      (loop [[hook & more-hooks] hooks
+             result (la/<!! entity-chan)]
+        (if (nil? hook)
+          (la/on-chan result-chan result)
+          (let [handle-result (fhp/handle hook result prev-entity)]
+            (recur more-hooks (if (or read-only?
+                                      (nil? handle-result))
+                                result
+                                handle-result)))))
+      (catch Throwable t
+        (la/on-chan result-chan t)))))
+
+(s/defschema PipeHooksMap
+  {:entity-chan (s/protocol ap/Channel)
+   :hooks [(s/protocol fhp/Hook)]
+   :prev-entity (s/maybe {s/Keyword s/Any})
+   :read-only? (s/maybe s/Bool)})
+
+(s/defn apply-hooks :- (s/protocol ap/Channel)
+  "Put a message on the pipe"
+  [m :- PipeHooksMap]
+  (let [result-chan (a/chan 1)]
+    (lp/add-job @pipe (assoc m :result-chan result-chan))
+    result-chan))
+
+(defn init-hooks-pipe! []
+  (reset! pipe
+          (doto (map->HooksPipe {:work-chan (a/chan 1000)
+                                 :worker-max-sleep-ms 250})
+            (lp/start-workers 20)))
+  (shutdown/register-hook!
+   :flows.hooks-pipe
+   (fn []
+     (swap! pipe
+            #(some-> % lp/shutdown!)))))

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -1,7 +1,7 @@
 (ns ctia.http.routes.bundle
   (:require [compojure.api.sweet :refer :all]
             [ctia.domain.entities :refer [realize-bundle]]
-            [ctia.flows.crud :as flows]
+            [ctia.flows.crud :as f]
             [ctia.store :refer :all]
             [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
             [ctia.schemas.core :refer [NewBundle StoredBundle]]
@@ -19,12 +19,14 @@
       :summary "Adds a new Bundle"
       :capabilities :create-bundle
       :identity identity
-      (created (flows/create-flow :entity-type :bundle
-                                  :realize-fn realize-bundle
-                                  :store-fn #(write-store :bundle create-bundle %)
-                                  :entity-type :bundle
-                                  :identity identity
-                                  :entity bundle)))
+      (created
+       (f/pop-result
+        (f/create-flow :entity-type :bundle
+                       :realize-fn realize-bundle
+                       :store-fn #(write-store :bundle create-bundle %)
+                       :entity-type :bundle
+                       :identity identity
+                       :entity bundle))))
     (GET "/:id" []
       :return (s/maybe StoredBundle)
       :summary "Gets a Bundle by ID"
@@ -42,10 +44,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :delete-bundle
       :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :bundle read-bundle %)
-                             :delete-fn #(write-store :bundle delete-bundle %)
-                             :entity-type :bundle
-                             :entity-id id
-                             :identity identity)
+      (if (f/pop-result
+           (f/delete-flow :get-fn #(read-store :bundle read-bundle %)
+                          :delete-fn #(write-store :bundle delete-bundle %)
+                          :entity-type :bundle
+                          :entity-id id
+                          :identity identity))
         (no-content)
         (not-found)))))

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -3,7 +3,7 @@
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :refer [realize-data-table]]
    [ctia.domain.entities.data-table :refer [with-long-id page-with-long-id]]
-   [ctia.flows.crud :as flows]
+   [ctia.flows.crud :as f]
    [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewDataTable StoredDataTable]]
@@ -28,12 +28,13 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :entity-type :data-table
-                                       :realize-fn realize-data-table
-                                       :store-fn #(write-store :data-table create-data-table %)
-                                       :entity-type :data-table
-                                       :identity identity
-                                       :entity data-table))))
+                    (f/pop-result
+                     (f/create-flow :entity-type :data-table
+                                    :realize-fn realize-data-table
+                                    :store-fn #(write-store :data-table create-data-table %)
+                                    :entity-type :data-table
+                                    :identity identity
+                                    :entity data-table)))))
            (GET "/external_id" []
                 :return [(s/maybe StoredDataTable)]
                 :query [q DataTableByExternalIdQueryParams]
@@ -62,10 +63,11 @@
                    :header-params [api_key :- (s/maybe s/Str)]
                    :capabilities :delete-data-table
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :data-table read-data-table %)
-                                          :delete-fn #(write-store :data-table delete-data-table %)
-                                          :entity-type :data-table
-                                          :entity-id id
-                                          :identity identity)
+                   (if (f/pop-result
+                        (f/delete-flow :get-fn #(read-store :data-table read-data-table %)
+                                       :delete-fn #(write-store :data-table delete-data-table %)
+                                       :entity-type :data-table
+                                       :entity-id id
+                                       :identity identity))
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -3,7 +3,7 @@
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :refer [realize-exploit-target]]
    [ctia.domain.entities.exploit-target :refer [with-long-id page-with-long-id]]
-   [ctia.flows.crud :as flows]
+   [ctia.flows.crud :as f]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewExploitTarget StoredExploitTarget]]
    [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
@@ -29,11 +29,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-exploit-target
-                            :store-fn #(write-store :exploit-target create-exploit-target %)
-                            :entity-type :exploit-target
-                            :identity identity
-                            :entity exploit-target))))
+         (f/pop-result
+          (f/create-flow :realize-fn realize-exploit-target
+                         :store-fn #(write-store :exploit-target create-exploit-target %)
+                         :entity-type :exploit-target
+                         :identity identity
+                         :entity exploit-target)))))
     (PUT "/:id" []
       :return StoredExploitTarget
       :body [exploit-target
@@ -46,13 +47,14 @@
       :identity identity
       (ok
        (with-long-id
-         (flows/update-flow :get-fn #(read-store :exploit-target read-exploit-target %)
-                            :realize-fn realize-exploit-target
-                            :update-fn #(write-store :exploit-target update-exploit-target (:id %) %)
-                            :entity-type :exploit-target
-                            :entity-id id
-                            :identity identity
-                            :entity exploit-target))))
+         (f/pop-result
+          (f/update-flow :get-fn #(read-store :exploit-target read-exploit-target %)
+                         :realize-fn realize-exploit-target
+                         :update-fn #(write-store :exploit-target update-exploit-target id %)
+                         :entity-type :exploit-target
+                         :entity-id id
+                         :identity identity
+                         :entity exploit-target)))))
 
     (GET "/external_id" []
       :return [(s/maybe StoredExploitTarget)]
@@ -74,6 +76,7 @@
       (if-let [d (read-store :exploit-target read-exploit-target id)]
         (ok (with-long-id d))
         (not-found)))
+
     (DELETE "/:id" []
       :no-doc true
       :path-params [id :- s/Str]
@@ -81,10 +84,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :delete-exploit-target
       :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :exploit-target read-exploit-target %)
-                             :delete-fn #(write-store :exploit-target delete-exploit-target %)
-                             :entity-type :exploit-target
-                             :entity-id id
-                             :identity identity)
+      (if (f/pop-result
+           (f/delete-flow :get-fn #(read-store :exploit-target read-exploit-target %)
+                          :delete-fn #(write-store :exploit-target delete-exploit-target %)
+                          :entity-type :exploit-target
+                          :entity-id id
+                          :identity identity))
         (no-content)
         (not-found)))))

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -3,7 +3,7 @@
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :refer [realize-feedback]]
    [ctia.domain.entities.feedback :refer [with-long-id page-with-long-id]]
-   [ctia.flows.crud :as flows]
+   [ctia.flows.crud :as f]
    [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewFeedback StoredFeedback]]
@@ -33,11 +33,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-feedback
-                            :store-fn #(write-store :feedback create-feedback %)
-                            :entity-type :feedback
-                            :identity identity
-                            :entity feedback))))
+         (f/pop-result
+          (f/create-flow :realize-fn realize-feedback
+                         :store-fn #(write-store :feedback create-feedback %)
+                         :entity-type :feedback
+                         :identity identity
+                         :entity feedback)))))
 
     (GET "/" []
       :return [StoredFeedback]
@@ -81,10 +82,11 @@
       :header-params [api_key :- (s/maybe s/Str)]
       :capabilities :delete-feedback
       :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :feedback read-feedback %)
-                             :delete-fn #(write-store :feedback delete-feedback %)
-                             :entity-type :feedback
-                             :entity-id id
-                             :identity identity)
+      (if (f/pop-result
+           (f/delete-flow :get-fn #(read-store :feedback read-feedback %)
+                          :delete-fn #(write-store :feedback delete-feedback %)
+                          :entity-type :feedback
+                          :entity-id id
+                          :identity identity))
         (no-content)
         (not-found)))))

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -5,7 +5,7 @@
             [ctia.domain.entities
              [indicator :refer [with-long-id page-with-long-id]]
              [sighting :as sighting]]
-            [ctia.flows.crud :as flows]
+            [ctia.flows.crud :as f]
             [ctia.http.routes.common
              :refer [created PagingParams paginated-ok]]
             [ctia.store :refer :all]
@@ -54,11 +54,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-indicator
-                            :store-fn #(write-store :indicator create-indicator %)
-                            :entity-type :indicator
-                            :identity identity
-                            :entity indicator))))
+         (f/pop-result
+          (f/create-flow :realize-fn realize-indicator
+                         :store-fn #(write-store :indicator create-indicator %)
+                         :entity-type :indicator
+                         :identity identity
+                         :entity indicator)))))
     (PUT "/:id" []
       :return StoredIndicator
       :body [indicator NewIndicator {:description "an updated Indicator"}]
@@ -69,13 +70,14 @@
       :identity identity
       (ok
        (with-long-id
-         (flows/update-flow :get-fn #(read-store :indicator read-indicator %)
-                            :realize-fn realize-indicator
-                            :update-fn #(write-store :indicator update-indicator (:id %) %)
-                            :entity-type :indicator
-                            :entity-id id
-                            :identity identity
-                            :entity indicator))))
+         (f/pop-result
+          (f/update-flow :get-fn #(read-store :indicator read-indicator %)
+                         :realize-fn realize-indicator
+                         :update-fn #(write-store :indicator update-indicator id %)
+                         :entity-type :indicator
+                         :entity-id id
+                         :identity identity
+                         :entity indicator)))))
 
     (GET "/external_id" []
       :return [(s/maybe StoredIndicator)]

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -3,7 +3,7 @@
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :refer [realize-feedback realize-judgement]]
    [ctia.domain.entities.judgement :refer [with-long-id page-with-long-id]]
-   [ctia.flows.crud :as flows]
+   [ctia.flows.crud :as f]
    [ctia.http.routes.common
     :refer [created paginated-ok PagingParams]]
    [ctia.properties :refer [get-http-show]]
@@ -44,11 +44,12 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :realize-fn realize-judgement
-                                       :store-fn #(write-store :judgement create-judgement %)
-                                       :entity-type :judgement
-                                       :identity identity
-                                       :entity judgement))))
+                    (f/pop-result
+                     (f/create-flow :realize-fn realize-judgement
+                                    :store-fn #(write-store :judgement create-judgement %)
+                                    :entity-type :judgement
+                                    :identity identity
+                                    :entity judgement)))))
            (POST "/:judgement-id/indicator" []
                  :return (s/maybe RelatedIndicator)
                  :path-params [judgement-id :- s/Str]
@@ -94,10 +95,11 @@
                    :summary "Deletes a Judgement"
                    :capabilities :delete-judgement
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :judgement read-judgement %)
-                                          :delete-fn #(write-store :judgement delete-judgement %)
-                                          :entity-type :judgement
-                                          :entity-id id
-                                          :identity identity)
+                   (if (f/pop-result
+                        (f/delete-flow :get-fn #(read-store :judgement read-judgement %)
+                                       :delete-fn #(write-store :judgement delete-judgement %)
+                                       :entity-type :judgement
+                                       :entity-id id
+                                       :identity identity))
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -3,7 +3,7 @@
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :refer [realize-relationship]]
    [ctia.domain.entities.relationship :refer [with-long-id page-with-long-id]]
-   [ctia.flows.crud :as flows]
+   [ctia.flows.crud :as f]
    [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewRelationship StoredRelationship]]
@@ -28,12 +28,13 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :entity-type :relationship
-                                       :realize-fn realize-relationship
-                                       :store-fn #(write-store :relationship create-relationship %)
-                                       :entity-type :relationship
-                                       :identity identity
-                                       :entity relationship))))
+                    (f/pop-result
+                     (f/create-flow :entity-type :relationship
+                                    :realize-fn realize-relationship
+                                    :store-fn #(write-store :relationship create-relationship %)
+                                    :entity-type :relationship
+                                    :identity identity
+                                    :entity relationship)))))
            (GET "/external_id" []
                 :return [(s/maybe StoredRelationship)]
                 :query [q RelationshipByExternalIdQueryParams]
@@ -62,10 +63,11 @@
                    :header-params [api_key :- (s/maybe s/Str)]
                    :capabilities :delete-relationship
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :relationship read-relationship %)
-                                          :delete-fn #(write-store :relationship delete-relationship %)
-                                          :entity-type :relationship
-                                          :entity-id id
-                                          :identity identity)
+                   (if (f/pop-result
+                        (f/delete-flow :get-fn #(read-store :relationship read-relationship %)
+                                       :delete-fn #(write-store :relationship delete-relationship %)
+                                       :entity-type :relationship
+                                       :entity-id id
+                                       :identity identity))
                      (no-content)
                      (not-found)))))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -21,7 +21,9 @@
             [ctia.http.server :as http-server]
             [ctia.shutdown :as shutdown]
             [ctia.stores.atom.store :as as-store]
-            [ctia.stores.es.store :as es-store]))
+            [ctia.stores.es.store :as es-store]
+            [ctia.stores.es.create-pipe :as es-create-pipe]
+            [ctia.stores.store-pipe :as store-pipe]))
 
 (defn init-auth-service! []
   (let [auth-service-type (get-in @p/properties [:ctia :auth :type])]
@@ -104,6 +106,8 @@
     :es es-store/->BundleStore}})
 
 (defn init-store-service! []
+  (store-pipe/init!)
+  (es-create-pipe/init!)
   (doseq [[entity-key impls] @store/stores]
     (swap! store/stores assoc entity-key []))
 

--- a/src/ctia/lib/async.clj
+++ b/src/ctia/lib/async.clj
@@ -125,36 +125,6 @@
            (nil? v) results
            :else (recur (conj results v))))))))
 
-(defn pipe
-  "Alternative to a/pipe that uses a/thread."
-  ([from to]
-   (pipe from to true))
-  ([from to close?]
-   (a/thread
-     (let [v (a/<!! from)]
-       (if (nil? v)
-         (when close? (a/close! to))
-         (when (a/>!! to v)
-           (recur)))))
-   to))
-
-(defn pipe!
-  "Immediate alternative to a/pipe that uses the current thread.
-  Since this isn't asynchronous, it may block the current thread!  In
-  such a case, if some other thread isn't taking from the 'to channel,
-  the current thread will never un-block.  This can be resolved by
-  buffering the 'to channel, but use with caution."
-  ([from to]
-   (pipe! from to true))
-  ([from to close?]
-   (loop []
-     (let [v (a/<!! from)]
-       (if (nil? v)
-         (when close? (a/close! to))
-         (when (a/>!! to v)
-           (recur)))))
-   to))
-
 (defn onto-chan
   "Alternative to a/onto-chan that returns the channel where items are put"
   [chan collection]

--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -2,6 +2,8 @@
   (:require
    [ctia.lib.pagination :as pagination]
    [ctia.lib.es.query :refer [filter-map->terms-query]]
+   [clojurewerkz.elastisch.native.bulk :as native-bulk]
+   [clojurewerkz.elastisch.rest.bulk :as rest-bulk]
    [clojurewerkz.elastisch.native.document :as native-document]
    [clojurewerkz.elastisch.rest.document :as rest-document]
    [clojurewerkz.elastisch.native.response :as native-response]
@@ -21,6 +23,16 @@
   (if (native-conn? conn)
     native-document/create
     rest-document/create))
+
+(defn bulk-create-fn [conn]
+  (if (native-conn? conn)
+    native-bulk/bulk-create
+    rest-bulk/bulk-create))
+
+(defn bulk-fn [conn]
+  (if (native-conn? conn)
+    native-bulk/bulk
+    rest-bulk/bulk))
 
 (defn update-doc-fn [conn]
   (if (native-conn? conn)
@@ -63,6 +75,17 @@
    {:id (:id doc)
     :refresh refresh?})
   doc)
+
+(defn bulk-create-doc
+  "create multiple documents on ES and return the created documents"
+  [conn docs refresh?]
+  (let [bulk-create (bulk-create-fn conn)
+        bulk (bulk-fn conn)
+        create-operations (bulk-create docs)]
+    (bulk conn
+          create-operations
+          {:refresh refresh?}))
+  docs)
 
 (defn update-doc
   "update a document on es return the updated document"

--- a/src/ctia/lib/pipes.clj
+++ b/src/ctia/lib/pipes.clj
@@ -1,0 +1,14 @@
+(ns ctia.lib.pipes)
+
+(defprotocol AsyncPipe
+  (start-workers [this num])
+  (shutdown! [this])
+  (add-job [this job-msg]))
+
+(defprotocol WorkHandler
+  (make-worker [this])
+  (do-some-work [this work]))
+
+(defn do-start-workers [pipe num-workers]
+  (dotimes [_ num-workers]
+    (make-worker pipe)))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -2,92 +2,92 @@
 
 (defprotocol IActorStore
   (read-actor [this id])
-  (create-actor [this new-actor])
-  (update-actor [this id actor])
-  (delete-actor [this id])
+  (create-actor [this new-actor-chan])
+  (update-actor [this id actor-chan])
+  (delete-actor [this id-chan])
   (list-actors [this filtermap params]))
 
 (defprotocol IJudgementStore
-  (create-judgement [this new-judgement])
+  (create-judgement [this new-judgement-chan])
   (read-judgement [this id])
-  (delete-judgement [this id])
+  (delete-judgement [this id-chan])
   (list-judgements [this filter-map params])
   (calculate-verdict [this observable])
   (list-judgements-by-observable [this observable params])
   (add-indicator-to-judgement [this judgement-id indicator-relationship]))
 
 (defprotocol IVerdictStore
-  (create-verdict [this new-verdict])
+  (create-verdict [this new-verdict-chan])
   (read-verdict [this id])
-  (delete-verdict [this id])
+  (delete-verdict [this id-chan])
   (list-verdicts [this filter-map params]))
 
 (defprotocol IIndicatorStore
-  (create-indicator [this new-indicator])
-  (update-indicator [this id indicator])
+  (create-indicator [this new-indicator-chan])
+  (update-indicator [this id indicator-chan])
   (read-indicator [this id])
-  (delete-indicator [this id])
+  (delete-indicator [this id-chan])
   (list-indicators [this filtermap params])
   (list-indicators-by-judgements [this judgements params]))
 
 (defprotocol IExploitTargetStore
   (read-exploit-target [this id])
-  (create-exploit-target [this new-exploit-target])
-  (update-exploit-target [this id exploit-target])
-  (delete-exploit-target [this id])
+  (create-exploit-target [this new-exploit-target-chan])
+  (update-exploit-target [this id exploit-target-chan])
+  (delete-exploit-target [this id-chan])
   (list-exploit-targets [this filtermap params]))
 
 (defprotocol IFeedbackStore
   (read-feedback [this id])
-  (create-feedback [this new-feedback])
-  (delete-feedback [this id])
+  (create-feedback [this new-feedback-chan])
+  (delete-feedback [this id-chan])
   (list-feedback [this filtermap params]))
 
 (defprotocol ITTPStore
   (read-ttp [this id])
-  (create-ttp [this new-ttp])
-  (update-ttp [this id ttp])
-  (delete-ttp [this id])
+  (create-ttp [this new-ttp-chan])
+  (update-ttp [this id ttp-chan])
+  (delete-ttp [this id-chan])
   (list-ttps [this filtermap params]))
 
 (defprotocol ICampaignStore
   (read-campaign [this id])
-  (create-campaign [this new-campaign])
-  (update-campaign [this id campaign])
-  (delete-campaign [this id])
+  (create-campaign [this new-campaign-chan])
+  (update-campaign [this id campaign-chan])
+  (delete-campaign [this id-chan])
   (list-campaigns [this filtermap params]))
 
 (defprotocol ICOAStore
   (read-coa [this id])
-  (create-coa [this new-coa])
-  (update-coa [this id coa])
-  (delete-coa [this id])
+  (create-coa [this new-coa-chan])
+  (update-coa [this id coa-chan])
+  (delete-coa [this id-chan])
   (list-coas [this filtermap params]))
 
 (defprotocol ISightingStore
   (read-sighting [this id])
-  (create-sighting [this new-sighting])
-  (update-sighting [this id sighting])
-  (delete-sighting [this id])
+  (create-sighting [this new-sighting-chan])
+  (update-sighting [this id sighting-chan])
+  (delete-sighting [this id-chan])
   (list-sightings [this filtermap params])
   (list-sightings-by-observables [this observable params]))
 
 (defprotocol IIncidentStore
   (read-incident [this id])
-  (create-incident [this new-incident])
-  (update-incident [this id incident])
-  (delete-incident [this id])
+  (create-incident [this new-incident-chan])
+  (update-incident [this id incident-chan])
+  (delete-incident [this id-chan])
   (list-incidents [this filtermap params]))
 
 (defprotocol IBundleStore
   (read-bundle [this id])
-  (create-bundle [this new-bundle])
-  (delete-bundle [this id]))
+  (create-bundle [this new-bundle-chan])
+  (delete-bundle [this id-chan]))
 
 (defprotocol IRelationshipStore
   (read-relationship [this id])
-  (create-relationship [this new-relation])
-  (delete-relationship [this id])
+  (create-relationship [this new-relation-chan])
+  (delete-relationship [this id-chan])
   (list-relationships [this filtermap params]))
 
 (defprotocol IIdentityStore
@@ -97,8 +97,8 @@
 
 (defprotocol IDataTableStore
   (read-data-table [this login])
-  (create-data-table [this new-data-table])
-  (delete-data-table [this role])
+  (create-data-table [this new-data-table-chan])
+  (delete-data-table [this id-chan])
   (list-data-tables [this filtermap params]))
 
 (defonce stores (atom {:judgement []
@@ -117,8 +117,10 @@
                        :verdict []
                        :bundle []}))
 
-(defn write-store [store write-fn & args]
-  (first (doall (map #(apply write-fn % args) (store @stores)))))
+(defn write-store [store-key write-fn & args]
+  (first (doall (map (fn apply-write-fn [store]
+                       (apply write-fn store args))
+                     (get @stores store-key)))))
 
-(defn read-store [store read-fn & args]
-  (apply read-fn (first (get @stores store)) args))
+(defn read-store [store-key read-fn & args]
+  (apply read-fn (first (get @stores store-key)) args))

--- a/src/ctia/stores/atom/store.clj
+++ b/src/ctia/stores/atom/store.clj
@@ -29,12 +29,12 @@
   IActorStore
   (read-actor [_ id]
     (actor/handle-read-actor state id))
-  (create-actor [_ new-actor]
-    (actor/handle-create-actor state new-actor))
-  (update-actor [_ id actor]
-    (actor/handle-update-actor state id actor))
-  (delete-actor [_ id]
-    (actor/handle-delete-actor state id))
+  (create-actor [_ new-actor-chan]
+    (actor/handle-create-actor state new-actor-chan))
+  (update-actor [_ id actor-chan]
+    (actor/handle-update-actor state id actor-chan))
+  (delete-actor [_ id-chan]
+    (actor/handle-delete-actor state id-chan))
   (list-actors [_ filter-map params]
     (actor/handle-list-actors state filter-map params)))
 
@@ -42,12 +42,12 @@
   ICampaignStore
   (read-campaign [_ id]
     (campaign/handle-read-campaign state id))
-  (create-campaign [_ new-campaign]
-    (campaign/handle-create-campaign state new-campaign))
-  (update-campaign [_ id new-campaign]
-    (campaign/handle-update-campaign state id new-campaign))
-  (delete-campaign [_ id]
-    (campaign/handle-delete-campaign state id))
+  (create-campaign [_ new-campaign-chan]
+    (campaign/handle-create-campaign state new-campaign-chan))
+  (update-campaign [_ id new-campaign-chan]
+    (campaign/handle-update-campaign state id new-campaign-chan))
+  (delete-campaign [_ id-chan]
+    (campaign/handle-delete-campaign state id-chan))
   (list-campaigns [_ filter-map params]
     (campaign/handle-list-campaigns state filter-map params)))
 
@@ -55,12 +55,12 @@
   ICOAStore
   (read-coa [_ id]
     (coa/handle-read-coa state id))
-  (create-coa [_ new-coa]
-    (coa/handle-create-coa state new-coa))
-  (update-coa [_ id new-coa]
-    (coa/handle-update-coa state id new-coa))
-  (delete-coa [_ id]
-    (coa/handle-delete-coa state id))
+  (create-coa [_ new-coa-chan]
+    (coa/handle-create-coa state new-coa-chan))
+  (update-coa [_ id coa-chan]
+    (coa/handle-update-coa state id coa-chan))
+  (delete-coa [_ id-chan]
+    (coa/handle-delete-coa state id-chan))
   (list-coas [_ filter-map params]
     (coa/handle-list-coas state filter-map params)))
 
@@ -68,10 +68,10 @@
   IDataTableStore
   (read-data-table [_ id]
     (data-table/handle-read-data-table state id))
-  (create-data-table [_ new-data-table]
-    (data-table/handle-create-data-table state new-data-table))
-  (delete-data-table [_ id]
-    (data-table/handle-delete-data-table state id))
+  (create-data-table [_ new-data-table-chan]
+    (data-table/handle-create-data-table state new-data-table-chan))
+  (delete-data-table [_ id-chan]
+    (data-table/handle-delete-data-table state id-chan))
   (list-data-tables [_ filter-map params]
     (data-table/handle-list-data-tables state filter-map params)))
 
@@ -79,25 +79,25 @@
   IExploitTargetStore
   (read-exploit-target [_ id]
     (expl-tar/handle-read-exploit-target state id))
-  (create-exploit-target [_ new-exploit-target]
-    (expl-tar/handle-create-exploit-target state new-exploit-target))
-  (update-exploit-target [_ id new-exploit-target]
-    (expl-tar/handle-update-exploit-target state id new-exploit-target))
-  (delete-exploit-target [_ id]
-    (expl-tar/handle-delete-exploit-target state id))
+  (create-exploit-target [_ new-exploit-target-chan]
+    (expl-tar/handle-create-exploit-target state new-exploit-target-chan))
+  (update-exploit-target [_ id exploit-target-chan]
+    (expl-tar/handle-update-exploit-target state id exploit-target-chan))
+  (delete-exploit-target [_ id-chan]
+    (expl-tar/handle-delete-exploit-target state id-chan))
   (list-exploit-targets [_ filter-map params]
     (expl-tar/handle-list-exploit-targets state filter-map params)))
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedback [_ new-feedback]
-    (feedback/handle-create-feedback state new-feedback))
+  (create-feedback [_ new-feedback-chan]
+    (feedback/handle-create-feedback state new-feedback-chan))
   (read-feedback [_ id]
     (feedback/handle-read-feedback state id))
   (list-feedback [_ filter-map params]
     (feedback/handle-list-feedback state filter-map params))
-  (delete-feedback [_ id]
-    (feedback/handle-delete-feedback state id)))
+  (delete-feedback [_ id-chan]
+    (feedback/handle-delete-feedback state id-chan)))
 
 (defrecord IdentityStore [state]
   IIdentityStore
@@ -112,25 +112,25 @@
   IIncidentStore
   (read-incident [_ id]
     (incident/handle-read-incident state id))
-  (create-incident [_ new-incident]
-    (incident/handle-create-incident state new-incident))
-  (update-incident [_ id incident]
-    (incident/handle-update-incident state id incident))
-  (delete-incident [_ id]
-    (incident/handle-delete-incident state id))
+  (create-incident [_ new-incident-chan]
+    (incident/handle-create-incident state new-incident-chan))
+  (update-incident [_ id incident-chan]
+    (incident/handle-update-incident state id incident-chan))
+  (delete-incident [_ id-chan]
+    (incident/handle-delete-incident state id-chan))
   (list-incidents [_ filter-map params]
     (incident/handle-list-incidents state filter-map params)))
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicator [_ new-indicator]
-    (indicator/handle-create-indicator state new-indicator))
-  (update-indicator [_ id new-indicator]
-    (indicator/handle-update-indicator state id new-indicator))
+  (create-indicator [_ new-indicator-chan]
+    (indicator/handle-create-indicator state new-indicator-chan))
+  (update-indicator [_ id indicator-chan]
+    (indicator/handle-update-indicator state id indicator-chan))
   (read-indicator [_ id]
     (indicator/handle-read-indicator state id))
-  (delete-indicator [_ id]
-    (indicator/handle-delete-indicator state id))
+  (delete-indicator [_ id-chan]
+    (indicator/handle-delete-indicator state id-chan))
   (list-indicators [_ filter-map params]
     (indicator/handle-list-indicators state filter-map params))
   (list-indicators-by-judgements [_ judgements params]
@@ -138,12 +138,12 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgement]
-    (judgement/handle-create-judgement state new-judgement))
+  (create-judgement [_ new-judgement-chan]
+    (judgement/handle-create-judgement state new-judgement-chan))
   (read-judgement [_ id]
     (judgement/handle-read-judgement state id))
-  (delete-judgement [_ id]
-    (judgement/handle-delete-judgement state id))
+  (delete-judgement [_ id-chan]
+    (judgement/handle-delete-judgement state id-chan))
   (list-judgements [_ filter-map params]
     (judgement/handle-list-judgements state filter-map params))
   (calculate-verdict [_ observable]
@@ -158,23 +158,23 @@
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationship [_ new-relationship]
-    (relationship/handle-create-relationship state new-relationship))
+  (create-relationship [_ new-relationship-chan]
+    (relationship/handle-create-relationship state new-relationship-chan))
   (read-relationship [_ id]
     (relationship/handle-read-relationship state id))
-  (delete-relationship [_ id]
-    (relationship/handle-delete-relationship state id))
+  (delete-relationship [_ id-chan]
+    (relationship/handle-delete-relationship state id-chan))
   (list-relationships [_ filter-map params]
     (relationship/handle-list-relationships state filter-map params)))
 
 (defrecord VerdictStore [state]
   IVerdictStore
-  (create-verdict [_ new-verdict]
-    (verdict/handle-create state new-verdict))
+  (create-verdict [_ new-verdict-chan]
+    (verdict/handle-create state new-verdict-chan))
   (read-verdict [_ id]
     (verdict/handle-read state id))
-  (delete-verdict [_ id]
-    (verdict/handle-delete state id))
+  (delete-verdict [_ id-chan]
+    (verdict/handle-delete state id-chan))
   (list-verdicts [_ filter-map params]
     (verdict/handle-list state filter-map params)))
 
@@ -182,12 +182,12 @@
   ISightingStore
   (read-sighting [_ id]
     (sighting/handle-read-sighting state id))
-  (create-sighting [_ new-sighting]
-    (sighting/handle-create-sighting state new-sighting))
-  (update-sighting [_ id sighting]
-    (sighting/handle-update-sighting state id sighting))
-  (delete-sighting [_ id]
-    (sighting/handle-delete-sighting state id))
+  (create-sighting [_ new-sighting-chan]
+    (sighting/handle-create-sighting state new-sighting-chan))
+  (update-sighting [_ id sighting-chan]
+    (sighting/handle-update-sighting state id sighting-chan))
+  (delete-sighting [_ id-chan]
+    (sighting/handle-delete-sighting state id-chan))
   (list-sightings [_ filter-map params]
     (sighting/handle-list-sightings state filter-map params))
   (list-sightings-by-observables [_ observables params]
@@ -197,12 +197,12 @@
   ITTPStore
   (read-ttp [_ id]
     (ttp/handle-read-ttp state id))
-  (create-ttp [_ new-ttp]
-    (ttp/handle-create-ttp state new-ttp))
-  (update-ttp [_ id new-ttp]
-    (ttp/handle-update-ttp state id new-ttp))
-  (delete-ttp [_ id]
-    (ttp/handle-delete-ttp state id))
+  (create-ttp [_ new-ttp-chan]
+    (ttp/handle-create-ttp state new-ttp-chan))
+  (update-ttp [_ id ttp-chan]
+    (ttp/handle-update-ttp state id ttp-chan))
+  (delete-ttp [_ id-chan]
+    (ttp/handle-delete-ttp state id-chan))
   (list-ttps [_ filter-map params]
     (ttp/handle-list-ttps state filter-map params)))
 
@@ -210,7 +210,7 @@
   IBundleStore
   (read-bundle [_ id]
     (bundle/handle-read-bundle state id))
-  (create-bundle [_ new-bundle]
-    (bundle/handle-create-bundle state new-bundle))
-  (delete-bundle [_ id]
-    (bundle/handle-delete-bundle state id)))
+  (create-bundle [_ new-bundle-chan]
+    (bundle/handle-create-bundle state new-bundle-chan))
+  (delete-bundle [_ id-chan]
+    (bundle/handle-delete-bundle state id-chan)))

--- a/src/ctia/stores/es/create_pipe.clj
+++ b/src/ctia/stores/es/create_pipe.clj
@@ -1,0 +1,99 @@
+(ns ctia.stores.es.create-pipe
+  (:require [clojure.core.async :as a]
+            [clojure.core.async.impl.protocols :as ap]
+            [ctia.lib.async :as la]
+            [ctia.lib.es
+             [document :as esd]
+             [index :as esi]]
+            [ctia.lib.pipes :as lp]
+            [ctia.shutdown :as shutdown]
+            [schema.core :as s]
+            [ctia.lib.async :as la]
+            [ctia.lib.pipes :as lp]))
+
+(def pipe (atom nil))
+
+(defrecord ESCreatePipe [work-chan worker-max-sleep-ms max-messages-per-job]
+  lp/AsyncPipe
+  (start-workers [this num-workers]
+    (dotimes [_ num-workers]
+      (lp/make-worker this)))
+
+  (shutdown! [_]
+    (a/close! work-chan))
+
+  (add-job [_ job]
+    (a/>!! work-chan job))
+
+  lp/WorkHandler
+  (make-worker [this]
+    (a/thread
+      ;; block for a bit while waiting for a work message
+      (let [[msg port] (a/alts!! [work-chan (a/timeout worker-max-sleep-ms)]
+                                 :priority true)]
+        (cond
+          ;; timed out while waiting
+          (not= port work-chan) (recur)
+
+          ;; the work-chan was closed; terminate
+          (nil? msg) nil
+
+          ;; gather more work messages and then do-some-work; avoid blocking
+          :else (let [msgs
+                      (loop [msgs [msg]]
+                        (if (>= (count msgs) max-messages-per-job)
+                          msgs
+                          (if-let [msg (a/poll! work-chan)]
+                            (recur (conj msgs msg))
+                            msgs)))]
+                  (lp/do-some-work this msgs)
+                  (recur))))))
+
+  (do-some-work [_ msgs]
+    (let [refresh? (boolean (some :refresh? msgs))
+          results (try
+                    (esd/bulk-create-doc
+                     (:conn (first msgs))
+                     (for [{:keys [document-chan index mapping-type]} msgs
+                           :let [{:keys [id] :as document} (la/<!! document-chan)]]
+                       (assoc document
+                              :_id id
+                              :_index index
+                              :_type mapping-type))
+                     refresh?)
+                    (catch Throwable t
+                      (repeat t)))]
+
+      (doall
+       (map (fn [result {:keys [result-chan] :as msg}]
+               (la/on-chan result-chan
+                           (if (map? result)
+                             (dissoc result :_id :_index :_type)
+                             result)))
+             results
+             msgs)))))
+
+(s/defschema ESCreateMap
+  {:document-chan (s/protocol ap/Channel)
+   :conn esi/ESConn
+   :index s/Str
+   :mapping-type s/Str
+   :refresh? s/Bool})
+
+(s/defn es-create :- (s/protocol ap/Channel)
+  [m :- ESCreateMap]
+  (let [result-chan (a/chan 1)]
+    (lp/add-job @pipe (assoc m :result-chan result-chan))
+    result-chan))
+
+(defn init! []
+  (reset! pipe
+          (doto (map->ESCreatePipe {:work-chan (a/chan 1000)
+                                    :worker-max-sleep-ms 250
+                                    :max-messages-per-job 50})
+            (lp/start-workers 20)))
+  (shutdown/register-hook!
+   :store.es.create-pipe
+   (fn []
+     (swap! pipe
+            #(some-> % lp/shutdown!)))))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -1,48 +1,62 @@
 (ns ctia.stores.es.crud
-  (:require [ctia.lib.es.index :refer [ESConnState]]
+  (:require [clojure.core.async.impl.protocols :as ap]
+            [ctia.lib.es.index :refer [ESConnState]]
             [schema.core :as s]
             [schema.coerce :as c]
             [ring.swagger.coerce :as sc]
             [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.lib.es.document :refer [create-doc
-                                          update-doc
-                                          get-doc
-                                          delete-doc
-                                          search-docs]]))
+            [ctia.lib.es.document :as d]
+            [ctia.schemas.core :refer [ID]]
+            [ctia.stores.store-pipe :as sp]
+            [ctia.stores.es.create-pipe :as ecp]))
 
 (defn coerce-to-fn
   [Model]
   (c/coercer! Model sc/json-schema-coercion-matcher))
 
+(defn create-doc [entity state mapping]
+  (d/create-doc (:conn state)
+                (:index state)
+                (name mapping)
+                entity
+                (get-in state [:props :refresh] false)))
+
 (defn handle-create
   "Generate an ES create handler using some mapping and schema"
   [mapping Model]
   (let [coerce! (coerce-to-fn (s/maybe Model))]
-    (s/fn :- (s/maybe Model)
+    (s/fn :- (s/protocol ap/Channel)
       [state :- ESConnState
-       realized :- Model]
-      (-> (create-doc (:conn state)
-                      (:index state)
-                      (name mapping)
-                      realized
-                      (get-in state [:props :refresh] false))
-          coerce!))))
+       entity-chan :- (s/protocol ap/Channel)]
+      (ecp/es-create
+       {:conn (:conn state)
+        :document-chan entity-chan
+        :index (:index state)
+        :mapping-type (name mapping)
+        :refresh? (get-in state [:props :refresh] false)}))))
+
+(defn update-doc [entity id state mapping]
+  (d/update-doc (:conn state)
+                (:index state)
+                (name mapping)
+                id
+                entity
+                (get-in state [:props :refresh] false)))
 
 (defn handle-update
   "Generate an ES update handler using some mapping and schema"
   [mapping Model]
   (let [coerce! (coerce-to-fn (s/maybe Model))]
-    (s/fn :- (s/maybe Model)
+    (s/fn :- (s/protocol ap/Channel)
       [state :- ESConnState
-       id :- s/Str
-       realized :- Model]
-      (-> (update-doc (:conn state)
-                      (:index state)
-                      (name mapping)
-                      id
-                      realized
-                      (get-in state [:props :refresh] false))
-          coerce!))))
+       id :- ID
+       updated-entity-chan :- (s/protocol ap/Channel)]
+      (sp/apply-store-fn
+       {:store-fn (s/fn update-fn :- (s/maybe Model)
+                    [updated-entity :- Model]
+                    (-> (update-doc updated-entity id state mapping)
+                        coerce!))
+        :input-chan updated-entity-chan}))))
 
 (defn handle-read
   "Generate an ES read handler using some mapping and schema"
@@ -50,25 +64,28 @@
   (let [coerce! (coerce-to-fn (s/maybe Model))]
     (s/fn :- (s/maybe Model)
       [state :- ESConnState
-       id :- s/Str]
-      (-> (get-doc (:conn state)
-                   (:index state)
-                   (name mapping)
-                   id)
+       id :- ID]
+      (-> (d/get-doc (:conn state)
+                     (:index state)
+                     (name mapping)
+                     id)
           coerce!))))
 
 (defn handle-delete
   "Generate an ES delete handler using some mapping and schema"
   [mapping Model]
-  (s/fn :- s/Bool
+  (s/fn :- (s/protocol ap/Channel)
     [state :- ESConnState
-     id :- s/Str]
-
-    (delete-doc (:conn state)
-                (:index state)
-                (name mapping)
-                id
-                (get-in state [:props :refresh] false))))
+     id-chan :- (s/protocol ap/Channel)]
+    (sp/apply-store-fn
+     {:store-fn (s/fn delete-fn :- s/Bool
+                  [id :- ID]
+                  (d/delete-doc (:conn state)
+                                (:index state)
+                                (name mapping)
+                                id
+                                (get-in state [:props :refresh] false)))
+      :input-chan id-chan})))
 
 (defn handle-find
   "Generate an ES find/list handler using some mapping and schema"
@@ -81,8 +98,8 @@
        params]
 
       (coerce!
-       (search-docs (:conn state)
-                    (:index state)
-                    (name mapping)
-                    filter-map
-                    params)))))
+       (d/search-docs (:conn state)
+                      (:index state)
+                      (name mapping)
+                      filter-map
+                      params)))))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -54,14 +54,14 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgement]
-    (ju/handle-create-judgement state new-judgement))
+  (create-judgement [_ new-judgement-chan]
+    (ju/handle-create-judgement state new-judgement-chan))
   (add-indicator-to-judgement [_ judgement-id indicator-rel]
     (ju/handle-add-indicator-to-judgement state judgement-id indicator-rel))
   (read-judgement [_ id]
     (ju/handle-read-judgement state id))
-  (delete-judgement [_ id]
-    (ju/handle-delete-judgement state id))
+  (delete-judgement [_ id-chan]
+    (ju/handle-delete-judgement state id-chan))
   (list-judgements [_ filter-map params]
     (ju/handle-list-judgements state filter-map params))
   (list-judgements-by-observable [this observable params]
@@ -72,12 +72,12 @@
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationship [_ new-relationship]
-    (rel/handle-create-relationship state new-relationship))
+  (create-relationship [_ new-relationship-chan]
+    (rel/handle-create-relationship state new-relationship-chan))
   (read-relationship [_ id]
     (rel/handle-read-relationship state id))
-  (delete-relationship [_ id]
-    (rel/handle-delete-relationship state id))
+  (delete-relationship [_ id-chan]
+    (rel/handle-delete-relationship state id-chan))
   (list-relationships [_ filter-map params]
     (rel/handle-list-relationships state filter-map params)))
 
@@ -94,25 +94,25 @@
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedback [_ new-feedback]
-    (fe/handle-create-feedback state new-feedback))
+  (create-feedback [_ new-feedback-chan]
+    (fe/handle-create-feedback state new-feedback-chan))
   (read-feedback [_ id]
     (fe/handle-read-feedback state id))
-  (delete-feedback [_ id]
-    (fe/handle-delete-feedback state id))
+  (delete-feedback [_ id-chan]
+    (fe/handle-delete-feedback state id-chan))
   (list-feedback [_ filter-map params]
     (fe/handle-list-feedback state filter-map params)))
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicator [_ new-indicator]
-    (in/handle-create-indicator state new-indicator))
-  (update-indicator [_ id new-indicator]
-    (in/handle-update-indicator state id new-indicator))
+  (create-indicator [_ new-indicator-chan]
+    (in/handle-create-indicator state new-indicator-chan))
+  (update-indicator [_ id indicator-chan]
+    (in/handle-update-indicator state id indicator-chan))
   (read-indicator [_ id]
     (in/handle-read-indicator state id))
-  (delete-indicator [_ id]
-    (in/handle-delete-indicator state id))
+  (delete-indicator [_ id-chan]
+    (in/handle-delete-indicator state id-chan))
   (list-indicators [_ filter-map params]
     (in/handle-list-indicators state filter-map params))
   (list-indicators-by-judgements [_ judgements params]
@@ -122,12 +122,12 @@
   ITTPStore
   (read-ttp [_ id]
     (ttp/handle-read-ttp state id))
-  (create-ttp [_ new-ttp]
-    (ttp/handle-create-ttp state new-ttp))
-  (update-ttp [_ id new-ttp]
-    (ttp/handle-update-ttp state id new-ttp))
-  (delete-ttp [_ id]
-    (ttp/handle-delete-ttp state id))
+  (create-ttp [_ new-ttp-chan]
+    (ttp/handle-create-ttp state new-ttp-chan))
+  (update-ttp [_ id ttp-chan]
+    (ttp/handle-update-ttp state id ttp-chan))
+  (delete-ttp [_ id-chan]
+    (ttp/handle-delete-ttp state id-chan))
   (list-ttps [_ filter-map params]
     (ttp/handle-list-ttps state filter-map params)))
 
@@ -135,12 +135,12 @@
   IActorStore
   (read-actor [_ id]
     (ac/handle-read-actor state id))
-  (create-actor [_ new-actor]
-    (ac/handle-create-actor state new-actor))
-  (update-actor [_ id actor]
-    (ac/handle-update-actor state id actor))
-  (delete-actor [_ id]
-    (ac/handle-delete-actor state id))
+  (create-actor [_ new-actor-chan]
+    (ac/handle-create-actor state new-actor-chan))
+  (update-actor [_ id actor-chan]
+    (ac/handle-update-actor state id actor-chan))
+  (delete-actor [_ id-chan]
+    (ac/handle-delete-actor state id-chan))
   (list-actors [_ filter-map params]
     (ac/handle-list-actors state filter-map params)))
 
@@ -148,12 +148,12 @@
   ICampaignStore
   (read-campaign [_ id]
     (ca/handle-read-campaign state id))
-  (create-campaign [_ new-campaign]
-    (ca/handle-create-campaign state new-campaign))
-  (update-campaign [_ id new-campaign]
-    (ca/handle-update-campaign state id new-campaign))
-  (delete-campaign [_ id]
-    (ca/handle-delete-campaign state id))
+  (create-campaign [_ new-campaign-chan]
+    (ca/handle-create-campaign state new-campaign-chan))
+  (update-campaign [_ id new-campaign-chan]
+    (ca/handle-update-campaign state id new-campaign-chan))
+  (delete-campaign [_ id-chan]
+    (ca/handle-delete-campaign state id-chan))
   (list-campaigns [_ filter-map params]
     (ca/handle-list-campaigns state filter-map params)))
 
@@ -161,12 +161,12 @@
   ICOAStore
   (read-coa [_ id]
     (coa/handle-read-coa state id))
-  (create-coa [_ new-coa]
-    (coa/handle-create-coa state new-coa))
-  (update-coa [_ id new-coa]
-    (coa/handle-update-coa state id new-coa))
-  (delete-coa [_ id]
-    (coa/handle-delete-coa state id))
+  (create-coa [_ new-coa-chan]
+    (coa/handle-create-coa state new-coa-chan))
+  (update-coa [_ id coa-chan]
+    (coa/handle-update-coa state id coa-chan))
+  (delete-coa [_ id-chan]
+    (coa/handle-delete-coa state id-chan))
   (list-coas [_ filter-map params]
     (coa/handle-list-coas state filter-map params)))
 
@@ -174,10 +174,10 @@
   IDataTableStore
   (read-data-table [_ id]
     (dt/handle-read-data-table state id))
-  (create-data-table [_ new-data-table]
-    (dt/handle-create-data-table state new-data-table))
-  (delete-data-table [_ id]
-    (dt/handle-delete-data-table state id))
+  (create-data-table [_ new-data-table-chan]
+    (dt/handle-create-data-table state new-data-table-chan))
+  (delete-data-table [_ id-chan]
+    (dt/handle-delete-data-table state id-chan))
   (list-data-tables [_ filter-map params]
     (dt/handle-list-data-tables state filter-map params)))
 
@@ -185,12 +185,12 @@
   IIncidentStore
   (read-incident [_ id]
     (inc/handle-read-incident state id))
-  (create-incident [_ new-incident]
-    (inc/handle-create-incident state new-incident))
-  (update-incident [_ id new-incident]
-    (inc/handle-update-incident state id new-incident))
-  (delete-incident [_ id]
-    (inc/handle-delete-incident state id))
+  (create-incident [_ new-incident-chan]
+    (inc/handle-create-incident state new-incident-chan))
+  (update-incident [_ id incident-chan]
+    (inc/handle-update-incident state id incident-chan))
+  (delete-incident [_ id-chan]
+    (inc/handle-delete-incident state id-chan))
   (list-incidents [_ filter-map params]
     (inc/handle-list-incidents state filter-map params)))
 
@@ -198,12 +198,12 @@
   IExploitTargetStore
   (read-exploit-target [_ id]
     (et/handle-read-exploit-target state id))
-  (create-exploit-target [_ new-exploit-target]
-    (et/handle-create-exploit-target state new-exploit-target))
-  (update-exploit-target [_ id new-exploit-target]
-    (et/handle-update-exploit-target state id new-exploit-target))
-  (delete-exploit-target [_ id]
-    (et/handle-delete-exploit-target state id))
+  (create-exploit-target [_ new-exploit-target-chan]
+    (et/handle-create-exploit-target state new-exploit-target-chan))
+  (update-exploit-target [_ id exploit-target-chan]
+    (et/handle-update-exploit-target state id exploit-target-chan))
+  (delete-exploit-target [_ id-chan]
+    (et/handle-delete-exploit-target state id-chan))
   (list-exploit-targets [_ filter-map params]
     (et/handle-list-exploit-targets state filter-map params)))
 
@@ -220,12 +220,12 @@
   ISightingStore
   (read-sighting [_ id]
     (sig/handle-read-sighting state id))
-  (create-sighting [_ new-sighting]
-    (sig/handle-create-sighting state new-sighting))
-  (update-sighting [_ id sighting]
-    (sig/handle-update-sighting state id sighting))
-  (delete-sighting [_ id]
-    (sig/handle-delete-sighting state id))
+  (create-sighting [_ new-sighting-chan]
+    (sig/handle-create-sighting state new-sighting-chan))
+  (update-sighting [_ id sighting-chan]
+    (sig/handle-update-sighting state id sighting-chan))
+  (delete-sighting [_ id-chan]
+    (sig/handle-delete-sighting state id-chan))
   (list-sightings [_ filter-map params]
     (sig/handle-list-sightings state filter-map params))
   (list-sightings-by-observables [_ observables params]
@@ -235,7 +235,7 @@
   IBundleStore
   (read-bundle [_ id]
     (bu/handle-read-bundle state id))
-  (create-bundle [_ new-bundle]
-    (bu/handle-create-bundle state new-bundle))
-  (delete-bundle [_ id]
-    (bu/handle-delete-bundle state id)))
+  (create-bundle [_ new-bundle-chan]
+    (bu/handle-create-bundle state new-bundle-chan))
+  (delete-bundle [_ id-chan]
+    (bu/handle-delete-bundle state id-chan)))

--- a/src/ctia/stores/store_pipe.clj
+++ b/src/ctia/stores/store_pipe.clj
@@ -22,18 +22,9 @@
   lp/WorkHandler
   (make-worker [this]
     (a/thread
-      (let [[msg port] (a/alts!! [work-chan (a/timeout worker-max-sleep-ms)]
-                                 :priority true)]
-        (cond
-          ;; timed out while waiting
-          (not= port work-chan) (recur)
-
-          ;; the work-chan closed; terminate
-          (nil? msg) nil
-
-          ;; do some work
-          :else (do (lp/do-some-work this msg)
-                    (recur))))))
+      (when-let [msg (la/<!! work-chan)]
+        (lp/do-some-work this msg)
+        (recur))))
 
   (do-some-work [_ {:keys [input-chan store-fn result-chan]}]
     (la/on-chan result-chan

--- a/src/ctia/stores/store_pipe.clj
+++ b/src/ctia/stores/store_pipe.clj
@@ -1,0 +1,64 @@
+(ns ctia.stores.store-pipe
+  (:require [clojure.core.async :as a]
+            [clojure.core.async.impl.protocols :as ap]
+            [ctia.lib.async :as la]
+            [ctia.lib.pipes :as lp]
+            [ctia.shutdown :as shutdown]
+            [schema.core :as s]))
+
+(def pipe (atom nil))
+
+(defrecord StorePipe [work-chan worker-max-sleep-ms]
+  lp/AsyncPipe
+  (start-workers [this num-workers]
+    (lp/do-start-workers this num-workers))
+
+  (shutdown! [_]
+    (a/close! work-chan))
+
+  (add-job [_ job]
+    (a/>!! work-chan job))
+
+  lp/WorkHandler
+  (make-worker [this]
+    (a/thread
+      (let [[msg port] (a/alts!! [work-chan (a/timeout worker-max-sleep-ms)]
+                                 :priority true)]
+        (cond
+          ;; timed out while waiting
+          (not= port work-chan) (recur)
+
+          ;; the work-chan closed; terminate
+          (nil? msg) nil
+
+          ;; do some work
+          :else (do (lp/do-some-work this msg)
+                    (recur))))))
+
+  (do-some-work [_ {:keys [input-chan store-fn result-chan]}]
+    (la/on-chan result-chan
+                (try
+                  (store-fn (la/<!! input-chan))
+                  (catch Throwable t t)))))
+
+(s/defschema StorePipeMap
+  {:input-chan (s/protocol ap/Channel)
+   :store-fn (s/pred fn?)})
+
+(s/defn apply-store-fn :- (s/protocol ap/Channel)
+  "Put a message on the pipe"
+  [m :- StorePipeMap]
+  (let [result-chan (a/chan 1)]
+    (lp/add-job @pipe (assoc m :result-chan result-chan))
+    result-chan))
+
+(defn init! []
+  (reset! pipe
+          (doto (map->StorePipe {:work-chan (a/chan 1000)
+                                 :worker-max-sleep-ms 250})
+            (lp/start-workers 20)))
+  (shutdown/register-hook!
+   :stores.pipes.store-pipe
+   (fn []
+     (swap! pipe
+            #(some-> % lp/shutdown!)))))

--- a/test/ctia/http/routes/bulk_test.clj
+++ b/test/ctia/http/routes/bulk_test.clj
@@ -8,7 +8,7 @@
              [string :as str]
              [test :refer [deftest is join-fixtures testing use-fixtures]]]
             [ctia.auth :refer [all-capabilities]]
-            [ctia.http.routes.bulk :refer [bulk-size gen-bulk-from-fn get-bulk-max-size]]
+            [ctia.http.routes.bulk :refer [bulk-size get-bulk-max-size]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
              [core :as helpers :refer [get post]]
@@ -161,21 +161,6 @@
                 {:indicator_id "indicator-2"}]
    :exploit_targets [{:exploit_target_id "exploit-target-123"}
                      {:exploit_target_id "exploit-target-234"}]})
-
-(deftest testing-gen-bulk-from-fn
-  (let [new-bulk {:actors (map mk-new-actor (range 6))
-                  :campaigns (map mk-new-campaign (range 6))}]
-    (testing "testing gen-bulk-from-fn with 2 args"
-      (is (= (gen-bulk-from-fn (fn [lst _] (map (fn [_] :s) lst))
-                               new-bulk)
-             {:actors [:s :s :s :s :s :s]
-              :campaigns [:s :s :s :s :s :s]})))
-    (testing "testing gen-bulk-from-fn with 3 args"
-      (is (= (gen-bulk-from-fn (fn [lst _ x] (map (fn [_] x) lst))
-                               new-bulk
-                               :x)
-             {:actors [:x :x :x :x :x :x]
-              :campaigns [:x :x :x :x :x :x]})))))
 
 (def tst-bulk {:actors (map #(str "actor-" %) (range 6))
                :campaigns (map #(str "campaign-" %) (range 6))})

--- a/test/ctia/http/routes/sighting_test.clj
+++ b/test/ctia/http/routes/sighting_test.clj
@@ -11,7 +11,8 @@
              [fake-whoami-service :as whoami-helpers]
              [http :refer [api-key]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]))
+            [ctim.domain.id :as id]
+            [ctia.store :as store]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -154,3 +154,12 @@
 
 (def put
   (mthh/with-port-fn get-http-port mthh/put))
+
+(defn only
+  "Works like clojure.core/first, but throws an exception when there
+  col has more than one item"
+  [col]
+  (when (> (count col) 1)
+    (throw (ex-info "Collection must only have one or zero items"
+                    {:collection col})))
+  (first col))


### PR DESCRIPTION
Performance is (hopefully) improved in three ways:

- Uses the bulk API for all creates when inserting into ES
- The flow code is changed to be asynchronous to allow for create methods on the store to happen in parallel (uses core.async and dedicated threads)
- In the flow code, events and store methods are handled in parallel