### PR TITLE
COA, ExploitTarget, Incident and Relationship query string search support

### DIFF
--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -189,6 +189,16 @@
     (s/optional-key :confidence) s/Str
     (s/optional-key :sort_by)  judgement-sort-fields}))
 
+(s/defschema RelationshipSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   {(s/optional-key :query) s/Str
+    (s/optional-key :relationship_type) s/Str
+    (s/optional-key :source_ref) s/Str
+    (s/optional-key :target_ref) s/Str
+    (s/optional-key :sort_by)  judgement-sort-fields}))
 
 (s/defschema SightingSearchParams
   (st/merge

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -32,6 +32,31 @@
                          :confidence
                          :specification])))
 
+(def incident-sort-fields
+  (apply s/enum (concat default-entity-sort-fields
+                        describable-entity-sort-fields
+                        sourcable-entity-sort-fields
+                        [:valid_time.start
+                         :valid_time.end
+                         :confidence
+                         :status
+                         :incident_time
+                         :reporter
+                         :coordinator
+                         :victim
+                         :security_compromise
+                         :discovery_method
+                         :contact
+                         :intended_effect])))
+
+(def relationship-sort-fields
+  (apply s/enum (concat default-entity-sort-fields
+                        describable-entity-sort-fields
+                        sourcable-entity-sort-fields
+                        [:relationship_type
+                         :source_ref
+                         :target_ref])))
+
 (def judgement-sort-fields
   (apply s/enum (concat base-entity-sort-fields
                         sourcable-entity-sort-fields
@@ -162,6 +187,15 @@
 (s/defschema SourcableEntityFilterParams
   {(s/optional-key :source) s/Str})
 
+(s/defschema IncidentSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   {(s/optional-key :query) s/Str
+    (s/optional-key :categories) s/Str
+    (s/optional-key :sort_by) incident-sort-fields}))
+
 (s/defschema IndicatorSearchParams
   (st/merge
    PagingParams
@@ -198,7 +232,7 @@
     (s/optional-key :relationship_type) s/Str
     (s/optional-key :source_ref) s/Str
     (s/optional-key :target_ref) s/Str
-    (s/optional-key :sort_by)  judgement-sort-fields}))
+    (s/optional-key :sort_by)  relationship-sort-fields}))
 
 (s/defschema SightingSearchParams
   (st/merge

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -25,6 +25,14 @@
           sourcable-entity-sort-fields
           describable-entity-sort-fields))
 
+
+(def exploit-target-sort-fields
+  (apply s/enum (concat default-entity-sort-fields
+                        describable-entity-sort-fields
+                        sourcable-entity-sort-fields
+                        [:valid_time.start
+                         :valid_time.end])))
+
 (def incident-sort-fields
   (apply s/enum (concat default-entity-sort-fields
                         describable-entity-sort-fields
@@ -186,6 +194,15 @@
 
 (s/defschema SourcableEntityFilterParams
   {(s/optional-key :source) s/Str})
+
+
+(s/defschema ExploitTargetSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   {(s/optional-key :query) s/Str
+    (s/optional-key :sort_by) exploit-target-sort-fields}))
 
 (s/defschema IncidentSearchParams
   (st/merge

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -25,13 +25,6 @@
           sourcable-entity-sort-fields
           describable-entity-sort-fields))
 
-(def indicator-sort-fields
-  (apply s/enum (concat default-entity-sort-fields
-                        [:indicator_type
-                         :likely_impact
-                         :confidence
-                         :specification])))
-
 (def incident-sort-fields
   (apply s/enum (concat default-entity-sort-fields
                         describable-entity-sort-fields
@@ -48,6 +41,13 @@
                          :discovery_method
                          :contact
                          :intended_effect])))
+
+(def indicator-sort-fields
+  (apply s/enum (concat default-entity-sort-fields
+                        [:indicator_type
+                         :likely_impact
+                         :confidence
+                         :specification])))
 
 (def relationship-sort-fields
   (apply s/enum (concat default-entity-sort-fields
@@ -193,6 +193,15 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    {(s/optional-key :query) s/Str
+    (s/optional-key :confidence) s/Str
+    (s/optional-key :status) s/Str
+    (s/optional-key :reporter) s/Str
+    (s/optional-key :coordinator) s/Str
+    (s/optional-key :victim) s/Str
+    (s/optional-key :security_compromise) s/Str
+    (s/optional-key :discovery_method) s/Str
+    (s/optional-key :contact) s/Str
+    (s/optional-key :intended_effect) s/Str
     (s/optional-key :categories) s/Str
     (s/optional-key :sort_by) incident-sort-fields}))
 
@@ -309,4 +318,4 @@
     (s/optional-key :cost) s/Str
     (s/optional-key :efficacy) s/Str
     (s/optional-key :structured_coa_type) s/Str
-    (s/optional-key :sort_by)  coa-sort-fields}))
+    (s/optional-key :sort_by) coa-sort-fields}))

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -6,7 +6,8 @@
    [ctia.flows.crud :as flows]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewExploitTarget StoredExploitTarget]]
