### PR TITLE
Modified stores and the flow to create multiple entities in bulk

### DIFF
--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -1,5 +1,6 @@
 (ns ctia.flows.crud
-  "This namespace handle all necessary flows for creating, updating and deleting entities."
+  "This namespace handle all necessary flows for creating, updating
+  and deleting entities."
   (:import java.util.UUID)
   (:require [clojure.tools.logging :as log]
             [ctia.auth :as auth]
@@ -8,7 +9,20 @@
                                               to-update-event
                                               to-delete-event]]
             [ctim.domain.id :as id]
-            [ring.util.http-response :as http-response]))
+            [ring.util.http-response :as http-response]
+            [schema.core :as s]))
+
+(s/defschema FlowMap
+  {:create-event-fn (s/pred fn?)
+   :entities [{s/Keyword s/Any}]
+   :entity-type s/Keyword
+   (s/optional-key :events) [{s/Keyword s/Any}]
+   :flow-type (s/enum :create :update :delete)
+   :identity (s/protocol auth/IIdentity)
+   (s/optional-key :prev-entity) (s/maybe {s/Keyword s/Any})
+   (s/optional-key :realize-fn) (s/pred fn?)
+   (s/optional-key :results) [s/Bool]
+   :store-fn (s/pred fn?)})
 
 (defn- find-id
   "Lookup an ID in a given entity.  Parse it, because it might be a
@@ -22,7 +36,9 @@
   [entity-type]
   (str (name entity-type) "-" (UUID/randomUUID)))
 
-(defn- find-entity-id [identity entity-type entity prev-entity]
+(s/defn ^:private find-entity-id :- s/Str
+  [{:keys [identity entity-type prev-entity]} :- FlowMap
+   entity :- {s/Keyword s/Any}]
   (or (find-id prev-entity)
       (when-let [entity-id (find-id entity)]
         (when-not (auth/capable? identity :specify-id)
@@ -36,50 +52,100 @@
                    :entity entity}))))
       (make-id entity-type)))
 
-(defn- handle-flow
-  [& {:keys [flow-type
-             entity-type
-             entity
-             prev-entity
-             identity
-             realize-fn
-             store-fn
-             create-event-fn]}]
-  (let [login (auth/login identity)
-        entity-id (find-entity-id identity entity-type entity prev-entity)
-        realized (h/apply-hooks :entity (case flow-type
-                                          :create (realize-fn entity entity-id login)
-                                          :update (realize-fn entity entity-id login prev-entity)
-                                          :delete entity)
-                                :prev-entity prev-entity
-                                :hook-type (case flow-type
-                                             :create :before-create
-                                             :update :before-update
-                                             :delete :before-delete)
-                                :read-only? (= flow-type :delete))
-        event (try
-                (if (= :update flow-type)
-                  (create-event-fn realized prev-entity)
-                  (create-event-fn realized))
-                (catch Throwable e
-                  (log/error "Could not create event" e)
-                  (throw (ex-info "Could not create event"
-                                  {:flow-type flow-type
-                                   :login login
-                                   :entity realized
-                                   :prev-entity prev-entity}))))
-        result (if (= :delete flow-type)
-                 (store-fn entity-id)
-                 (store-fn realized))]
-    (h/apply-event-hooks event)
-    (h/apply-hooks :entity realized
-                   :prev-entity prev-entity
-                   :hook-type (case flow-type
-                                :create :after-create
-                                :update :after-update
-                                :delete :after-delete)
-                   :read-only? true)
-    result))
+(s/defn ^:private realize-entities :- FlowMap
+  [{:keys [entities flow-type identity prev-entity realize-fn] :as fm} :- FlowMap]
+  (let [login (auth/login identity)]
+    (assoc fm
+           :entities
+           (doall
+            (for [entity entities
+                  :let [entity-id (find-entity-id fm entity)]]
+              (case flow-type
+                :create (realize-fn entity entity-id login)
+                :update (realize-fn entity entity-id login prev-entity)
+                :delete entity))))))
+
+(s/defn ^:private apply-before-hooks :- FlowMap
+  [{:keys [entities flow-type prev-entity] :as fm} :- FlowMap]
+  (assoc fm
+         :entities
+         (doall
+          (for [entity entities]
+            (h/apply-hooks :entity entity
+                           :prev-entity prev-entity
+                           :hook-type (case flow-type
+                                        :create :before-create
+                                        :update :before-update
+                                        :delete :before-delete)
+                           :read-only? (= flow-type :delete))))))
+
+(s/defn ^:privae apply-after-hooks :- FlowMap
+  [{:keys [entities flow-type prev-entity] :as fm} :- FlowMap]
+  (doall
+   (for [entity entities]
+     (h/apply-hooks :entity entity
+                    :prev-entity prev-entity
+                    :hook-type (case flow-type
+                                 :create :after-create
+                                 :update :after-update
+                                 :delete :after-delete)
+                    :read-only? true)))
+  fm)
+
+(s/defn ^:private create-events :- FlowMap
+  [{:keys [create-event-fn entities flow-type identity prev-entity]
+    :as fm} :- FlowMap]
+  (assoc fm
+         :events
+         (doall
+          (for [entity entities]
+            (try
+              (if (= :update flow-type)
+                (create-event-fn entity prev-entity)
+                (create-event-fn entity))
+              (catch Throwable e
+                (log/error "Could not create event" e)
+                (throw (ex-info "Could not create event"
+                                {:flow-type flow-type
+                                 :login (auth/login identity)
+                                 :entity entity
+                                 :prev-entity prev-entity}))))))))
+
+(s/defn ^:private apply-store-fn :- FlowMap
+  [{:keys [entities flow-type store-fn] :as fm} :- FlowMap]
+  (case flow-type
+    :create
+    (assoc fm
+           :entities
+           (store-fn entities))
+
+    :delete
+    (assoc fm
+           :results
+           (doall
+            (for [{entity-id :id} entities]
+              (store-fn entity-id))))
+
+    :update
+    (assoc fm
+           :entities
+           (doall
+            (for [entity entities]
+              (store-fn entity))))))
+
+(s/defn ^:private apply-event-hooks :- FlowMap
+  [{:keys [events] :as fm} :- FlowMap]
+  (doall
+   (for [event events]
+     (h/apply-event-hooks event)))
+  fm)
+
+(s/defn ^:private make-result :- s/Any
+  [{:keys [flow-type] :as fm} :- FlowMap]
+  (case flow-type
+    :create (:entities fm)
+    :delete (first (:results fm))
+    :update (first (:entities fm))))
 
 (defn create-flow
   "This function centralizes the create workflow.
@@ -92,14 +158,21 @@
              realize-fn
              store-fn
              identity
-             entity]}]
-  (handle-flow :flow-type :create
-               :entity-type entity-type
-               :entity entity
-               :identity identity
-               :realize-fn realize-fn
-               :store-fn store-fn
-               :create-event-fn to-create-event))
+             entities]}]
+  (-> {:flow-type :create
+       :entity-type entity-type
+       :entities entities
+       :identity identity
+       :realize-fn realize-fn
+       :store-fn store-fn
+       :create-event-fn to-create-event}
+      realize-entities
+      apply-before-hooks
+      create-events
+      apply-store-fn
+      apply-event-hooks
+      apply-after-hooks
+      make-result))
 
 (defn update-flow
   "This function centralize the update workflow.
@@ -116,14 +189,21 @@
              identity
              entity]}]
   (let [prev-entity (get-fn entity-id)]
-    (handle-flow :flow-type :update
-                 :entity-type entity-type
-                 :entity entity
-                 :prev-entity prev-entity
-                 :identity identity
-                 :realize-fn realize-fn
-                 :store-fn update-fn
-                 :create-event-fn to-update-event)))
+    (-> {:flow-type :update
+         :entity-type entity-type
+         :entities [entity]
+         :prev-entity prev-entity
+         :identity identity
+         :realize-fn realize-fn
+         :store-fn update-fn
+         :create-event-fn to-update-event}
+        realize-entities
+        apply-before-hooks
+        create-events
+        apply-store-fn
+        apply-event-hooks
+        apply-after-hooks
+        make-result)))
 
 (defn delete-flow
   "This function centralize the deletion workflow.
@@ -139,10 +219,16 @@
              entity-id
              identity]}]
   (let [entity (get-fn entity-id)]
-    (handle-flow :flow-type :delete
-                 :entity-type entity-type
-                 :entity entity
-                 :prev-entity entity
-                 :identity identity
-                 :store-fn delete-fn
-                 :create-event-fn to-delete-event)))
+    (-> {:flow-type :delete
+         :entity-type entity-type
+         :entities [entity]
+         :prev-entity entity
+         :identity identity
+         :store-fn delete-fn
+         :create-event-fn to-delete-event}
+        apply-before-hooks
+        create-events
+        apply-store-fn
+        apply-event-hooks
+        apply-after-hooks
+        make-result)))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -135,9 +135,8 @@
 
 (s/defn ^:private apply-event-hooks :- FlowMap
   [{:keys [events] :as fm} :- FlowMap]
-  (doall
-   (for [event events]
-     (h/apply-event-hooks event)))
+  (doseq [event events]
+    (h/apply-event-hooks event))
   fm)
 
 (s/defn ^:private make-result :- s/Any

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -96,7 +96,7 @@
                                                   store/calculate-verdict
                                                   observable)
                                 (realize-verdict-wrapper judgement owner))]
-          (store/write-store :verdict store/create-verdict new-verdict))))
+          (store/write-store :verdict store/create-verdict [new-verdict]))))
     event))
 
 (s/defn register-hooks :- {s/Keyword [(s/protocol Hook)]}

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -91,12 +91,13 @@
   (handle [_ event _]
     (when (judgement? event)
       (let [{{observable :observable :as judgement} :entity owner :owner} event]
-        (when-let [new-verdict (some->
-                                (store/read-store :judgement
-                                                  store/calculate-verdict
-                                                  observable)
-                                (realize-verdict-wrapper judgement owner))]
-          (store/write-store :verdict store/create-verdict [new-verdict]))))
+        (when-let [new-verdict
+                   (some->
+                    (store/read-store :judgement
+                                      store/calculate-verdict
+                                      observable)
+                    (realize-verdict-wrapper judgement owner))]
+          (store/write-store :verdict store/create-verdicts [new-verdict]))))
     event))
 
 (s/defn register-hooks :- {s/Keyword [(s/protocol Hook)]}

--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -31,7 +31,7 @@
          (first
           (flows/create-flow :entity-type :actor
                              :realize-fn realize-actor
-                             :store-fn #(write-store :actor create-actor %)
+                             :store-fn #(write-store :actor create-actors %)
                              :entity-type :actor
                              :identity identity
                              :entities [actor])))))

