### PR TITLE
use path-params instead of query-params for external_id lookup

### DIFF
--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -12,93 +12,92 @@
    [schema.core :as s]))
 
 (s/defschema ActorByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes actor-routes
   (context "/actor" []
-    :tags ["Actor"]
-    (POST "/" []
-      :return StoredActor
-      :body [actor NewActor {:description "a new Actor"}]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "Adds a new Actor"
-      :capabilities :create-actor
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :entity-type :actor
-                             :realize-fn realize-actor
-                             :store-fn #(write-store :actor create-actors %)
-                             :entity-type :actor
-                             :identity identity
-                             :entities [actor])))))
-    (PUT "/:id" []
-      :return StoredActor
-      :body [actor NewActor {:description "an updated Actor"}]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "Updates an Actor"
-      :path-params [id :- s/Str]
-      :capabilities :create-actor
-      :identity identity
-      (ok
-       (with-long-id
-         (flows/update-flow :get-fn #(read-store :actor read-actor %)
-                            :realize-fn realize-actor
-                            :update-fn #(write-store :actor update-actor (:id %) %)
-                            :entity-type :actor
-                            :entity-id id
-                            :identity identity
-                            :entity actor))))
+           :tags ["Actor"]
+           (POST "/" []
+                 :return StoredActor
+                 :body [actor NewActor {:description "a new Actor"}]
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :summary "Adds a new Actor"
+                 :capabilities :create-actor
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow :entity-type :actor
+                                        :realize-fn realize-actor
+                                        :store-fn #(write-store :actor create-actors %)
+                                        :entity-type :actor
+                                        :identity identity
+                                        :entities [actor])))))
+           (PUT "/:id" []
+                :return StoredActor
+                :body [actor NewActor {:description "an updated Actor"}]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "Updates an Actor"
+                :path-params [id :- s/Str]
+                :capabilities :create-actor
+                :identity identity
+                (ok
+                 (with-long-id
+                   (flows/update-flow :get-fn #(read-store :actor read-actor %)
+                                      :realize-fn realize-actor
+                                      :update-fn #(write-store :actor update-actor (:id %) %)
+                                      :entity-type :actor
+                                      :entity-id id
+                                      :identity identity
+                                      :entity actor))))
 
-    (GET "/external_id" []
-      :return [(s/maybe StoredActor)]
-      :query [q ActorByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List actors by external id"
-      :capabilities #{:read-actor :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :actor list-actors
-                    {:external_ids (:external_id q)} q))))
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredActor)]
+                :query [q ActorByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List actors by external id"
+                :capabilities #{:read-actor :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :actor list-actors
+                              {:external_ids external_id} q))))
 
-    (GET "/search" []
-         :return (s/maybe [StoredActor])
-         :summary "Search for an Actor using a Lucene/ES query string"
-         :query [params ActorSearchParams]
-         :capabilities #{:read-actor :search-actor}
-         :header-params [api_key :- (s/maybe s/Str)]
-         (paginated-ok
-          (page-with-long-id
-           (query-string-search-store :actor
-                                      query-string-search
-                                      (:query params)
-                                      (dissoc params :query :sort_by :sort_order :offset :limit)
-                                      (select-keys params [:sort_by :sort_order :offset :limit])))))
-    
-    (GET "/:id" []
-      :return (s/maybe StoredActor)
-      :summary "Gets an Actor by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-actor
-      (if-let [d (read-store :actor read-actor id)]
-        (ok (with-long-id d))
-        (not-found)))
+           (GET "/search" []
+                :return (s/maybe [StoredActor])
+                :summary "Search for an Actor using a Lucene/ES query string"
+                :query [params ActorSearchParams]
+                :capabilities #{:read-actor :search-actor}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store :actor
+                                             query-string-search
+                                             (:query params)
+                                             (dissoc params :query :sort_by :sort_order :offset :limit)
+                                             (select-keys params [:sort_by :sort_order :offset :limit])))))
 
-    (DELETE "/:id" []
-      :no-doc true
-      :path-params [id :- s/Str]
-      :summary "Deletes an Actor"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-actor
-      :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :actor read-actor %)
-                             :delete-fn #(write-store :actor delete-actor %)
-                             :entity-type :actor
-                             :entity-id id
-                             :identity identity)
-        (no-content)
-        (not-found)))))
+           (GET "/:id" []
+                :return (s/maybe StoredActor)
+                :summary "Gets an Actor by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-actor
+                (if-let [d (read-store :actor read-actor id)]
+                  (ok (with-long-id d))
+                  (not-found)))
+
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes an Actor"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-actor
+                   :identity identity
+                   (if (flows/delete-flow :get-fn #(read-store :actor read-actor %)
+                                          :delete-fn #(write-store :actor delete-actor %)
+                                          :entity-type :actor
+                                          :entity-id id
+                                          :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -12,90 +12,89 @@
    [schema.core :as s]))
 
 (s/defschema CampaignByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes campaign-routes
   (context "/campaign" []
-    :tags ["Campaign"]
-    (POST "/" []
-      :return StoredCampaign
-      :body [campaign NewCampaign {:description "a new campaign"}]
-      :summary "Adds a new Campaign"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-campaign
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :realize-fn realize-campaign
-                             :store-fn #(write-store :campaign create-campaigns %)
-                             :entity-type :campaign
-                             :identity identity
-                             :entities [campaign])))))
-    (PUT "/:id" []
-      :return StoredCampaign
-      :body [campaign NewCampaign {:description "an updated campaign"}]
-      :summary "Updates a Campaign"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-campaign
-      :identity identity
-      (ok
-       (with-long-id
-         (flows/update-flow :get-fn #(read-store :campaign read-campaign %)
-                            :realize-fn realize-campaign
-                            :update-fn #(write-store :campaign update-campaign (:id %) %)
-                            :entity-type :campaign
-                            :entity-id id
-                            :identity identity
-                            :entity campaign))))
-    (GET "/external_id" []
-      :return [(s/maybe StoredCampaign)]
-      :query [q CampaignByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List campaigns by external id"
-      :capabilities #{:read-campaign :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :campaign list-campaigns
-                    {:external_ids (:external_id q)} q))))
+           :tags ["Campaign"]
+           (POST "/" []
+                 :return StoredCampaign
+                 :body [campaign NewCampaign {:description "a new campaign"}]
+                 :summary "Adds a new Campaign"
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :capabilities :create-campaign
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow :realize-fn realize-campaign
+                                        :store-fn #(write-store :campaign create-campaigns %)
+                                        :entity-type :campaign
+                                        :identity identity
+                                        :entities [campaign])))))
+           (PUT "/:id" []
+                :return StoredCampaign
+                :body [campaign NewCampaign {:description "an updated campaign"}]
+                :summary "Updates a Campaign"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :create-campaign
+                :identity identity
+                (ok
+                 (with-long-id
+                   (flows/update-flow :get-fn #(read-store :campaign read-campaign %)
+                                      :realize-fn realize-campaign
+                                      :update-fn #(write-store :campaign update-campaign (:id %) %)
+                                      :entity-type :campaign
+                                      :entity-id id
+                                      :identity identity
+                                      :entity campaign))))
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredCampaign)]
+                :query [q CampaignByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List campaigns by external id"
+                :capabilities #{:read-campaign :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :campaign list-campaigns
+                              {:external_ids external_id} q))))
 