-   [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
+   [ctia.http.routes.common :refer [created paginated-ok
+                                    ExploitTargetSearchParams PagingParams]]
    [ring.util.http-response :refer [ok no-content not-found]]
    [schema.core :as s]
    [schema-tools.core :as st]
@@ -72,6 +73,20 @@
                  (page-with-long-id
                   (read-store :exploit-target list-exploit-targets
                               {:external_ids external_id} q))))
+           (GET "/search" []
+                :return (s/maybe [StoredExploitTarget])
+                :summary "Search for an ExploitTarget using a Lucene/ES query string"
+                :query [params ExploitTargetSearchParams]
+                :capabilities #{:read-exploit-target :search-exploit-target}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store
+                   :exploit-target
+                   query-string-search
+                   (:query params)
+                   (dissoc params :query :sort_by :sort_order :offset :limit)
+                   (select-keys params [:sort_by :sort_order :offset :limit])))))
 
            (GET "/:id" []
                 :return (s/maybe StoredExploitTarget)

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -5,7 +5,8 @@
             [ctia.flows.crud :as flows]
             [ctia.store :refer :all]
             [ctia.schemas.core :refer [NewIncident StoredIncident]]
-            [ctia.http.routes.common :refer [created PagingParams paginated-ok]]
+            [ctia.http.routes.common :refer [created IncidentSearchParams
+                                             PagingParams paginated-ok]]
             [ring.util.http-response :refer [ok no-content not-found]]
             [schema.core :as s]
             [schema-tools.core :as st]))
@@ -61,6 +62,21 @@
                  (page-with-long-id
                   (read-store :incident list-incidents
                               {:external_ids external_id} q))))
+
+           (GET "/search" []
+                :return (s/maybe [StoredIncident])
+                :summary "Search for an Incident using a Lucene/ES query string"
+                :query [params IncidentSearchParams]
+                :capabilities #{:read-incident :search-incident}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store
+                   :incident
+                   query-string-search
+                   (:query params)
+                   (dissoc params :query :sort_by :sort_order :offset :limit)
+                   (select-keys params [:sort_by :sort_order :offset :limit])))))
 
            (GET "/:id" []
                 :return (s/maybe StoredIncident)

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -4,7 +4,7 @@
    [ctia.domain.entities :refer [realize-relationship]]
    [ctia.domain.entities.relationship :refer [with-long-id page-with-long-id]]
    [ctia.flows.crud :as flows]
-   [ctia.http.routes.common :refer [created paginated-ok PagingParams]]
+   [ctia.http.routes.common :refer [created paginated-ok PagingParams RelationshipSearchParams]]
    [ctia.store :refer :all]
    [ctia.schemas.core :refer [NewRelationship StoredRelationship]]
    [ring.util.http-response :refer [no-content not-found ok]]
@@ -47,6 +47,21 @@
                  (page-with-long-id
                   (read-store :relationship list-relationships
                               {:external_ids external_id} q))))
