### PR TITLE
JWT autofill (SwaggerUI, GraphiQL, GraphQL Voyager)

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -12,6 +12,7 @@ ctia.http.access-control-allow-origin=http://(localhost|127.0.0.1)(:\\d+)?
 ctia.http.access-control-allow-methods=get,post,put,delete
 ctia.http.jwt.enabled=true
 ctia.http.jwt.public-key-path=resources/cert/ctia-jwt.pub
+ctia.http.jwt.local-storage-key=:iroh-auth-token
 ctia.http.min-threads=10
 ctia.http.max-threads=100
 ctia.http.show.hostname=localhost

--- a/resources/graphiql/index.html
+++ b/resources/graphiql/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+
+    <script src="node_modules/react/dist/react.min.js"></script>
+    <script src="node_modules/react-dom/dist/react-dom.min.js"></script>
+    <script src='conf.js' type='text/javascript'></script>
+
+    <link rel="stylesheet" href="custom-graphiql.css" />
+    <script src="custom-graphiql.min.js"></script>
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script>
+     function log() {
+         if ('console' in window) {
+             console.log.apply(console, arguments);
+         }
+     }
+
+     function setJwtHeader() {
+         log("detect JWT token");
+         var jwt_token = window.localStorage.getItem(":iroh-auth-token");
+         var graphiql_headers = JSON.parse(window.localStorage.getItem("cgraphiql:headers")) || {};
+         
+         if(jwt_token && jwt_token.trim() != "") {
+             log("Set bearer token: " + jwt_token);
+             graphiql_headers['Authorization'] = "Bearer " + jwt_token;
+         }
+         window.localStorage.setItem("cgraphiql:headers", JSON.stringify(graphiql_headers));
+     }
+
+     setJwtHeader();
+
+     ReactDOM.render(
+         React.createElement(CustomGraphiQL, {currentURL: window.GRAPHIQL_CONF.endpoint}),
+         document.getElementById('graphiql')
+     );
+    </script>
+  </body>
+</html>

--- a/resources/graphiql/index.html
+++ b/resources/graphiql/index.html
@@ -32,14 +32,14 @@
 
      function setJwtHeader() {
          log("detect JWT token");
-         var jwt_token = window.localStorage.getItem(":iroh-auth-token");
-         var graphiql_headers = JSON.parse(window.localStorage.getItem("cgraphiql:headers")) || {};
-         
+         var jwt_token = window.localStorage.getItem(window.GRAPHIQL_CONF.jwtLocalStorageKey);
+         var headers = JSON.parse(window.localStorage.getItem("cgraphiql:headers")) || {};
+
          if(jwt_token && jwt_token.trim() != "") {
+             headers['Authorization'] = "Bearer " + jwt_token;
              log("Set bearer token: " + jwt_token);
-             graphiql_headers['Authorization'] = "Bearer " + jwt_token;
          }
-         window.localStorage.setItem("cgraphiql:headers", JSON.stringify(graphiql_headers));
+         window.localStorage.setItem("cgraphiql:headers", JSON.stringify(headers));
      }
 
      setJwtHeader();

--- a/resources/graphql-voyager/index.html
+++ b/resources/graphql-voyager/index.html
@@ -43,10 +43,11 @@
                  'Accept': 'application/json',
                  'Content-Type': 'application/json',
              };
-             var jwt_token = window.localStorage.getItem(":iroh-auth-token");
+             
+             var jwt_token = window.localStorage.getItem(window.GRAPHQL_VOYAGER_CONF.jwtLocalStorageKey);
              if(jwt_token && jwt_token.trim() != "") {
-                 log("Set bearer token: " + jwt_token);
                  headers['Authorization'] = "Bearer " + jwt_token;
+                 log("Set bearer token: " + jwt_token);
              }
 
              // This example expects a GraphQL server at the path /graphql.