-    (GET "/search" []
-         :return (s/maybe [StoredCampaign])
-         :summary "Search for a Campaign using a Lucene/ES query string"
-         :query [params CampaignSearchParams]
-         :capabilities #{:read-campaign :search-campaign}
-         :header-params [api_key :- (s/maybe s/Str)]
-         (paginated-ok
-          (page-with-long-id
-           (query-string-search-store :campaign
-                                      query-string-search
-                                      (:query params)
-                                      (dissoc params :query :sort_by :sort_order :offset :limit)
-                                      (select-keys params [:sort_by :sort_order :offset :limit])))))
+           (GET "/search" []
+                :return (s/maybe [StoredCampaign])
+                :summary "Search for a Campaign using a Lucene/ES query string"
+                :query [params CampaignSearchParams]
+                :capabilities #{:read-campaign :search-campaign}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store :campaign
+                                             query-string-search
+                                             (:query params)
+                                             (dissoc params :query :sort_by :sort_order :offset :limit)
+                                             (select-keys params [:sort_by :sort_order :offset :limit])))))
 
-    (GET "/:id" []
-      :return (s/maybe StoredCampaign)
-      :summary "Gets a Campaign by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-campaign
-      (if-let [d (read-store :campaign read-campaign id)]
-        (ok (with-long-id d))
-        (not-found)))
-    (DELETE "/:id" []
-      :no-doc true
-      :path-params [id :- s/Str]
-      :summary "Deletes a Campaign"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-campaign
-      :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :campaign read-campaign %)
-                             :delete-fn #(write-store :campaign delete-campaign %)
-                             :entity-type :campaign
-                             :entity-id id
-                             :identity identity)
-        (no-content)
-        (not-found)))))
+           (GET "/:id" []
+                :return (s/maybe StoredCampaign)
+                :summary "Gets a Campaign by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-campaign
+                (if-let [d (read-store :campaign read-campaign id)]
+                  (ok (with-long-id d))
+                  (not-found)))
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes a Campaign"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-campaign
+                   :identity identity
+                   (if (flows/delete-flow :get-fn #(read-store :campaign read-campaign %)
+                                          :delete-fn #(write-store :campaign delete-campaign %)
+                                          :entity-type :campaign
+                                          :entity-id id
+                                          :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -11,94 +11,90 @@
             [schema-tools.core :as st]))
 
 (s/defschema COAByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes coa-routes
   (context "/coa" []
-    :tags ["COA"]
-    (POST "/" []
-      :return StoredCOA
-      :body [coa NewCOA {:description "a new COA"}]
-      :summary "Adds a new COA"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-coa
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :realize-fn realize-coa
-                             :store-fn #(write-store :coa create-coas %)
-                             :entity-type :coa
-                             :identity identity
-                             :entities [coa])))))
-    (PUT "/:id" []
-      :return StoredCOA
-      :body [coa NewCOA {:description "an updated COA"}]
-      :summary "Updates a COA"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-coa
-      :identity identity
-      (ok
-       (with-long-id
-         (flows/update-flow :get-fn #(read-store :coa read-coa %)
-                            :realize-fn realize-coa
-                            :update-fn #(write-store :coa update-coa (:id %) %)
-                            :entity-type :coa
-                            :entity-id id
-                            :identity identity
-                            :entity coa))))
+           :tags ["COA"]
+           (POST "/" []
+                 :return StoredCOA
+                 :body [coa NewCOA {:description "a new COA"}]
+                 :summary "Adds a new COA"
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :capabilities :create-coa
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow :realize-fn realize-coa
+                                        :store-fn #(write-store :coa create-coas %)
+                                        :entity-type :coa
+                                        :identity identity
+                                        :entities [coa])))))
+           (PUT "/:id" []
+                :return StoredCOA
+                :body [coa NewCOA {:description "an updated COA"}]
+                :summary "Updates a COA"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :create-coa
+                :identity identity
+                (ok
+                 (with-long-id
+                   (flows/update-flow :get-fn #(read-store :coa read-coa %)
+                                      :realize-fn realize-coa
+                                      :update-fn #(write-store :coa update-coa (:id %) %)
+                                      :entity-type :coa
+                                      :entity-id id
+                                      :identity identity
+                                      :entity coa))))
 
-    (GET "/external_id" []
-      :return [(s/maybe StoredCOA)]
-      :query [q COAByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List COAs by external id"
-      :capabilities #{:read-coa :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :coa
-                    list-coas
-                    {:external_ids (:external_id q)}
-                    q))))
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredCOA)]
+                :query [q COAByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List COAs by external id"
+                :capabilities #{:read-coa :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :coa list-coas {:external_ids external_id} q))))
 
-    (GET "/search" []
-         :return (s/maybe [StoredCOA])
-         :summary "Search for a Course of Action using a Lucene/ES query string"
-         :query [params COASearchParams]
-         :capabilities #{:read-coa :search-coa}
-         :header-params [api_key :- (s/maybe s/Str)]
-         (paginated-ok
-          (page-with-long-id
-           (query-string-search-store :coa
-                                      query-string-search
-                                      (:query params)
-                                      (dissoc params :query :sort_by :sort_order :offset :limit)
-                                      (select-keys params [:sort_by :sort_order :offset :limit])))))
-    
-    (GET "/:id" []
-      :return (s/maybe StoredCOA)
-      :summary "Gets a COA by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-coa
-      (if-let [d (read-store :coa (fn [s] (read-coa s id)))]
-        (ok (with-long-id d))
-        (not-found)))
+           (GET "/search" []
+                :return (s/maybe [StoredCOA])
+                :summary "Search for a Course of Action using a Lucene/ES query string"
+                :query [params COASearchParams]
+                :capabilities #{:read-coa :search-coa}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store :coa
+                                             query-string-search
+                                             (:query params)
+                                             (dissoc params :query :sort_by :sort_order :offset :limit)
+                                             (select-keys params [:sort_by :sort_order :offset :limit])))))
 