+
+           (GET "/search" []
+                :return (s/maybe [StoredRelationship])
+                :summary "Search for a Relationship using a Lucene/ES query string"
+                :query [params RelationshipSearchParams]
+                :capabilities #{:read-relationship :search-relationship}
+                :header-params [api_key :- (s/maybe s/Str)]
+                (paginated-ok
+                 (page-with-long-id
+                  (query-string-search-store
+                   :relationship
+                   query-string-search
+                   (:query params)
+                   (dissoc params :query :sort_by :sort_order :offset :limit)
+                   (select-keys params [:sort_by :sort_order :offset :limit])))))
 
            (GET "/:id" []
                 :return (s/maybe StoredRelationship)

--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -140,7 +140,7 @@
 (defn search-docs
   "Search for documents on es using a query string search.  Also applies a filter map, converting the values in the filter-map into must match terms."
   [conn index-name mapping query filter-map params]
-  (let [ es-params (generate-es-params query filter-map params)
+  (let [es-params (generate-es-params query filter-map params)
         res (->> ((search-doc-fn conn)
                   conn
                   index-name
@@ -150,9 +150,9 @@
         results (->> res
                      ((hits-from-fn conn))
                      (map :_source))]
-    
-    (log/debug "search-docs: " es-params )
-    
+
+    (log/debug "search-docs:" es-params)
+
     (pagination/response (or results [])
                          (:from es-params)
                          (:size es-params)

--- a/src/ctia/lib/es/query.clj
+++ b/src/ctia/lib/es/query.clj
@@ -8,8 +8,7 @@
   ->
   [{:terms {observable.type [ip]}} {:terms {observable.value [42.42.42.1]}}]
 
-We we force all values to lowercase, since our indexing does the same for all terms.
-"
+we force all values to lowercase, since our indexing does the same for all terms."
   (vec (map (fn [[k v]]
               (q/terms (->> k
                             (map name)
@@ -50,8 +49,12 @@ We we force all values to lowercase, since our indexing does the same for all te
                             (if (relationship? v)
                               (terms-from-relationship t-key v)
                               [t-key v])))
-                        filter-map)]
-         {:filtered
-          {:query q
-           :filter (q/bool {:must (nested-terms terms)})}})
+                        filter-map)
+             must-filters (nested-terms terms)]
+
+         (if (empty? must-filters)
+           q {:filtered
+              {:query q
+               :filter (q/bool {:must must-filters})}}))
+
        q))))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -128,5 +128,5 @@
   (apply read-fn (first (get @stores store)) args))
 
 (defn query-string-search-store [store read-fn & args]
-  (log/debug "query-string-search-store args: " args)
+  (log/debug "query-string-search-store args: " store read-fn args)
   (apply read-fn (first (get @stores store)) args))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -106,7 +106,6 @@
        (search-docs (:conn state)
                     (:index state)
                     (name mapping)
-                    {:query_string {:query query
-                                           }}
+                    {:query_string {:query query}}
                     filter-map
                     params)))))

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -21,11 +21,7 @@
 
 (def all_text
   "The same as the `text` maping, but will be included in the _all field"
-  {:type "string"
-   :analyzer "text_analyzer"
-   :search_analyzer "search_analyzer"
-   :search_quote_analyzer "text_analyzer"
-   :include_in_all true})
+  (assoc text :include_in_all true))
 
 (def token
   "A mapping for fields whose value should be treated like a symbol.
@@ -50,12 +46,11 @@
    :external_ids all_token
    :timestamp ts
    :language token
-   :tlp token
-   })
+   :tlp token})
 
 (def describable-entity-mapping
-  {:title (merge all_text
-                 {:fields {:whole all_token}})
+  {:title (assoc all_text
+                 :fields {:whole all_token})
    :short_description all_text
    :description all_text})
 
@@ -680,18 +675,15 @@
     {:default_search ;; same as text_analyzer
      {:type "custom"
       :tokenizer "standard"
-      :filter ["lowercase" "english_stop"]
-      }
+      :filter ["lowercase" "english_stop"]}
      :text_analyzer
      {:type "custom"
       :tokenizer "standard"
-      :filter ["lowercase"]
-      }
+      :filter ["lowercase"]}
      :search_analyzer
      {:type "custom"
       :tokenizer "standard"
-      :filter ["lowercase" "english_stop"]
-      }
+      :filter ["lowercase" "english_stop"]}
      :token_analyzer
      {:filter ["token_len" "lowercase"]
       :tokenizer "keyword"

--- a/src/ctia/stores/es/relationship.clj
+++ b/src/ctia/stores/es/relationship.clj
@@ -6,3 +6,4 @@
 (def handle-read (crud/handle-read :relationship StoredRelationship))
 (def handle-delete (crud/handle-delete :relationship StoredRelationship))
 (def handle-list (crud/handle-find :relationship StoredRelationship))
+(def handle-query-string-search (crud/handle-query-string-search :relationship StoredRelationship))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -84,7 +84,10 @@
   (delete-relationship [_ id]
     (rel/handle-delete state id))
   (list-relationships [_ filter-map params]
-    (rel/handle-list state filter-map params)))
+    (rel/handle-list state filter-map params))
+  IQueryStringSearchableStore
+  (query-string-search [_ query filtermap params]
+    (rel/handle-query-string-search state query filtermap params)))
 
 (defrecord VerdictStore [state]
   IVerdictStore

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -189,7 +189,7 @@
     (coa/handle-list state filter-map params))
   IQueryStringSearchableStore
   (query-string-search [_ query filtermap params]
-    (ca/handle-query-string-search state query filtermap params)))
+    (coa/handle-query-string-search state query filtermap params)))
 
 (defrecord DataTableStore [state]
   IDataTableStore

--- a/test/ctia/http/routes/coa_test.clj
+++ b/test/ctia/http/routes/coa_test.clj
@@ -116,9 +116,6 @@
                  :owner "foouser"}]
                (map #(dissoc % :created :modified) coas)))))
 
-      ;; CLB: FIXME
-      ;;(test-query-string-search :coa "description:description" :description)
-      
       (testing "GET /ctia/coa/:id"
         (let [response (get (str "ctia/coa/" (:short-id coa-id))
                             :headers {"api_key" "45c1f5e3f05d0"})
@@ -151,6 +148,8 @@
                (dissoc coa
                        :created
                        :modified)))))