--- a/resources/graphql-voyager/index.html
+++ b/resources/graphql-voyager/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <style>
+         body {
+             height: 100%;
+             margin: 0;
+             width: 100%;
+             overflow: hidden;
+         }
+         #voyager {
+             height: 100vh;
+         }
+        </style>
+        <script src="node_modules/react/dist/react.min.js"></script>
+        <script src="node_modules/react-dom/dist/react-dom.min.js"></script>
+        <script src='conf.js' type='text/javascript'></script>
+        
+        <!--
+             These two files can be found in the npm module, however you may wish to
+             copy them directly into your environment, or perhaps include them in your
+             favored resource bundler.
+           -->
+        <link rel="stylesheet" href="dist/voyager.css" />
+        <script src="dist/voyager.min.js"></script>
+    </head>
+    <body>
+        <div id="voyager">Loading...</div>
+        <script>
+         function log() {
+             if ('console' in window) {
+                 console.log.apply(console, arguments);
+             }
+         }
+
+         // Defines a GraphQL introspection fetcher using the fetch API. You're not required to
+         // use fetch, and could instead implement introspectionProvider however you like,
+         // as long as it returns a Promise
+         // Voyager passes introspectionQuery as an agrument for this function
+         function introspectionProvider(introspectionQuery) {
+             var headers = {
+                 'Accept': 'application/json',
+                 'Content-Type': 'application/json',
+             };
+             var jwt_token = window.localStorage.getItem(":iroh-auth-token");
+             if(jwt_token && jwt_token.trim() != "") {
+                 log("Set bearer token: " + jwt_token);
+                 headers['Authorization'] = "Bearer " + jwt_token;
+             }
+
+             // This example expects a GraphQL server at the path /graphql.
+             // Change this to point wherever you host your GraphQL server.
+             return fetch(window.GRAPHQL_VOYAGER_CONF.endpoint, {
+                 method: 'post',
+                 headers: headers,
+                 body: JSON.stringify({query: introspectionQuery}),
+                 credentials: 'include',
+             }).then(function (response) {
+                 return response.text();
+             }).then(function (responseBody) {
+                 try {
+                     return JSON.parse(responseBody);
+                 } catch (error) {
+                     return responseBody;
+                 }
+             });
+         }
+         // Render <Voyager /> into the body.
+         GraphQLVoyager.init(document.getElementById('voyager'), {
+             introspection: introspectionProvider
+         });
+        </script>
+    </body>
+</html>

--- a/resources/swagger-ui/index.html
+++ b/resources/swagger-ui/index.html
@@ -74,9 +74,8 @@
 
        function addJWTAuthorization() {
            log("detect JWT token");
-           var jwt_token = window.localStorage.getItem(":iroh-auth-token");
+           var jwt_token = window.localStorage.getItem(window.API_CONF.jwtLocalStorageKey);
            if(jwt_token && jwt_token.trim() != "") {
-               log(jwt_token);
                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + jwt_token, "header");
                window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
                log("Set bearer token: " + jwt_token);

--- a/resources/swagger-ui/index.html
+++ b/resources/swagger-ui/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>IROH - Swagger UI</title>
+  <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
+  <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='css/print.css' media='print' rel='stylesheet' type='text/css'/>
+
+  <script src='lib/object-assign-pollyfill.js' type='text/javascript'></script>
+  <script src='lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='lib/handlebars-4.0.5.js' type='text/javascript'></script>
+  <script src='lib/lodash.min.js' type='text/javascript'></script>
+  <script src='lib/backbone-min.js' type='text/javascript'></script>
+  <script src='swagger-ui.js' type='text/javascript'></script>
+  <script src='lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+  <script src='lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
+  <script src='lib/jsoneditor.min.js' type='text/javascript'></script>
+  <script src='lib/marked.js' type='text/javascript'></script>
+  <script src='lib/swagger-oauth.js' type='text/javascript'></script>
+
+  <script src='conf.js' type='text/javascript'></script>
+
+  <!-- Some basic translations -->
+  <!-- <script src='lang/translator.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/ru.js' type='text/javascript'></script> -->
+  <!-- <script src='lang/en.js' type='text/javascript'></script> -->
+
+  <script type="text/javascript">
+
+   $(function () {
+       var url = API_CONF.url;
+
+       hljs.configure({
+           highlightSizeThreshold: 5000
+       });
+
+       // Pre load translate...
+       if(window.SwaggerTranslator) {
+           window.SwaggerTranslator.translate();
+       }
+       window.swaggerUi = new SwaggerUi($.extend({}, {
+           url: url,
+           dom_id: "swagger-ui-container",
+           supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+           onComplete: function(swaggerApi, swaggerUi){
+               if(typeof initOAuth == "function") {
+                   if (API_CONF.hasOwnProperty('oauth2')) {
+                       initOAuth(API_CONF.oauth2);
+                   }
+               }
+
+               if(window.SwaggerTranslator) {
+                   window.SwaggerTranslator.translate();
+               }
+
+               addJWTAuthorization();
+           },
+           onFailure: function(data) {
+               log("Unable to Load SwaggerUI");
+           },
+           docExpansion: "none",
+           jsonEditor: false,
+           defaultModelRendering: 'schema',
+           showRequestHeaders: false
+       }, API_CONF));
+
+       function addJWTAuthorization() {
+           log("detect JWT token");
+           var jwt_token = window.localStorage.getItem(":iroh-auth-token");
+           if(jwt_token && jwt_token.trim() != "") {
+               log(jwt_token);
+               var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + jwt_token, "header");
+               window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
+               log("Set bearer token: " + jwt_token);
+           }
+       };
+
+       window.swaggerUi.load();
+
+       function log() {
+           if ('console' in window) {
+               console.log.apply(console, arguments);
+           }
+       }
+  });
+  </script>
+</head>
+
+<body class="swagger-section">
+<div id='header'>
+  <div class="swagger-ui-wrap">
+    <a id="logo" href="http://swagger.io"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">swagger</span></a>
+    <form id='api_selector'>
+      <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
+      <div id='auth_container'></div>
+      <div class='input'><a id="explore" class="header__btn" href="#" data-sw-translate>Explore</a></div>
+    </form>
+  </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap" data-sw-translate>&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>

