### PR TITLE
safer docker properties init 

### DIFF
--- a/scripts/init-properties-for-docker.sh
+++ b/scripts/init-properties-for-docker.sh
@@ -3,7 +3,11 @@
 
 ip=127.0.0.1
 command -v docker-machine >/dev/null 2>&1 && \
-ip=$(docker-machine ip)
+    ip=$(docker-machine ip)
+
+if [ -z "${ip}" ]; then
+    ip="localhost"
+fi
 
 echo "Detected IP for docker machine: $ip"
 
@@ -22,6 +26,7 @@ ctia.store.es.default.port=9200
 ctia.hook.es.host=$ip
 ctia.hook.es.port=9200
 ctia.hook.redis.host=$ip
+ctia.hook.redismq.host=$ip
 EOF
 
 echo "$resourcefile initialized"

--- a/scripts/init-properties-for-docker.sh
+++ b/scripts/init-properties-for-docker.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-
-ip=127.0.0.1
 command -v docker-machine >/dev/null 2>&1 && \
     ip=$(docker-machine ip)
 
 if [ -z "${ip}" ]; then
-    ip="localhost"
+    ip="127.0.0.1"
 fi
 
 echo "Detected IP for docker machine: $ip"


### PR DESCRIPTION
closes #465 
- fallback to localhost when docker-machine isn't running
- set redismq hook ip