### PR TITLE
Observable routes new Sort fields

### DIFF
--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -30,15 +30,15 @@
   (apply s/enum (concat default-entity-sort-fields
                         describable-entity-sort-fields
                         sourcable-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end])))
+                        [:valid_time.start_time
+                         :valid_time.end_time])))
 
 (def incident-sort-fields
   (apply s/enum (concat default-entity-sort-fields
                         describable-entity-sort-fields
                         sourcable-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end
+                        [:valid_time.start_time
+                         :valid_time.end_time
                          :confidence
                          :status
                          :incident_time
@@ -72,30 +72,30 @@
                          :priority
                          :confidence
                          :severity
-                         :valid_time.start
-                         :valid_time.end
+                         :valid_time.start_time
+                         :valid_time.end_time
                          :reason
                          :observable.type
                          :observable.value])))
 
 (def sighting-sort-fields
   (apply s/enum (concat default-entity-sort-fields
-                        [:observed_time.start
-                         :observed_time.end
+                        [:observed_time.start_time
+                         :observed_time.end_time
                          :confidence
                          :count
                          :sensor])))
 
 (def ttp-sort-fields
   (apply s/enum (concat default-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end
+                        [:valid_time.start_time
+                         :valid_time.end_time
                          :ttp_type])))
 
 (def actor-sort-fields
   (apply s/enum (concat default-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end
+                        [:valid_time.start_time
+                         :valid_time.end_time
                          :actor_type
                          :motivation
                          :sophistication
@@ -103,8 +103,8 @@
 
 (def campaign-sort-fields
   (apply s/enum (concat default-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end
+                        [:valid_time.start_time
+                         :valid_time.end_time
                          :campaign_type
                          :status
                          :activity
@@ -112,8 +112,8 @@
 
 (def coa-sort-fields
   (apply s/enum (concat default-entity-sort-fields
-                        [:valid_time.start
-                         :valid_time.end
+                        [:valid_time.start_time
+                         :valid_time.end_time
                          :stage
                          :coa_type
                          :impact

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -30,7 +30,8 @@
                                :disposition
                                :priority
                                :severity
-                               :confidence)}))
+                               :confidence
+                               :valid_time.start_time)}))
 
 (s/defschema RefsByObservableQueryParams
   (st/dissoc PagingParams :sort_by :sort_order))
@@ -38,7 +39,11 @@
 (s/defschema SightingsByObservableQueryParams
   (st/merge
    PagingParams
-   {(s/optional-key :sort_by) (s/enum :id :timestamp :confidence)}))
+   {(s/optional-key :sort_by) (s/enum
+                               :id
+                               :timestamp
+                               :confidence
+                               :observed_time.start_time)}))
 
 (defroutes observable-routes
   (GET "/:observable_type/:observable_value/verdict" []

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -72,7 +72,10 @@
     (testing "sightings by observable"
       (pagination-test (str route-pref "/sightings")
                        {"api_key" "45c1f5e3f05d0"}
-                       [:id :timestamp :confidence]))
+                       [:id
+                        :timestamp
+                        :confidence
+                        :observed_time.start_time]))
 
     (testing "sightings/indicators by observable"
       (pagination-test-no-sort (str route-pref "/sightings/indicators")
@@ -82,7 +85,12 @@
     (testing "judgements by observable"
       (pagination-test (str route-pref "/judgements")
                        {"api_key" "45c1f5e3f05d0"}
-                       [:id :disposition :priority :severity :confidence]))
+                       [:id
+                        :disposition
+                        :priority
+                        :severity
+                        :confidence
+                        :valid_time.start_time]))
 
     (testing "judgements/indicators by observable"
       (pagination-test-no-sort (str route-pref "/judgements/indicators")


### PR DESCRIPTION
closes #534 

This adds the new sort fields described on #534 and fix those declared for the search route.