### PR TITLE
Fixed schemas and routes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.3"]
+                 [threatgrid/ctim "0.4.4-SNAPSHOT"]
 
                  ;; Web server
                  ;; ring-swagger 0.22.10 provided by compojure-api

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -35,7 +35,7 @@
             StoredTTP
             NewRelationship
             StoredRelationship
-            Verdict
+            NewVerdict
             StoredVerdict]])
   (:import [java.util UUID]))
 
@@ -140,17 +140,18 @@
                                         now)})))
 
 (s/defn realize-verdict :- StoredVerdict
-  ([new-verdict :- Verdict
+  ([new-verdict :- NewVerdict
     login :- s/Str]
    (realize-verdict new-verdict (str "verdict-" (UUID/randomUUID)) login))
-  ([new-verdict :- Verdict
+  ([new-verdict :- NewVerdict
     id :- s/Str
     login :- s/Str]
    (let [now (time/now)]
      (assoc new-verdict
             :id id
             :schema_version schema-version
-            :created now))))
+            :created now
+            :owner login))))
 
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -7,7 +7,7 @@
     [ctia.flows.hook-protocol :refer [Hook]]
     [ctia.lib.redis :as lr]
     [ctia.properties :refer [properties]]
-    [ctia.schemas.core :refer [Verdict
+    [ctia.schemas.core :refer [NewVerdict
                                StoredVerdict
                                StoredJudgement]]
     [ctia.store :as store]
@@ -86,7 +86,7 @@
 (s/defn realize-verdict-wrapper :- StoredVerdict
   "Realizes a verdict, using the associated judgement ID, if available,
    to build the verdict ID"
-  [verdict :- Verdict
+  [verdict :- NewVerdict
    {j-lng-id :id :as judgement} :- StoredJudgement
    owner :- s/Str
    verdict-id :- s/Str]

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -18,7 +18,7 @@
             [ctia.flows.crud :as flows]
             [ctia.http.routes.common :as common]
             [ctia.lib.keyword :refer [singular]]
-            [ctia.schemas.bulk :refer [Bulk BulkRefs NewBulk StoredBulk]]
+            [ctia.schemas.bulk :refer [Bulk BulkRefs NewBulk]]
             [ctia.properties :refer [properties]]
             [ctia.store :refer :all]
             [ctia.schemas.core :refer [Reference]]

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -129,6 +129,10 @@
 
 ;; verdict
 
+(defschema NewVerdict
+  vs/NewVerdict
+  "new-verdict")
+
 (defschema Verdict
   vs/Verdict
   "verdict")

--- a/src/ctia/stores/es/judgement.clj
+++ b/src/ctia/stores/es/judgement.clj
@@ -9,7 +9,7 @@
    [ring.swagger.coerce :as sc]
    [ctim.schemas.common :refer [disposition-map]]
 
-   [ctia.schemas.core :refer [Verdict
+   [ctia.schemas.core :refer [NewVerdict
                               StoredJudgement
                               NewJudgement
                               StoredJudgement]]
@@ -75,7 +75,7 @@
              :data
              coerce-stored-judgement-list)))
 
-(s/defn make-verdict :- Verdict
+(s/defn make-verdict :- NewVerdict
   [judgement :- StoredJudgement]
   {:type "verdict"
    :disposition (:disposition judgement)
@@ -84,7 +84,7 @@
    :disposition_name (get disposition-map (:disposition judgement))
    :valid_time (:valid_time judgement)})
 
-(s/defn handle-calculate-verdict :- (s/maybe Verdict)
+(s/defn handle-calculate-verdict :- (s/maybe NewVerdict)
   [state observable]
 
   (some-> (list-active-by-observable state observable)

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -355,16 +355,14 @@
    {:dynamic "strict"
     :include_in_all false
     :properties
-    {:id all_token
-     :type token
-     :schema_version token
-     :judgement_id token
-     :observable observable
-     :disposition {:type "long"}
-     :disposition_name token
-     :valid_time valid-time
-     :owner token
-     :created ts}}})
+    (merge
+     base-entity-mapping
+     stored-entity-mapping
+     {:judgement_id token
+      :observable observable
+      :disposition {:type "long"}
+      :disposition_name token
+      :valid_time valid-time})}})
 
 (def feedback-mapping
   {"feedback"

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -8,7 +8,8 @@
              [core :as helpers :refer [delete get post]]
              [fake-whoami-service :as whoami-helpers]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]))
+            [ctim.domain.id :as id]
+            [ctim.schemas.common :as csc]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -116,8 +117,9 @@
                   :judgement_id (:id judgement)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T00:00:00.000-00:00",
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                 (dissoc verdict :owner :created :schema_version))))))))
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
+                  :schema_version csc/ctim-schema-version}
+                 verdict)))))))
 
 (deftest-for-each-store test-observable-verdict-route-2
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -178,8 +180,9 @@
                     :disposition_name "Malicious"
                     :judgement_id (:id judgement)
                     :valid_time {:start_time #inst "2016-02-12T14:56:26.814-00:00",
-                                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                   (dissoc verdict :owner :created :schema_version)))))))))
+                                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}
+                    :schema_version csc/ctim-schema-version}
+                   verdict))))))))
 
 (deftest-for-each-store ^:sleepy test-observable-verdict-route-with-expired-judgement
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -260,8 +263,9 @@
                   :judgement_id (:id judgement-2)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T14:56:26.814-00:00"
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                 (dissoc verdict :id :owner :created :schema_version))))))))
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
+                  :schema_version csc/ctim-schema-version}
+                 (dissoc verdict :id))))))))
 
 (deftest-for-each-store test-observable-verdict-route-when-judgement-deleted
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -355,5 +359,6 @@
                   :judgement_id (:id judgement-2)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T00:00:00.000-00:00"
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                 (dissoc verdict :owner :created :schema_version))))))))
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
+                  :schema_version csc/ctim-schema-version}
+                 verdict)))))))