--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -28,12 +28,13 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :entity-type :actor
-                            :realize-fn realize-actor
-                            :store-fn #(write-store :actor create-actor %)
-                            :entity-type :actor
-                            :identity identity
-                            :entity actor))))
+         (first
+          (flows/create-flow :entity-type :actor
+                             :realize-fn realize-actor
+                             :store-fn #(write-store :actor create-actor %)
+                             :entity-type :actor
+                             :identity identity
+                             :entities [actor])))))
     (PUT "/:id" []
       :return StoredActor
       :body [actor NewActor {:description "an updated Actor"}]

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -46,18 +46,19 @@
   "return the create function provided an entity type key"
   [k]
   #(write-store k (case k
-                    :actor          create-actor
-                    :campaign       create-campaign
-                    :coa            create-coa
-                    :data-table     create-data-table
-                    :exploit-target create-exploit-target
-                    :feedback       create-feedback
-                    :incident       create-incident
-                    :indicator      create-indicator
-                    :judgement      create-judgement
-                    :relationship   create-relationship
-                    :sighting       create-sighting
-                    :ttp            create-ttp) %))
+                    :actor          create-actors
+                    :campaign       create-campaigns
+                    :coa            create-coas
+                    :data-table     create-data-tables
+                    :exploit-target create-exploit-targets
+                    :feedback       create-feedbacks
+                    :incident       create-incidents
+                    :indicator      create-indicators
+                    :judgement      create-judgements
+                    :relationship   create-relationships
+                    :sighting       create-sightings
+                    :ttp            create-ttps)
+                %))
 
 (defn read-fn
   "return the create function provided an entity type key"
@@ -74,7 +75,8 @@
                    :judgement      read-judgement
                    :relationship   read-relationship
                    :sighting       read-sighting
-                   :ttp            read-ttp) %))
+                   :ttp            read-ttp)
+               %))
 
 (defn with-long-id-fn
   "return the with-long-id function provided an entity type key"

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -25,7 +25,7 @@
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
-(defn realize
+(defn realize-fn
   "return the realize function provided an entity type key"
   [k]
   (case k
@@ -97,18 +97,13 @@
   "Create many entities provided their type and returns a list of ids"
   [entities entity-type login]
   (let [with-long-id (with-long-id-fn entity-type)]
-    (->> entities
-         (map #(try
-                 (with-long-id
-                   (flows/create-flow
-                    :entity-type entity-type
-                    :realize-fn (realize entity-type)
-                    :store-fn (create-fn entity-type)
-                    :identity login
-                    :entity %))
-                 (catch Exception e
-                   (do (log/error (pr-str e))
-                       nil))))
+    (->> (flows/create-flow
+          :entity-type entity-type
+          :realize-fn (realize-fn entity-type)
+          :store-fn (create-fn entity-type)
+          :identity login
+          :entities entities)
+         (map with-long-id)
          (map :id))))
 
 (defn read-entities

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -19,12 +19,14 @@
       :summary "Adds a new Bundle"
       :capabilities :create-bundle
       :identity identity
-      (created (flows/create-flow :entity-type :bundle
-                                  :realize-fn realize-bundle
-                                  :store-fn #(write-store :bundle create-bundle %)
-                                  :entity-type :bundle
-                                  :identity identity
-                                  :entity bundle)))
+      (created
+       (first
+        (flows/create-flow :entity-type :bundle
+                           :realize-fn realize-bundle
+                           :store-fn #(write-store :bundle create-bundle %)
+                           :entity-type :bundle
+                           :identity identity
+                           :entities [bundle]))))
     (GET "/:id" []
       :return (s/maybe StoredBundle)
       :summary "Gets a Bundle by ID"

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -23,7 +23,7 @@
        (first
         (flows/create-flow :entity-type :bundle
                            :realize-fn realize-bundle
-                           :store-fn #(write-store :bundle create-bundle %)
+                           :store-fn #(write-store :bundle create-bundles %)
                            :entity-type :bundle
                            :identity identity
                            :entities [bundle]))))

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -30,7 +30,7 @@
        (with-long-id
          (first
           (flows/create-flow :realize-fn realize-campaign
-                             :store-fn #(write-store :campaign create-campaign %)
+                             :store-fn #(write-store :campaign create-campaigns %)
                              :entity-type :campaign
                              :identity identity
                              :entities [campaign])))))

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -28,11 +28,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-campaign
-                            :store-fn #(write-store :campaign create-campaign %)
-                            :entity-type :campaign
-                            :identity identity
-                            :entity campaign))))
+         (first
+          (flows/create-flow :realize-fn realize-campaign
+                             :store-fn #(write-store :campaign create-campaign %)
+                             :entity-type :campaign
+                             :identity identity
+                             :entities [campaign])))))
     (PUT "/:id" []
       :return StoredCampaign
       :body [campaign NewCampaign {:description "an updated campaign"}]

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -29,7 +29,7 @@
        (with-long-id
          (first
           (flows/create-flow :realize-fn realize-coa
-                             :store-fn #(write-store :coa create-coa %)
+                             :store-fn #(write-store :coa create-coas %)
                              :entity-type :coa
                              :identity identity
                              :entities [coa])))))

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -27,11 +27,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-coa
-                            :store-fn #(write-store :coa create-coa %)
-                            :entity-type :coa
-                            :identity identity
-                            :entity coa))))
+         (first
+          (flows/create-flow :realize-fn realize-coa
+                             :store-fn #(write-store :coa create-coa %)
+                             :entity-type :coa
+                             :identity identity
+                             :entities [coa])))))
     (PUT "/:id" []
       :return StoredCOA
       :body [coa NewCOA {:description "an updated COA"}]

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -29,12 +29,13 @@
                  (created
                   (with-long-id
                     (first
-                     (flows/create-flow :entity-type :data-table
-                                        :realize-fn realize-data-table
-                                        :store-fn #(write-store :data-table create-data-table %)
-                                        :entity-type :data-table
-                                        :identity identity
-                                        :entities [data-table])))))
+                     (flows/create-flow
+                      :entity-type :data-table
+                      :realize-fn realize-data-table
+                      :store-fn #(write-store :data-table create-data-tables %)
+                      :entity-type :data-table
+                      :identity identity
+                      :entities [data-table])))))
            (GET "/external_id" []
                 :return [(s/maybe StoredDataTable)]
                 :query [q DataTableByExternalIdQueryParams]
@@ -63,10 +64,11 @@
                    :header-params [api_key :- (s/maybe s/Str)]
                    :capabilities :delete-data-table
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :data-table read-data-table %)
-                                          :delete-fn #(write-store :data-table delete-data-table %)
-                                          :entity-type :data-table
-                                          :entity-id id
-                                          :identity identity)
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :data-table read-data-table %)
+                        :delete-fn #(write-store :data-table delete-data-table %)
+                        :entity-type :data-table
+                        :entity-id id
+                        :identity identity)
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -28,12 +28,13 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :entity-type :data-table
-                                       :realize-fn realize-data-table
-                                       :store-fn #(write-store :data-table create-data-table %)
-                                       :entity-type :data-table
-                                       :identity identity
-                                       :entity data-table))))
+                    (first
+                     (flows/create-flow :entity-type :data-table
+                                        :realize-fn realize-data-table
+                                        :store-fn #(write-store :data-table create-data-table %)
+                                        :entity-type :data-table
+                                        :identity identity
+                                        :entities [data-table])))))
            (GET "/external_id" []
                 :return [(s/maybe StoredDataTable)]
                 :query [q DataTableByExternalIdQueryParams]

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -19,73 +19,84 @@
 
 (defroutes exploit-target-routes
   (context "/exploit-target" []
-    :tags ["ExploitTarget"]
-    (POST "/" []
-      :return StoredExploitTarget
-      :body [exploit-target NewExploitTarget {:description "a new ExploitTarget"}]
-      :summary "Adds a new ExploitTarget"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-exploit-target
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :realize-fn realize-exploit-target
-                             :store-fn #(write-store :exploit-target create-exploit-target %)
-                             :entity-type :exploit-target
-                             :identity identity
-                             :entities [exploit-target])))))
-    (PUT "/:id" []
-      :return StoredExploitTarget
-      :body [exploit-target
-             NewExploitTarget
-             {:description "an updated ExploitTarget"}]
-      :summary "Updates an ExploitTarget"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-exploit-target
-      :identity identity
-      (ok
-       (with-long-id
-         (flows/update-flow :get-fn #(read-store :exploit-target read-exploit-target %)
-                            :realize-fn realize-exploit-target
-                            :update-fn #(write-store :exploit-target update-exploit-target (:id %) %)
-                            :entity-type :exploit-target
-                            :entity-id id
-                            :identity identity
-                            :entity exploit-target))))
+           :tags ["ExploitTarget"]
+           (POST "/" []
+                 :return StoredExploitTarget
+                 :body [exploit-target NewExploitTarget
+                        {:description "a new ExploitTarget"}]
+                 :summary "Adds a new ExploitTarget"
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :capabilities :create-exploit-target
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow
+                      :realize-fn realize-exploit-target
+                      :store-fn #(write-store :exploit-target
+                                              create-exploit-targets
+                                              %)
+                      :entity-type :exploit-target
+                      :identity identity
+                      :entities [exploit-target])))))
+           (PUT "/:id" []
+                :return StoredExploitTarget
+                :body [exploit-target
+                       NewExploitTarget
+                       {:description "an updated ExploitTarget"}]
+                :summary "Updates an ExploitTarget"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :create-exploit-target
+                :identity identity
+                (ok
+                 (with-long-id
+                   (flows/update-flow
+                    :get-fn #(read-store :exploit-target read-exploit-target %)
+                    :realize-fn realize-exploit-target
+                    :update-fn #(write-store :exploit-target
+                                             update-exploit-target
+                                             (:id %)
+                                             %)
+                    :entity-type :exploit-target
+                    :entity-id id
+                    :identity identity
+                    :entity exploit-target))))
 
-    (GET "/external_id" []
-      :return [(s/maybe StoredExploitTarget)]
-      :query [q ExploitTargetByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List ExploitTarget by external id"
-      :capabilities #{:read-exploit-target :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :exploit-target list-exploit-targets
-                    {:external_ids (:external_id q)} q))))
+           (GET "/external_id" []
+                :return [(s/maybe StoredExploitTarget)]
+                :query [q ExploitTargetByExternalIdQueryParams]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List ExploitTarget by external id"
+                :capabilities #{:read-exploit-target :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :exploit-target list-exploit-targets
+                              {:external_ids (:external_id q)} q))))
 