-    (DELETE "/:id" []
-      :no-doc true
-      :path-params [id :- s/Str]
-      :summary "Deletes a COA"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-coa
-      :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :coa read-coa %)
-                             :delete-fn #(write-store :coa delete-coa %)
-                             :entity-type :coa
-                             :entity-id id
-                             :identity identity)
-        (no-content)
-        (not-found)))))
+           (GET "/:id" []
+                :return (s/maybe StoredCOA)
+                :summary "Gets a COA by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-coa
+                (if-let [d (read-store :coa (fn [s] (read-coa s id)))]
+                  (ok (with-long-id d))
+                  (not-found)))
+
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes a COA"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-coa
+                   :identity identity
+                   (if (flows/delete-flow :get-fn #(read-store :coa read-coa %)
+                                          :delete-fn #(write-store :coa delete-coa %)
+                                          :entity-type :coa
+                                          :entity-id id
+                                          :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -12,9 +12,7 @@
    [schema.core :as s]))
 
 (s/defschema DataTableByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes data-table-routes
   (context "/data-table" []
@@ -36,16 +34,17 @@
                       :entity-type :data-table
                       :identity identity
                       :entities [data-table])))))
-           (GET "/external_id" []
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredDataTable)]
                 :query [q DataTableByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "List data-tables by external id"
                 :capabilities #{:read-data-table :external-id}
                 (paginated-ok
                  (page-with-long-id
                   (read-store :data-table list-data-tables
-                              {:external_ids (:external_id q)} q))))
+                              {:external_ids external_id} q))))
 
            (GET "/:id" []
                 :return (s/maybe StoredDataTable)

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -13,9 +13,7 @@
    [flanders.schema :as fs]))
 
 (s/defschema ExploitTargetByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes exploit-target-routes
   (context "/exploit-target" []
@@ -63,16 +61,17 @@
                     :identity identity
                     :entity exploit-target))))
 
-           (GET "/external_id" []
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredExploitTarget)]
                 :query [q ExploitTargetByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "List ExploitTarget by external id"
                 :capabilities #{:read-exploit-target :external-id}
                 (paginated-ok
                  (page-with-long-id
                   (read-store :exploit-target list-exploit-targets
-                              {:external_ids (:external_id q)} q))))
+                              {:external_ids external_id} q))))
 
            (GET "/:id" []
                 :return (s/maybe StoredExploitTarget)

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -18,74 +18,73 @@
     (s/optional-key :sort_by) (s/enum :id :feedback :reason)}))
 
 (s/defschema FeedbackByExternalIdQueryParams
-  (st/merge (st/dissoc FeedbackQueryParams :entity_id)
-            {:external_id s/Str}))
+  (st/dissoc FeedbackQueryParams :entity_id))
 
 (defroutes feedback-routes
   (context "/feedback" []
-    :tags ["Feedback"]
-    (POST "/" []
-      :return StoredFeedback
-      :body [feedback NewFeedback {:description "a new Feedback on an entity"}]
-      :summary "Adds a new Feedback"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-feedback
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :realize-fn realize-feedback
-                             :store-fn #(write-store :feedback create-feedbacks %)
-                             :entity-type :feedback
-                             :identity identity
-                             :entities [feedback])))))
+           :tags ["Feedback"]
+           (POST "/" []
+                 :return StoredFeedback
+                 :body [feedback NewFeedback {:description "a new Feedback on an entity"}]
+                 :summary "Adds a new Feedback"
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :capabilities :create-feedback
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow :realize-fn realize-feedback
+                                        :store-fn #(write-store :feedback create-feedbacks %)
+                                        :entity-type :feedback
+                                        :identity identity
+                                        :entities [feedback])))))
 
-    (GET "/" []
-      :return [StoredFeedback]
-      :query [params FeedbackQueryParams]
-      :summary "Search Feedback"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-feedback
-      (paginated-ok
-       (page-with-long-id
-        (read-store :feedback
-                    list-feedback
-                    (select-keys params [:entity_id])
-                    (dissoc params :entity_id)))))
+           (GET "/" []
+                :return [StoredFeedback]
+                :query [params FeedbackQueryParams]
+                :summary "Search Feedback"
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-feedback
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :feedback
+                              list-feedback
+                              (select-keys params [:entity_id])
+                              (dissoc params :entity_id)))))
 
-    (GET "/external_id" []
-      :return [(s/maybe StoredFeedback)]
-      :query [q FeedbackByExternalIdQueryParams]
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredFeedback)]
+                :query [q FeedbackByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List feedback by external id"
+                :capabilities #{:read-feedback :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :feedback list-feedback
+                              {:external_ids external_id} q))))
 
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List feedback by external id"
-      :capabilities #{:read-feedback :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :feedback list-feedback
-                    {:external_ids (:external_id q)} q))))
+           (GET "/:id" []
+                :return (s/maybe StoredFeedback)
+                :summary "Gets a Feedback by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-feedback
+                (if-let [d (read-store :feedback read-feedback id)]
+                  (ok (with-long-id d))
+                  (not-found)))
 
-    (GET "/:id" []
-      :return (s/maybe StoredFeedback)
-      :summary "Gets a Feedback by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-feedback
-      (if-let [d (read-store :feedback read-feedback id)]
-        (ok (with-long-id d))
-        (not-found)))
-
-    (DELETE "/:id" []
-      :no-doc true
-      :path-params [id :- s/Str]
-      :summary "Deletes a feedback"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-feedback
-      :identity identity
-      (if (flows/delete-flow :get-fn #(read-store :feedback read-feedback %)
-                             :delete-fn #(write-store :feedback delete-feedback %)
-                             :entity-type :feedback
-                             :entity-id id
-                             :identity identity)
-        (no-content)
-        (not-found)))))
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes a feedback"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-feedback
+                   :identity identity
+                   (if (flows/delete-flow :get-fn #(read-store :feedback read-feedback %)
+                                          :delete-fn #(write-store :feedback delete-feedback %)
+                                          :entity-type :feedback
+                                          :entity-id id
+                                          :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -11,9 +11,7 @@
             [schema-tools.core :as st]))
 
 (s/defschema IncidentByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes incident-routes
   (context "/incident" []
@@ -52,16 +50,17 @@
                        :identity identity
                        :entity incident))))
 
