### PR TITLE
ES5 Compatibility changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jdk:
     - oraclejdk8
 
 before_install:
+    # ES5 needs this
+    - sudo sysctl -w vm.max_map_count=262144
     # create log & bin dir if missing
     - mkdir -p $LOG_DIR
     - mkdir -p $BIN_DIR
@@ -40,8 +42,8 @@ env:
       - JAVA_OPTS="-XX:MaxPermSize=256m"
       - LOG_DIR=$HOME/log
       - BIN_DIR=$HOME/bin
-      - COMPOSE_URI=https://github.com/docker/compose/releases/download/1.4.2
-      - COMPOSE_BIN=$HOME/bin/docker-compose
+      - COMPOSE_URI=https://github.com/docker/compose/releases/download/1.9.0
+      - COMPOSE_BIN=$HOME/bin/docker-compose-1-9-0
       - COMPOSE_LOG=$HOME/log/docker-compose.log
       - CTIA_STORE_ES_DEFAULT_HOST=127.0.0.1
       - CTIA_STORE_ES_DEFAULT_INDEXNAME=elasticsearch

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ a crash course in running clojure projects, check out
 CTIA uses Leiningen as it's "build" tool, you can install it by
 following the instructions here: http://leiningen.org/#install
 
-By default, CTIA uses Elasticsearch as it's data store.  Assuming you
-have Elasticsearch running on 127.0.0.1:9200 you can simply start
+By default, CTIA uses Elasticsearch 5.x as it's data store.  Assuming you
+have it running on 127.0.0.1:9200 you can simply start
 CTIA.
 
 You can jump to the [Developer](#Developer) section to see instructions

--- a/benchmarks/ctia/http/routes/actor_bench.clj
+++ b/benchmarks/ctia/http/routes/actor_bench.clj
@@ -11,12 +11,6 @@
    :actor_type "Hacker"
    :source "a source"
    :confidence "High"
-   :associated_actors [{:actor_id "actor-123"}
-                       {:actor_id "actor-456"}]
-   :associated_campaigns [{:campaign_id "campaign-444"}
-                          {:campaign_id "campaign-555"}]
-   :observed_TTPs [{:ttp_id "ttp-333"}
-                   {:ttp_id "ttp-999"}]
    :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
                 :end_time "2016-07-11T00:40:48.212-00:00"}})
 
@@ -29,9 +23,6 @@
    :actor_type "Hacker"
    :source "a source"
    :confidence "High"
-   :associated_actors (gen 100 :actor_id "actor")
-   :associated_campaigns (gen 100 :campaign_id "campaign")
-   :observed_TTPs (gen 100 :ttp_id "ttp")
    :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
                 :end_time "2016-07-11T00:40:48.212-00:00"}})
 

--- a/benchmarks/ctia/http/routes/actor_bench.clj
+++ b/benchmarks/ctia/http/routes/actor_bench.clj
@@ -1,9 +1,7 @@
 (ns ctia.http.routes.actor-bench
   (:require [ctia.test-helpers
              [benchmark :refer [cleanup-ctia!
-                                setup-ctia-atom-store!
-                                setup-ctia-es-store!
-                                setup-ctia-es-store-native!]]
+                                setup-ctia-es-store!]]
              [core :as helpers :refer [delete post]]]
             [perforate.core :refer :all]))
 
@@ -51,14 +49,6 @@
       (delete (str "ctia/actor" (:id parsed_body)))
       (prn "play-big: " status))))
 