-    (GET "/:id" []
-      :return (s/maybe StoredExploitTarget)
-      :summary "Gets an ExploitTarget by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-exploit-target
-      (if-let [d (read-store :exploit-target read-exploit-target id)]
-        (ok (with-long-id d))
-        (not-found)))
-    (DELETE "/:id" []
-      :no-doc true
-      :path-params [id :- s/Str]
-      :summary "Deletes an ExploitTarget"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-exploit-target
-      :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :exploit-target read-exploit-target %)
-                             :delete-fn #(write-store :exploit-target delete-exploit-target %)
-                             :entity-type :exploit-target
-                             :entity-id id
-                             :identity identity)
-        (no-content)
-        (not-found)))))
+           (GET "/:id" []
+                :return (s/maybe StoredExploitTarget)
+                :summary "Gets an ExploitTarget by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-exploit-target
+                (if-let [d (read-store :exploit-target read-exploit-target id)]
+                  (ok (with-long-id d))
+                  (not-found)))
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes an ExploitTarget"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-exploit-target
+                   :identity identity
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :exploit-target read-exploit-target %)
+                        :delete-fn #(write-store :exploit-target
+                                                 delete-exploit-target
+                                                 %)
+                        :entity-type :exploit-target
+                        :entity-id id
+                        :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -29,11 +29,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-exploit-target
-                            :store-fn #(write-store :exploit-target create-exploit-target %)
-                            :entity-type :exploit-target
-                            :identity identity
-                            :entity exploit-target))))
+         (first
+          (flows/create-flow :realize-fn realize-exploit-target
+                             :store-fn #(write-store :exploit-target create-exploit-target %)
+                             :entity-type :exploit-target
+                             :identity identity
+                             :entities [exploit-target])))))
     (PUT "/:id" []
       :return StoredExploitTarget
       :body [exploit-target

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -33,11 +33,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-feedback
-                            :store-fn #(write-store :feedback create-feedback %)
-                            :entity-type :feedback
-                            :identity identity
-                            :entity feedback))))
+         (first
+          (flows/create-flow :realize-fn realize-feedback
+                             :store-fn #(write-store :feedback create-feedback %)
+                             :entity-type :feedback
+                             :identity identity
+                             :entities [feedback])))))
 
     (GET "/" []
       :return [StoredFeedback]

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -35,7 +35,7 @@
        (with-long-id
          (first
           (flows/create-flow :realize-fn realize-feedback
-                             :store-fn #(write-store :feedback create-feedback %)
+                             :store-fn #(write-store :feedback create-feedbacks %)
                              :entity-type :feedback
                              :identity identity
                              :entities [feedback])))))

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -27,11 +27,12 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :realize-fn realize-incident
-                                       :store-fn #(write-store :incident create-incident %)
-                                       :entity-type :incident
-                                       :identity identity
-                                       :entity incident))))
+                    (first
+                     (flows/create-flow :realize-fn realize-incident
+                                        :store-fn #(write-store :incident create-incident %)
+                                        :entity-type :incident
+                                        :identity identity
+                                        :entities [incident])))))
            (PUT "/:id" []
                 :return StoredIncident
                 :body [incident NewIncident {:description "an updated incident"}]

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -28,11 +28,12 @@
                  (created
                   (with-long-id
                     (first
-                     (flows/create-flow :realize-fn realize-incident
-                                        :store-fn #(write-store :incident create-incident %)
-                                        :entity-type :incident
-                                        :identity identity
-                                        :entities [incident])))))
+                     (flows/create-flow
+                      :realize-fn realize-incident
+                      :store-fn #(write-store :incident create-incidents %)
+                      :entity-type :incident
+                      :identity identity
+                      :entities [incident])))))
            (PUT "/:id" []
                 :return StoredIncident
                 :body [incident NewIncident {:description "an updated incident"}]
@@ -42,13 +43,14 @@
                 :capabilities :create-incident
                 :identity identity
                 (ok (with-long-id
-                      (flows/update-flow :get-fn #(read-store :incident read-incident %)
-                                         :realize-fn realize-incident
-                                         :update-fn #(write-store :incident update-incident (:id %) %)
-                                         :entity-type :incident
-                                         :entity-id id
-                                         :identity identity
-                                         :entity incident))))
+                      (flows/update-flow
+                       :get-fn #(read-store :incident read-incident %)
+                       :realize-fn realize-incident
+                       :update-fn #(write-store :incident update-incident (:id %) %)
+                       :entity-type :incident
+                       :entity-id id
+                       :identity identity
+                       :entity incident))))
 
            (GET "/external_id" []
                 :return [(s/maybe StoredIncident)]
@@ -77,10 +79,11 @@
                    :header-params [api_key :- (s/maybe s/Str)]
                    :capabilities :delete-incident
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :incident read-incident %)
-                                          :delete-fn #(write-store :incident delete-incident %)
-                                          :entity-type :incident
-                                          :entity-id id
-                                          :identity identity)
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :incident read-incident %)
+                        :delete-fn #(write-store :incident delete-incident %)
+                        :entity-type :incident
+                        :entity-id id
+                        :identity identity)
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -56,7 +56,7 @@
        (with-long-id
          (first
           (flows/create-flow :realize-fn realize-indicator
-                             :store-fn #(write-store :indicator create-indicator %)
+                             :store-fn #(write-store :indicator create-indicators %)
                              :entity-type :indicator
                              :identity identity
                              :entities [indicator])))))

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -54,11 +54,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-indicator
-                            :store-fn #(write-store :indicator create-indicator %)
-                            :entity-type :indicator
-                            :identity identity
-                            :entity indicator))))
+         (first
+          (flows/create-flow :realize-fn realize-indicator
+                             :store-fn #(write-store :indicator create-indicator %)
+                             :entity-type :indicator
+                             :identity identity
+                             :entities [indicator])))))
     (PUT "/:id" []
       :return StoredIndicator
       :body [indicator NewIndicator {:description "an updated Indicator"}]

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -44,11 +44,12 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :realize-fn realize-judgement
-                                       :store-fn #(write-store :judgement create-judgement %)
-                                       :entity-type :judgement
-                                       :identity identity
-                                       :entity judgement))))
+                    (first
+                     (flows/create-flow :realize-fn realize-judgement
+                                        :store-fn #(write-store :judgement create-judgement %)
+                                        :entity-type :judgement
+                                        :identity identity
+                                        :entities [judgement])))))
            (POST "/:judgement-id/indicator" []
                  :return (s/maybe RelatedIndicator)
                  :path-params [judgement-id :- s/Str]

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -45,11 +45,12 @@
                  (created
                   (with-long-id
                     (first
-                     (flows/create-flow :realize-fn realize-judgement
-                                        :store-fn #(write-store :judgement create-judgement %)
-                                        :entity-type :judgement
-                                        :identity identity
-                                        :entities [judgement])))))
+                     (flows/create-flow
+                      :realize-fn realize-judgement
+                      :store-fn #(write-store :judgement create-judgements %)
+                      :entity-type :judgement
+                      :identity identity
+                      :entities [judgement])))))
            (POST "/:judgement-id/indicator" []
                  :return (s/maybe RelatedIndicator)
                  :path-params [judgement-id :- s/Str]
@@ -95,10 +96,11 @@
                    :summary "Deletes a Judgement"
                    :capabilities :delete-judgement
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :judgement read-judgement %)
-                                          :delete-fn #(write-store :judgement delete-judgement %)
-                                          :entity-type :judgement
-                                          :entity-id id
-                                          :identity identity)
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :judgement read-judgement %)
+                        :delete-fn #(write-store :judgement delete-judgement %)
+                        :entity-type :judgement
+                        :entity-id id
+                        :identity identity)
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -21,7 +21,8 @@
            :tags ["Relationship"]
            (POST "/" []
                  :return StoredRelationship
-                 :body [relationship NewRelationship {:description "a new Relationship"}]
+                 :body [relationship NewRelationship
+                        {:description "a new Relationship"}]
                  :header-params [api_key :- (s/maybe s/Str)]
                  :summary "Adds a new Relationship"
                  :capabilities :create-relationship
@@ -29,12 +30,13 @@
                  (created
                   (with-long-id
                     (first
-                     (flows/create-flow :entity-type :relationship
-                                        :realize-fn realize-relationship
-                                        :store-fn #(write-store :relationship create-relationship %)
-                                        :entity-type :relationship
-                                        :identity identity
-                                        :entities [relationship])))))
+                     (flows/create-flow
+                      :entity-type :relationship
+                      :realize-fn realize-relationship
+                      :store-fn #(write-store :relationship create-relationships %)
+                      :entity-type :relationship
+                      :identity identity
+                      :entities [relationship])))))
            (GET "/external_id" []
                 :return [(s/maybe StoredRelationship)]
                 :query [q RelationshipByExternalIdQueryParams]
@@ -63,10 +65,11 @@
                    :header-params [api_key :- (s/maybe s/Str)]
                    :capabilities :delete-relationship
                    :identity identity
-                   (if (flows/delete-flow :get-fn #(read-store :relationship read-relationship %)
-                                          :delete-fn #(write-store :relationship delete-relationship %)
-                                          :entity-type :relationship
-                                          :entity-id id
-                                          :identity identity)
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :relationship read-relationship %)
+                        :delete-fn #(write-store :relationship delete-relationship %)
+                        :entity-type :relationship
+                        :entity-id id
+                        :identity identity)
                      (no-content)
                      (not-found)))))

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -28,12 +28,13 @@
                  :identity identity
                  (created
                   (with-long-id
-                    (flows/create-flow :entity-type :relationship
-                                       :realize-fn realize-relationship
-                                       :store-fn #(write-store :relationship create-relationship %)
-                                       :entity-type :relationship
-                                       :identity identity
-                                       :entity relationship))))
+                    (first
+                     (flows/create-flow :entity-type :relationship
+                                        :realize-fn realize-relationship
+                                        :store-fn #(write-store :relationship create-relationship %)
+                                        :entity-type :relationship
+                                        :identity identity
+                                        :entities [relationship])))))
            (GET "/external_id" []
                 :return [(s/maybe StoredRelationship)]
                 :query [q RelationshipByExternalIdQueryParams]

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -31,7 +31,7 @@
          (with-long-id
            (first
             (flows/create-flow :realize-fn realize-sighting
-                               :store-fn #(write-store :sighting create-sighting %)
+                               :store-fn #(write-store :sighting create-sightings %)
                                :entity-type :sighting
                                :identity identity
                                :entities [sighting]))))

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -29,11 +29,12 @@
       (if (check-new-sighting sighting)
         (created
          (with-long-id
-           (flows/create-flow :realize-fn realize-sighting
-                              :store-fn #(write-store :sighting create-sighting %)
-                              :entity-type :sighting
-                              :identity identity
-                              :entity sighting)))
+           (first
+            (flows/create-flow :realize-fn realize-sighting
+                               :store-fn #(write-store :sighting create-sighting %)
+                               :entity-type :sighting
+                               :identity identity
+                               :entities [sighting]))))
         (unprocessable-entity)))
     (PUT "/:id" []
       :return StoredSighting

--- a/src/ctia/http/routes/ttp.clj
+++ b/src/ctia/http/routes/ttp.clj
@@ -30,7 +30,7 @@
        (with-long-id
          (first
           (flows/create-flow :realize-fn realize-ttp
-                             :store-fn #(write-store :ttp create-ttp %)
+                             :store-fn #(write-store :ttp create-ttps %)
                              :entity-type :ttp
                              :identity identity
                              :entities [ttp])))))