-           (GET "/external_id" []
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredIncident)]
                 :query [q IncidentByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "List Incidents by external id"
                 :capabilities #{:read-incident :external-id}
                 (paginated-ok
                  (page-with-long-id
                   (read-store :incident list-incidents
-                              {:external_ids (:external_id q)} q))))
+                              {:external_ids external_id} q))))
 
            (GET "/:id" []
                 :return (s/maybe StoredIncident)

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -24,17 +24,13 @@
                                        StoredSighting
                                        StoredTTP]]))
 
-
 (s/defschema IndicatorsListQueryParams
   (st/merge
    PagingParams
    {(s/optional-key :sort_by) indicator-sort-fields}))
 
 (s/defschema IndicatorsByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str
-    (s/optional-key :sort_by) indicator-sort-fields}))
+  IndicatorsListQueryParams)
 
 (s/defschema SightingsByIndicatorQueryParams
   (st/merge
@@ -43,164 +39,165 @@
 
 (defroutes indicator-routes
   (context "/indicator" []
-    :tags ["Indicator"]
-    (POST "/" []
-      :return StoredIndicator
-      :body [indicator NewIndicator {:description "a new Indicator"}]
-      :summary "Adds a new Indicator"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-indicator
-      :identity identity
-      (created
-       (with-long-id
-         (first
-          (flows/create-flow :realize-fn realize-indicator
-                             :store-fn #(write-store :indicator create-indicators %)
-                             :entity-type :indicator
-                             :identity identity
-                             :entities [indicator])))))
-    (PUT "/:id" []
-      :return StoredIndicator
-      :body [indicator NewIndicator {:description "an updated Indicator"}]
-      :summary "Updates an Indicator"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :create-indicator
-      :identity identity
-      (ok
-       (with-long-id
-         (flows/update-flow :get-fn #(read-store :indicator read-indicator %)
-                            :realize-fn realize-indicator
-                            :update-fn #(write-store :indicator update-indicator (:id %) %)
-                            :entity-type :indicator
-                            :entity-id id
-                            :identity identity
-                            :entity indicator))))
-    ;; MORE TESTS, INCLUDING FILTER MAP TEST
-    ;; ADD TO OTHER ENTITIES
-    (GET "/search" []
-         :return (s/maybe [StoredIndicator])
-         :summary "Search for an indicator using a Lucene/ES query string"
-         :query [params IndicatorSearchParams]
-         :capabilities #{:read-indicator :search-indicator}
-         :header-params [api_key :- (s/maybe s/Str)]
-         (paginated-ok
-          (page-with-long-id
-           (query-string-search-store :indicator
-                       query-string-search
-                       (:query params)
-                       (dissoc params :query :sort_by :sort_order :offset :limit)
-                       (select-keys params [:sort_by :sort_order :offset :limit])))))
+           :tags ["Indicator"]
+           (POST "/" []
+                 :return StoredIndicator
+                 :body [indicator NewIndicator {:description "a new Indicator"}]
+                 :summary "Adds a new Indicator"
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :capabilities :create-indicator
+                 :identity identity
+                 (created
+                  (with-long-id
+                    (first
+                     (flows/create-flow :realize-fn realize-indicator
+                                        :store-fn #(write-store :indicator create-indicators %)
+                                        :entity-type :indicator
+                                        :identity identity
+                                        :entities [indicator])))))
+           (PUT "/:id" []
+                :return StoredIndicator
+                :body [indicator NewIndicator {:description "an updated Indicator"}]
+                :summary "Updates an Indicator"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :create-indicator
+                :identity identity
+                (ok
+                 (with-long-id
+                   (flows/update-flow :get-fn #(read-store :indicator read-indicator %)
+                                      :realize-fn realize-indicator
+                                      :update-fn #(write-store :indicator update-indicator (:id %) %)
+                                      :entity-type :indicator
+                                      :entity-id id
+                                      :identity identity
+                                      :entity indicator))))
+           ;; MORE TESTS, INCLUDING FILTER MAP TEST
+           ;; ADD TO OTHER ENTITIES
+           (GET "/search" []
+                :return (s/maybe [StoredIndicator])
+                :summary "Search for an indicator using a Lucene/ES query string"
+                :query [params IndicatorSearchParams]
+                :capabilities #{:read-indicator :search-indicator}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store :indicator
+                                             query-string-search
+                                             (:query params)
+                                             (dissoc params :query :sort_by :sort_order :offset :limit)
+                                             (select-keys params [:sort_by :sort_order :offset :limit])))))
 
 
-    
-    (GET "/external_id" []
-      :return [(s/maybe StoredIndicator)]
-      :query [q IndicatorsByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List Indicators by external id"
-      :capabilities #{:read-indicator :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :indicator list-indicators
-                    {:external_ids (:external_id q)} q))))
-    
-    (GET "/:id" []
-      :return (s/maybe StoredIndicator)
-      :summary "Gets an Indicator by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-indicator
-      (if-let [d (read-store :indicator read-indicator id)]
-        (ok (with-long-id d))
-        (not-found)))
 
