### PR TITLE
Undoing changes to verdict chema

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.4"]
+                 [threatgrid/ctim "0.4.5"]
 
                  ;; Web server
                  ;; ring-swagger 0.22.10 provided by compojure-api

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -140,18 +140,15 @@
                                         now)})))
 
 (s/defn realize-verdict :- StoredVerdict
+  ([new-verdict :- NewVerdict]
+   (realize-verdict new-verdict (str "verdict-" (UUID/randomUUID))))
   ([new-verdict :- NewVerdict
-    login :- s/Str]
-   (realize-verdict new-verdict (str "verdict-" (UUID/randomUUID)) login))
-  ([new-verdict :- NewVerdict
-    id :- s/Str
-    login :- s/Str]
+    id :- s/Str]
    (let [now (time/now)]
      (assoc new-verdict
             :id id
             :schema_version schema-version
-            :created now
-            :owner login))))
+            :created now))))
 
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -88,13 +88,12 @@
    to build the verdict ID"
   [verdict :- NewVerdict
    {j-lng-id :id :as judgement} :- StoredJudgement
-   owner :- s/Str
    verdict-id :- s/Str]
   (let [j-id-obj (id/long-id->id j-lng-id)
         j-shrt-id (:short-id j-id-obj)]
     (if (str/starts-with? j-shrt-id judgement-prefix)
-      (entities/realize-verdict verdict verdict-id owner)
-      (entities/realize-verdict verdict owner))))
+      (entities/realize-verdict verdict verdict-id)
+      (entities/realize-verdict verdict))))
 
 (defrecord VerdictGenerator []
   Hook
@@ -105,7 +104,7 @@
   (handle [_ event _]
     (log/info "VERDICT HANDLER FIRED")
     (when (judgement? event)
-      (let [{{:keys [id observable] :as judgement} :entity owner :owner} event
+      (let [{{:keys [id observable] :as judgement} :entity} event
             judgement-id (id/str->short-id id)
             verdict-id (str "verdict-" (subs judgement-id (count judgement-prefix)))]
         (cond
@@ -115,7 +114,7 @@
                       (store/read-store :judgement
                                         store/calculate-verdict
                                         observable)
-                      (realize-verdict-wrapper judgement owner verdict-id))]
+                      (realize-verdict-wrapper judgement verdict-id))]
             (log/info "Generated New Verdict:" (pr-str new-verdict))
             (store/write-store :verdict store/create-verdicts [new-verdict]))
 

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -65,13 +65,14 @@
                                        calculate-verdict
                                        {:type observable_type
                                         :value observable_value})
-                           (entities/realize-verdict login)
+                           entities/realize-verdict
                            (#(write-store :verdict create-verdicts [%])))
                        verdict)]
          (if verdict
            (-> verdict
                verdict/with-long-id
                entities/un-store
+               (dissoc :id :schema_version) ;; remove some store fields
                ok)
            (not-found))))
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -16,6 +16,7 @@
              [verdict :as vs]
              [vocabularies :as vocs]]
             [flanders
+             [core :as f]
              [schema :as f-schema]
              [spec :as f-spec]
              [utils :as fu]]
@@ -130,7 +131,13 @@
 ;; verdict
 
 (defschema NewVerdict
-  vs/NewVerdict
+  (f/map-of
+   {:description "An unrealized verdict"}
+   (:entries vs/Verdict)
+   (f/optional-entries
+    (f/entry :id cos/ID)
+    (f/entry :created cos/Time)
+    (f/entry :schema_version f/any-str)))
   "new-verdict")
 
 (defschema Verdict

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -355,14 +355,16 @@
    {:dynamic "strict"
     :include_in_all false
     :properties
-    (merge
-     base-entity-mapping
-     stored-entity-mapping
-     {:judgement_id token
-      :observable observable
-      :disposition {:type "long"}
-      :disposition_name token
-      :valid_time valid-time})}})
+    {:id all_token
+     :type token
+     :schema_version token
+     :judgement_id token
+     :observable observable
+     :disposition {:type "long"}
+     :disposition_name token
+     :valid_time valid-time
+     :owner token
+     :created ts}}})
 
 (def feedback-mapping
   {"feedback"

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -8,8 +8,7 @@
              [core :as helpers :refer [delete get post]]
              [fake-whoami-service :as whoami-helpers]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as csc]))
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -110,15 +109,13 @@
               (get "ctia/ip/10.0.0.1/verdict"
                    :headers {"api_key" "45c1f5e3f05d0"})]
           (is (= 200 status))
-          (is (= {:id (str "verdict-" (-> (:short-id judgment-id) (subs 10)))
-                  :type "verdict"
+          (is (= {:type "verdict"
                   :disposition 2
                   :disposition_name "Malicious"
                   :judgement_id (:id judgement)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T00:00:00.000-00:00",
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
-                  :schema_version csc/ctim-schema-version}
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
                  verdict)))))))
 
 (deftest-for-each-store test-observable-verdict-route-2
@@ -173,15 +170,13 @@
                 (get "ctia/ip/10.0.0.1/verdict"
                      :headers {"api_key" "45c1f5e3f05d0"})]
             (is (= 200 status))
-            (is (= {:id (str "verdict-" (-> (:short-id judgement-id) (subs 10)))
-                    :observable {:value "10.0.0.1",:type "ip"}
+            (is (= {:observable {:value "10.0.0.1",:type "ip"}
                     :type "verdict"
                     :disposition 2
                     :disposition_name "Malicious"
                     :judgement_id (:id judgement)
                     :valid_time {:start_time #inst "2016-02-12T14:56:26.814-00:00",
-                                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}
-                    :schema_version csc/ctim-schema-version}
+                                 :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
                    verdict))))))))
 
 (deftest-for-each-store ^:sleepy test-observable-verdict-route-with-expired-judgement
@@ -263,9 +258,8 @@
                   :judgement_id (:id judgement-2)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T14:56:26.814-00:00"
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
-                  :schema_version csc/ctim-schema-version}
-                 (dissoc verdict :id))))))))
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
+                 verdict)))))))
 
 (deftest-for-each-store test-observable-verdict-route-when-judgement-deleted
   (helpers/set-capabilities! "foouser" "user" all-capabilities)
@@ -353,12 +347,10 @@
                    :headers {"api_key" "45c1f5e3f05d0"})]
           (is (= 200 status))
           (is (= {:type "verdict"
-                  :id (str "verdict-" (-> (:short-id judgement-2-id) (subs 10)))
                   :disposition 1
                   :disposition_name "Clean"
                   :judgement_id (:id judgement-2)
                   :observable {:value "10.0.0.1", :type "ip"}
                   :valid_time {:start_time #inst "2016-02-12T00:00:00.000-00:00"
-                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}
-                  :schema_version csc/ctim-schema-version}
+                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
                  verdict)))))))


### PR DESCRIPTION
Closes #527 

- I removed the :owner field from verdict.  Its not desired and its not part of the schema (honestly I don't know how it was passing schema validation when we used CTIM 0.4.3).

- I did not remove :owner from the ES mapping (yet).  I need to find out if that would cause a problem first.

- CTIM 0.4.5 makes the :schema_version fields accept any string.

This is needed so that we can fix iroh-enrich and allow us to deploy without reloading data.