--- a/src/ctia/http/routes/ttp.clj
+++ b/src/ctia/http/routes/ttp.clj
@@ -28,11 +28,12 @@
       :identity identity
       (created
        (with-long-id
-         (flows/create-flow :realize-fn realize-ttp
-                            :store-fn #(write-store :ttp create-ttp %)
-                            :entity-type :ttp
-                            :identity identity
-                            :entity ttp))))
+         (first
+          (flows/create-flow :realize-fn realize-ttp
+                             :store-fn #(write-store :ttp create-ttp %)
+                             :entity-type :ttp
+                             :identity identity
+                             :entities [ttp])))))
     (PUT "/:id" []
       :return StoredTTP
       :body [ttp NewTTP {:description "an updated TTP"}]

--- a/src/ctia/http/routes/verdict.clj
+++ b/src/ctia/http/routes/verdict.clj
@@ -9,20 +9,23 @@
 
 (defroutes verdict-routes
   (GET "/:observable_type/:observable_value/verdict" []
-    :tags ["Verdict"]
-    :path-params [observable_type :- ObservableTypeIdentifier
-                  observable_value :- s/Str]
-    :return (s/maybe StoredVerdict)
-    :summary "Returns the current Verdict associated with the specified observable."
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :read-verdict
-    (if-let [d (-> (read-store :verdict list-verdicts
-                               {[:observable :type] observable_type
-                                [:observable :value] observable_value} {:sort_by :created
-                                                                        :sort_order :desc
-                                                                        :limit 1})
-                   :data
-                   first)]
+       :tags ["Verdict"]
+       :path-params [observable_type :- ObservableTypeIdentifier
+                     observable_value :- s/Str]
+       :return (s/maybe StoredVerdict)
+       :summary (str "Returns the current Verdict associated with the specified "
+                     "observable.")
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :read-verdict
+       (if-let [d (-> (read-store
+                       :verdict list-verdicts
+                       {[:observable :type] observable_type
+                        [:observable :value] observable_value}
+                       {:sort_by :created
+                        :sort_order :desc
+                        :limit 1})
+                      :data
+                      first)]
 
-      (ok (with-long-id d))
-      (not-found))))
+         (ok (with-long-id d))
+         (not-found))))

--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -2,6 +2,8 @@
   (:require
    [ctia.lib.pagination :as pagination]
    [ctia.lib.es.query :refer [filter-map->terms-query]]
+   [clojurewerkz.elastisch.native.bulk :as native-bulk]
+   [clojurewerkz.elastisch.rest.bulk :as rest-bulk]
    [clojurewerkz.elastisch.native.document :as native-document]
    [clojurewerkz.elastisch.rest.document :as rest-document]
    [clojurewerkz.elastisch.native.response :as native-response]
@@ -16,6 +18,16 @@
   (if (native-conn? conn)
     native-document/get
     rest-document/get))
+
+(defn bulk-index-fn [conn]
+  (if (native-conn? conn)
+    native-bulk/bulk-index
+    rest-bulk/bulk-index))
+
+(defn bulk-fn [conn]
+  (if (native-conn? conn)
+    native-bulk/bulk
+    rest-bulk/bulk))
 
 (defn create-doc-fn [conn]
   (if (native-conn? conn)
@@ -63,6 +75,17 @@
    {:id (:id doc)
     :refresh refresh?})
   doc)