-    (GET "/:id/sightings" []
-      :return [StoredSighting]
-      :path-params [id :- s/Str]
-      :query [params SightingsByIndicatorQueryParams]
-      :summary "Gets all Sightings associated with the Indicator"
-      :capabilities #{:read-indicator :list-sightings}
-      (if-let [indicator (read-store :indicator read-indicator id)]
-        (paginated-ok
-         (sighting/page-with-long-id
-          (read-store :sighting
-                      list-sightings
-                      {:indicators #{{:indicator_id (->long-id :indicator id)}}}
-                      params)))
-        (not-found))))
-  
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredIndicator)]
+                :query [q IndicatorsByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List Indicators by external id"
+                :capabilities #{:read-indicator :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :indicator list-indicators
+                              {:external_ids external_id} q))))
+
+           (GET "/:id" []
+                :return (s/maybe StoredIndicator)
+                :summary "Gets an Indicator by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-indicator
+                (if-let [d (read-store :indicator read-indicator id)]
+                  (ok (with-long-id d))
+                  (not-found)))
+
+           (GET "/:id/sightings" []
+                :return [StoredSighting]
+                :path-params [id :- s/Str]
+                :query [params SightingsByIndicatorQueryParams]
+                :summary "Gets all Sightings associated with the Indicator"
+                :capabilities #{:read-indicator :list-sightings}
+                (if-let [indicator (read-store :indicator read-indicator id)]
+                  (paginated-ok
+                   (sighting/page-with-long-id
+                    (read-store :sighting
+                                list-sightings
+                                {:indicators #{{:indicator_id (->long-id :indicator id)}}}
+                                params)))
+                  (not-found))))
+
   (GET "/judgement/:id/indicators" []
-    :tags ["Indicator"]
-    :return (s/maybe [StoredIndicator])
-    :summary "Gets all indicators referencing some judgement"
-    :query [params IndicatorsListQueryParams]
-    :path-params [id :- s/Str]
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :list-indicators
-    (paginated-ok
-     (page-with-long-id
-      (read-store :indicator
-                  list-indicators
-                  {:judgements #{{:judgement_id (->long-id :judgement id)}}}
-                  params))))
+       :tags ["Indicator"]
+       :return (s/maybe [StoredIndicator])
+       :summary "Gets all indicators referencing some judgement"
+       :query [params IndicatorsListQueryParams]
+       :path-params [id :- s/Str]
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :list-indicators
+       (paginated-ok
+        (page-with-long-id
+         (read-store :indicator
+                     list-indicators
+                     {:judgements #{{:judgement_id (->long-id :judgement id)}}}
+                     params))))
 
   (GET "/campaign/:id/indicators" []
-    :tags ["Indicator"]
-    :return (s/maybe [StoredIndicator])
-    :summary "Gets all indicators related to a campaign"
-    :query [params IndicatorsListQueryParams]
-    :path-params [id :- s/Str]
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :list-indicators
-    (paginated-ok
-     (page-with-long-id
-      (read-store :indicator
-                  list-indicators
-                  {:related_campaigns #{{:campaign_id (->long-id :campaign id)}}}
-                  params))))
+       :tags ["Indicator"]
+       :return (s/maybe [StoredIndicator])
+       :summary "Gets all indicators related to a campaign"
+       :query [params IndicatorsListQueryParams]
+       :path-params [id :- s/Str]
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :list-indicators
+       (paginated-ok
+        (page-with-long-id
+         (read-store :indicator
+                     list-indicators
+                     {:related_campaigns #{{:campaign_id (->long-id :campaign id)}}}
+                     params))))
 
   (GET "/coa/:id/indicators" []
-    :tags ["Indicator"]
-    :return (s/maybe [StoredIndicator])
-    :summary "Gets all indicators related to a coa"
-    :query [params IndicatorsListQueryParams]
-    :path-params [id :- s/Str]
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :list-indicators
-    (paginated-ok
-     (page-with-long-id
-      (read-store :indicator
-                  list-indicators
-                  {:related_COAs #{{:COA_id (->long-id :coa id)}}}
-                  params))))
+       :tags ["Indicator"]
+       :return (s/maybe [StoredIndicator])
+       :summary "Gets all indicators related to a coa"
+       :query [params IndicatorsListQueryParams]
+       :path-params [id :- s/Str]
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :list-indicators
+       (paginated-ok
+        (page-with-long-id
+         (read-store :indicator
+                     list-indicators
+                     {:related_COAs #{{:COA_id (->long-id :coa id)}}}
+                     params))))
 
   (GET "/ttp/:id/indicators" []
-    :tags ["Indicator"]
-    :return (s/maybe [StoredIndicator])
-    :summary "Gets all indicators indicating a TTP"
-    :query [params IndicatorsListQueryParams]
-    :path-params [id :- s/Str]
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :list-indicators
-    (paginated-ok
-     (page-with-long-id
-      (read-store :indicator
-                  list-indicators
-                  {:indicated_TTP #{{:ttp_id (->long-id :ttp id)}}}
-                  params))))
+       :tags ["Indicator"]
+       :return (s/maybe [StoredIndicator])
+       :summary "Gets all indicators indicating a TTP"
+       :query [params IndicatorsListQueryParams]
+       :path-params [id :- s/Str]
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :list-indicators
+       (paginated-ok
+        (page-with-long-id
+         (read-store :indicator
+                     list-indicators
+                     {:indicated_TTP #{{:ttp_id (->long-id :ttp id)}}}
+                     params))))
 
   (GET "/indicator/:id/indicators" []
-    :tags ["Indicator"]
-    :return (s/maybe [StoredIndicator])
-    :summary "Gets all indicators related to another indicator"
-    :query [params IndicatorsListQueryParams]
-    :path-params [id :- s/Str]
-    :header-params [api_key :- (s/maybe s/Str)]
-    :capabilities :list-indicators
-    (paginated-ok
-     (page-with-long-id
-      (read-store :indicator
-                  list-indicators
-                  {:related_indicators #{{:indicator_id (->long-id :indicator id)}}}
-                  params)))))
+       :tags ["Indicator"]
+       :return (s/maybe [StoredIndicator])
+       :summary "Gets all indicators related to another indicator"
+       :query [params IndicatorsListQueryParams]
+       :path-params [id :- s/Str]
+       :header-params [api_key :- (s/maybe s/Str)]
+       :capabilities :list-indicators
+       (paginated-ok
+        (page-with-long-id
+         (read-store :indicator
+                     list-indicators
+                     {:related_indicators #{{:indicator_id (->long-id :indicator id)}}}
+                     params)))))

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -20,7 +20,6 @@
                               StoredJudgement
                               RelatedIndicator]]))
 
-
 (s/defschema FeedbacksByJudgementQueryParams
   (st/merge
    PagingParams
@@ -32,9 +31,7 @@
    {(s/optional-key :sort_by) judgement-sort-fields}))
 
 (s/defschema JudgementsByExternalIdQueryParams
-  (st/merge PagingParams
-            {:external_id s/Str
-             (s/optional-key :sort_by) judgement-sort-fields}))
+  JudgementsQueryParams)
 
 (defroutes judgement-routes
   (context "/judgement" []
@@ -82,7 +79,7 @@
                                          indicator-relationship)]
                    (ok d)
                    (not-found)))
-           
+
            (GET "/search" []
                 :return (s/maybe [StoredJudgement])
                 :summary "Search for a Judgement using a Lucene/ES query string"
@@ -96,12 +93,12 @@
                                              (:query params)
                                              (dissoc params :query :sort_by :sort_order :offset :limit)
                                              (select-keys params [:sort_by :sort_order :offset :limit])))))
-           
-           
-           (GET "/external_id" []
+
+
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredJudgement)]
                 :query [q JudgementsByExternalIdQueryParams]
-                
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "Get Judgements by external ids"
                 :capabilities #{:read-judgement :external-id}
@@ -109,9 +106,9 @@
                  (page-with-long-id
                   (read-store :judgement
                               list-judgements
-                              {:external_ids (:external_id q)}
+                              {:external_ids external_id}
                               q))))
