### PR TITLE
Allow setting a min TLP and default TLP configurations

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -1,6 +1,9 @@
 ctia.auth.type=allow-all
 ctia.auth.threatgrid.cache=true
 
+ctia.access-control.min-tlp green
+ctia.access-control.default-tlp green
+
 # You can optionaly require a specific API key
 #ctia.auth.type=static
 #ctia.auth.static.name=example

--- a/src/ctia/domain/access_control.clj
+++ b/src/ctia/domain/access_control.clj
@@ -1,8 +1,24 @@
 (ns ctia.domain.access-control
-  (:require [schema.core :as s]))
+  (:require [ctia.properties :refer [get-access-control]]
+            [ctim.schemas.common :as csc]
+            [schema.core :as s]))
 
 (def public-tlps
   ["white" "green"])
+
+(def tlps ["white" "green" "amber" "red"])
+
+(defn properties-default-tlp []
+  (or (:default-tlp (get-access-control))
+      csc/default-tlp))
+
+(defn allowed-tlps []
+  (let [min-tlp (or (:min-tlp (get-access-control) "white"))]
+    (nthrest tlps
+             (.indexOf tlps min-tlp))))
+
+(defn allowed-tlp? [tlp]
+  (some #{tlp} (allowed-tlps)))
 
 (s/defn allowed-group? :- s/Bool
   [doc ident]

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -1,41 +1,39 @@
 (ns ctia.domain.entities
-  (:require
-   [clj-momo.lib.time :as time]
-   [ctia.properties :refer [get-http-show]]
-   [ctim.domain.id :as id]
-   [ring.util.http-response :as http-response]
-   [schema.core :as s]
-   [ctim.schemas.common
-    :refer [ctim-schema-version
-            default-tlp
-            determine-disposition-id
-            disposition-map]]
-   [ctia.schemas.core
-    :refer [NewActor
-            StoredActor
-            NewCampaign
-            StoredCampaign
-            NewCOA
-            StoredCOA
-            NewDataTable
-            StoredDataTable
-            NewExploitTarget
-            StoredExploitTarget
-            NewFeedback
-            StoredFeedback
-            NewIncident
-            StoredIncident
-            NewIndicator
-            StoredIndicator
-            NewJudgement
-            StoredJudgement
-            NewSighting
-            StoredSighting
-            NewTTP
-            StoredTTP
-            NewRelationship
-            StoredRelationship]])
-  (:import [java.util UUID]))
+  (:require [clj-momo.lib.time :as time]
+            [ctia.domain.access-control :refer [properties-default-tlp]]
+            [ctia.properties :refer [get-http-show]]
+            [ctia.schemas.core
+             :refer
+             [NewActor
+              NewCampaign
+              NewCOA
+              NewDataTable
+              NewExploitTarget
+              NewFeedback
+              NewIncident
+              NewIndicator
+              NewJudgement
+              NewRelationship
+              NewSighting
+              NewTTP
+              StoredActor
+              StoredCampaign
+              StoredCOA
+              StoredDataTable
+              StoredExploitTarget
+              StoredFeedback
+              StoredIncident
+              StoredIndicator
+              StoredJudgement
+              StoredRelationship
+              StoredSighting
+              StoredTTP]]
+            [ctim.domain.id :as id]
+            [ctim.schemas.common
+             :refer
+             [ctim-schema-version determine-disposition-id disposition-map]]
+            [ring.util.http-response :as http-response]
+            [schema.core :as s]))
 
 (def schema-version ctim-schema-version)
 
@@ -60,7 +58,8 @@
               :schema_version schema-version
               :created (or (:created prev-object) now)
               :modified now
-              :tlp (:tlp new-object (:tlp prev-object default-tlp))
+              :tlp (:tlp new-object
+                         (:tlp prev-object (properties-default-tlp)))
               :valid_time (or (:valid_time prev-object)
                               {:end_time (or (get-in new-object [:valid_time :end_time])
                                              time/default-expire-date)
@@ -93,7 +92,7 @@
          :created (time/now)
          :owner owner
          :groups groups
-         :tlp (:tlp new-feedback default-tlp)
+         :tlp (:tlp new-feedback (properties-default-tlp))
          :schema_version schema-version))
 
 (def realize-incident
@@ -113,7 +112,7 @@
          :created (time/now)
          :owner owner
          :groups groups
-         :tlp (:tlp new-relationship default-tlp)
+         :tlp (:tlp new-relationship (properties-default-tlp))
          :schema_version schema-version))
 
 
@@ -139,7 +138,7 @@
            :owner owner
            :groups groups
            :created now
-           :tlp (:tlp new-judgement default-tlp)
+           :tlp (:tlp new-judgement (properties-default-tlp))
            :schema_version schema-version
            :valid_time {:end_time (or (get-in new-judgement
                                               [:valid_time :end_time])
@@ -170,7 +169,7 @@
             :confidence (:confidence new-sighting
                                      (:confidence prev-sighting "Unknown"))
             :tlp (:tlp new-sighting
-                       (:tlp prev-sighting default-tlp))
+                       (:tlp prev-sighting (properties-default-tlp)))
             :schema_version schema-version
             :created (or (:created prev-sighting) now)
             :modified now))))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -1,18 +1,16 @@
