### PR TITLE
add configurable CORS support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -63,6 +63,7 @@
                  [ring/ring-jetty-adapter "1.5.0"]
                  [javax.servlet/servlet-api "2.5"]
                  [ring/ring-devel "1.4.0"]
+                 [ring-cors "0.1.8"]
                  [ring/ring-codec "1.0.1"
                   ;; Exclusions:
                   ;; - ring-codec 1.0.1 is not using the latest commons-codec

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -3,7 +3,7 @@ ctia.auth.threatgrid.cache=true
 
 ctia.http.enabled=true
 ctia.http.port=3000
-ctia.http.access-control-allow-origin=http://localhost,http://localhost:6886
+ctia.http.access-control-allow-origin=http://(localhost|127.0.0.1)(:\\d+)?
 ctia.http.access-control-allow-methods=get,post,put,delete
 ctia.http.min-threads=10
 ctia.http.max-threads=100

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -3,6 +3,8 @@ ctia.auth.threatgrid.cache=true
 
 ctia.http.enabled=true
 ctia.http.port=3000
+ctia.http.access-control-allow-origin=http://localhost,http://localhost:6886
+ctia.http.access-control-allow-methods=get,post,put,delete
 ctia.http.min-threads=10
 ctia.http.max-threads=100
 ctia.http.show.hostname=localhost

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -1,9 +1,12 @@
 (ns ctia.http.handler
-  (:require [compojure.api.sweet :refer [context defapi]]
-            [compojure.api.core :refer [middleware]]
-            [ctia.http.middleware.auth :as auth]
+  (:require [compojure.api
+             [core :refer [middleware]]
+             [sweet :refer [context defapi]]]
             [ctia.http.exceptions :as ex]
-            [ctia.http.middleware.metrics :as metrics]
+            [ctia.http.middleware
+             [auth :as auth]
+             [cache-control :refer [wrap-cache-control-headers]]
+             [metrics :as metrics]]
             [ctia.http.routes
              [actor :refer [actor-routes]]
              [bulk :refer [bulk-routes]]
@@ -17,18 +20,14 @@
              [incident :refer [incident-routes]]
              [indicator :refer [indicator-routes]]
              [judgement :refer [judgement-routes]]
-             [relationship :refer [relationship-routes]]
              [metrics :refer [metrics-routes]]
              [observable :refer [observable-routes]]
              [properties :refer [properties-routes]]
+             [relationship :refer [relationship-routes]]
              [sighting :refer [sighting-routes]]
              [ttp :refer [ttp-routes]]
              [verdict :refer [verdict-routes]]
              [version :refer [version-routes]]]
-            [ring.middleware
-             [format :refer [wrap-restful-format]]
-             [params :as params]]
-            [ctia.http.middleware.cache-control :refer [wrap-cache-control-headers]]
             [ring.middleware.not-modified :refer [wrap-not-modified]]))
 
 (def api-description

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -44,8 +44,8 @@
     (st/optional-keys
      (reduce merge {}
              (map (fn [s] (merge (default-store-properties s)
-                                 (es-store-impl-properties s)
-                                 (atom-store-impl-properties s)))
+                                (es-store-impl-properties s)
+                                (atom-store-impl-properties s)))
                   store-names)))))
 
 (s/defschema PropertiesSchema
@@ -62,6 +62,8 @@
 
    (st/required-keys {"ctia.http.enabled" s/Bool
                       "ctia.http.port" s/Int
+                      "ctia.http.access-control-allow-origin" s/Str
+                      "ctia.http.access-control-allow-methods" s/Str
                       "ctia.http.min-threads" s/Int
                       "ctia.http.max-threads" s/Int})
 


### PR DESCRIPTION
closes #482 

- Use ring-cors
- expose access-control-allow-origin and access-control-allow-methods config
- default development friendly config