+
+(defn bulk-create-doc
+  "create multiple documents on ES and return the created documents"
+  [conn docs refresh?]
+  (let [bulk-index (bulk-index-fn conn)
+        bulk (bulk-fn conn)
+        index-operations (bulk-index docs)]
+    (bulk conn
+          index-operations
+          {:refresh refresh?}))
+  docs)
 
 (defn update-doc
   "update a document on es return the updated document"

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -2,13 +2,13 @@
 
 (defprotocol IActorStore
   (read-actor [this id])
-  (create-actor [this new-actors])
+  (create-actors [this new-actors])
   (update-actor [this id actor])
   (delete-actor [this id])
   (list-actors [this filtermap params]))
 
 (defprotocol IJudgementStore
-  (create-judgement [this new-judgements])
+  (create-judgements [this new-judgements])
   (read-judgement [this id])
   (delete-judgement [this id])
   (list-judgements [this filter-map params])
@@ -17,13 +17,13 @@
   (add-indicator-to-judgement [this judgement-id indicator-relationship]))
 
 (defprotocol IVerdictStore
-  (create-verdict [this new-verdicts])
+  (create-verdicts [this new-verdicts])
   (read-verdict [this id])
   (delete-verdict [this id])
   (list-verdicts [this filter-map params]))
 
 (defprotocol IIndicatorStore
-  (create-indicator [this new-indicators])
+  (create-indicators [this new-indicators])
   (update-indicator [this id indicator])
   (read-indicator [this id])
   (delete-indicator [this id])
@@ -32,41 +32,41 @@
 
 (defprotocol IExploitTargetStore
   (read-exploit-target [this id])
-  (create-exploit-target [this new-exploit-targets])
+  (create-exploit-targets [this new-exploit-targets])
   (update-exploit-target [this id exploit-target])
   (delete-exploit-target [this id])
   (list-exploit-targets [this filtermap params]))
 
 (defprotocol IFeedbackStore
   (read-feedback [this id])
-  (create-feedback [this new-feedbacks])
+  (create-feedbacks [this new-feedbacks])
   (delete-feedback [this id])
   (list-feedback [this filtermap params]))
 
 (defprotocol ITTPStore
   (read-ttp [this id])
-  (create-ttp [this new-ttps])
+  (create-ttps [this new-ttps])
   (update-ttp [this id ttp])
   (delete-ttp [this id])
   (list-ttps [this filtermap params]))
 
 (defprotocol ICampaignStore
   (read-campaign [this id])
-  (create-campaign [this new-campaigns])
+  (create-campaigns [this new-campaigns])
   (update-campaign [this id campaign])
   (delete-campaign [this id])
   (list-campaigns [this filtermap params]))
 
 (defprotocol ICOAStore
   (read-coa [this id])
-  (create-coa [this new-coas])
+  (create-coas [this new-coas])
   (update-coa [this id coa])
   (delete-coa [this id])
   (list-coas [this filtermap params]))
 
 (defprotocol ISightingStore
   (read-sighting [this id])
-  (create-sighting [this new-sightings])
+  (create-sightings [this new-sightings])
   (update-sighting [this id sighting])
   (delete-sighting [this id])
   (list-sightings [this filtermap params])
@@ -74,19 +74,19 @@
 
 (defprotocol IIncidentStore
   (read-incident [this id])
-  (create-incident [this new-incidents])
+  (create-incidents [this new-incidents])
   (update-incident [this id incident])
   (delete-incident [this id])
   (list-incidents [this filtermap params]))
 
 (defprotocol IBundleStore
   (read-bundle [this id])
-  (create-bundle [this new-bundles])
+  (create-bundles [this new-bundles])
   (delete-bundle [this id]))
 
 (defprotocol IRelationshipStore
   (read-relationship [this id])
-  (create-relationship [this new-relations])
+  (create-relationships [this new-relations])
   (delete-relationship [this id])
   (list-relationships [this filtermap params]))
 
@@ -97,7 +97,7 @@
 
 (defprotocol IDataTableStore
   (read-data-table [this login])
-  (create-data-table [this new-data-tables])
+  (create-data-tables [this new-data-tables])
   (delete-data-table [this role])
   (list-data-tables [this filtermap params]))
 

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -2,13 +2,13 @@
 
 (defprotocol IActorStore
   (read-actor [this id])
-  (create-actor [this new-actor])
+  (create-actor [this new-actors])
   (update-actor [this id actor])
   (delete-actor [this id])
   (list-actors [this filtermap params]))
 
 (defprotocol IJudgementStore
-  (create-judgement [this new-judgement])
+  (create-judgement [this new-judgements])
   (read-judgement [this id])
   (delete-judgement [this id])
   (list-judgements [this filter-map params])
@@ -17,13 +17,13 @@
   (add-indicator-to-judgement [this judgement-id indicator-relationship]))
 
 (defprotocol IVerdictStore
-  (create-verdict [this new-verdict])
+  (create-verdict [this new-verdicts])
   (read-verdict [this id])
   (delete-verdict [this id])
   (list-verdicts [this filter-map params]))
 
 (defprotocol IIndicatorStore
-  (create-indicator [this new-indicator])
+  (create-indicator [this new-indicators])
   (update-indicator [this id indicator])
   (read-indicator [this id])
   (delete-indicator [this id])
@@ -32,41 +32,41 @@
 
 (defprotocol IExploitTargetStore
   (read-exploit-target [this id])
-  (create-exploit-target [this new-exploit-target])
+  (create-exploit-target [this new-exploit-targets])
   (update-exploit-target [this id exploit-target])
   (delete-exploit-target [this id])
   (list-exploit-targets [this filtermap params]))
 
 (defprotocol IFeedbackStore
   (read-feedback [this id])
-  (create-feedback [this new-feedback])
+  (create-feedback [this new-feedbacks])
   (delete-feedback [this id])
   (list-feedback [this filtermap params]))
 
 (defprotocol ITTPStore
   (read-ttp [this id])
-  (create-ttp [this new-ttp])
+  (create-ttp [this new-ttps])
   (update-ttp [this id ttp])
   (delete-ttp [this id])
   (list-ttps [this filtermap params]))
 
 (defprotocol ICampaignStore
   (read-campaign [this id])
-  (create-campaign [this new-campaign])
+  (create-campaign [this new-campaigns])
   (update-campaign [this id campaign])
   (delete-campaign [this id])
   (list-campaigns [this filtermap params]))
 
 (defprotocol ICOAStore
   (read-coa [this id])
-  (create-coa [this new-coa])
+  (create-coa [this new-coas])
   (update-coa [this id coa])
   (delete-coa [this id])
   (list-coas [this filtermap params]))
 
 (defprotocol ISightingStore
   (read-sighting [this id])
-  (create-sighting [this new-sighting])
+  (create-sighting [this new-sightings])
   (update-sighting [this id sighting])
   (delete-sighting [this id])
   (list-sightings [this filtermap params])
@@ -74,19 +74,19 @@
 
 (defprotocol IIncidentStore
   (read-incident [this id])
-  (create-incident [this new-incident])
+  (create-incident [this new-incidents])
   (update-incident [this id incident])
   (delete-incident [this id])
   (list-incidents [this filtermap params]))
 
 (defprotocol IBundleStore
   (read-bundle [this id])
-  (create-bundle [this new-bundle])
+  (create-bundle [this new-bundles])
   (delete-bundle [this id]))
 
 (defprotocol IRelationshipStore
   (read-relationship [this id])
-  (create-relationship [this new-relation])
+  (create-relationship [this new-relations])
   (delete-relationship [this id])
   (list-relationships [this filtermap params]))
 
@@ -97,7 +97,7 @@
 
 (defprotocol IDataTableStore
   (read-data-table [this login])
-  (create-data-table [this new-data-table])
+  (create-data-table [this new-data-tables])
   (delete-data-table [this role])
   (list-data-tables [this filtermap params]))
 

--- a/src/ctia/stores/atom/common.clj
+++ b/src/ctia/stores/atom/common.clj
@@ -22,11 +22,13 @@
 (defn create-handler-from-realized
   "Create a new resource from a realized object"
   [Model]
-  (s/fn :- Model
+  (s/fn :- [Model]
     [state :- (ls/atom {s/Str Model})
-     model :- Model]
-    (let [id (:id model)]
-      (get (swap! state assoc id model) id))))
+     models :- [Model]]
+    (doall
+     (for [model models]
+       (let [id (:id model)]
+         (get (swap! state assoc id model) id))))))
 
 (defn update-handler-from-realized
   "Update a resource using an id and a realized object"

--- a/src/ctia/stores/atom/store.clj
+++ b/src/ctia/stores/atom/store.clj
@@ -138,8 +138,8 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgement]
-    (judgement/handle-create-judgement state new-judgement))
+  (create-judgement [_ new-judgements]
+    (judgement/handle-create-judgement state new-judgements))
   (read-judgement [_ id]
     (judgement/handle-read-judgement state id))
   (delete-judgement [_ id]
@@ -169,8 +169,8 @@
 
 (defrecord VerdictStore [state]
   IVerdictStore
-  (create-verdict [_ new-verdict]
-    (verdict/handle-create state new-verdict))
+  (create-verdict [_ new-verdicts]
+    (verdict/handle-create state new-verdicts))
   (read-verdict [_ id]
     (verdict/handle-read state id))
   (delete-verdict [_ id]

--- a/src/ctia/stores/atom/store.clj
+++ b/src/ctia/stores/atom/store.clj
@@ -29,7 +29,7 @@
   IActorStore
   (read-actor [_ id]
     (actor/handle-read-actor state id))
-  (create-actor [_ new-actor]
+  (create-actors [_ new-actor]
     (actor/handle-create-actor state new-actor))
   (update-actor [_ id actor]
     (actor/handle-update-actor state id actor))
@@ -42,7 +42,7 @@
   ICampaignStore
   (read-campaign [_ id]
     (campaign/handle-read-campaign state id))
-  (create-campaign [_ new-campaign]
+  (create-campaigns [_ new-campaign]
     (campaign/handle-create-campaign state new-campaign))
   (update-campaign [_ id new-campaign]
     (campaign/handle-update-campaign state id new-campaign))
@@ -55,7 +55,7 @@
   ICOAStore
   (read-coa [_ id]
     (coa/handle-read-coa state id))
-  (create-coa [_ new-coa]
+  (create-coas [_ new-coa]
     (coa/handle-create-coa state new-coa))
   (update-coa [_ id new-coa]
     (coa/handle-update-coa state id new-coa))
@@ -68,7 +68,7 @@
   IDataTableStore
   (read-data-table [_ id]
     (data-table/handle-read-data-table state id))
-  (create-data-table [_ new-data-table]
+  (create-data-tables [_ new-data-table]
     (data-table/handle-create-data-table state new-data-table))
   (delete-data-table [_ id]
     (data-table/handle-delete-data-table state id))
@@ -79,7 +79,7 @@
   IExploitTargetStore
   (read-exploit-target [_ id]
     (expl-tar/handle-read-exploit-target state id))
-  (create-exploit-target [_ new-exploit-target]
+  (create-exploit-targets [_ new-exploit-target]
     (expl-tar/handle-create-exploit-target state new-exploit-target))
   (update-exploit-target [_ id new-exploit-target]
     (expl-tar/handle-update-exploit-target state id new-exploit-target))
@@ -90,7 +90,7 @@
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedback [_ new-feedback]
+  (create-feedbacks [_ new-feedback]
     (feedback/handle-create-feedback state new-feedback))
   (read-feedback [_ id]
     (feedback/handle-read-feedback state id))
@@ -112,7 +112,7 @@
   IIncidentStore
   (read-incident [_ id]
     (incident/handle-read-incident state id))
-  (create-incident [_ new-incident]
+  (create-incidents [_ new-incident]
     (incident/handle-create-incident state new-incident))
   (update-incident [_ id incident]
     (incident/handle-update-incident state id incident))
@@ -123,8 +123,8 @@
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicator [_ new-indicator]
-    (indicator/handle-create-indicator state new-indicator))
+  (create-indicators [_ new-indicators]
+    (indicator/handle-create-indicator state new-indicators))
   (update-indicator [_ id new-indicator]
     (indicator/handle-update-indicator state id new-indicator))
   (read-indicator [_ id]
@@ -138,7 +138,7 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgements]
+  (create-judgements [_ new-judgements]
     (judgement/handle-create-judgement state new-judgements))
   (read-judgement [_ id]
     (judgement/handle-read-judgement state id))
@@ -158,8 +158,8 @@
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationship [_ new-relationship]
-    (relationship/handle-create-relationship state new-relationship))
+  (create-relationships [_ new-relationships]
+    (relationship/handle-create-relationship state new-relationships))
   (read-relationship [_ id]
     (relationship/handle-read-relationship state id))
   (delete-relationship [_ id]
@@ -169,7 +169,7 @@
 
 (defrecord VerdictStore [state]
   IVerdictStore
-  (create-verdict [_ new-verdicts]
+  (create-verdicts [_ new-verdicts]
     (verdict/handle-create state new-verdicts))
   (read-verdict [_ id]
     (verdict/handle-read state id))
@@ -182,7 +182,7 @@
   ISightingStore
   (read-sighting [_ id]
     (sighting/handle-read-sighting state id))
-  (create-sighting [_ new-sighting]
+  (create-sightings [_ new-sighting]
     (sighting/handle-create-sighting state new-sighting))
   (update-sighting [_ id sighting]
     (sighting/handle-update-sighting state id sighting))
@@ -197,8 +197,8 @@
   ITTPStore
   (read-ttp [_ id]
     (ttp/handle-read-ttp state id))
-  (create-ttp [_ new-ttp]
-    (ttp/handle-create-ttp state new-ttp))
+  (create-ttps [_ new-ttps]
+    (ttp/handle-create-ttp state new-ttps))
   (update-ttp [_ id new-ttp]
     (ttp/handle-update-ttp state id new-ttp))
   (delete-ttp [_ id]
@@ -210,7 +210,7 @@
   IBundleStore
   (read-bundle [_ id]
     (bundle/handle-read-bundle state id))
-  (create-bundle [_ new-bundle]
-    (bundle/handle-create-bundle state new-bundle))
+  (create-bundles [_ new-bundles]
+    (bundle/handle-create-bundle state new-bundles))
   (delete-bundle [_ id]
     (bundle/handle-delete-bundle state id)))

--- a/src/ctia/stores/es/actor.clj
+++ b/src/ctia/stores/es/actor.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredActor]]))
 
-(def handle-create-actor (crud/handle-create :actor StoredActor))
-(def handle-read-actor (crud/handle-read :actor StoredActor))
-(def handle-update-actor (crud/handle-update :actor StoredActor))
-(def handle-delete-actor (crud/handle-delete :actor StoredActor))
-(def handle-list-actors (crud/handle-find :actor StoredActor))
+(def handle-create (crud/handle-create :actor StoredActor))
+(def handle-read (crud/handle-read :actor StoredActor))
+(def handle-update (crud/handle-update :actor StoredActor))
+(def handle-delete (crud/handle-delete :actor StoredActor))
+(def handle-list (crud/handle-find :actor StoredActor))

--- a/src/ctia/stores/es/bundle.clj
+++ b/src/ctia/stores/es/bundle.clj
@@ -2,6 +2,6 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredBundle]]))
 
-(def handle-create-bundle (crud/handle-create :bundle StoredBundle))
-(def handle-read-bundle (crud/handle-read :bundle StoredBundle))
-(def handle-delete-bundle (crud/handle-delete :bundle StoredBundle))
+(def handle-create (crud/handle-create :bundle StoredBundle))
+(def handle-read (crud/handle-read :bundle StoredBundle))
+(def handle-delete (crud/handle-delete :bundle StoredBundle))

--- a/src/ctia/stores/es/campaign.clj
+++ b/src/ctia/stores/es/campaign.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredCampaign]]))
 
-(def handle-create-campaign (crud/handle-create :campaign StoredCampaign))
-(def handle-read-campaign (crud/handle-read :campaign StoredCampaign))
-(def handle-update-campaign (crud/handle-update :campaign StoredCampaign))
-(def handle-delete-campaign (crud/handle-delete :campaign StoredCampaign))
-(def handle-list-campaigns (crud/handle-find :campaign StoredCampaign))
+(def handle-create (crud/handle-create :campaign StoredCampaign))
+(def handle-read (crud/handle-read :campaign StoredCampaign))
+(def handle-update (crud/handle-update :campaign StoredCampaign))
+(def handle-delete (crud/handle-delete :campaign StoredCampaign))
+(def handle-list (crud/handle-find :campaign StoredCampaign))

--- a/src/ctia/stores/es/coa.clj
+++ b/src/ctia/stores/es/coa.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredCOA]]))
 
