### PR TITLE
Using CTIM 0.4.17, which adds more field constraints

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.16b"
+                 [threatgrid/ctim "0.4.17"
                   :exclusions [joda-time
                                clj-time
                                riemann-clojure-client

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -128,7 +128,8 @@
   ;; This test case catches a bug that was in the atom store
   ;; It tests the code path where priority is equal but dispositions differ
   (testing "test setup: create a judgement (1)"
-    (let [{status :status}
+    (let [{status :status
+           :as response}
           (post "ctia/judgement"
                 :body {:observable {:value "string",
                                     :type "device"},
@@ -143,6 +144,7 @@
                                     :end_time "2016-02-12T14:56:26.719-00:00"}
                        :confidence "Medium"}
                 :headers {"api_key" "45c1f5e3f05d0"})]
+      (clojure.pprint/pprint ['response response])
       (is (= 201 status))))
 
   (testing "with a verdict judgement"

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -128,8 +128,7 @@
   ;; This test case catches a bug that was in the atom store
   ;; It tests the code path where priority is equal but dispositions differ
   (testing "test setup: create a judgement (1)"
-    (let [{status :status
-           :as response}
+    (let [{status :status}
           (post "ctia/judgement"
                 :body {:observable {:value "string",
                                     :type "device"},
@@ -140,11 +139,10 @@
                        :source_uri "string",
                        :priority 99,
                        :severity "Low"
-                       :valid_time {:start_time "2016-02-12T14:56:26.814-00:00"
-                                    :end_time "2016-02-12T14:56:26.719-00:00"}
+                       :valid_time {:start_time "2016-02-12T14:56:26.719-00:00"
+                                    :end_time "2016-02-12T14:56:26.814-00:00"}
                        :confidence "Medium"}
                 :headers {"api_key" "45c1f5e3f05d0"})]
-      (clojure.pprint/pprint ['response response])
       (is (= 201 status))))
 
   (testing "with a verdict judgement"


### PR DESCRIPTION
See also threatgrid/ctim#170.


- Testing that :revision, and :count on Sighting, is either zero or a positive integer.
- Testing that observed_time end_time is equal to or greater than start_time (end_time is optional)
- Testing that valid_time end_time is equal to or greater than start_time (both are optional)