+
+      (test-query-string-search :coa "description" :description)
 
       (testing "PUT /ctia/coa/:id"
         (let [{updated-coa :parsed-body

--- a/test/ctia/http/routes/exploit_target_test.clj
+++ b/test/ctia/http/routes/exploit_target_test.clj
@@ -7,6 +7,7 @@
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
+             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
@@ -104,7 +105,7 @@
                  :owner "foouser"}]
                (map #(dissoc % :created :modified) exploit-targets)))))
 
-      ;;(test-query-string-search :exploit-target "description" :description)
+      (test-query-string-search :exploit-target "description" :description)
 
       (testing "GET /ctia/exploit-target/:id"
         (let [response (get (str "ctia/exploit-target/" (:short-id exploit-target-id))

--- a/test/ctia/http/routes/incident_test.clj
+++ b/test/ctia/http/routes/incident_test.clj
@@ -7,6 +7,7 @@
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
+             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
@@ -109,7 +110,7 @@
                  :owner "foouser"}]
                (map #(dissoc % :created :modified) incidents)))))
 
-      ;;(test-query-string-search :incident "description" :description)
+      (test-query-string-search :incident "description" :description)
       
       (testing "GET /ctia/incident/:id"
         (let [response (get (str "ctia/incident/" (:short-id incident-id))

--- a/test/ctia/http/routes/relationship_test.clj
+++ b/test/ctia/http/routes/relationship_test.clj
@@ -7,6 +7,7 @@
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
+             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post]]
              [fake-whoami-service :as whoami-helpers]
@@ -110,7 +111,7 @@
                        :created
                        :modified)))))
 
-      ;;(test-query-string-search :relationship "description" :description)
+      (test-query-string-search :relationship "description" :description)
 
       (testing "GET /ctia/relationship/external_id/:external_id"
         (let [response (get (format "ctia/relationship/external_id/%s"

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -1,34 +1,35 @@
 (ns ctia.test-helpers.search
   (:refer-clojure :exclude [get])
   (:require [clojure.test :refer [is testing]]
-            [ctia.test-helpers
-             [core :as helpers :refer [delete get post put]]]))
+            [ctia.test-helpers.core :as helpers :refer [get]]))
 
-(defmacro test-query-string-search [entity query query-field]
-  `(testing (str "GET /ctia/" (name ~entity) "/search")
-     ;; only when ES store
-     (when (= "es" (get-in @ctia.properties/properties [:ctia :store ~entity]))
-       (let [query-url# (str "ctia/" (name ~entity) "/search")]
-         
-         (let [response# (get query-url#
-                              :headers {"api_key" "45c1f5e3f05d0"}
-                              :query-params {"query" ~query})]
-           (is (= 200 (:status response#)))
-           (is (= ~query (first (map ~query-field (:parsed-body response#))))
-               "query term works"))
-         
-         (let [response# (get query-url#
-                              :headers {"api_key" "45c1f5e3f05d0"}
-                              :query-params {"query" ~query
-                                             "tlp" "red"})]
-           (is (= 200 (:status response#)))
-           (is (empty? (:parsed-body response#))
-               "filters are applied, and discriminate"))
-         
-         (let [response# (get query-url#
-                              :headers {"api_key" "45c1f5e3f05d0"}
-                              :query-params {"query" ~query
-                                             "tlp" "green"})]
-           (is (= 200 (:status response#)))
-           (is (= 1  (count (:parsed-body response#)))
-               "filters are applied, and match properly"))))))
+(defn test-query-string-search [entity query query-field]
+  (let [search-uri (format "ctia/%s/search" (name entity))]
+
+    (testing (format "GET %s" search-uri)
+      ;; only when ES store
+      (when (= "es" (get-in @ctia.properties/properties [:ctia :store entity]))
+
+        (let [response (get search-uri
+                            :headers {"api_key" "45c1f5e3f05d0"}
+                            :query-params {:query query})]
+
+          (is (= 200 (:status response)))
+          (is (= query (first (map query-field (:parsed-body response))))
+              "query term works"))
+
+        (let [response (get search-uri
+                            :headers {"api_key" "45c1f5e3f05d0"}
+                            :query-params {"query" query
+                                           "tlp" "red"})]
+          (is (= 200 (:status response)))
+          (is (empty? (:parsed-body response))
+              "filters are applied, and discriminate"))
+
+        (let [response (get search-uri
+                            :headers {"api_key" "45c1f5e3f05d0"}
+                            :query-params {"query" query
+                                           "tlp" "green"})]
+          (is (= 200 (:status response)))
+          (is (= 1 (count (:parsed-body response)))
+              "filters are applied, and match properly"))))))


### PR DESCRIPTION
Completes search support for COA, Incident, Exploit-Target and Relationship entities

closes #453
closes #454 
closes #455 
closes #456 

also changed the test helpers from a macro to a fn as it is easier to investigate when it fails.