### PR TITLE
Issue-563: Use full path to source environment

### DIFF
--- a/build/package/deb/srv/ctia/start.sh
+++ b/build/package/deb/srv/ctia/start.sh
@@ -11,7 +11,7 @@
 # CTIA_LOGFILE
 
 # Load the deployment-specific env variables
-source ./environment
+source /srv/ctia/environment
 
 # ***********************************************
 # These are package-specific settings and do not


### PR DESCRIPTION
Using the relative path was preventing init.d from starting the
CTIA service.

Resolves #563