-(def handle-create-coa (crud/handle-create :coa StoredCOA))
-(def handle-read-coa (crud/handle-read :coa StoredCOA))
-(def handle-update-coa (crud/handle-update :coa StoredCOA))
-(def handle-delete-coa (crud/handle-delete :coa StoredCOA))
-(def handle-list-coas (crud/handle-find :coa StoredCOA))
+(def handle-create (crud/handle-create :coa StoredCOA))
+(def handle-read (crud/handle-read :coa StoredCOA))
+(def handle-update (crud/handle-update :coa StoredCOA))
+(def handle-delete (crud/handle-delete :coa StoredCOA))
+(def handle-list (crud/handle-find :coa StoredCOA))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -4,7 +4,7 @@
             [schema.coerce :as c]
             [ring.swagger.coerce :as sc]
             [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.lib.es.document :refer [create-doc
+            [ctia.lib.es.document :refer [bulk-create-doc
                                           update-doc
                                           get-doc
                                           delete-doc
@@ -18,15 +18,18 @@
   "Generate an ES create handler using some mapping and schema"
   [mapping Model]
   (let [coerce! (coerce-to-fn (s/maybe Model))]
-    (s/fn :- (s/maybe Model)
+    (s/fn :- (s/maybe [Model])
       [state :- ESConnState
-       realized :- Model]
-      (-> (create-doc (:conn state)
-                      (:index state)
-                      (name mapping)
-                      realized
-                      (get-in state [:props :refresh] false))
-          coerce!))))
+       models :- [Model]]
+      (->> (bulk-create-doc (:conn state)
+                            (map #(assoc %
+                                         :_id (:id %)
+                                         :_index (:index state)
+                                         :_type (name mapping))
+                                 models)
+                            (get-in state [:props :refresh] false))
+           (map #(dissoc % :_id :_index :_type))
+           (map coerce!)))))
 
 (defn handle-update
   "Generate an ES update handler using some mapping and schema"

--- a/src/ctia/stores/es/data_table.clj
+++ b/src/ctia/stores/es/data_table.clj
@@ -2,7 +2,7 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredDataTable]]))
 
-(def handle-create-data-table (crud/handle-create :data-table StoredDataTable))
-(def handle-read-data-table (crud/handle-read :data-table StoredDataTable))
-(def handle-delete-data-table (crud/handle-delete :data-table StoredDataTable))
-(def handle-list-data-tables (crud/handle-find :data-table StoredDataTable))
+(def handle-create (crud/handle-create :data-table StoredDataTable))
+(def handle-read (crud/handle-read :data-table StoredDataTable))
+(def handle-delete (crud/handle-delete :data-table StoredDataTable))
+(def handle-list (crud/handle-find :data-table StoredDataTable))

--- a/src/ctia/stores/es/exploit_target.clj
+++ b/src/ctia/stores/es/exploit_target.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredExploitTarget]]))
 
-(def handle-create-exploit-target (crud/handle-create :exploit-target StoredExploitTarget))
-(def handle-read-exploit-target (crud/handle-read :exploit-target StoredExploitTarget))
-(def handle-update-exploit-target (crud/handle-update :exploit-target StoredExploitTarget))
-(def handle-delete-exploit-target (crud/handle-delete :exploit-target StoredExploitTarget))
-(def handle-list-exploit-targets (crud/handle-find :exploit-target StoredExploitTarget))
+(def handle-create (crud/handle-create :exploit-target StoredExploitTarget))
+(def handle-read (crud/handle-read :exploit-target StoredExploitTarget))
+(def handle-update (crud/handle-update :exploit-target StoredExploitTarget))
+(def handle-delete (crud/handle-delete :exploit-target StoredExploitTarget))
+(def handle-list (crud/handle-find :exploit-target StoredExploitTarget))

--- a/src/ctia/stores/es/feedback.clj
+++ b/src/ctia/stores/es/feedback.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredFeedback]]))
 
-(def handle-create-feedback (crud/handle-create :feedback StoredFeedback))
-(def handle-read-feedback (crud/handle-read :feedback StoredFeedback))
-(def handle-update-feedback (crud/handle-update :feedback StoredFeedback))
-(def handle-delete-feedback (crud/handle-delete :feedback StoredFeedback))
-(def handle-list-feedback (crud/handle-find :feedback StoredFeedback))
+(def handle-create (crud/handle-create :feedback StoredFeedback))
+(def handle-read (crud/handle-read :feedback StoredFeedback))
+(def handle-update (crud/handle-update :feedback StoredFeedback))
+(def handle-delete (crud/handle-delete :feedback StoredFeedback))
+(def handle-list (crud/handle-find :feedback StoredFeedback))

--- a/src/ctia/stores/es/identity.clj
+++ b/src/ctia/stores/es/identity.clj
@@ -19,7 +19,7 @@
    into a vec of strings"
   (vec (map name caps)))
 