-(defcase* create-actor :big-actor-atom-store
-  (fn [_] (let [port (setup-ctia-atom-store!)]
-           [#(play-big port) cleanup-ctia!])))
-
 (defcase* create-actor :big-actor-es-store
   (fn [_] (let [port (setup-ctia-es-store!)]
-           [#(play-big port) cleanup-ctia!])))
-
-(defcase* create-actor :big-actor-es-store-native
-  (fn [_] (let [port (setup-ctia-es-store-native!)]
            [#(play-big port) cleanup-ctia!])))

--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "6379:6379"
 
   elasticsearch:
-    image: elasticsearch:2.3.3
+    image: elasticsearch:5
     command: "elasticsearch -Des.network.host=0.0.0.0 -Des.cluster.name=elasticsearch -Des.node.master=true"
     volumes:
       - ./elasticsearch/data:/usr/share/elasticsearch/data

--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -20,15 +20,18 @@ services:
       - "6379:6379"
 
   elasticsearch:
-    image: elasticsearch:5
-    command: "elasticsearch -Des.network.host=0.0.0.0 -Des.cluster.name=elasticsearch -Des.node.master=true"
+    image: elasticsearch:5.1
+    environment:
+      ES_NETWORK_HOST: 0.0.0.0
+      ES_NODE_MASTER: "true"
+      ES_CLUSTER_NAME: elasticsearch
     volumes:
       - ./elasticsearch/data:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
       - "9300:9300"
   logstash:
-    image: logstash:latest
+    image: logstash:5.1
     command: logstash -f /etc/logstash/conf.d/logstash.conf
     volumes:
       - ./logstash/config:/etc/logstash/conf.d

--- a/containers/demo/kibana/Dockerfile
+++ b/containers/demo/kibana/Dockerfile
@@ -1,10 +1,8 @@
-FROM kibana:latest
+FROM kibana:5.1
 
 RUN apt-get update && apt-get install -y netcat
 
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
-
-RUN kibana plugin --install elastic/sense
 
 CMD ["/tmp/entrypoint.sh"]

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -3,14 +3,14 @@ redis-dev:
   ports:
     - "6379:6379"
 elasticsearch-dev:
-  image: elasticsearch:5
+  image: elasticsearch:5.1
   environment:
     - cluster.name=elasticsearch
   ports:
     - "9200:9200"
     - "9300:9300"
 kibana-dev:
-  image: kibana:5
+  image: kibana:5.1
   ports:
     - "5601:5601"
   environment:

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -3,13 +3,14 @@ redis-dev:
   ports:
     - "6379:6379"
 elasticsearch-dev:
-  image: elasticsearch:2.3.3
-  command: "elasticsearch -Des.cluster.name=elasticsearch -Des.node.master=true"
+  image: elasticsearch:5
+  environment:
+    - cluster.name=elasticsearch
   ports:
     - "9200:9200"
     - "9300:9300"
 kibana-dev:
-  image: kibana:4.5.1
+  image: kibana:5
   ports:
     - "5601:5601"
   environment:

--- a/project.clj
+++ b/project.clj
@@ -106,11 +106,9 @@
   :uberjar-exclusions [#"ctia\.properties"]
   :min-lein-version "2.4.0"
   :test-selectors {:es-store :es-store
-                   :es-store-native :es-store-native
                    :disabled :disabled
                    :default #(not= :disabled %)
                    :integration #(or (:es-store %)
-                                     (:es-store-native %)
                                      (:integration %)
                                      (:es-aliased-index %))
                    :no-gen #(not (:generative %))

--- a/project.clj
+++ b/project.clj
@@ -54,12 +54,7 @@
                  ;; overriding here
                  [metosin/ring-swagger "0.22.11"]
                  [metosin/compojure-api ~compojure-api-version
-                  ;; Exclusions:
-                  ;; - ring-swagger as CTIM provides 0.22.9
-                  ;; - compojure-api 1.1.7 is not using the latest snakeyaml
-                  ;;  - As of 2016-08-25, the latest version is 1.17, elastich
-                  ;;    3.0.0-beta1 wants 1.15, while compojure-api wants 1.13
-                  :exclusions [org.yaml/snakeyaml metosin/ring-swagger]]
+                  :exclusions [metosin/ring-swagger]]
                  [ring/ring-jetty-adapter "1.5.0"]
                  [javax.servlet/servlet-api "2.5"]
                  [ring/ring-devel "1.4.0"]
@@ -73,9 +68,6 @@
                  ;; nREPL server
                  [org.clojure/tools.nrepl "0.2.12"]
                  [cider/cider-nrepl "0.14.0"]
-
-                 ;; Database
-                 [clojurewerkz/elastisch "3.0.0-beta1"]
 
                  ;; clients
                  [clj-http "2.2.0"

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -20,12 +20,13 @@ ctia.events.enabled=true
 ctia.events.log=false
 
 # Use ES for all Stores
-ctia.store.es.default.transport=http
 ctia.store.es.default.host=127.0.0.1
 ctia.store.es.default.port=9200
 ctia.store.es.default.indexname=ctia
 ctia.store.es.default.replicas=1
 ctia.store.es.default.shards=5
+ctia.store.es.default.refresh=false
+
 ctia.store.actor=es
 ctia.store.event=es
 ctia.store.feedback=es

--- a/src/ctia/lib/es/conn.clj
+++ b/src/ctia/lib/es/conn.clj
@@ -1,0 +1,41 @@
+(ns ctia.lib.es.conn
+  (:require [clj-http.conn-mgr :refer [make-reusable-conn-manager]]
+            [clojure.tools.logging :as log]
+            [schema.core :as s])
+  (:import [org.apache.http.impl.conn PoolingClientConnectionManager
+            PoolingHttpClientConnectionManager]))
+
+(def default-cm-options {:timeout 30000
+                         :threads 100
+                         :default-per-route 100})
+
+(def default-opts
+  {:as :json
+   :content-type :json
+   :throw-exceptions false})
+
+(defn make-connection-manager []
+  (make-reusable-conn-manager default-cm-options))
+
+(s/defschema ESConn
+  {:cm (s/either PoolingClientConnectionManager
+                 PoolingHttpClientConnectionManager)
+   :uri s/Str})
+
+(defn connect
+  "instantiate an ES conn from props"
+  [{:keys [transport host port clustername]
+    :or {transport :http}}]
+
+  {:cm (make-connection-manager)
+   :uri (format "http://%s:%s" host port)})
+
+(defn safe-es-read [{:keys [status body :as res]}]
+  (case status
+    200 body
+    201 body
+    404 nil
+    (do (log/warn "ES query failed:" res)
+        (throw
+         (ex-info "ES query failed"
+                  {:es-http-res res})))))

--- a/src/ctia/lib/es/conn.clj
+++ b/src/ctia/lib/es/conn.clj
@@ -17,11 +17,6 @@
 (defn make-connection-manager []
   (make-reusable-conn-manager default-cm-options))
 
-(s/defschema ESConn
-  {:cm (s/either PoolingClientConnectionManager
-                 PoolingHttpClientConnectionManager)
-   :uri s/Str})
-
 (defn connect
   "instantiate an ES conn from props"
   [{:keys [transport host port clustername]
@@ -30,12 +25,12 @@
   {:cm (make-connection-manager)
    :uri (format "http://%s:%s" host port)})
 
-(defn safe-es-read [{:keys [status body :as res]}]
+(defn safe-es-read [{:keys [status body]
+                     :as res}]
   (case status
     200 body
     201 body
     404 nil
     (do (log/warn "ES query failed:" res)
-        (throw
-         (ex-info "ES query failed"
-                  {:es-http-res res})))))
+        (throw (ex-info "ES query failed"
+                        {:es-http-res res})))))

--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -3,16 +3,17 @@
             [clj-http.client :as client]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [ctia.lib.es
-             [index :refer [ESConn]]
-             [query :refer [filter-map->terms-query]]]
+            [ctia.lib.es.index :refer [ESConn]]
             [ctia.lib.pagination :as pagination]
+            [ctia.stores.es.query :refer [filter-map->terms-query]]
             [schema.core :as s]))
 
 (def default-limit 1000)
 
 (s/defschema Refresh
-  (s/enum true false "wait_for"))
+  (s/enum "true"
+          "false"
+          "wait_for"))
 
 (defn create-doc-uri [uri index-name mapping id]
   (format "%s/%s/%s/%s" uri index-name mapping id))

--- a/src/ctia/lib/es/document.clj
+++ b/src/ctia/lib/es/document.clj
@@ -1,120 +1,135 @@
 (ns ctia.lib.es.document
-  (:require [clojure.tools.logging :as log]
-            [clojurewerkz.elastisch.native
-             [bulk :as native-bulk]
-             [document :as native-document]
-             [response :as native-response]]
-            [clojurewerkz.elastisch.rest
-             [bulk :as rest-bulk]
-             [document :as rest-document]
-             [response :as rest-response]]
-            [ctia.lib.es.query :refer [filter-map->terms-query]]
-            [ctia.lib.pagination :as pagination]))
+  (:require [cheshire.core :as json]
+            [clj-http.client :as client]
+            [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [ctia.lib.es
+             [index :refer [ESConn]]
+             [query :refer [filter-map->terms-query]]]
+            [ctia.lib.pagination :as pagination]
+            [schema.core :as s]))
 
 (def default-limit 1000)
 
-(defn native-conn? [conn]
-  (not (:uri conn)))
+(s/defschema Refresh
+  (s/enum true false "wait_for"))
 
-(defn get-doc-fn [conn]
-  (if (native-conn? conn)
-    native-document/get
-    rest-document/get))
+(defn create-doc-uri [uri index-name mapping id]
+  (format "%s/%s/%s/%s" uri index-name mapping id))
 
-(defn bulk-index-fn [conn]
-  (if (native-conn? conn)
-    native-bulk/bulk-index
-    rest-bulk/bulk-index))
+(def delete-doc-uri create-doc-uri)
+(def get-doc-uri create-doc-uri)
 
-(defn bulk-fn [conn]
-  (if (native-conn? conn)
-    native-bulk/bulk
-    rest-bulk/bulk))
+(defn update-doc-uri [uri index-name mapping id]
+  (format "%s/%s/%s/%s/_update" uri index-name mapping id))
 
-(defn create-doc-fn [conn]
-  (if (native-conn? conn)
-    native-document/create
-    rest-document/create))
+(defn bulk-uri [uri]
+  (format "%s/_bulk" uri))
 
-(defn update-doc-fn [conn]
-  (if (native-conn? conn)
-    native-document/update-with-partial-doc
-    rest-document/update-with-partial-doc))
+(defn search-uri [uri index-name mapping]
+  (format "%s/%s/%s/_search" uri index-name mapping))
 
-(defn delete-doc-fn [conn]
-  (if (native-conn? conn)
-    native-document/delete
-    rest-document/delete))
+(def ^:private special-operation-keys
+  [:_doc_as_upsert
+   :_index
+   :_type
+   :_id
+   :_retry_on_conflict
+   :_routing
+   :_percolate
+   :_parent
+   :_script
+   :_script_params
+   :_scripted_upsert
+   :_timestamp
+   :_ttl
+   :_version
+   :_version_type])
 
-(defn search-doc-fn [conn]
-  (if (native-conn? conn)
-    native-document/search
-    rest-document/search))
+(defn index-operation [doc]
+  {"index" (select-keys doc special-operation-keys)})
 
-(defn hits-from-fn [conn]
-  (if (native-conn? conn)
-    native-response/hits-from
-    rest-response/hits-from))
+(defn bulk-index
+  "generates the content for a bulk insert operation"
+  ([documents]
+   (let [operations (map index-operation documents)
+         documents  (map #(apply dissoc % special-operation-keys) documents)]
+     (interleave operations documents))))
 
-(defn get-doc
+(s/defn get-doc
   "get a document on es and return only the source"
-  [conn index-name mapping id]
+  [{:keys [uri cm]} :- ESConn index-name mapping id]
+  (-> (client/get (get-doc-uri uri index-name mapping id)
+                  {:throw-exceptions false
+                   :connection-manager cm
+                   :as :json})
+      :body
+      :_source))
 
-  (:_source ((get-doc-fn conn)
-             conn
-             index-name
-             mapping
-             id)))
-
-(defn create-doc
+(s/defn create-doc
   "create a document on es return the created document"
-  [conn index-name mapping doc refresh?]
-  ((create-doc-fn conn)
-   conn
-   index-name
-   mapping
-   doc
-   {:id (:id doc)
-    :refresh refresh?})
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str
+   mapping :- s/Str
+   {:keys [id] :as doc} :- s/Any
+   refresh? :- Refresh]
+
+  (client/put (create-doc-uri uri index-name mapping id)
+              {:form-params doc
+               :query-params
+               {:refresh refresh?}
+               :connection-manager cm
+               :content-type :json
+               :as :json})
   doc)
 
-(defn bulk-create-doc
+(s/defn bulk-create-doc
   "create multiple documents on ES and return the created documents"
-  [conn docs refresh?]
-  (let [bulk-index (bulk-index-fn conn)
-        bulk (bulk-fn conn)
-        index-operations (bulk-index docs)]
-    (bulk conn
-          index-operations
-          {:refresh refresh?}))
+  [{:keys [uri cm]} :- ESConn
+   docs :- [s/Any]
+   refresh? :- Refresh]
+
+  (let [ops (bulk-index docs)
+        json-ops (map #(json/generate-string % {:pretty false}) ops)
+        bulk-body (-> json-ops
+                      (interleave (repeat "\n"))
+                      string/join)]
+    (client/post (bulk-uri uri)
+                 {:query-params {:refresh refresh?}
+                  :body bulk-body}))
   docs)
 
-(defn update-doc
+(s/defn update-doc
   "update a document on es return the updated document"
-  [conn index-name mapping id doc refresh?]
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str
+   mapping :- s/Str
+   id :- s/Str
+   doc :- s/Any
+   refresh? :- Refresh]
 
-  (let [res ((update-doc-fn conn)
-             conn
-             index-name
-             mapping
-             id
-             doc
-             {:refresh refresh?
-              :fields "_source"})]
-    (or (get-in res [:get-result :source])
-        (get-in res [:get :_source]))))
+  (client/post (update-doc-uri uri index-name mapping id)
+               {:form-params {:doc doc}
+                :query-params {:refresh refresh?}
+                :connection-manager cm
+                :content-type :json
+                :as :json})
+  doc)
 
-(defn delete-doc
+(s/defn delete-doc
   "delete a document on es and return nil if ok"
-  [conn index-name mapping id refresh?]
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str
+   mapping :- s/Str
+   id :- s/Str
+   refresh? :- Refresh]
 
-  (:found
-   ((delete-doc-fn conn)
-    conn
-    index-name
-    mapping
-    id
-    {:refresh refresh?})))
+  (-> (client/delete (delete-doc-uri uri index-name mapping id)
+                     {:query-params {:refresh refresh?}
+                      :connection-manager cm
+                      :as :json})
+      :body
+      :found))
 
 (defn params->pagination
   [{:keys [sort_by sort_order offset limit]
@@ -138,19 +153,26 @@
            {:query query-map}
            (select-keys params [:sort]))))
 
-(defn search-docs
-  "Search for documents on es using a query string search.  Also applies a filter map, converting the values in the filter-map into must match terms."
-  [conn index-name mapping query filter-map params]
+(s/defn search-docs
+  "Search for documents on es using a query string search.  Also applies a filter map, converting
+   the values in the filter-map into must match terms."
+
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str
+   mapping :- s/Str
+   query :- s/Any
+   filter-map :- s/Any
+   params :- s/Any]
+
   (let [es-params (generate-es-params query filter-map params)
-        res (->> ((search-doc-fn conn)
-                  conn
-                  index-name
-                  mapping
-                  es-params))
+        res (:body (client/post
+                    (search-uri uri index-name mapping)
+                    {:form-params es-params
+                     :connection-manager cm
+                     :content-type :json
+                     :as :json}))
         hits (get-in res [:hits :total] 0)
-        results (->> res
-                     ((hits-from-fn conn))
-                     (map :_source))]
+        results (->> res :hits :hits (map :_source))]
 
     (log/debug "search-docs:" es-params)
 

--- a/src/ctia/lib/es/index.clj
+++ b/src/ctia/lib/es/index.clj
@@ -6,7 +6,9 @@
   (:import [org.apache.http.impl.conn PoolingClientConnectionManager
             PoolingHttpClientConnectionManager]))
 
-(def default-cm-options {:timeout 30000 :threads 100})
+(def default-cm-options {:timeout 30000
+                         :threads 100
+                         :default-per-route 100})
 
 (defn make-connection-manager []
   (make-reusable-conn-manager default-cm-options))

--- a/src/ctia/lib/es/index.clj
+++ b/src/ctia/lib/es/index.clj
@@ -1,16 +1,20 @@
 (ns ctia.lib.es.index
-  (:require [clojure.core.memoize :as memo]
-            [clojurewerkz.elastisch.native :as n]
-            [clojurewerkz.elastisch.native.index :as native-index]
-            [clojurewerkz.elastisch.rest :as h]
-            [clojurewerkz.elastisch.rest.index :as rest-index]
-            [schema.core :as s]))
+  (:require [clj-http
+             [client :as client]
+             [conn-mgr :refer [make-reusable-conn-manager]]]
+            [schema.core :as s])
+  (:import [org.apache.http.impl.conn PoolingClientConnectionManager
+            PoolingHttpClientConnectionManager]))
+
+(def default-cm-options {:timeout 30000 :threads 100})
+
+(defn make-connection-manager []
+  (make-reusable-conn-manager default-cm-options))
 
 (s/defschema ESConn
-  (s/either clojurewerkz.elastisch.rest.Connection
-            org.elasticsearch.client.transport.TransportClient))
-
-(def alias-create-fifo-threshold 5)
+  {:cm (s/either PoolingClientConnectionManager
+                 PoolingHttpClientConnectionManager)
+   :uri s/Str})
 
 (s/defschema ESSlicing
   {:strategy s/Keyword
@@ -23,58 +27,58 @@
    :conn ESConn
    (s/optional-key :slicing) ESSlicing})
 
-(defn native-conn? [conn]
-  (not (:uri conn)))
-
-(defn create-template-fn [conn]
-  (if (native-conn? conn)
-    native-index/create-template
-    rest-index/create-template))
-
-(defn index-exists?-fn [conn]
-  (if (native-conn? conn)
-    native-index/exists?
-    rest-index/exists?))
-
-(defn index-create-fn [conn]
-  (if (native-conn? conn)
-    native-index/create
-    rest-index/create))
-
-(defn index-delete-fn [conn]
-  (if (native-conn? conn)
-    native-index/delete
-    rest-index/delete))
-
-(defn update-alias-fn [conn]
-  (if (native-conn? conn)
-    native-index/update-aliases
-    rest-index/update-aliases))
-
-(defn refresh-fn [conn]
-  (if (native-conn? conn)
-    native-index/refresh
-    rest-index/refresh))
-
 (defn connect
   "instantiate an ES conn from props"
   [{:keys [transport host port clustername]
     :or {transport :http}}]
-  (case transport
-    :native (n/connect [[host port]]
-                       {"cluster.name" clustername})
-    :http (h/connect  (str "http://" host ":" port))))
 
-(defn delete!
+  {:cm (make-connection-manager)
+   :uri (format "http://%s:%s" host port)})
+
+(s/defn index-uri :- s/Str
+  [uri :- s/Str
+   index-name :- s/Str]
+  "make an index uri from a host and an index name"
+  (format "%s/%s" uri index-name))
+
+(s/defn template-uri :- s/Str
+  [uri :- s/Str
+   template-name :- s/Str]
+  "make a template uri from a host and a template name"
+  (format "%s/_template/%s" uri template-name))
+
+(s/defn index-exists? :- s/Bool
+  "check if the supplied ES index exists"
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str]
+
+  (->> (client/head (index-uri uri index-name)
+                    {:throw-exceptions false
+                     :connection-manager cm})
+
+       :status
+       (= 200)))
+
+(s/defn delete!
   "delete an index, abort if non existant"
-  [conn index-name]
-  (when ((index-exists?-fn conn) conn index-name)
-    ((index-delete-fn conn) conn index-name)))
+  [{:keys [uri cm] :as conn} :- ESConn
+   index-name :- s/Str]
 
-(defn create-template!
+  (when (index-exists? conn index-name)
+    (:body (client/delete (index-uri uri index-name)
+                          {:connection-manager cm}))))
+
+(s/defn create-template!
   "create an index template, update if already exists"
-  [conn index-name index-config]
+  [{:keys [uri cm]} :- ESConn
+   index-name :- s/Str
+   index-config]
 
   (let [template (str index-name "*")
         opts (assoc index-config :template template)]
-    ((create-template-fn conn) conn index-name opts)))
+
+    (:body (client/put (template-uri uri index-name)
+                       {:form-params opts
+                        :as :json
+                        :content-type :json
+                        :connection-manager cm}))))

--- a/src/ctia/lib/es/query.clj
+++ b/src/ctia/lib/es/query.clj
@@ -1,5 +1,4 @@
-(ns ctia.lib.es.query
-  (:require [clojure.string :as str]))
+(ns ctia.lib.es.query)
 
 (defn bool
   "Boolean Query"
@@ -28,60 +27,3 @@
   ([key values] (terms key values nil))
   ([key values opts]
    (term key values opts)))
-
-(defn nested-terms [filters]
-  "make nested terms from a ctia filter:
-  [[[:observable :type] ip] [[:observable :value] 42.42.42.1]]
-  ->
-  [{:terms {observable.type [ip]}} {:terms {observable.value [42.42.42.1]}}]
-
-we force all values to lowercase, since our indexing does the same for all terms."
-  (vec (map (fn [[k v]]
-              (terms (->> k
-                          (map name)
-                          (str/join "."))
-                     (map str/lower-case
-                          (if (coll? v) v [v]))))
-            filters)))
-
-(defn- relationship?
-  "Check if some value correspond to a relationship query."
-  [v]
-  (and (set? v)
-       (every? map? v)
-       (every? #(= 1 (count (keys %))) v)))
-
-(defn- terms-from-relationship
-  "If we have a relationship kind of search
-
-  {:related_COAs #{{:COA_id \"coa-1\"} {:COA_id \"coa-2\"}}}
-
-  that will returns
-
-  [[:related_COAs :COA_id] [\"coa-1\" \"coa-2\"]]
-  "
-  [t-key v]
-  (let [common-key (first (keys (first v)))]
-    [(concat t-key [common-key]) (mapv #(get % common-key) v)]))
-
-(defn filter-map->terms-query
-  "transforms a filter map to en ES terms query"
-  ([filter-map]
-   (filter-map->terms-query filter-map {:match_all {}}))
-  ([filter-map query]
-   (let [q (or query {:match_all {}})]
-     (if filter-map
-       (let [terms (map (fn [[k v]]
-                          (let [t-key (if (sequential? k) k [k])]
-                            (if (relationship? v)
-                              (terms-from-relationship t-key v)
-                              [t-key v])))
-                        filter-map)
-             must-filters (nested-terms terms)]
-
-         (if (empty? must-filters)
-           q {:filtered
-              {:query q
-               :filter (bool {:must must-filters})}}))
-
-       q))))

--- a/src/ctia/lib/es/query.clj
+++ b/src/ctia/lib/es/query.clj
@@ -1,6 +1,33 @@
 (ns ctia.lib.es.query
-  (:require [clojure.string :as str]
-            [clojurewerkz.elastisch.query :as q]))
+  (:require [clojure.string :as str]))
+
+(defn bool
+  "Boolean Query"
+  [opts]
+  {:bool opts})
+
+(defn filtered
+  "Filtered query"
+  [opts]
+  {:filtered opts})
+
+(defn nested
+  "Nested document query"
+  [opts]
+  {:nested opts})
+
+(defn term
+  "Term Query"
+  ([key values] (term key values nil))
+  ([key values opts]
+   (merge { (if (coll? values) :terms :term) (hash-map key values) }
+          opts)))
+
+(defn terms
+  "Terms Query"
+  ([key values] (terms key values nil))
+  ([key values opts]
+   (term key values opts)))
 
 (defn nested-terms [filters]
   "make nested terms from a ctia filter:
@@ -10,11 +37,11 @@
 
 we force all values to lowercase, since our indexing does the same for all terms."
   (vec (map (fn [[k v]]
-              (q/terms (->> k
-                            (map name)
-                            (str/join "."))
-                       (map str/lower-case
-                            (if (coll? v) v [v]))))
+              (terms (->> k
+                          (map name)
+                          (str/join "."))
+                     (map str/lower-case
+                          (if (coll? v) v [v]))))
             filters)))
 
 (defn- relationship?
@@ -55,6 +82,6 @@ we force all values to lowercase, since our indexing does the same for all terms
          (if (empty? must-filters)
            q {:filtered
               {:query q
-               :filter (q/bool {:must must-filters})}}))
+               :filter (bool {:must must-filters})}}))
 
        q))))

--- a/src/ctia/lib/es/schemas.clj
+++ b/src/ctia/lib/es/schemas.clj
@@ -1,0 +1,43 @@
+(ns ctia.lib.es.schemas
+  "All ES related schemas should be defined here"
+  (:require [schema.core :as s])
+  (:import [org.apache.http.impl.conn PoolingClientConnectionManager
+            PoolingHttpClientConnectionManager]))
+
+(s/defschema ESConn
+  "an ES conn is a map with a
+   connection manager and an index name"
+  {:cm (s/either PoolingClientConnectionManager
+                 PoolingHttpClientConnectionManager)
+   :uri s/Str})
+
+(s/defschema Refresh
+  "ES refresh parameter, see
+   https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html"
+  (s/enum true false "wait_for"))
+
+(s/defschema ESSlicing
+  {:strategy s/Keyword
+   :granularity s/Keyword})
+
+(s/defschema ESConnState
+  "a Store ESConnState shall contain an ESConn
+   and all store properties"
+  {:index s/Str
+   :props {s/Any s/Any}
+   :config {s/Any s/Any}
+   :conn ESConn
+   (s/optional-key :slicing) ESSlicing})
+
+(s/defschema DateRangeFilter
+  "a Date range filter for a filtered alias"
+  {:range
+   {:timestamp {:gte s/Str
+                :lt s/Str}}})
+
+(s/defschema SliceProperties
+  "Slice configuration properties"
+  {:name s/Str
+   :granularity s/Keyword
+   :strategy s/Keyword
+   (s/optional-key :filter) DateRangeFilter})

--- a/src/ctia/lib/es/slice.clj
+++ b/src/ctia/lib/es/slice.clj
@@ -1,25 +1,13 @@
 (ns ctia.lib.es.slice
-  (:require [clj-momo.lib.time :refer [format-date-time
+  (:require [ctia.lib.es.schemas :refer [SliceProperties
+                                         DateRangeFilter]]
+            [clj-momo.lib.time :refer [format-date-time
                                        format-index-time
                                        round-date]]
-            [ctia.lib.es.index :refer [ESConnState]]
             [schema.core :as s]))
 
-(s/defschema DateRangeFilter
-  "a Date range filter for a filtered alias"
-  {:range
-   {:timestamp {:gte s/Str
-                :lt s/Str}}})
-
-(s/defschema SliceProperties
-  "Slice configuration properties"
-  {:name s/Str
-   :granularity s/Keyword
-   :strategy s/Keyword
-   (s/optional-key :filter) DateRangeFilter})
-
 (s/defn slice-name :- s/Str
-  "make a slice name from an index name and a timestamp"
+  "make a slice name composed of an index name and a timestamp"
   [index :- s/Str
    ts :- s/Str]
   (str index "_" ts))
@@ -45,7 +33,7 @@
 (s/defn get-slice-props :- SliceProperties
   "make slice properties from a date an index name and config"
   [t :- java.util.Date
-   state :- ESConnState]
+   state]
 
   (let [slice-config (get-in state [:props :slicing])
         granularity (:granularity slice-config)

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -30,7 +30,7 @@
    (str "ctia.store.es." store ".port") s/Int
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
-   (str "ctia.store.es." store ".refresh") (s/enum "true" "false" "wait_for")
+   (str "ctia.store.es." store ".refresh") s/Bool
    (str "ctia.store.es." store ".replicas") s/Num
    (str "ctia.store.es." store ".shards") s/Num})
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -26,12 +26,11 @@
   {(str "ctia.store." store) s/Str})
 
 (defn es-store-impl-properties [store]
-  {(str "ctia.store.es." store ".transport") (s/enum :http :native)
-   (str "ctia.store.es." store ".host") s/Str
+  {(str "ctia.store.es." store ".host") s/Str
    (str "ctia.store.es." store ".port") s/Int
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
-   (str "ctia.store.es." store ".refresh") s/Bool
+   (str "ctia.store.es." store ".refresh") (s/enum "true" "false" "wait_for")
    (str "ctia.store.es." store ".replicas") s/Num
    (str "ctia.store.es." store ".shards") s/Num})
 

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -1,5 +1,5 @@
 (ns ctia.stores.es.crud
-  (:require [ctia.lib.es.index :refer [ESConnState]]
+  (:require [ctia.lib.es.schemas :refer [ESConnState]]
             [schema.core :as s]
             [schema.coerce :as c]
             [ring.swagger.coerce :as sc]

--- a/src/ctia/stores/es/event.clj
+++ b/src/ctia/stores/es/event.clj
@@ -3,8 +3,9 @@
             [ctia.stores.es.crud :as crud]
             [ctia.stores.es.mapping :refer [event-mapping]]
             [ctia.lib.es
+             [conn :refer [connect]]
              [document :as d]
-             [index :refer [connect ESConnState]]
+             [index :refer [ESConnState]]
              [slice :refer [get-slice-props SliceProperties]]]
             [ctia.lib.pagination :refer [list-response-schema]]
             [ctia.properties :refer [properties]]

--- a/src/ctia/stores/es/event.clj
+++ b/src/ctia/stores/es/event.clj
@@ -1,14 +1,11 @@
 (ns ctia.stores.es.event
-  (:require [ctia.schemas.event :as ctia-event-schemas]
-            [ctia.stores.es.crud :as crud]
-            [ctia.stores.es.mapping :refer [event-mapping]]
-            [ctia.lib.es
-             [conn :refer [connect]]
+  (:require [ctia.lib.es
              [document :as d]
-             [index :refer [ESConnState]]
-             [slice :refer [get-slice-props SliceProperties]]]
+             [schemas :refer [ESConnState SliceProperties]]
+             [slice :refer [get-slice-props]]]
             [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.properties :refer [properties]]
+            [ctia.schemas.event :as ctia-event-schemas]
+            [ctia.stores.es.crud :as crud]
             [ctim.events.schemas :as event-schemas]
             [schema.core :as s]))
 

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -1,6 +1,6 @@
 (ns ctia.stores.es.query
   (:require [clojure.string :as str]
-            [clojurewerkz.elastisch.query :as q]))
+            [ctia.lib.es.query :as q]))
 
 (defn indicators-by-judgements-query
   "filter to get all indicators

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -1,18 +1,7 @@
 (ns ctia.stores.es.query
-  (:require [clojure.string :as str]
-            [ctia.lib.es.query :as q]))
-
-(defn indicators-by-judgements-query
-  "filter to get all indicators
-   matching a set of judgement ids"
-  [judgement-ids]
-
-  (let [f (q/bool
-           {:must (q/terms :judgements.judgement_id
-                           judgement-ids)})]
-    (q/filtered
-     {:query {:match_all {}}
-      :filter f})))
+  (:require
+   [clojure.string :as str]
+   [ctia.lib.es.query :as q]))
 
 (def unexpired-time-range
   "ES filter that matches objects which
@@ -26,29 +15,43 @@
 (defn active-judgements-by-observable-query
   "a filtered query to get judgements for the specified
   observable, where valid time is in now range"
-
   [{:keys [value type]}]
 
-  (let [observable-filter
-        (q/bool
-         {:must [{:term {"observable.type" type}}
-                 {:term {"observable.value" value}}]})
-        time-filter (q/bool {:must unexpired-time-range})]
+  (q/bool {:filter (concat
+                    unexpired-time-range
+                    [{:term {"observable.type" type}}
+                     {:term {"observable.value" value}}])}))
 
-    (q/filtered {:query observable-filter
-                 :filter time-filter})))
+(defn nested-terms [filters]
+  "make nested terms from a ctia filter:
+  [[[:observable :type] ip] [[:observable :value] 42.42.42.1]]
+  ->
+  [{:terms {observable.type [ip]}} {:terms {observable.value [42.42.42.1]}}]
 
+we force all values to lowercase, since our indexing does the same for all terms."
+  (vec (map (fn [[k v]]
+              (q/terms (->> k
+                            (map name)
+                            (str/join "."))
+                       (map str/lower-case
+                            (if (coll? v) v [v]))))
+            filters)))
 
-(defn sightings-by-observables-query
-  "nested filter to get all indicators
-   matching a set of judgement ids"
-  [observables]
+(defn filter-map->terms-query
+  "transforms a filter map to en ES terms query"
+  ([filter-map]
+   (filter-map->terms-query filter-map {:match_all {}}))
+  ([filter-map query]
+   (let [q (or query {:match_all {}})]
+     (if filter-map
+       (let [terms (map (fn [[k v]]
+                          (let [t-key (if (sequential? k) k [k])]
+                            [t-key v]))
+                        filter-map)
+             must-filters (nested-terms terms)]
 
-  (q/nested
-   :path "observables"
-   :query (q/bool {:should
-                   (map (fn [{:keys [type value]}]
-                          (q/bool
-                           {:must
-                            [{:term {"observables.type" type}}
-                             {:term {"observables.value" value}}]})) observables)})))
+         (if (empty? must-filters)
+           q {:bool
+              {:must q
+               :filter (q/bool {:must must-filters})}}))
+       q))))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -1,5 +1,5 @@
 (ns ctia.stores.es.sighting
-  (:require [ctia.lib.es.index :refer [ESConnState]]
+  (:require [ctia.lib.es.schemas :refer [ESConnState]]
             [ctia.lib.pagination :refer [list-response-schema]]
             [ctia.stores.es.crud :as crud]
             [ctia.schemas.core :refer [Observable StoredSighting]]

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,8 +1,8 @@
 (ns ctia.stores.es.store
   (:require [ctia.lib.es
              [conn :refer [connect]]
-             [index :as es-index :refer [create-template!
-                                         ESConnState]]]
+             [schemas :refer [ESConnState]]
+             [index :as es-index :refer [create-template!]]]
             [ctia.store
              :refer
              [IActorStore
@@ -41,8 +41,8 @@
             [schema.core :as s]))
 
 (s/defn init-store-conn :- ESConnState
-  "initiate an ES store connection returns a map containing transport,
-   mapping, and the configured index name"
+  "initiate an ES store connection returns
+   a map containing a connection manager, dedicated store index properties"
   [{:keys [entity indexname shards replicas] :as props}]
 
   (let [settings {:number_of_shards shards
@@ -55,7 +55,7 @@
 
 (s/defn init! :- ESConnState
   "initiate an ES Store connection,
-  put the index template, returns the es conn state"
+   put the index template, return an ESConnState"
   [props]
   (let [{:keys [conn index config] :as conn-state} (init-store-conn props)]
     (es-index/create-template! conn index config)
@@ -182,7 +182,6 @@
   (query-string-search [_ query filtermap params]
     (ca/handle-query-string-search state query filtermap params)))
 
-
 (defrecord COAStore [state]
   ICOAStore
   (read-coa [_ id]
@@ -241,7 +240,6 @@
   IQueryStringSearchableStore
   (query-string-search [_ query filtermap params]
     (et/handle-query-string-search state query filtermap params)))
-
 
 (defrecord IdentityStore [state]
   IIdentityStore

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,6 +1,8 @@
 (ns ctia.stores.es.store
-  (:require [clojure.tools.logging :as log]
-            [ctia.lib.es.index :as es-index :refer [connect ESConnState]]
+  (:require [ctia.lib.es
+             [conn :refer [connect]]
+             [index :as es-index :refer [create-template!
+                                         ESConnState]]]
             [ctia.store
              :refer
              [IActorStore

--- a/test/ctia/lib/es/document_test.clj
+++ b/test/ctia/lib/es/document_test.clj
@@ -1,0 +1,82 @@
+(ns ctia.lib.es.document-test
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.lib.es
+             [conn :as es-conn]
+             [document :as es-doc]
+             [index :as es-index]]
+            [ctia.properties :refer [properties]]
+            [ctia.test-helpers
+             [core :as test-helpers]
+             [es :as es-helpers]]))
+
+(use-fixtures :once mth/fixture-schema-validation)
+(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
+                                    es-helpers/fixture-properties:es-store
+                                    test-helpers/fixture-ctia]))
+
+(deftest create-doc-uri-test
+  (testing "should generate a valid doc URI"
+    (is (= (es-doc/create-doc-uri "http://127.0.0.1"
+                                  "test_index"
+                                  "test_mapping"
+                                  "test")
+           "http://127.0.0.1/test_index/test_mapping/test"))))
+
+(deftest document-crud-ops
+  (testing "with ES conn test setup"
+    (let [conn (es-conn/connect
+                {:host (get-in @properties [:ctia :store :es :default :host])
+                 :port (get-in @properties [:ctia :store :es :default :port])})]
+
+      (es-index/delete! conn "test_index")
+
+      (testing "all ES Document CRUD operations"
+        (let [sample-doc {:id "test_doc"
+                          :foo "bar is a lie"
+                          :test_value 42}
+              sample-docs (repeatedly 10 #(hash-map :id (java.util.UUID/randomUUID)
+                                                    :_index "test_index"
+                                                    :_type "test_mapping"
+                                                    :bar "foo"))]
+          (is (nil?
+               (es-doc/get-doc conn
+                               "test_index"
+                               "test_mapping"
+                               (:id sample-doc))))
+
+          (is (= sample-doc
+                 (es-doc/create-doc conn
+                                    "test_index"
+                                    "test_mapping"
+                                    sample-doc
+                                    true)))
+          (is (= sample-docs
+                 (es-doc/bulk-create-doc conn
+                                         sample-docs
+                                         true)))
+
+          (is (= sample-doc
+                 (es-doc/get-doc conn
+                                 "test_index"
+                                 "test_mapping"
+                                 (:id sample-doc))))
+
+          (is (= {:data [sample-doc]
+                  :paging {:total-hits 1}}
+                 (es-doc/search-docs conn
+                                     "test_index"
+                                     "test_mapping"
+                                     {:query_string {:query "bar"}}
+                                     {:test_value 42}
+                                     {:sort_by "test_value"
+                                      :sort_order :desc})))
+
+          (is (true?
+               (es-doc/delete-doc conn
+                                  "test_index"
+                                  "test_mapping"
+                                  (:id sample-doc)
+                                  true)))))
+
+      (es-index/delete! conn "test_index"))))

--- a/test/ctia/lib/es/index_test.clj
+++ b/test/ctia/lib/es/index_test.clj
@@ -1,0 +1,61 @@
+(ns ctia.lib.es.index-test
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.lib.es
+             [conn :as es-conn]
+             [index :as es-index]]
+            [ctia.properties :refer [properties]]
+            [ctia.test-helpers
+             [core :as test-helpers]
+             [es :as es-helpers]]))
+
+(use-fixtures :once mth/fixture-schema-validation)
+(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
+                                    es-helpers/fixture-properties:es-store
+                                    test-helpers/fixture-ctia]))
+
+(deftest index-uri-test
+  (testing "should generate a valid index URI"
+    (is (= (es-index/index-uri "http://127.0.0.1" "test")
+           "http://127.0.0.1/test"))))
+
+(deftest template-uri-test
+  (testing "should generate a valid template URI"
+    (is (= (es-index/template-uri "http://127.0.0.1" "test")
+           "http://127.0.0.1/_template/test"))))
+
+(deftest index-crud-ops
+  (testing "with ES conn test setup"
+
+    (let [conn (es-conn/connect
+                {:host (get-in @properties [:ctia :store :es :default :host])
+                 :port (get-in @properties [:ctia :store :es :default :port])})]
+
+      (testing "all ES Index CRUD operations"
+        (let [index-create-res
+              (es-index/create! conn "test_index"
+                                {:settings {:number_of_shards 1
+                                            :number_of_replicas 1}})
+              index-get-res (es-index/get conn "test_index")
+              index-delete-res (es-index/delete! conn "test_index")]
+
+          (es-index/delete! conn "test_index")
+
+          (is (true? (boolean index-create-res)))
+          (is (= {:test_index
+                  {:aliases {},
+                   :mappings {},
+                   :settings
+                   {:index
+                    {:number_of_shards "1"
+                     :number_of_replicas "1"
+                     :provided_name "test_index"}}}}
+
+                 (update-in index-get-res
+                            [:test_index :settings :index]
+                            dissoc
+                            :creation_date
+                            :uuid
+                            :version)))
+
+          (is (true? (boolean index-delete-res))))))))

--- a/test/ctia/lib/es/query_test.clj
+++ b/test/ctia/lib/es/query_test.clj
@@ -1,24 +1,3 @@
 (ns ctia.lib.es.query-test
   (:require [ctia.lib.es.query :as q]
             [clojure.test :refer [deftest is]]))
-
-(deftest nested-terms-test
-  (is (= (q/nested-terms [[[:observable :type] "ip"]
-                          [[:observable :value] "42.42.42.1"]])
-         
-         [{:terms {"observable.type" ["ip"]}}
-          {:terms {"observable.value" ["42.42.42.1"]}}])))
-
-(deftest filter-map->terms-query-test
-  (is (= {:filtered
-          {:query {:match_all {}},
-           :filter
-           {:bool
-            {:must
-             [{:terms {"observable.type" ["ip"]}}
-              {:terms {"observable.value" ["10.0.0.1"]}}
-              {:terms {"test" ["ok"]}}]}}}}
-         
-         (q/filter-map->terms-query {[:observable :type] "ip"
-                                     [:observable :value] "10.0.0.1"
-                                     :test "ok"}))))

--- a/test/ctia/lib/es/query_test.clj
+++ b/test/ctia/lib/es/query_test.clj
@@ -1,3 +1,0 @@
-(ns ctia.lib.es.query-test
-  (:require [ctia.lib.es.query :as q]
-            [clojure.test :refer [deftest is]]))

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -1,34 +1,33 @@
 (ns ctia.stores.es.query-test
-  (:require [ctia.stores.es.query :as q]
-            [clojure.test :refer [deftest is]]))
-
-(deftest indicators-by-judgements-query-test
-  (is (= {:filtered
-          {:query {:match_all {}}
-           :filter
-           {:bool
-            {:must
-             {:terms
-              {:judgements.judgement_id
-               #{"judgement-41dae4cf-1721-4b25-a111-77cf28e8ca6d"
-                 "judgement-734f0a85-f862-4abd-83e0-beda53556e29"}}}}}}}
-
-         (q/indicators-by-judgements-query
-          #{"judgement-41dae4cf-1721-4b25-a111-77cf28e8ca6d"
-            "judgement-734f0a85-f862-4abd-83e0-beda53556e29"}))))
+  (:require [clojure.test :refer [deftest is]]
+            [ctia.stores.es.query :as q]))
 
 (deftest active-judgements-by-observable-query-test
-  (is (= {:filtered
-          {:query
-           {:bool
-            {:must
-             [{:term {"observable.type" "ip"}}
-              {:term {"observable.value" "10.0.0.1"}}]}},
-           :filter
-           {:bool
-            {:must
-             [{:range {"valid_time.start_time" {"lt" "now/d"}}}
-              {:range {"valid_time.end_time" {"gt" "now/d"}}}]}}}}
+  (is (= {:bool {:filter [{:range {"valid_time.start_time" {"lt" "now/d"}}}
+                          {:range {"valid_time.end_time" {"gt" "now/d"}}}
+                          {:term {"observable.type" "ip"}}
+                          {:term {"observable.value" "10.0.0.1"}}]}}
 
          (q/active-judgements-by-observable-query
           {:type "ip" :value "10.0.0.1"}))))
+
+(deftest nested-terms-test
+  (is (= (q/nested-terms [[[:observable :type] "ip"]
+                          [[:observable :value] "42.42.42.1"]])
+
+         [{:terms {"observable.type" ["ip"]}}
+          {:terms {"observable.value" ["42.42.42.1"]}}])))
+
+(deftest filter-map->terms-query-test
+  (is (= {:bool
+          {:must {:match_all {}}
+           :filter
+           {:bool
+            {:must
+             [{:terms {"observable.type" ["ip"]}}
+              {:terms {"observable.value" ["10.0.0.1"]}}
+              {:terms {"test" ["ok"]}}]}}}}
+
+         (q/filter-map->terms-query {[:observable :type] "ip"
+                                     [:observable :value] "10.0.0.1"
+                                     :test "ok"}))))

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -20,8 +20,7 @@
 
 (deftest filter-map->terms-query-test
   (is (= {:bool
-          {:must {:match_all {}}
-           :filter
+          {:filter
            {:bool
             {:must
              [{:terms {"observable.type" ["ip"]}}

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -3,10 +3,10 @@
             [ctia.stores.es.query :as q]))
 
 (deftest active-judgements-by-observable-query-test
-  (is (= {:bool {:filter [{:range {"valid_time.start_time" {"lt" "now/d"}}}
-                          {:range {"valid_time.end_time" {"gt" "now/d"}}}
-                          {:term {"observable.type" "ip"}}
-                          {:term {"observable.value" "10.0.0.1"}}]}}
+  (is (= [{:range {"valid_time.start_time" {"lt" "now/d"}}}
+          {:range {"valid_time.end_time" {"gt" "now/d"}}}
+          {:term {"observable.type" "ip"}}
+          {:term {"observable.value" "10.0.0.1"}}]
 
          (q/active-judgements-by-observable-query
           {:type "ip" :value "10.0.0.1"}))))
@@ -21,11 +21,9 @@
 (deftest filter-map->terms-query-test
   (is (= {:bool
           {:filter
-           {:bool
-            {:must
-             [{:terms {"observable.type" ["ip"]}}
-              {:terms {"observable.value" ["10.0.0.1"]}}
-              {:terms {"test" ["ok"]}}]}}}}
+           [{:terms {"observable.type" ["ip"]}}
+            {:terms {"observable.value" ["10.0.0.1"]}}
+            {:terms {"test" ["ok"]}}]}}
 
          (q/filter-map->terms-query {[:observable :type] "ip"
                                      [:observable :value] "10.0.0.1"

--- a/test/ctia/test_helpers/benchmark.clj
+++ b/test/ctia/test_helpers/benchmark.clj
@@ -12,7 +12,7 @@
   (let [http-port (net/available-port)]
     (println "Default: Launch CTIA on port" http-port)
     (fixture (fn [] (helpers/fixture-properties:clean
-                    #(helpers/with-properties ["ctia.store.es.default.refresh" false
+                    #(helpers/with-properties ["ctia.store.es.default.refresh" "false"
                                                "ctia.http.enabled" true
                                                "ctia.http.port" http-port
                                                "ctia.http.show.port" http-port]
@@ -22,9 +22,6 @@
 
 (defn setup-ctia-es-store! []
   (setup-ctia! esh/fixture-properties:es-store))
-
-(defn setup-ctia-es-store-native! []
-  (setup-ctia! esh/fixture-properties:es-store-native))
 
 (defn cleanup-ctia! [_]
   (shutdown/shutdown-ctia!))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -10,20 +10,12 @@
   (when conn
     (es-index/delete! conn (str index "*"))))
 
-(defn close-client [{:keys [conn]}]
-  "if the connection is native, close the client"
-  (when (instance? org.elasticsearch.client.transport.TransportClient conn)
-    (.close conn)))
-
 (defn fixture-delete-store-indexes [test]
   "walk through all the es stores delete each store indexes"
   (doseq [store-impls (vals @store/stores)
           {:keys [state]} store-impls]
     (delete-state-indexes state))
-  (test)
-  (doseq [store-impls (vals @store/stores)
-          {:keys [state]} store-impls]
-    (close-client state)))
+  (test))
 
 (defn purge-event-indexes []
   (let [{:keys [conn index]} (es-store/init-store-conn
@@ -31,7 +23,7 @@
                                (get-in @properties [:ctia :store :es :default])
                                (get-in @properties [:ctia :store :es :event])))]
     (when conn
-      ((es-index/index-delete-fn conn) conn (str index "*")))))
+      (es-index/delete! conn (str index "*")))))
 
 (defn fixture-purge-event-indexes [test]
   "walk through all producers and delete their index"
@@ -43,8 +35,7 @@
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.store.es.default.shards" 1
                       "ctia.store.es.default.replicas" 1
-                      "ctia.store.es.default.transport" "http"
-                      "ctia.store.es.default.refresh" true
+                      "ctia.store.es.default.refresh" "wait_for"
                       "ctia.store.es.default.port" "9200"
                       "ctia.store.es.default.indexname" "test_ctia"
                       "ctia.store.es.actor.indexname" "ctia_actor"
@@ -65,39 +56,9 @@
                       "ctia.store.ttp" "es"]
     (test)))
 
-
-(defn fixture-properties:es-store-native [test]
-  ;; Note: These properties may be overwritten by ENV variables
-  (h/with-properties ["ctia.store.es.default.shards" 1
-                      "ctia.store.es.default.replicas" 1
-                      "ctia.store.es.default.transport" "native"
-                      "ctia.store.es.default.refresh" true
-                      "ctia.store.es.default.port" "9300"
-                      "ctia.store.es.default.clustername" "elasticsearch"
-                      "ctia.store.es.default.indexname" "test_ctia"
-                      "ctia.store.es.actor.indexname" "ctia_actor"
-                      "ctia.store.actor" "es"
-                      "ctia.store.campaign" "es"
-                      "ctia.store.coa" "es"
-                      "ctia.store.data-table" "es"
-                      "ctia.store.event" "es"
-                      "ctia.store.exploit-target" "es"
-                      "ctia.store.feedback" "es"
-                      "ctia.store.identity" "es"
-                      "ctia.store.incident" "es"
-                      "ctia.store.indicator" "es"
-                      "ctia.store.judgement" "es"
-                      "ctia.store.relationship" "es"
-                      "ctia.store.verdict" "es"
-                      "ctia.store.sighting" "es"
-                      "ctia.store.ttp" "es"]
-    (test)))
-
-
 (defn fixture-properties:es-hook [test]
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.hook.es.enabled" true
-                      "ctia.hook.es.transport" "http"
                       "ctia.hook.es.port" 9200
                       "ctia.hook.es.indexname" "test_ctia_events"]
     (test)))
@@ -105,7 +66,6 @@
 (defn fixture-properties:es-hook:aliased-index [test]
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.hook.es.enabled" true
-                      "ctia.hook.es.transport" "http"
                       "ctia.hook.es.port" 9200
                       "ctia.hook.es.indexname" "test_ctia_events"
                       "ctia.hook.es.slicing.strategy" "aliased-index"

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -35,7 +35,7 @@
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.store.es.default.shards" 1
                       "ctia.store.es.default.replicas" 1
-                      "ctia.store.es.default.refresh" "wait_for"
+                      "ctia.store.es.default.refresh" "true"
                       "ctia.store.es.default.port" "9200"
                       "ctia.store.es.default.indexname" "test_ctia"
                       "ctia.store.es.actor.indexname" "ctia_actor"

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -8,9 +8,5 @@
   `(helpers/deftest-for-each-fixture ~test-name
      {:es-store   (join-fixtures [es-helpers/fixture-properties:es-store
                                   helpers/fixture-ctia
-                                  es-helpers/fixture-delete-store-indexes])
-
-      :es-store-native (join-fixtures [es-helpers/fixture-properties:es-store-native
-                                       helpers/fixture-ctia
-                                       es-helpers/fixture-delete-store-indexes])}
+                                  es-helpers/fixture-delete-store-indexes])}
      ~@body))


### PR DESCRIPTION
This PR makes CTIA compatible with ES5

This is a breaking change, previous versions of ES (2.x) will not work anymore.
other Elastic Product such as logstash and kibana also need to be upgraded to 5x as reflected on the demo docker-compose config.

- Changed Travis configuration to support ES5
- Dropped Elastisch, native transport support
- use a simple custom library based on clj-http
- Fixed queries to support ES5 changes
- Removed leftover obsolete mapping fields
- Upgraded docker-compose configuration
- Fixed benchmarks

for what it's worth, here's the result for big-actor:

`Case:  :big-actor-es-store
Evaluation count : 1440 in 60 samples of 24 calls.
             Execution time mean : 45.449006 ms
    Execution time std-deviation : 3.535146 ms
   Execution time lower quantile : 42.091023 ms ( 2.5%)
   Execution time upper quantile : 56.006288 ms (97.5%)`