-(ns ^{:doc "Properties (aka configuration) of the application.
-            Properties are stored in property files.  There is a
-            default file which can be overridden by placing an
-            alternative properties file on the classpath, or by
+(ns ^{:doc "Properties (aka configuration) of the application.\n
+            Properties are stored in property files.  There is a\n
+            default file which can be overridden by placing an\n
+            alternative properties file on the classpath or by\n
             setting system properties."}
     ctia.properties
-  (:require [clj-momo.properties :as mp]
-            [clj-momo.lib
-             [map :as map]
-             [schema :as mls]]
-            [schema.core :as s]
+  (:require [clj-momo.lib.schema :as mls]
+            [clj-momo.properties :as mp]
+            [ctia.store :as store]
             [schema-tools.core :as st]
-            [ctia.store :refer [stores]]
-            [ctia.store :as store])
-  (:import java.util.Properties))
+            [schema.core :as s]
+            [ctia.schemas.core
+             :refer [TLP]]))
 
 (def files
   "Property file names, they will be merged, with last one winning"
@@ -82,6 +80,9 @@
                       "ctia.hook.redis.enabled" s/Bool
                       "ctia.hook.redismq.enabled" s/Bool})
 
+   (st/required-keys {"ctia.access-control.min-tlp" TLP
+                      "ctia.access-control.default-tlp" TLP})
+
    (st/optional-keys {"ctia.events.log" s/Bool
                       "ctia.nrepl.port" s/Int
                       "ctia.hook.redis.host" s/Str
@@ -124,3 +125,6 @@
 
 (defn get-http-show []
   (get-in @properties [:ctia :http :show]))
+
+(defn get-access-control []
+  (get-in @properties [:ctia :access-control]))

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -217,6 +217,9 @@
 
 (f-spec/->spec ins/StoredIndicator "stored-indicator")
 
+
+
+
 ;; relationship
 
 (def-acl-schema Relationship
@@ -246,6 +249,10 @@
   "stored-ttp")
 
 ;; common
+
+(sc/defschema TLP
+  (f-schema/->schema
+   cos/TLP))
 
 (defschema Observable
   cos/Observable

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -44,24 +44,26 @@
   (mth/clear-properties PropertiesSchema)
   ;; Override any properties that are in the default properties file
   ;; yet are unsafe/undesirable for tests
-  (with-properties ["ctia.auth.type"               "allow-all"
-                    "ctia.events.enabled"          true
-                    "ctia.events.log"              false
-                    "ctia.http.dev-reload"         false
-                    "ctia.http.min-threads"        9
-                    "ctia.http.max-threads"        10
-                    "ctia.http.show.protocol"      "http"
-                    "ctia.http.show.hostname"      "localhost"
-                    "ctia.http.show.port"          "57254"
-                    "ctia.http.show.path-prefix"   ""
-                    "ctia.http.jwt.enabled"        true
-                    "ctia.http.jwt.public-key-path" "resources/cert/ctia-jwt.pub"
-                    "ctia.nrepl.enabled"           false
-                    "ctia.hook.redis.enabled"      false
-                    "ctia.hook.redis.channel-name" "events-test"
-                    "ctia.metrics.riemann.enabled" false
-                    "ctia.metrics.console.enabled" false
-                    "ctia.metrics.jmx.enabled"     false]
+  (with-properties ["ctia.auth.type"                  "allow-all"
+                    "ctia.access-control.default-tlp" "green"
+                    "ctia.access-control.min-tlp"     "white"
+                    "ctia.events.enabled"             true
+                    "ctia.events.log"                 false
+                    "ctia.http.dev-reload"            false
+                    "ctia.http.min-threads"           9
+                    "ctia.http.max-threads"           10
+                    "ctia.http.show.protocol"         "http"
+                    "ctia.http.show.hostname"         "localhost"
+                    "ctia.http.show.port"             "57254"
+                    "ctia.http.show.path-prefix"      ""
+                    "ctia.http.jwt.enabled"           true
+                    "ctia.http.jwt.public-key-path"   "resources/cert/ctia-jwt.pub"
+                    "ctia.nrepl.enabled"              false
+                    "ctia.hook.redis.enabled"         false
+                    "ctia.hook.redis.channel-name"    "events-test"
+                    "ctia.metrics.riemann.enabled"    false
+                    "ctia.metrics.console.enabled"    false
+                    "ctia.metrics.jmx.enabled"        false]
     ;; run tests
     (f)))
 


### PR DESCRIPTION
Allow configuring default, and minimum TLP level an API customer can submit documents with.

closes #599 