--- a/test/ctia/http/routes/relationship_test.clj
+++ b/test/ctia/http/routes/relationship_test.clj
@@ -78,7 +78,8 @@
           (:external_ids relationship)]
       (is (= 201 status))
       (is (deep=
-           {:external_ids ["http://ex.tld/ctia/relationship/relationship-123"
+           {:id (id/long-id relationship-id)
+            :external_ids ["http://ex.tld/ctia/relationship/relationship-123"
                            "http://ex.tld/ctia/relationship/relationship-456"]
             :type "relationship"
             :title "title"
@@ -87,7 +88,6 @@
             :revision 1
             :timestamp #inst "2016-02-11T00:40:48.212-00:00"
             :schema_version schema-version
-            :owner "foouser"
             :language "language"
             :tlp "green"
             :source "source"
@@ -97,10 +97,7 @@
                              "f9832ac2-ee90-4e18-9ce6-0c4e4ff61a7a")
             :target_ref (str "http://example.com/ctia/indicator/indicator-"
                              "8c94ca8d-fb2b-4556-8517-8e6923d8d3c7")}
-           (dissoc relationship
-                   :id
-                   :created
-                   :modified)))
+           relationship))
 
       (testing "the relationship ID has correct fields"
         (let [show-props (get-http-show)]
@@ -124,7 +121,6 @@
                 :short_description "short desc"
                 :revision 1
                 :schema_version schema-version
-                :owner "foouser"
                 :timestamp #inst "2016-02-11T00:40:48.212-00:00"
                 :language "language"
                 :tlp "green"
@@ -135,9 +131,7 @@
                                  "f9832ac2-ee90-4e18-9ce6-0c4e4ff61a7a")
                 :target_ref (str "http://example.com/ctia/indicator/indicator-"
                                  "8c94ca8d-fb2b-4556-8517-8e6923d8d3c7")}
-               (dissoc relationship
-                       :created
-                       :modified)))))
+               relationship))))
 
       (test-query-string-search :relationship "description" :description)
 
@@ -157,7 +151,6 @@
                  :short_description "short desc"
                  :revision 1
                  :schema_version schema-version
-                 :owner "foouser"
                  :timestamp #inst "2016-02-11T00:40:48.212-00:00"
                  :language "language"
                  :tlp "green"
@@ -168,7 +161,7 @@
                                   "f9832ac2-ee90-4e18-9ce6-0c4e4ff61a7a")
                  :target_ref (str "http://example.com/ctia/indicator/indicator-"
                                   "8c94ca8d-fb2b-4556-8517-8e6923d8d3c7")}]
-               (map #(dissoc % :created :modified) relationships)))))
+               relationships))))
 
       (testing "DELETE /ctia/relationship/:id"
         (let [response (delete (str "ctia/relationship/" (:short-id relationship-id))


### PR DESCRIPTION
Using fixed verdict schemas and fixing some routes that were still returning stored entity schemas.

Closes #525 

Note: The schema and mappings for verdicts are changed