--- a/src/ctia/http/routes/graphql.clj
+++ b/src/ctia/http/routes/graphql.clj
@@ -3,6 +3,7 @@
             [compojure.api
              [core :as c]
              [sweet :refer :all]]
+            [ctia.properties :refer [properties]]
             [ctia.schemas
              [graphql :as gql]]
             [ring-graphql-ui.core :refer [graphiql
@@ -10,14 +11,18 @@
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
 
-(def graphql-ui-routes
-  (c/undocumented
-   ;; --- GraphiQL https://github.com/shahankit/custom-graphiql/
-   (graphiql {:path "/graphiql"
-              :endpoint "/ctia/graphql"})
-   ;; --- GraphQL Voyager https://github.com/APIs-guru/graphql-voyager
-   (voyager {:path "/voyager"
-             :endpoint "/ctia/graphql"})))
+(defn graphql-ui-routes []
+  (let [jwt-storage-key
+        (get-in @properties [:ctia :http :jwt :local-storage-key])]
+    (c/undocumented
+     ;; --- GraphiQL https://github.com/shahankit/custom-graphiql/
+     (graphiql {:path "/graphiql"
+                :endpoint "/ctia/graphql"
+                :jwtLocalStorageKey jwt-storage-key})
+     ;; --- GraphQL Voyager https://github.com/APIs-guru/graphql-voyager
+     (voyager {:path "/voyager"
+               :endpoint "/ctia/graphql"
+               :jwtLocalStorageKey jwt-storage-key}))))
 
 (defroutes graphql-routes
   (POST "/graphql" []

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -42,7 +42,7 @@
     :or {access-control-allow-methods "get,post,put,delete"}}]
   (doto
       (jetty/run-jetty
-       (cond-> #'handler/api-handler
+       (cond-> (handler/api-handler)
 
          access-control-allow-origin
          (wrap-cors :access-control-allow-origin

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -67,7 +67,8 @@
                       "ctia.http.max-threads" s/Int})
 
    (st/optional-keys {"ctia.http.jwt.enabled" s/Bool
-                      "ctia.http.jwt.public-key-path" s/Str})
+                      "ctia.http.jwt.public-key-path" s/Str
+                      "ctia.http.jwt.local-storage-key" s/Str})
 
    (st/optional-keys {"ctia.http.dev-reload" s/Bool
                       "ctia.http.show.protocol" s/Str


### PR DESCRIPTION
- [x] SwaggerUI: backport the JWT autofill magic from the IROH repo
- [x] GraphiQL: add JWT autofill
- [x] GraphQL Voyager: add JWT autofill

The key used to get the JWT token from the browser local storage is configurable using this property:
```properties
ctia.http.jwt.local-storage-key=:iroh-auth-token
```

I changed the way the API is built by using a function and `api` instead of `defapi` to be able to get conf properties when building API routes (See `ctia.http.handler` and `ctia.http.server`).