-           
+
            (GET "/:id" []
                 :return (s/maybe StoredJudgement)
                 :path-params [id :- s/Str]
@@ -121,7 +118,7 @@
                 (if-let [d (read-store :judgement read-judgement id)]
                   (ok (with-long-id d))
                   (not-found)))
-           
+
 
            (DELETE "/:id" []
                    :no-doc true

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -12,9 +12,7 @@
    [schema.core :as s]))
 
 (s/defschema RelationshipByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes relationship-routes
   (context "/relationship" []
@@ -37,16 +35,17 @@
                       :entity-type :relationship
                       :identity identity
                       :entities [relationship])))))
-           (GET "/external_id" []
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredRelationship)]
                 :query [q RelationshipByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "List relationships by external id"
                 :capabilities #{:read-relationship :external-id}
                 (paginated-ok
                  (page-with-long-id
                   (read-store :relationship list-relationships
-                              {:external_ids (:external_id q)} q))))
+                              {:external_ids external_id} q))))
 
            (GET "/:id" []
                 :return (s/maybe StoredRelationship)

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -12,90 +12,88 @@
    [schema-tools.core :as st]))
 
 (s/defschema SightingByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes sighting-routes
   (context "/sighting" []
-    :tags ["Sighting"]
-    (POST "/" []
-      :return StoredSighting
-      :body [sighting NewSighting {:description "A new Sighting"}]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "Adds a new Sighting"
-      :capabilities :create-sighting
-      :identity identity
-      (if (check-new-sighting sighting)
-        (created
-         (with-long-id
-           (first
-            (flows/create-flow :realize-fn realize-sighting
-                               :store-fn #(write-store :sighting create-sightings %)
-                               :entity-type :sighting
-                               :identity identity
-                               :entities [sighting]))))
-        (unprocessable-entity)))
-    (PUT "/:id" []
-      :return StoredSighting
-      :body [sighting NewSighting {:description "An updated Sighting"}]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "Updates a Sighting"
-      :path-params [id :- s/Str]
-      :capabilities :create-sighting
-      :identity identity
-      (if (check-new-sighting sighting)
-        (ok
-         (with-long-id
-           (flows/update-flow :get-fn #(read-store :sighting read-sighting %)
-                              :realize-fn realize-sighting
-                              :update-fn #(write-store :sighting update-sighting (:id %) %)
-                              :entity-type :sighting
-                              :entity-id id
-                              :identity identity
-                              :entity sighting)))
-        (unprocessable-entity)))
+           :tags ["Sighting"]
+           (POST "/" []
+                 :return StoredSighting
+                 :body [sighting NewSighting {:description "A new Sighting"}]
+                 :header-params [api_key :- (s/maybe s/Str)]
+                 :summary "Adds a new Sighting"
+                 :capabilities :create-sighting
+                 :identity identity
+                 (if (check-new-sighting sighting)
+                   (created
+                    (with-long-id
+                      (first
+                       (flows/create-flow :realize-fn realize-sighting
+                                          :store-fn #(write-store :sighting create-sightings %)
+                                          :entity-type :sighting
+                                          :identity identity
+                                          :entities [sighting]))))
+                   (unprocessable-entity)))
+           (PUT "/:id" []
+                :return StoredSighting
+                :body [sighting NewSighting {:description "An updated Sighting"}]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "Updates a Sighting"
+                :path-params [id :- s/Str]
+                :capabilities :create-sighting
+                :identity identity
+                (if (check-new-sighting sighting)
+                  (ok
+                   (with-long-id
+                     (flows/update-flow :get-fn #(read-store :sighting read-sighting %)
+                                        :realize-fn realize-sighting
+                                        :update-fn #(write-store :sighting update-sighting (:id %) %)
+                                        :entity-type :sighting
+                                        :entity-id id
+                                        :identity identity
+                                        :entity sighting)))
+                  (unprocessable-entity)))
 
-    (GET "/external_id" []
-      :return [(s/maybe StoredSighting)]
-      :query [q SightingByExternalIdQueryParams]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :summary "List sightings by external id"
-      :capabilities #{:read-sighting :external-id}
-      (paginated-ok
-       (page-with-long-id
-        (read-store :sighting list-sightings
-                    {:external_ids (:external_id q)} q))))
+           (GET "/external_id/:external_id" []
+                :return [(s/maybe StoredSighting)]
+                :query [q SightingByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :summary "List sightings by external id"
+                :capabilities #{:read-sighting :external-id}
+                (paginated-ok
+                 (page-with-long-id
+                  (read-store :sighting list-sightings {:external_ids external_id} q))))
 
-    (GET "/search" []
-         :return (s/maybe [StoredSighting])
-         :summary "Search for Sightings using a Lucene/ES query string"
-         :query [params SightingSearchParams]
-         :capabilities #{:read-sighting :search-sighting}
-         :header-params [api_key :- (s/maybe s/Str)]
-         (paginated-ok
-          (page-with-long-id
-           (query-string-search-store :sighting
-                                      query-string-search
-                                      (:query params)
-                                      (dissoc params :query :sort_by :sort_order :offset :limit)
-                                      (select-keys params [:sort_by :sort_order :offset :limit])))))
+           (GET "/search" []
+                :return (s/maybe [StoredSighting])
+                :summary "Search for Sightings using a Lucene/ES query string"
+                :query [params SightingSearchParams]
+                :capabilities #{:read-sighting :search-sighting}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store :sighting
+                                             query-string-search
+                                             (:query params)
+                                             (dissoc params :query :sort_by :sort_order :offset :limit)
+                                             (select-keys params [:sort_by :sort_order :offset :limit])))))
 
-    (GET "/:id" []
-      :return (s/maybe StoredSighting)
-      :summary "Gets a Sighting by ID"
-      :path-params [id :- s/Str]
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :read-sighting
-      (if-let [d (read-store :sighting read-sighting id)]
-        (ok (with-long-id d))
-        (not-found)))
+           (GET "/:id" []
+                :return (s/maybe StoredSighting)
+                :summary "Gets a Sighting by ID"
+                :path-params [id :- s/Str]
+                :header-params [api_key :- (s/maybe s/Str)]
+                :capabilities :read-sighting
+                (if-let [d (read-store :sighting read-sighting id)]
+                  (ok (with-long-id d))
+                  (not-found)))
 
