### PR TITLE
Issue-476: Fix demo container ctia.properties

### DIFF
--- a/containers/demo/ctia/config/ctia.properties
+++ b/containers/demo/ctia/config/ctia.properties
@@ -1,14 +1,4 @@
-ctia.store.es.default.transport=http
 ctia.store.es.default.host=elasticsearch
-ctia.store.es.default.indexname=ctia
-ctia.store.es.default.port=9200
-
+ctia.hook.redismq.host=redis
 ctia.hook.redis.host=redis
-ctia.hook.redis.port=6379
-
-# ES archive of all CTIM Events
-ctia.hook.es.enabled=true
-ctia.hook.es.transport=http
-ctia.hook.es.host=elaticsearch
-ctia.hook.es.port=9200
-ctia.hook.es.indexname=ctia_events
+ctia.metrics.riemann.host=riemann


### PR DESCRIPTION
Recent updates to the event system, and how we manage the ES store
in our properties (see #464) overlooked updating the demo container
properties.  This remedies that.

Closes #476