### PR TITLE
With static auth enabled, allow reads-only when unauthed

### DIFF
--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -1,31 +1,54 @@
 (ns ctia.auth.static
   (:require [clj-momo.lib.set :refer [as-set]]
-            [clojure.set :as set]
+            [clojure
+             [set :as set]
+             [string :as str]]
             [ctia
              [auth :refer [IIdentity IAuth] :as auth]
              [properties :as p]]))
 
-(def ^:private my-capabilities
+(def ^:private write-capabilities
   (set/difference auth/all-capabilities
                   #{:specify-id}))
 
-(defrecord Identity [name]
+(def ^:private read-only-capabilities
+  (set/difference (->> auth/all-capabilities
+                       (remove (fn [cap]
+                                 (some #(str/starts-with? (name cap) %)
+                                       ["create" "delete"])))
+                       set)
+                  #{:developer
+                    :specify-id}))
+
+(defrecord WriteIdentity [name]
   IIdentity
   (authenticated? [_]
     true)
   (login [_]
     name)
   (allowed-capabilities [_]
-    my-capabilities)
+    write-capabilities)
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
-                 my-capabilities)))
+                 write-capabilities)))
+
+(defrecord ReadOnlyIdentity []
+  IIdentity
+  (authenticated? [_]
+    true)
+  (login [_]
+    auth/not-logged-in-owner)
+  (allowed-capabilities [_]
+    read-only-capabilities)
+  (capable? [this required-capabilities]
+    (set/subset? (as-set required-capabilities)
+                 read-only-capabilities)))
 
 (defrecord AuthService [auth-config]
   IAuth
   (identity-for-token [_ token]
     (if (= token (get-in auth-config [:static :secret]))
-      (->Identity (get-in auth-config [:static :name]))
-      auth/denied-identity-singleton))
+      (->WriteIdentity (get-in auth-config [:static :name]))
+      (->ReadOnlyIdentity)))
   (require-login? [_]
     true))

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -35,6 +35,34 @@
           (some-> judgement :id id/long-id->id)]
       (is (= 201 status))
 
+      (testing "fails without the correct key"
+        (let [{status :status}
+              (post "ctia/judgement"
+                    :body {:observable {:value "1.2.3.4"
+                                        :type "ip"}
+                           :disposition 2
+                           :source "test"
+                           :priority 100
+                           :severity "High"
+                           :confidence "Low"
+                           :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
+                                        :end_time "2016-03-11T00:00:00.000-00:00"}})]
+          (is (= 401 status)))
+
+        (let [{status :status}
+              (post "ctia/judgement"
+                    :body {:observable {:value "1.2.3.4"
+                                        :type "ip"}
+                           :disposition 2
+                           :source "test"
+                           :priority 100
+                           :severity "High"
+                           :confidence "Low"
+                           :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
+                                        :end_time "2016-03-11T00:00:00.000-00:00"}}
+                    :headers {"api_key" "bloodbending"})]
+          (is (= 401 status))))
+
       (testing "GET /ctia/judgement"
         (let [{status :status
                get-judgement :parsed-body}
@@ -58,12 +86,12 @@
                              :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
                get-judgement)))
 
-        (testing "fails without the correct key"
+        (testing "succeeds with any key"
           (let [{status :status}
                 (get (str "ctia/judgement/" (:short-id judgement-id))
                      :headers {"api_key" "bloodbending"})]
-            (is (= 403 status)))
+            (is (= 200 status)))
 
           (let [{status :status}
                 (get (str "ctia/judgement/" (:short-id judgement-id)))]
-            (is (= 403 status))))))))
+            (is (= 200 status))))))))


### PR DESCRIPTION
Closes #531.

Part of threatgrid/iroh#259

Note that if the client posts an incorrect api-key, it silently falls back to the read-only identity.  I could easily change that (to return a 403 in such cases).