-(defn handle-create-identity [state new-identity]
+(defn handle-create [state new-identity]
   (let [id (:login new-identity)
         realized (assoc new-identity :id id)
         transformed (update-in realized [:capabilities]
@@ -34,7 +34,7 @@
         (update-in [:capabilities] capabilities->capabilities-set)
         (dissoc :id))))
 
-(s/defn handle-read-identity :- (s/maybe Identity)
+(s/defn handle-read :- (s/maybe Identity)
   [state :- s/Any login :- s/Str]
   (some-> (get-doc (:conn state)
                    (:index state)
@@ -43,7 +43,7 @@
           (update-in [:capabilities] capabilities->capabilities-set)
           (dissoc :id)))
 
-(defn handle-delete-identity [state login]
+(defn handle-delete [state login]
   (delete-doc (:conn state)
               (:index state)
               mapping

--- a/src/ctia/stores/es/incident.clj
+++ b/src/ctia/stores/es/incident.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredIncident]]))
 
-(def handle-create-incident (crud/handle-create :incident StoredIncident))
-(def handle-read-incident (crud/handle-read :incident StoredIncident))
-(def handle-update-incident (crud/handle-update :incident StoredIncident))
-(def handle-delete-incident (crud/handle-delete :incident StoredIncident))
-(def handle-list-incidents (crud/handle-find :incident StoredIncident))
+(def handle-create (crud/handle-create :incident StoredIncident))
+(def handle-read (crud/handle-read :incident StoredIncident))
+(def handle-update (crud/handle-update :incident StoredIncident))
+(def handle-delete (crud/handle-delete :incident StoredIncident))
+(def handle-list (crud/handle-find :incident StoredIncident))

--- a/src/ctia/stores/es/indicator.clj
+++ b/src/ctia/stores/es/indicator.clj
@@ -4,15 +4,15 @@
             [ctia.schemas.core :refer [StoredIndicator]]
             [ctia.stores.es.crud :as crud]))
 
-(def handle-create-indicator (crud/handle-create :indicator StoredIndicator))
-(def handle-read-indicator (crud/handle-read :indicator StoredIndicator))
-(def handle-update-indicator (crud/handle-update :indicator StoredIndicator))
-(def handle-delete-indicator (crud/handle-delete :indicator StoredIndicator))
-(def handle-list-indicators (crud/handle-find :indicator StoredIndicator))
+(def handle-create (crud/handle-create :indicator StoredIndicator))
+(def handle-read (crud/handle-read :indicator StoredIndicator))
+(def handle-update (crud/handle-update :indicator StoredIndicator))
+(def handle-delete (crud/handle-delete :indicator StoredIndicator))
+(def handle-list (crud/handle-find :indicator StoredIndicator))
 
 (def ^{:private true} mapping "indicator")
 
-(defn handle-list-indicators-by-judgements
+(defn handle-list-by-judgements
   [state judgements params]
   (let [ids (some->> judgements
                      (map :indicators)

--- a/src/ctia/stores/es/judgement.clj
+++ b/src/ctia/stores/es/judgement.clj
@@ -26,16 +26,16 @@
   (c/coercer! [(s/maybe StoredJudgement)]
               sc/json-schema-coercion-matcher))
 
-(def handle-create-judgement (crud/handle-create :judgement StoredJudgement))
-(def handle-read-judgement (crud/handle-read :judgement StoredJudgement))
-(def handle-delete-judgement (crud/handle-delete :judgement StoredJudgement))
-(def handle-list-judgements (crud/handle-find :judgement StoredJudgement))
+(def handle-create (crud/handle-create :judgement StoredJudgement))
+(def handle-read (crud/handle-read :judgement StoredJudgement))
+(def handle-delete (crud/handle-delete :judgement StoredJudgement))
+(def handle-list (crud/handle-find :judgement StoredJudgement))
 
-(defn handle-add-indicator-to-judgement
+(defn handle-add-indicator-to
   "add an indicator relation to a judgement"
   [state judgement-id indicator-rel]
 
-  (let [judgement (handle-read-judgement state judgement-id)
+  (let [judgement (handle-read state judgement-id)
         indicator-rels (:indicators judgement)
         updated-rels (conj indicator-rels indicator-rel)
         updated {:indicators (set updated-rels)}]
@@ -49,7 +49,7 @@
     indicator-rel))
 
 
-(defn list-active-judgements-by-observable
+(defn list-active-by-observable
   [state observable]
   (let [params {:query (active-judgements-by-observable-query observable)
                 :sort {:priority "desc"
@@ -78,6 +78,6 @@
 (s/defn handle-calculate-verdict :- (s/maybe Verdict)
   [state observable]
 
-  (some-> (list-active-judgements-by-observable state observable)
+  (some-> (list-active-by-observable state observable)
           first
           make-verdict))

--- a/src/ctia/stores/es/relationship.clj
+++ b/src/ctia/stores/es/relationship.clj
@@ -2,7 +2,7 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredRelationship]]))
 
-(def handle-create-relationship (crud/handle-create :relationship StoredRelationship))
-(def handle-read-relationship (crud/handle-read :relationship StoredRelationship))
-(def handle-delete-relationship (crud/handle-delete :relationship StoredRelationship))
-(def handle-list-relationships (crud/handle-find :relationship StoredRelationship))
+(def handle-create (crud/handle-create :relationship StoredRelationship))
+(def handle-read (crud/handle-read :relationship StoredRelationship))
+(def handle-delete (crud/handle-delete :relationship StoredRelationship))
+(def handle-list (crud/handle-find :relationship StoredRelationship))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -39,7 +39,7 @@
   [s :- (s/maybe ESStoredSighting)]
   (when s (dissoc s :observables_hash)))
 
-(s/defn handle-create-sighting :- [StoredSighting]
+(s/defn handle-create :- [StoredSighting]
   [state :- ESConnState
    new-sightings :- [StoredSighting]]
   (doall
@@ -48,18 +48,18 @@
         (create-fn state)
         (map es-stored-sighting->stored-sighting))))
 
-(s/defn handle-read-sighting :- (s/maybe StoredSighting)
+(s/defn handle-read :- (s/maybe StoredSighting)
   [state id]
   (es-stored-sighting->stored-sighting
    (read-fn state id)))
 
-(s/defn handle-update-sighting :- StoredSighting
+(s/defn handle-update :- StoredSighting
   [state id realized]
   (->> (stored-sighting->es-stored-sighting realized)
        (update-fn state id)
        es-stored-sighting->stored-sighting))
 
-(def handle-delete-sighting (crud/handle-delete :sighting StoredSighting))
+(def handle-delete (crud/handle-delete :sighting StoredSighting))
 
 (s/defn es-paginated-list->paginated-list :- StoredSightingList
   [paginated-list :- ESStoredSightingList]
@@ -67,14 +67,14 @@
              [:data]
              #(map es-stored-sighting->stored-sighting (es-coerce! %))))
 
-(s/defn handle-list-sightings :- StoredSightingList
+(s/defn handle-list :- StoredSightingList
   [state filter-map params]
   (es-paginated-list->paginated-list
    (list-fn state filter-map params)))
 
-(s/defn handle-list-sightings-by-observables :- StoredSightingList
+(s/defn handle-list-by-observables :- StoredSightingList
   [state observables :- [Observable] params]
-  (handle-list-sightings state
-                         {:observables_hash
-                          (obs->hashes observables)}
-                         params))
+  (handle-list state
+               {:observables_hash
+                (obs->hashes observables)}
+               params))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -1,5 +1,6 @@
 (ns ctia.stores.es.sighting
-  (:require [ctia.lib.pagination :refer [list-response-schema]]
+  (:require [ctia.lib.es.index :refer [ESConnState]]
+            [ctia.lib.pagination :refer [list-response-schema]]
             [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [Observable StoredSighting]]
             [schema-tools.core :as st]
@@ -38,11 +39,14 @@
   [s :- (s/maybe ESStoredSighting)]
   (when s (dissoc s :observables_hash)))
 
-(s/defn handle-create-sighting :- StoredSighting
-  [state realized]
-  (->> (stored-sighting->es-stored-sighting realized)
-       (create-fn state)
-       es-stored-sighting->stored-sighting))
+(s/defn handle-create-sighting :- [StoredSighting]
+  [state :- ESConnState
+   new-sightings :- [StoredSighting]]
+  (doall
+   (->> new-sightings
+        (map stored-sighting->es-stored-sighting)
+        (create-fn state)
+        (map es-stored-sighting->stored-sighting))))
 
 (s/defn handle-read-sighting :- (s/maybe StoredSighting)
   [state id]

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -54,8 +54,8 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgement]
-    (ju/handle-create-judgement state new-judgement))
+  (create-judgement [_ new-judgements]
+    (ju/handle-create-judgement state new-judgements))
   (add-indicator-to-judgement [_ judgement-id indicator-rel]
     (ju/handle-add-indicator-to-judgement state judgement-id indicator-rel))
   (read-judgement [_ id]
@@ -72,8 +72,8 @@
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationship [_ new-relationship]
-    (rel/handle-create-relationship state new-relationship))
+  (create-relationship [_ new-relationships]
+    (rel/handle-create-relationship state new-relationships))
   (read-relationship [_ id]
     (rel/handle-read-relationship state id))
   (delete-relationship [_ id]
@@ -83,8 +83,8 @@
 
 (defrecord VerdictStore [state]
   IVerdictStore
-  (create-verdict [_ new-verdict]
-    (ve/handle-create-verdict state new-verdict))
+  (create-verdict [_ new-verdicts]
+    (ve/handle-create-verdict state new-verdicts))
   (read-verdict [_ id]
     (ve/handle-read-verdict state id))
   (delete-verdict [_ id]
@@ -94,8 +94,8 @@
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedback [_ new-feedback]
-    (fe/handle-create-feedback state new-feedback))
+  (create-feedback [_ new-feedbacks]
+    (fe/handle-create-feedback state new-feedbacks))
   (read-feedback [_ id]
     (fe/handle-read-feedback state id))
   (delete-feedback [_ id]
@@ -105,8 +105,8 @@
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicator [_ new-indicator]
-    (in/handle-create-indicator state new-indicator))
+  (create-indicator [_ new-indicators]
+    (in/handle-create-indicator state new-indicators))
   (update-indicator [_ id new-indicator]
     (in/handle-update-indicator state id new-indicator))
   (read-indicator [_ id]
@@ -122,8 +122,8 @@
   ITTPStore
   (read-ttp [_ id]
     (ttp/handle-read-ttp state id))
-  (create-ttp [_ new-ttp]
-    (ttp/handle-create-ttp state new-ttp))
+  (create-ttp [_ new-ttps]
+    (ttp/handle-create-ttp state new-ttps))
   (update-ttp [_ id new-ttp]
     (ttp/handle-update-ttp state id new-ttp))
   (delete-ttp [_ id]
@@ -135,8 +135,8 @@
   IActorStore
   (read-actor [_ id]
     (ac/handle-read-actor state id))
-  (create-actor [_ new-actor]
-    (ac/handle-create-actor state new-actor))
+  (create-actor [_ new-actors]
+    (ac/handle-create-actor state new-actors))
   (update-actor [_ id actor]
     (ac/handle-update-actor state id actor))
   (delete-actor [_ id]
@@ -148,8 +148,8 @@
   ICampaignStore
   (read-campaign [_ id]
     (ca/handle-read-campaign state id))
-  (create-campaign [_ new-campaign]
-    (ca/handle-create-campaign state new-campaign))
+  (create-campaign [_ new-campaigns]
+    (ca/handle-create-campaign state new-campaigns))
   (update-campaign [_ id new-campaign]
     (ca/handle-update-campaign state id new-campaign))
   (delete-campaign [_ id]
@@ -161,8 +161,8 @@
   ICOAStore
   (read-coa [_ id]
     (coa/handle-read-coa state id))
-  (create-coa [_ new-coa]
-    (coa/handle-create-coa state new-coa))
+  (create-coa [_ new-coas]
+    (coa/handle-create-coa state new-coas))
   (update-coa [_ id new-coa]
     (coa/handle-update-coa state id new-coa))
   (delete-coa [_ id]
@@ -174,8 +174,8 @@
   IDataTableStore
   (read-data-table [_ id]
     (dt/handle-read-data-table state id))
-  (create-data-table [_ new-data-table]
-    (dt/handle-create-data-table state new-data-table))
+  (create-data-table [_ new-data-tables]
+    (dt/handle-create-data-table state new-data-tables))
   (delete-data-table [_ id]
     (dt/handle-delete-data-table state id))
   (list-data-tables [_ filter-map params]
@@ -185,8 +185,8 @@
   IIncidentStore
   (read-incident [_ id]
     (inc/handle-read-incident state id))
-  (create-incident [_ new-incident]
-    (inc/handle-create-incident state new-incident))
+  (create-incident [_ new-incidents]
+    (inc/handle-create-incident state new-incidents))
   (update-incident [_ id new-incident]
     (inc/handle-update-incident state id new-incident))
   (delete-incident [_ id]
@@ -198,8 +198,8 @@
   IExploitTargetStore
   (read-exploit-target [_ id]
     (et/handle-read-exploit-target state id))
-  (create-exploit-target [_ new-exploit-target]
-    (et/handle-create-exploit-target state new-exploit-target))
+  (create-exploit-target [_ new-exploit-targets]
+    (et/handle-create-exploit-target state new-exploit-targets))
   (update-exploit-target [_ id new-exploit-target]
     (et/handle-update-exploit-target state id new-exploit-target))
   (delete-exploit-target [_ id]
@@ -220,8 +220,8 @@
   ISightingStore
   (read-sighting [_ id]
     (sig/handle-read-sighting state id))
-  (create-sighting [_ new-sighting]
-    (sig/handle-create-sighting state new-sighting))
+  (create-sighting [_ new-sightings]
+    (sig/handle-create-sighting state new-sightings))
   (update-sighting [_ id sighting]
     (sig/handle-update-sighting state id sighting))
   (delete-sighting [_ id]
@@ -235,7 +235,7 @@
   IBundleStore
   (read-bundle [_ id]
     (bu/handle-read-bundle state id))
-  (create-bundle [_ new-bundle]
-    (bu/handle-create-bundle state new-bundle))
+  (create-bundle [_ new-bundles]
+    (bu/handle-create-bundle state new-bundles))
   (delete-bundle [_ id]
     (bu/handle-delete-bundle state id)))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -54,188 +54,188 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgement [_ new-judgements]
-    (ju/handle-create-judgement state new-judgements))
+  (create-judgements [_ new-judgements]
+    (ju/handle-create state new-judgements))
   (add-indicator-to-judgement [_ judgement-id indicator-rel]
-    (ju/handle-add-indicator-to-judgement state judgement-id indicator-rel))
+    (ju/handle-add-indicator-to state judgement-id indicator-rel))
   (read-judgement [_ id]
-    (ju/handle-read-judgement state id))
+    (ju/handle-read state id))
   (delete-judgement [_ id]
-    (ju/handle-delete-judgement state id))
+    (ju/handle-delete state id))
   (list-judgements [_ filter-map params]
-    (ju/handle-list-judgements state filter-map params))
+    (ju/handle-list state filter-map params))
   (list-judgements-by-observable [this observable params]
-    (ju/handle-list-judgements state {[:observable :type]  (:type observable)
+    (ju/handle-list state {[:observable :type]  (:type observable)
                                       [:observable :value] (:value observable)} params))
   (calculate-verdict [_ observable]
     (ju/handle-calculate-verdict state observable)))
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationship [_ new-relationships]
-    (rel/handle-create-relationship state new-relationships))
+  (create-relationships [_ new-relationships]
+    (rel/handle-create state new-relationships))
   (read-relationship [_ id]
-    (rel/handle-read-relationship state id))
+    (rel/handle-read state id))
   (delete-relationship [_ id]
-    (rel/handle-delete-relationship state id))
+    (rel/handle-delete state id))
   (list-relationships [_ filter-map params]
-    (rel/handle-list-relationships state filter-map params)))
+    (rel/handle-list state filter-map params)))
 
 (defrecord VerdictStore [state]
   IVerdictStore
-  (create-verdict [_ new-verdicts]
-    (ve/handle-create-verdict state new-verdicts))
+  (create-verdicts [_ new-verdicts]
+    (ve/handle-create state new-verdicts))
   (read-verdict [_ id]
-    (ve/handle-read-verdict state id))
+    (ve/handle-read state id))
   (delete-verdict [_ id]
-    (ve/handle-delete-verdict state id))
+    (ve/handle-delete state id))
   (list-verdicts [_ filter-map params]
-    (ve/handle-list-verdicts state filter-map params)))
+    (ve/handle-list state filter-map params)))
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedback [_ new-feedbacks]
-    (fe/handle-create-feedback state new-feedbacks))
+  (create-feedbacks [_ new-feedbacks]
+    (fe/handle-create state new-feedbacks))
   (read-feedback [_ id]
-    (fe/handle-read-feedback state id))
+    (fe/handle-read state id))
   (delete-feedback [_ id]
-    (fe/handle-delete-feedback state id))
+    (fe/handle-delete state id))
   (list-feedback [_ filter-map params]
-    (fe/handle-list-feedback state filter-map params)))
+    (fe/handle-list state filter-map params)))
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicator [_ new-indicators]
-    (in/handle-create-indicator state new-indicators))
+  (create-indicators [_ new-indicators]
+    (in/handle-create state new-indicators))
   (update-indicator [_ id new-indicator]
-    (in/handle-update-indicator state id new-indicator))
+    (in/handle-update state id new-indicator))
   (read-indicator [_ id]
-    (in/handle-read-indicator state id))
+    (in/handle-read state id))
   (delete-indicator [_ id]
-    (in/handle-delete-indicator state id))
+    (in/handle-delete state id))
   (list-indicators [_ filter-map params]
-    (in/handle-list-indicators state filter-map params))
+    (in/handle-list state filter-map params))
   (list-indicators-by-judgements [_ judgements params]
-    (in/handle-list-indicators-by-judgements state judgements params)))
+    (in/handle-list-by-judgements state judgements params)))
 
 (defrecord TTPStore [state]
   ITTPStore
   (read-ttp [_ id]
-    (ttp/handle-read-ttp state id))
-  (create-ttp [_ new-ttps]
-    (ttp/handle-create-ttp state new-ttps))
+    (ttp/handle-read state id))
+  (create-ttps [_ new-ttps]
+    (ttp/handle-create state new-ttps))
   (update-ttp [_ id new-ttp]
-    (ttp/handle-update-ttp state id new-ttp))
+    (ttp/handle-update state id new-ttp))
   (delete-ttp [_ id]
-    (ttp/handle-delete-ttp state id))
+    (ttp/handle-delete state id))
   (list-ttps [_ filter-map params]
-    (ttp/handle-list-ttps state filter-map params)))
+    (ttp/handle-list state filter-map params)))
 
 (defrecord ActorStore [state]
   IActorStore
   (read-actor [_ id]
-    (ac/handle-read-actor state id))
-  (create-actor [_ new-actors]
-    (ac/handle-create-actor state new-actors))
+    (ac/handle-read state id))
+  (create-actors [_ new-actors]
+    (ac/handle-create state new-actors))
   (update-actor [_ id actor]
-    (ac/handle-update-actor state id actor))
+    (ac/handle-update state id actor))
   (delete-actor [_ id]
-    (ac/handle-delete-actor state id))
+    (ac/handle-delete state id))
   (list-actors [_ filter-map params]
-    (ac/handle-list-actors state filter-map params)))
+    (ac/handle-list state filter-map params)))
 
 (defrecord CampaignStore [state]
   ICampaignStore
   (read-campaign [_ id]
-    (ca/handle-read-campaign state id))
-  (create-campaign [_ new-campaigns]
-    (ca/handle-create-campaign state new-campaigns))
+    (ca/handle-read state id))
+  (create-campaigns [_ new-campaigns]
+    (ca/handle-create state new-campaigns))
   (update-campaign [_ id new-campaign]
-    (ca/handle-update-campaign state id new-campaign))
+    (ca/handle-update state id new-campaign))
   (delete-campaign [_ id]
-    (ca/handle-delete-campaign state id))
+    (ca/handle-delete state id))
   (list-campaigns [_ filter-map params]
-    (ca/handle-list-campaigns state filter-map params)))
+    (ca/handle-list state filter-map params)))
 
 (defrecord COAStore [state]
   ICOAStore
   (read-coa [_ id]
-    (coa/handle-read-coa state id))
-  (create-coa [_ new-coas]
-    (coa/handle-create-coa state new-coas))
+    (coa/handle-read state id))
+  (create-coas [_ new-coas]
+    (coa/handle-create state new-coas))
   (update-coa [_ id new-coa]
-    (coa/handle-update-coa state id new-coa))
+    (coa/handle-update state id new-coa))
   (delete-coa [_ id]
-    (coa/handle-delete-coa state id))
+    (coa/handle-delete state id))
   (list-coas [_ filter-map params]
-    (coa/handle-list-coas state filter-map params)))
+    (coa/handle-list state filter-map params)))
 
 (defrecord DataTableStore [state]
   IDataTableStore
   (read-data-table [_ id]
-    (dt/handle-read-data-table state id))
-  (create-data-table [_ new-data-tables]
-    (dt/handle-create-data-table state new-data-tables))
+    (dt/handle-read state id))
+  (create-data-tables [_ new-data-tables]
+    (dt/handle-create state new-data-tables))
   (delete-data-table [_ id]
-    (dt/handle-delete-data-table state id))
+    (dt/handle-delete state id))
   (list-data-tables [_ filter-map params]
-    (dt/handle-list-data-tables state filter-map params)))
+    (dt/handle-list state filter-map params)))
 
 (defrecord IncidentStore [state]
   IIncidentStore
   (read-incident [_ id]
-    (inc/handle-read-incident state id))
-  (create-incident [_ new-incidents]
-    (inc/handle-create-incident state new-incidents))
+    (inc/handle-read state id))
+  (create-incidents [_ new-incidents]
+    (inc/handle-create state new-incidents))
   (update-incident [_ id new-incident]
-    (inc/handle-update-incident state id new-incident))
+    (inc/handle-update state id new-incident))
   (delete-incident [_ id]
-    (inc/handle-delete-incident state id))
+    (inc/handle-delete state id))
   (list-incidents [_ filter-map params]
-    (inc/handle-list-incidents state filter-map params)))
+    (inc/handle-list state filter-map params)))
 
 (defrecord ExploitTargetStore [state]
   IExploitTargetStore
   (read-exploit-target [_ id]
-    (et/handle-read-exploit-target state id))
-  (create-exploit-target [_ new-exploit-targets]
-    (et/handle-create-exploit-target state new-exploit-targets))
+    (et/handle-read state id))
+  (create-exploit-targets [_ new-exploit-targets]
+    (et/handle-create state new-exploit-targets))
   (update-exploit-target [_ id new-exploit-target]
-    (et/handle-update-exploit-target state id new-exploit-target))
+    (et/handle-update state id new-exploit-target))
   (delete-exploit-target [_ id]
-    (et/handle-delete-exploit-target state id))
+    (et/handle-delete state id))
   (list-exploit-targets [_ filter-map params]
-    (et/handle-list-exploit-targets state filter-map params)))
+    (et/handle-list state filter-map params)))
 
 (defrecord IdentityStore [state]
   IIdentityStore
   (read-identity [_ login]
-    (id/handle-read-identity state login))
+    (id/handle-read state login))
   (create-identity [_ new-identity]
-    (id/handle-create-identity state new-identity))
+    (id/handle-create state new-identity))
   (delete-identity [_ org-id role]
-    (id/handle-delete-identity state org-id role)))
+    (id/handle-delete state org-id role)))
 
 (defrecord SightingStore [state]
   ISightingStore
   (read-sighting [_ id]
-    (sig/handle-read-sighting state id))
-  (create-sighting [_ new-sightings]
-    (sig/handle-create-sighting state new-sightings))
+    (sig/handle-read state id))
+  (create-sightings [_ new-sightings]
+    (sig/handle-create state new-sightings))
   (update-sighting [_ id sighting]
-    (sig/handle-update-sighting state id sighting))
+    (sig/handle-update state id sighting))
   (delete-sighting [_ id]
-    (sig/handle-delete-sighting state id))
+    (sig/handle-delete state id))
   (list-sightings [_ filter-map params]
-    (sig/handle-list-sightings state filter-map params))
+    (sig/handle-list state filter-map params))
   (list-sightings-by-observables [_ observables params]
-    (sig/handle-list-sightings-by-observables state observables params)))
+    (sig/handle-list-by-observables state observables params)))
 
 (defrecord BundleStore [state]
   IBundleStore
   (read-bundle [_ id]
-    (bu/handle-read-bundle state id))
-  (create-bundle [_ new-bundles]
-    (bu/handle-create-bundle state new-bundles))
+    (bu/handle-read state id))
+  (create-bundles [_ new-bundles]
+    (bu/handle-create state new-bundles))
   (delete-bundle [_ id]
-    (bu/handle-delete-bundle state id)))
+    (bu/handle-delete state id)))