-    (DELETE "/:id" []
-      :path-params [id :- s/Str]
-      :summary "Deletes a Sighting"
-      :header-params [api_key :- (s/maybe s/Str)]
-      :capabilities :delete-sighting
-      (if (write-store :sighting delete-sighting id)
-        (no-content)
-        (not-found)))))
+           (DELETE "/:id" []
+                   :path-params [id :- s/Str]
+                   :summary "Deletes a Sighting"
+                   :header-params [api_key :- (s/maybe s/Str)]
+                   :capabilities :delete-sighting
+                   (if (write-store :sighting delete-sighting id)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/ttp.clj
+++ b/src/ctia/http/routes/ttp.clj
@@ -12,9 +12,7 @@
    [schema-tools.core :as st]))
 
 (s/defschema TTPByExternalIdQueryParams
-  (st/merge
-   PagingParams
-   {:external_id s/Str}))
+  PagingParams)
 
 (defroutes ttp-routes
   (context "/ttp" []
@@ -33,7 +31,7 @@
                                               :entity-type :ttp
                                               :identity identity
                                               :entities [ttp])))))
-           
+
            (PUT "/:id" []
                 :return StoredTTP
                 :body [ttp NewTTP {:description "an updated TTP"}]
@@ -52,18 +50,19 @@
                                       :entity-id id
                                       :identity identity
                                       :entity ttp))))
-           
-           (GET "/external_id" []
+
+           (GET "/external_id/:external_id" []
                 :return [(s/maybe StoredTTP)]
                 :query [q TTPByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
                 :header-params [api_key :- (s/maybe s/Str)]
                 :summary "List TTPs by external id"
                 :capabilities #{:read-ttp :external-id}
                 (paginated-ok
                  (page-with-long-id
                   (read-store :ttp list-ttps
-                              {:external_ids (:external_id q)} q))))
-           
+                              {:external_ids external_id} q))))
+
            (GET "/search" []
                 :return (s/maybe [StoredTTP])
                 :summary "Search for a TTP using a Lucene/ES query string"
@@ -77,7 +76,7 @@
                                              (:query params)
                                              (dissoc params :query :sort_by :sort_order :offset :limit)
                                              (select-keys params [:sort_by :sort_order :offset :limit])))))
-           
+
            (GET "/:id" []
                 :return (s/maybe StoredTTP)
                 :summary "Gets a TTP by ID"

--- a/test/ctia/http/routes/actor_test.clj
+++ b/test/ctia/http/routes/actor_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.http.routes.actor-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [search :refer [test-query-string-search]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -113,11 +114,11 @@
                        :modified)))))
 
       (test-query-string-search :actor "description" :description)
