### PR TITLE
CTIM issue 81 support PR

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,11 +43,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.3.3"
-                  ;; Exclusions:
-                  ;; - ring-swagger as 0.22.9 lacks s/Any support
-                  :exclusions [metosin/ring-swagger]]
-
+                 [threatgrid/ctim "0.3.4-SNAPSHOT"]
                  ;; Web server
                  ;; ring-swagger 0.22.10 provided by compojure-api
                  ;; 1.1.8 fails to generate JSON schema for s/Any

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.3.4-SNAPSHOT"]
+                 [threatgrid/ctim "0.3.4"]
                  ;; Web server
                  ;; ring-swagger 0.22.10 provided by compojure-api
                  ;; 1.1.8 fails to generate JSON schema for s/Any


### PR DESCRIPTION
related to: https://github.com/threatgrid/ctim/pull/115

will upgrade the CTIM dep to non snapshot once it is released on clojars