--- a/src/ctia/stores/es/ttp.clj
+++ b/src/ctia/stores/es/ttp.clj
@@ -2,8 +2,8 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredTTP]]))
 
-(def handle-create-ttp (crud/handle-create :ttp StoredTTP))
-(def handle-read-ttp (crud/handle-read :ttp StoredTTP))
-(def handle-update-ttp (crud/handle-update :ttp StoredTTP))
-(def handle-delete-ttp (crud/handle-delete :ttp StoredTTP))
-(def handle-list-ttps (crud/handle-find :ttp StoredTTP))
+(def handle-create (crud/handle-create :ttp StoredTTP))
+(def handle-read (crud/handle-read :ttp StoredTTP))
+(def handle-update (crud/handle-update :ttp StoredTTP))
+(def handle-delete (crud/handle-delete :ttp StoredTTP))
+(def handle-list (crud/handle-find :ttp StoredTTP))

--- a/src/ctia/stores/es/verdict.clj
+++ b/src/ctia/stores/es/verdict.clj
@@ -2,7 +2,7 @@
   (:require [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [StoredVerdict]]))
 
-(def handle-create-verdict (crud/handle-create :verdict StoredVerdict))
-(def handle-read-verdict (crud/handle-read :verdict StoredVerdict))
-(def handle-delete-verdict (crud/handle-delete :verdict StoredVerdict))
-(def handle-list-verdicts (crud/handle-find :verdict StoredVerdict))
+(def handle-create (crud/handle-create :verdict StoredVerdict))
+(def handle-read (crud/handle-read :verdict StoredVerdict))
+(def handle-delete (crud/handle-delete :verdict StoredVerdict))
+(def handle-list (crud/handle-find :verdict StoredVerdict))


### PR DESCRIPTION
- Store methods that create entities take multiple items
- Flow code is refactored and modified to support the new store methods
- Updated HTTP create routes
- When ES is the backing store, create methods use the ES bulk API

Related to #442 