-      
-      (testing "GET /ctia/actor/external_id"
-        (let [response (get "ctia/actor/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth actor-external-ids)})
+
+      (testing "GET /ctia/actor/external_id/:external_id"
+        (let [response (get (format "ctia/actor/external_id/%s"
+                                    (encode (rand-nth actor-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               actors (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/campaign_test.clj
+++ b/test/ctia/http/routes/campaign_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.http.routes.campaign-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
+             [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]))
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -94,10 +95,10 @@
           (is (= (:port        campaign-id)      (:port        show-props)))
           (is (= (:path-prefix campaign-id) (seq (:path-prefix show-props))))))
 
-      (testing "GET /ctia/campaign/external_id"
-        (let [response (get "ctia/campaign/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth campaign-external-ids)})
+      (testing "GET /ctia/campaign/external_id/:external_id"
+        (let [response (get (format "ctia/campaign/external_id/%s"
+                                    (encode (rand-nth campaign-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               campaigns (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
@@ -131,7 +132,7 @@
                (map #(dissoc % :created :modified) campaigns)))))
 
       (test-query-string-search :campaign "description" :description)
-      
+
       (testing "GET /ctia/campaign/:id"
         (let [response (get (str "ctia/campaign/" (:short-id campaign-id))
                             :headers {"api_key" "45c1f5e3f05d0"})

--- a/test/ctia/http/routes/coa_test.clj
+++ b/test/ctia/http/routes/coa_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.http.routes.coa-test
   (:refer-clojure :exclude [get])
   (:require [clj-momo.test-helpers.core :as mth]
+            [clj-momo.test-helpers.http :refer [encode]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
@@ -84,10 +85,9 @@
           (is (= (:port        coa-id)      (:port        show-props)))
           (is (= (:path-prefix coa-id) (seq (:path-prefix show-props))))))
 
-      (testing "GET /ctia/coa/external_id"
-        (let [response (get "ctia/coa/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth coa-external-ids)})
+      (testing "GET /ctia/coa/external_id/:external_id"
+        (let [response (get (format "ctia/coa/external_id/%s" (encode (rand-nth coa-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               coas (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/data_table_test.clj
+++ b/test/ctia/http/routes/data_table_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.http.routes.data-table-test
   (:refer-clojure :exclude [get])
   (:require [clj-momo.test-helpers.core :as mth]
+            [clj-momo.test-helpers.http :refer [encode]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
@@ -98,10 +99,10 @@
                        :created
                        :modified)))))
 
-      (testing "GET /ctia/data-table/external_id"
-        (let [response (get "ctia/data-table/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth data-table-external-ids)})
+      (testing "GET /ctia/data-table/external_id/:external_id"
+        (let [response (get (format "ctia/data-table/external_id/%s"
+                                    (encode (rand-nth data-table-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               data-tables (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/exploit_target_test.clj
+++ b/test/ctia/http/routes/exploit_target_test.clj
@@ -1,16 +1,17 @@
 (ns ctia.http.routes.exploit-target-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -75,10 +76,10 @@
           (is (= (:port        exploit-target-id)      (:port        show-props)))
           (is (= (:path-prefix exploit-target-id) (seq (:path-prefix show-props))))))
 
-      (testing "GET /ctia/exploit-target/external_id"
-        (let [response (get "ctia/exploit-target/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth exploit-targets-external-ids)})
+      (testing "GET /ctia/exploit-target/external_id/:external_id"
+        (let [response (get (format "ctia/exploit-target/external_id/%s"
+                                    (encode (rand-nth exploit-targets-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               exploit-targets (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
@@ -104,7 +105,7 @@
                (map #(dissoc % :created :modified) exploit-targets)))))
 
       ;;(test-query-string-search :exploit-target "description" :description)
-      
+
       (testing "GET /ctia/exploit-target/:id"
         (let [response (get (str "ctia/exploit-target/" (:short-id exploit-target-id))
                             :headers {"api_key" "45c1f5e3f05d0"})

--- a/test/ctia/http/routes/feedback_test.clj
+++ b/test/ctia/http/routes/feedback_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.http.routes.feedback-test
   (:refer-clojure :exclude [get])
   (:require [clj-momo.test-helpers.core :as mth]
+            [clj-momo.test-helpers.http :refer [encode]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
@@ -94,10 +95,10 @@
                  :tlp "green"}]
                (map #(dissoc % :created :owner) feedbacks)))))
 
-      (testing "GET /ctia/feedback/external_id"
-        (let [response (get "ctia/feedback/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth feedback-external-ids)})
+      (testing "GET /ctia/feedback/external_id/:external_id"
+        (let [response (get (format "ctia/feedback/external_id/%s"
+                                    (encode (rand-nth feedback-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               feedback (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/incident_test.clj
+++ b/test/ctia/http/routes/incident_test.clj
@@ -1,19 +1,17 @@
 (ns ctia.http.routes.incident-test
   (:refer-clojure :exclude [get])
-  (:require
-    [clj-momo.test-helpers.core :as mth]
-    [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
-    [ctia.domain.entities :refer [schema-version]]
-    [ctia.properties :refer [get-http-show]]
-    [ctia.test-helpers
-     [core :as helpers :refer [delete get post put]]
-     [fake-whoami-service :as whoami-helpers]
-     [store :refer [deftest-for-each-store]]
-     [auth :refer [all-capabilities]]]
-    [ctim.domain.id :as id]
-    [ctim.schemas
-     [common :as c]
-     [incident :refer [NewIncident StoredIncident]]]))
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
+            [clojure.test :refer [is join-fixtures testing use-fixtures]]
+            [ctia.domain.entities :refer [schema-version]]
+            [ctia.properties :refer [get-http-show]]
+            [ctia.test-helpers
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [delete get post put]]
+             [fake-whoami-service :as whoami-helpers]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -81,10 +79,10 @@
           (is (= (:port        incident-id)      (:port        show-props)))
           (is (= (:path-prefix incident-id) (seq (:path-prefix show-props))))))
 
-      (testing "GET /ctia/incident/external_id"
-        (let [response (get "ctia/incident/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth incident-external-ids)})
+      (testing "GET /ctia/incident/external_id/:external_id"
+        (let [response (get (format "ctia/incident/external_id/%s"
+                                    (encode (rand-nth incident-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               incidents (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/indicator_test.clj
+++ b/test/ctia/http/routes/indicator_test.clj
@@ -1,18 +1,20 @@
 (ns ctia.http.routes.indicator-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
+            [ctia
+             [auth :as auth]
+             [properties :refer [get-http-show]]]
             [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
-            [ctia.auth :as auth]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
              [http :refer [api-key assert-post test-get-list]]
+             [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]
             [ring.util.codec :refer [url-encode]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -88,11 +90,11 @@
           (is (= (:path-prefix indicator-id) (seq (:path-prefix show-props))))))
 
       (test-query-string-search :indicator "description" :description)
-      
-      (testing "GET /ctia/indicator/external_id"
-        (let [response (get "ctia/indicator/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth indicator-external-ids)})
+
+      (testing "GET /ctia/indicator/external_id/:external_id"
+        (let [response (get (format "ctia/indicator/external_id/%s"
+                                    (encode (rand-nth indicator-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               indicators (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/relationship_test.clj
+++ b/test/ctia/http/routes/relationship_test.clj
@@ -1,17 +1,17 @@
 (ns ctia.http.routes.relationship-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [delete get post]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -111,11 +111,11 @@
                        :modified)))))
 
       ;;(test-query-string-search :relationship "description" :description)
-      
-      (testing "GET /ctia/relationship/external_id"
-        (let [response (get "ctia/relationship/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth relationship-external-ids)})
+
+      (testing "GET /ctia/relationship/external_id/:external_id"
+        (let [response (get (format "ctia/relationship/external_id/%s"
+                                    (encode (rand-nth relationship-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               relationships (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=

--- a/test/ctia/http/routes/sighting_test.clj
+++ b/test/ctia/http/routes/sighting_test.clj
@@ -1,16 +1,17 @@
 (ns ctia.http.routes.sighting-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
              [http :refer [api-key]]
+             [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
             [ctim.domain.id :as id]))
 
@@ -113,10 +114,10 @@
           (is (= (:path-prefix sighting-id) (seq (:path-prefix show-props))))))
 
 
-      (testing "GET /ctia/sighting/external_id"
-        (let [response (get "ctia/sighting/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth sighting-external-ids)})
+      (testing "GET /ctia/sighting/external_id/:external_id"
+        (let [response (get (format "ctia/sighting/external_id/%s"
+                                    (encode (rand-nth sighting-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               sightings (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
@@ -138,7 +139,7 @@
                (map #(dissoc % :created :modified) sightings)))))
 
       (test-query-string-search :sighting "description" :description)
-      
+
       (testing "GET /ctia/sighting/:id"
         (let [{status :status
                sighting :parsed-body}

--- a/test/ctia/http/routes/ttp_test.clj
+++ b/test/ctia/http/routes/ttp_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.http.routes.ttp-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers.core :as mht]
+  (:require [clj-momo.test-helpers
+             [core :as mht]
+             [http :refer [encode]]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [search :refer [test-query-string-search]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -21,7 +22,9 @@
 
 (deftest-for-each-store test-ttp-routes
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
+  (helpers/set-capabilities! "baruser" "user" #{})
   (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "user")
+  (whoami-helpers/set-whoami-response "2222222222222" "baruser" "user")
 
   (testing "POST /ctia/ttp"
     (let [{status :status
@@ -71,10 +74,10 @@
           (is (= (:port        ttp-id)      (:port        show-props)))
           (is (= (:path-prefix ttp-id) (seq (:path-prefix show-props))))))
 
-      (testing "GET /ctia/ttp/external_id"
-        (let [response (get "ctia/ttp/external_id"
-                            :headers {"api_key" "45c1f5e3f05d0"}
-                            :query-params {"external_id" (rand-nth ttp-external-ids)})
+      (testing "GET /ctia/ttp/external_id/:external_id"
+        (let [response (get (format "ctia/ttp/external_id/%s"
+                                    (encode (rand-nth ttp-external-ids)))
+                            :headers {"api_key" "45c1f5e3f05d0"})
               ttps (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
@@ -98,7 +101,7 @@
 
 
       (test-query-string-search :ttp "description" :description)
-      
+
 
       (testing "GET /ctia/ttp/:id"
         (let [response (get (str "ctia/ttp/" (:short-id ttp-id))


### PR DESCRIPTION
closes #425 

changed from /entity/external_id?external_id=<external_id>
to /entity/external_id/<external_id>