### PR TITLE
initial CTIA ES migration task

### DIFF
--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -101,26 +101,24 @@
   "Create many entities provided their type and returns a list of ids"
   [entities entity-type login]
   (let [with-long-id (with-long-id-fn entity-type)]
-    (->> (flows/create-flow
-          :entity-type entity-type
-          :realize-fn (realize-fn entity-type)
-          :store-fn (create-fn entity-type login)
-          :long-id-fn with-long-id
-          :identity login
-          :entities entities)
-         (map :id))))
+    (map :id (flows/create-flow
+              :entity-type entity-type
+              :realize-fn (realize-fn entity-type)
+              :store-fn (create-fn entity-type login)
+              :long-id-fn with-long-id
+              :identity login
+              :entities entities))))
 
 (defn read-entities
   "Retrieve many entities of the same type provided their ids and common type"
   [ids entity-type ident]
   (let [read-entity (read-fn entity-type ident)
         with-long-id (with-long-id-fn entity-type)]
-    (->> ids
-         (map (fn [id] (try (with-long-id
-                             (read-entity id))
-                           (catch Exception e
-                             (do (log/error (pr-str e))
-                                 nil))))))))
+    (map (fn [id] (try (with-long-id
+                        (read-entity id))
+                      (catch Exception e
+                        (do (log/error (pr-str e))
+                            nil)))) ids)))
 
 (defn gen-bulk-from-fn
   "Kind of fmap but adapted for bulk

--- a/src/ctia/task/codegen.clj
+++ b/src/ctia/task/codegen.clj
@@ -1,13 +1,13 @@
 (ns ctia.task.codegen
-  ^{:doc "A task to generate swagger client libraries for a handful of languages"}
-  (:require [ctia.init :refer [start-ctia!]]
-            [clojure.java.io :as io]
-            [clojure.java.shell :as shell]
-            [ctia.properties :refer [properties]]
-            [clojure.string :as str]))
+  (:require [clojure.java
+             [io :as io]
+             [shell :as shell]]
+            [ctia
+             [init :refer [start-ctia!]]
+             [properties :refer [properties]]]))
 
 ;; swagger codegen package
-(def codegen-version "2.1.6")
+(def codegen-version "2.2.3")
 (def codegen-repo "http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/")
 (def jar-uri (str codegen-repo
                   codegen-version
@@ -15,7 +15,6 @@
                   codegen-version ".jar"))
 
 (def local-jar-uri (str "/tmp/swagger-codegen-" codegen-version ".jar"))
-
 
 (def artifact-id "ctia-client")
 (def description "a client library for CTIA")
@@ -56,8 +55,9 @@
   (when-let [err (:err (apply shell/sh args))]
     (println err)))
 
-(defn setup []
+(defn setup
   "start CTIA and download swagger-codegen if needed"
+  []
   (println "starting CTIA...")
   (start-ctia! :join? false)
   (when-not (.exists (io/file local-jar-uri))
@@ -79,7 +79,6 @@
    "--artifact-id" (get-in langs [lang :artifact-id] artifact-id)
    "--artifact-version" artifact-version])
 
-
 (defn props->additional-properties [props]
   ["--additional-properties"
    (->> props
@@ -99,8 +98,9 @@
         full-command (into base additional)]
     (apply exec-command full-command)))
 
-(defn -main [output-dir]
+(defn -main
   "invoke with lein run -m ctia.task.codegen <output-dir>"
+  [output-dir]
   (setup)
   (doseq [[lang props] langs]
     (generate-language lang props output-dir))

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -61,7 +61,7 @@
   (update store :indexname #(str "v" prefix "_" %)))
 
 (defn store->map
-  "transfrom a store record
+  "transform a store record
    into a properties map for easier manipulation"
   [store]
   {:conn (-> store first :state :conn)

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -1,13 +1,16 @@
 (ns ctia.task.migrate-es-stores
-  (:require [clj-momo.lib.es
-             [document :as es-doc]
-             [index :as es-index]]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [ctia
-             [init :refer [init-store-service! log-properties]]
-             [properties :as p]
-             [store :refer [stores]]]))
+  (:require
+   [clj-momo.lib.clj-time.core :as time-core]
+   [clj-momo.lib.clj-time.coerce :as time-coerce]
+   [clj-momo.lib.es
+    [document :as es-doc]
+    [index :as es-index]]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [ctia
+    [init :refer [init-store-service! log-properties]]
+    [properties :as p]
+    [store :refer [stores]]]))
 
 (def default-batch-size 100)
 
@@ -28,9 +31,11 @@
        (update-in doc
                   [:valid_time
                    :end_time]
-                  #(string/replace %
-                                   #"2535"
-                                   "2525"))
+                  #(let [max-end-time (time-core/internal-date 2525 01 01)
+                         end-time (time-coerce/to-internal-date %)]
+                     (if (time-core/after? end-time max-end-time)
+                       max-end-time
+                       end-time)))
        doc))))
 
 (def available-operations

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -1,0 +1,204 @@
+(ns ctia.task.migrate-es-stores
+  (:require [clj-momo.lib.es
+             [document :as es-doc]
+             [index :as es-index]]
+            [clojure.tools.logging :as log]
+            [ctia
+             [init :refer [init-store-service! log-properties]]
+             [properties :as p]
+             [store :refer [stores]]]))
+
+(def default-batch-size 100)
+
+(def add-groups
+  "set a document group to [\"tenzin\"] if unset"
+  (map (fn [{:keys [groups]
+            :as doc}]
+         (if-not (seq groups)
+           (assoc doc :groups ["tenzin"])
+           doc))))
+
+(def fix-end-time
+  "fix end_time to 2535"
+  (map
+   (fn [{:keys [valid_time]
+        :as doc}]
+     (if (:end_time valid_time)
+       (update-in doc
+                  [:valid_time
+                   :end_time]
+                  #(clojure.string/replace % #"2535" "2525"))
+       doc))))
+
+(def available-operations
+  "define all migration operations here"
+  {:default (map identity)
+   :add-groups add-groups
+   :fix-end-time fix-end-time})
+
+(defn compose-operations
+  "compose operations from a list of keywords"
+  [ops]
+  (let [operation-keys (map keyword
+                            (clojure.string/split ops #","))
+        operations (vals (select-keys available-operations
+                                      operation-keys))]
+    (apply comp
+           (:default available-operations)
+           operations)))
+
+(defn source-store-map->target-store-map
+  "transform a source store map into a target map,
+  essentially updating indexname"
+  [store suffix]
+  (update store :indexname str "_" suffix))
+
+(defn store->map
+  "transfrom a store record
+   into a properties map for easier manipulation"
+  [store]
+  {:conn (-> store first :state :conn)
+   :indexname (-> store first :state :index)
+   :mapping (-> store first :state :props :entity name)
+   :settings (-> store first :state :props :settings)})
+
+(defn stores->maps
+  "transform store records to maps"
+  [stores]
+  (into {}
+        (map (fn [[sk sr]]
+               {sk (store->map sr)}) stores)))
+
+(defn source-store-maps->target-store-maps
+  "transform target store records to maps"
+  [current-stores suffix]
+  (into {}
+        (map (fn [[sk sr]]
+               {sk (source-store-map->target-store-map sr suffix)})
+             current-stores)))
+
+(defn setup
+  "iit properties, start CTIA and its store service"
+  []
+  (log/warn "starting CTIA Stores...")
+  (p/init!)
+  (log-properties)
+  (init-store-service!))
+
+(defn fetch-batch
+  "fetch a batch of documents from an es index"
+  [{:keys [conn indexname mapping]} batch-size offset]
+  (es-doc/search-docs
+   conn
+   indexname
+   mapping
+   nil
+   {}
+   {:offset (or offset 0)
+    :limit batch-size}))
+
+(defn store-batch
+  "store a batch of documents using a bulk operation"
+  [{:keys [conn indexname mapping]} batch]
+  (log/warnf "storing %s records" (count batch))
+  (let [prepared-docs
+        (map #(assoc %
+                     :_id (:id %)
+                     :_index indexname
+                     :_type mapping)
+             batch)]
+    (es-doc/bulk-create-doc
+     conn
+     prepared-docs
+     false)))
+
+(defn create-target-store
+  "create the target store, pushing its template"
+  [target-store]
+  (let [wildcard (str (:indexname target-store) "*")]
+    (log/warnf "purging index: %s"
+               wildcard)
+    (es-index/delete! (:conn target-store)
+                      wildcard))
+  (log/warnf "creating index template: %s"
+             (:indexname target-store))
+  (log/warnf "creating index: %s"
+             (:indexname target-store))
+
+  (es-index/create! (:conn target-store)
+                    (:indexname target-store)
+                    (:settings target-store)))
+
+(defn migrate-store
+  "migrate a single store"
+  [current-store
+   target-store
+   operations
+   batch-size
+   confirm?]
+
+  (when confirm?
+    (create-target-store target-store))
+  (let [store-size (-> (fetch-batch current-store 1 0)
+                       :paging
+                       :total-hits)]
+    (log/warnf "store size: %s records" store-size))
+  (loop [offset 0
+         migrated-count 0]
+    (let [{:keys [data paging]
+           :as batch}
+          (fetch-batch current-store
+                       batch-size
+                       offset)
+          next (:next paging)
+          offset (:offset next)
+          migrated (transduce operations conj data)
+          migrated-count (+ migrated-count
+                            (count migrated))]
+      (when (seq migrated)
+        (when confirm?
+          (store-batch target-store migrated))
+        (log/warnf "migrated: %s" migrated-count))
+      (if next
+        (recur offset migrated-count)
+        (log/warnf "finished migrating store: %s"
+                   (:indexname current-store))))))
+
+(defn migrate-store-indexes
+  "migrate all es store indexes"
+  [suffix ops batch-size confirm?]
+  (let [current-stores (stores->maps @stores)
+        target-stores
+        (source-store-maps->target-store-maps current-stores
+                                              suffix)
+        operations (compose-operations ops)
+        batch-size (or batch-size default-batch-size)]
+
+    (log/warnf "migrating stores: %s" (keys current-stores))
+    (log/warnf "batch size: %s" batch-size)
+
+    (doseq [[sk sr] current-stores]
+      (log/warnf "migrating store: %s" sk)
+      (migrate-store sr
+                     (sk target-stores)
+                     operations
+                     batch-size
+                     confirm?))))
+
+(defn -main
+  "invoke with lein run -m ctia.task.migrate-es-stores <suffix> <operations> <batch-size> <confirm?>"
+  [suffix ops batch-size confirm?]
+
+  (assert suffix
+          "Please provide an indexname suffix for target store creation")
+  (assert ops "Please provide a csv operation list")
+  (assert batch-size "Please specify a batch size")
+
+  (log/warn "migrating all ES Stores")
+  (setup)
+  (migrate-store-indexes suffix
+                         ops
+                         (read-string batch-size)
+                         (boolean (or confirm? false)))
+  (log/warn "migration complete")
+  (System/exit 0))

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -24,7 +24,7 @@
           (map identity)))))
 
 (defn prefixed-index [index prefix]
-  (let [version-trimmed (string/replace index #"^v\w+.\w+.\w_" "")]
+  (let [version-trimmed (string/replace index #"^v[^_]*_" "")]
     (str "v" prefix "_" version-trimmed)))
 
 (defn source-store-map->target-store-map

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -28,12 +28,15 @@
        (update-in doc
                   [:valid_time
                    :end_time]
-                  #(string/replace % #"2535" "2525"))
+                  #(string/replace %
+                                   #"2535"
+                                   "2525"))
        doc))))
 
 (def available-operations
   "define all migration operations here"
-  {:default (map identity)
+  {:__test (map #(assoc % :groups ["migration-test"]))
+   :default (map identity)
    :add-groups add-groups
    :fix-end-time fix-end-time})
 
@@ -126,8 +129,9 @@
     (log/infof "%s - purging indexes: %s"
                (:type target-store)
                wildcard)
-    (es-index/delete! (:conn target-store)
-                      wildcard))
+    (es-index/delete!
+     (:conn target-store)
+     wildcard))
   (log/infof "%s - creating index template: %s"
              (:type target-store)
              (:indexname target-store))
@@ -135,13 +139,15 @@
              (:type target-store)
              (:indexname target-store))
 
-  (es-index/create-template! (:conn target-store)
-                             (:indexname target-store)
-                             (:config target-store))
+  (es-index/create-template!
+   (:conn target-store)
+   (:indexname target-store)
+   (:config target-store))
 
-  (es-index/create! (:conn target-store)
-                    (:indexname target-store)
-                    (:settings target-store)))
+  (es-index/create!
+   (:conn target-store)
+   (:indexname target-store)
+   (:settings target-store)))
 
 (defn migrate-store
   "migrate a single store"
@@ -213,7 +219,6 @@
   (assert prefix "Please provide an indexname suffix for target store creation")
   (assert ops "Please provide a csv operation list")
   (assert batch-size "Please specify a batch size")
-
   (log/info "migrating all ES Stores")
   (setup)
   (migrate-store-indexes prefix

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -47,10 +47,8 @@
 
 (defn compose-operations
   "compose operations from a list of keywords"
-  [ops]
-  (let [operation-keys (map keyword
-                            (clojure.string/split ops #","))
-        operations (vals (select-keys available-operations
+  [operation-keys]
+  (let [operations (vals (select-keys available-operations
                                       operation-keys))]
     (apply comp
            (:default available-operations)
@@ -60,7 +58,7 @@
   "transform a source store map into a target map,
   essentially updating indexname"
   [store prefix]
-  (update store :indexname #(str prefix "_" %)))
+  (update store :indexname #(str "v" prefix "_" %)))
 
 (defn store->map
   "transfrom a store record
@@ -163,7 +161,6 @@
    confirm?]
   (when confirm?
     (create-target-store target-store))
-
   (let [store-size (-> (fetch-batch current-store 1 0)
                        :paging
                        :total-hits)]
@@ -221,13 +218,13 @@
   "invoke with lein run -m ctia.task.migrate-es-stores <prefix> <operations> <batch-size> <confirm?>"
   [prefix ops batch-size confirm?]
 
-  (assert prefix "Please provide an indexname suffix for target store creation")
+  (assert prefix "Please provide an indexname prefix for target store creation")
   (assert ops "Please provide a csv operation list")
   (assert batch-size "Please specify a batch size")
   (log/info "migrating all ES Stores")
   (setup)
   (migrate-store-indexes prefix
-                         ops
+                         (map keyword (clojure.string/split ops #","))
                          (read-string batch-size)
                          (boolean (or confirm? false)))
   (log/info "migration complete")

--- a/src/ctia/task/migrations.clj
+++ b/src/ctia/task/migrations.clj
@@ -1,0 +1,37 @@
+(ns ctia.task.migrations
+  (:require [clj-momo.lib.clj-time
+             [coerce :as time-coerce]
+             [core :as time-core]]))
+
+(def add-groups
+  "set a document group to [\"tenzin\"] if unset"
+  (map (fn [{:keys [groups]
+            :as doc}]
+         (if-not (seq groups)
+           (assoc doc :groups ["tenzin"])
+           doc))))
+
+(def fix-end-time
+  "fix end_time to 2535"
+  (map
+   (fn [{:keys [valid_time]
+        :as doc}]
+     (if (:end_time valid_time)
+       (update-in doc
+                  [:valid_time
+                   :end_time]
+                  #(let [max-end-time (time-core/internal-date 2525 01 01)
+                         end-time (time-coerce/to-internal-date %)]
+                     (if (time-core/after? end-time max-end-time)
+                       max-end-time
+                       end-time)))
+       doc))))
+
+(defn append-version [version]
+  (map #(assoc % :schema_version version)))
+
+(def available-migrations
+  {:__test (map #(assoc % :groups ["migration-test"]))
+   :0.4.16 (comp add-groups
+              fix-end-time
+              (append-version "0.4.16"))})

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -2,22 +2,26 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [ctia.task.migrate-es-stores :as sut]
+            [ctia.properties :as props]
+            [clj-http.client :as client]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post]]
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
+            [ctim.domain.id :refer [make-transient-id]]
             [ctim.examples
-             [actors :refer [actor-maximal]]
-             [campaigns :refer [campaign-maximal]]
-             [coas :refer [coa-maximal]]
-             [exploit-targets :refer [exploit-target-maximal]]
-             [incidents :refer [incident-maximal]]
-             [indicators :refer [indicator-maximal]]
-             [judgements :refer [judgement-maximal]]
-             [relationships :refer [relationship-maximal]]
-             [sightings :refer [sighting-maximal]]
-             [ttps :refer [ttp-maximal]]]))
+             [actors :refer [actor-minimal]]
+             [campaigns :refer [campaign-minimal]]
+             [coas :refer [coa-minimal]]
+             [exploit-targets :refer [exploit-target-minimal]]
+             [incidents :refer [incident-minimal]]
+             [indicators :refer [indicator-minimal]]
+             [judgements :refer [judgement-minimal]]
+             [relationships :refer [relationship-minimal]]
+             [sightings :refer [sighting-minimal]]
+             [ttps :refer [ttp-minimal]]]
+            [clojure.tools.logging :as log]))
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
@@ -30,7 +34,7 @@
 (use-fixtures :each
   whoami-helpers/fixture-reset-state)
 
-(def fixtures-nb 200)
+(def fixtures-nb 100)
 
 (defn post-bulk [examples]
   (let [{status :status
@@ -42,46 +46,39 @@
 
 (defn randomize [doc]
   (assoc doc
-         :id (str "transient:"
-                  (str (java.util.UUID/randomUUID)))))
+         :id (make-transient-id "_")))
 
 (defn n-doc [fixture nb]
   (map randomize (repeat nb fixture)))
 
+(defn refresh-index [host port index]
+  (let [index-refresh-url
+        (format "http://%s:%s/%s/_refresh" host port index)]
+    (:status (client/post index-refresh-url))))
+
+(defmacro with-atom-logger
+  [atom-logger & body]
+  `(let [patched-log#
+         (fn [logger#
+             level#
+             throwable#
+             message#]
+           (swap! ~atom-logger conj message#))]
+     (with-redefs [log/log* patched-log#]
+       ~@body)))
+
 (def examples
-  {:actors (n-doc actor-maximal fixtures-nb)
-   :campaigns (n-doc campaign-maximal fixtures-nb)
-   :coas (n-doc coa-maximal fixtures-nb)
-   :exploit-targets (n-doc exploit-target-maximal fixtures-nb)
-   :incidents (n-doc incident-maximal fixtures-nb)
-   :indicators (n-doc indicator-maximal fixtures-nb)
-   :judgements (n-doc judgement-maximal fixtures-nb)
-   :relationships (n-doc relationship-maximal fixtures-nb)
-   :sightings (n-doc sighting-maximal fixtures-nb)
-   :ttps (n-doc ttp-maximal fixtures-nb)})
+  {:actors (n-doc actor-minimal fixtures-nb)
+   :campaigns (n-doc campaign-minimal fixtures-nb)
+   :coas (n-doc coa-minimal fixtures-nb)
+   :exploit-targets (n-doc exploit-target-minimal fixtures-nb)
+   :incidents (n-doc incident-minimal fixtures-nb)
+   :indicators (n-doc indicator-minimal fixtures-nb)
+   :judgements (n-doc judgement-minimal fixtures-nb)
+   :relationships (n-doc relationship-minimal fixtures-nb)
+   :sightings (n-doc sighting-minimal fixtures-nb)
+   :ttps (n-doc ttp-minimal fixtures-nb)})
 
-(deftest test-migrate-store-indexes
-  (helpers/set-capabilities! "foouser"
-                             ["foogroup"]
-                             "user"
-                             all-capabilities)
-  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
-                                      "foouser"
-                                      "foogroup"
-                                      "user")
-
-  (testing "migrate ES Stores test setup"
-    (post-bulk examples)
-    (testing "simulate migrate es indexes"
-      (sut/migrate-store-indexes "foo"
-                                 "add-groups,fix-end-time"
-                                 100
-                                 false))
-    (testing "migrate es indexes"
-      (sut/migrate-store-indexes "foo"
-                                 "add-groups,fix-end-time"
-                                 100
-                                 true))))
 (deftest add-groups-test
   (is (= (transduce sut/add-groups conj [{}])
          [{:groups ["tenzin"]}]))
@@ -101,3 +98,102 @@
                       {:end_time "2535"}}])
          [{:valid_time
            {:end_time "2525"}}])))
+
+(deftest test-migrate-store-indexes
+  (helpers/set-capabilities! "foouser"
+                             ["foogroup"]
+                             "user"
+                             all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (testing "migrate ES Stores test setup"
+    (post-bulk examples)
+    (testing "simulate migrate es indexes"
+      (sut/migrate-store-indexes "foo"
+                                 "add-groups,fix-end-time"
+                                 10
+                                 false))
+    (testing "migrate es indexes"
+      (let [logger (atom [])]
+        (with-atom-logger logger
+          (sut/migrate-store-indexes "foo"
+                                     "add-groups,fix-end-time"
+                                     10
+                                     true))
+
+        (testing "shall produce valid logs"
+          (let [messages (set @logger)]
+            (is (contains? messages "set batch size: 10"))
+            (is (clojure.set/subset?
+                 ["campaign - finished migrating 100 documents"
+                  "indicator - finished migrating 100 documents"
+                  "exploit-target - finished migrating 100 documents"
+                  "event - finished migrating 1000 documents"
+                  "actor - finished migrating 100 documents"
+                  "relationship - finished migrating 100 documents"
+                  "incident - finished migrating 100 documents"
+                  "coa - finished migrating 100 documents"
+                  "identity - finished migrating 1 documents"
+                  "judgement - finished migrating 100 documents"
+                  "data-table - finished migrating 0 documents"
+                  "feedback - finished migrating 0 documents"
+                  "sighting - finished migrating 100 documents"
+                  "ttp - finished migrating 100 documents"]
+                 messages))))
+
+        (testing "shall produce new indices with enough documents"
+          (let [{:keys [default
+                        data-table
+                        relationship
+                        judgement
+                        exploit-target
+                        coa
+                        ttp
+                        incident
+                        event
+                        indicator
+                        campaign
+                        sighting
+                        actor]
+                 :as es-props}
+                (get-in @props/properties [:ctia :store :es])
+                expected-indices
+                (->> {(:indexname relationship) fixtures-nb
+                      (:indexname judgement) fixtures-nb
+                      (:indexname exploit-target) fixtures-nb
+                      (:indexname coa) fixtures-nb
+                      (:indexname ttp) fixtures-nb
+                      (:indexname incident) fixtures-nb
+                      (:indexname event) (* (count (keys examples)) fixtures-nb)
+                      (:indexname indicator) fixtures-nb
+                      (:indexname campaign) fixtures-nb
+                      (:indexname sighting) fixtures-nb
+                      (:indexname actor) fixtures-nb}
+                     (map (fn [[k v]] {(str k "_foo") v}))
+                     (into {})
+                     clojure.walk/keywordize-keys)
+                refreshes (doseq [index (keys expected-indices)]
+                            (refresh-index (:host default)
+                                           (:port default) (name index)))
+                cat-indices-url
+                (format "http://%s:%s/_cat/indices?format=json&pretty=true"
+                        (:host default)
+                        (:port default))
+                {:keys [body]
+                 :as cat-response}
+                (client/get cat-indices-url {:as :json})
+                formatted-cat-indices
+                (->> body
+                     (map (fn [{:keys [index]
+                               :as entry}]
+                            {index (read-string
+                                    (:docs.count entry))}))
+                     (into {})
+                     clojure.walk/keywordize-keys)]
+
+            (is (= expected-indices
+                   (select-keys formatted-cat-indices
+                                (keys expected-indices))))))))))

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -69,32 +69,11 @@
    :sightings (n-doc sighting-minimal fixtures-nb)
    :ttps (n-doc ttp-minimal fixtures-nb)})
 
-(deftest add-groups-test
-  (is (= (transduce sut/add-groups conj [{}])
-         [{:groups ["tenzin"]}]))
-  (is (= (transduce sut/add-groups conj [{:groups []}])
-         [{:groups ["tenzin"]}]))
-  (is (= (transduce sut/add-groups conj [{:groups ["foo"]}])
-         [{:groups ["foo"]}])))
-
-(deftest fix-end-time-test
-  (is (= (transduce sut/fix-end-time conj [{}]) [{}]))
-  (is (= (transduce sut/fix-end-time conj
-                    [{:valid_time
-                      {:start_time "foo"}}])
-         [{:valid_time
-           {:start_time "foo"}}]))
-  (is (= (transduce sut/fix-end-time conj
-                    [{:valid_time
-                      {:end_time #inst "2535-01-01T00:00:00.000-00:00"}}])
-         [{:valid_time
-           {:end_time #inst "2525-01-01T00:00:00.000-00:00"}}]))
-
-  (is (= (transduce sut/fix-end-time conj
-                    [{:valid_time
-                      {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])
-         [{:valid_time
-           {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])))
+(deftest prefixed-index-test
+  (is (= "v0.4.2_ctia_actor"
+         (sut/prefixed-index "ctia_actor" "0.4.2")))
+  (is (= "v0.4.2_ctia_actor"
+         (sut/prefixed-index "v0.4.1_ctia_actor" "0.4.2"))))
 
 (deftest test-migrate-store-indexes
   (helpers/set-capabilities! "foouser"
@@ -109,15 +88,15 @@
   (testing "migrate ES Stores test setup"
     (post-bulk examples)
     (testing "simulate migrate es indexes"
-      (sut/migrate-store-indexes "foo"
-                                 "add-groups,fix-end-time"
+      (sut/migrate-store-indexes "0.0.0"
+                                 [:0.4.16]
                                  10
                                  false))
     (testing "migrate es indexes"
       (let [logger (atom [])]
         (with-atom-logger logger
-          (sut/migrate-store-indexes "foo"
-                                     "__test"
+          (sut/migrate-store-indexes "0.0.0"
+                                     [:__test]
                                      10
                                      true))
 
@@ -172,7 +151,7 @@
                       sighting fixtures-nb
                       actor fixtures-nb}
                      (map (fn [[k v]]
-                            {(str  "foo_" (:indexname k)) v}))
+                            {(str  "v0.0.0_" (:indexname k)) v}))
                      (into {})
                      keywordize-keys)
                 refreshes

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -1,0 +1,103 @@
+(ns ctia.task.migrate-es-stores-test
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.task.migrate-es-stores :as sut]
+            [ctia.test-helpers
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post]]
+             [es :as es-helpers]
+             [fake-whoami-service :as whoami-helpers]]
+            [ctim.examples
+             [actors :refer [actor-maximal]]
+             [campaigns :refer [campaign-maximal]]
+             [coas :refer [coa-maximal]]
+             [exploit-targets :refer [exploit-target-maximal]]
+             [incidents :refer [incident-maximal]]
+             [indicators :refer [indicator-maximal]]
+             [judgements :refer [judgement-maximal]]
+             [relationships :refer [relationship-maximal]]
+             [sightings :refer [sighting-maximal]]
+             [ttps :refer [ttp-maximal]]]))
+
+(use-fixtures :once
+  (join-fixtures [mth/fixture-schema-validation
+                  helpers/fixture-properties:clean
+                  es-helpers/fixture-properties:es-store
+                  helpers/fixture-ctia
+                  whoami-helpers/fixture-server
+                  es-helpers/fixture-delete-store-indexes]))
+
+(use-fixtures :each
+  whoami-helpers/fixture-reset-state)
+
+(def fixtures-nb 200)
+
+(defn post-bulk [examples]
+  (let [{status :status
+         bulk-res :parsed-body}
+        (post "ctia/bulk"
+              :body examples
+              :headers {"Authorization" "45c1f5e3f05d0"})]
+    (is (= 201 status))))
+
+(defn randomize [doc]
+  (assoc doc
+         :id (str "transient:"
+                  (str (java.util.UUID/randomUUID)))))
+
+(defn n-doc [fixture nb]
+  (map randomize (repeat nb fixture)))
+
+(def examples
+  {:actors (n-doc actor-maximal fixtures-nb)
+   :campaigns (n-doc campaign-maximal fixtures-nb)
+   :coas (n-doc coa-maximal fixtures-nb)
+   :exploit-targets (n-doc exploit-target-maximal fixtures-nb)
+   :incidents (n-doc incident-maximal fixtures-nb)
+   :indicators (n-doc indicator-maximal fixtures-nb)
+   :judgements (n-doc judgement-maximal fixtures-nb)
+   :relationships (n-doc relationship-maximal fixtures-nb)
+   :sightings (n-doc sighting-maximal fixtures-nb)
+   :ttps (n-doc ttp-maximal fixtures-nb)})
+
+(deftest test-migrate-store-indexes
+  (helpers/set-capabilities! "foouser"
+                             ["foogroup"]
+                             "user"
+                             all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (testing "migrate ES Stores test setup"
+    (post-bulk examples)
+    (testing "simulate migrate es indexes"
+      (sut/migrate-store-indexes "foo"
+                                 "add-groups,fix-end-time"
+                                 100
+                                 false))
+    (testing "migrate es indexes"
+      (sut/migrate-store-indexes "foo"
+                                 "add-groups,fix-end-time"
+                                 100
+                                 true))))
+(deftest add-groups-test
+  (is (= (transduce sut/add-groups conj [{}])
+         [{:groups ["tenzin"]}]))
+  (is (= (transduce sut/add-groups conj [{:groups []}])
+         [{:groups ["tenzin"]}]))
+  (is (= (transduce sut/add-groups conj [{:groups ["foo"]}])
+         [{:groups ["foo"]}])))
+
+(deftest fix-end-time-test
+  (is (= (transduce sut/fix-end-time conj [{}]) [{}]))
+  (is (= (transduce sut/fix-end-time conj [{:valid_time
+                                            {:start_time "foo"}}])
+         [{:valid_time
+           {:start_time "foo"}}]))
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:end_time "2535"}}])
+         [{:valid_time
+           {:end_time "2525"}}])))

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -79,15 +79,22 @@
 
 (deftest fix-end-time-test
   (is (= (transduce sut/fix-end-time conj [{}]) [{}]))
-  (is (= (transduce sut/fix-end-time conj [{:valid_time
-                                            {:start_time "foo"}}])
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:start_time "foo"}}])
          [{:valid_time
            {:start_time "foo"}}]))
   (is (= (transduce sut/fix-end-time conj
                     [{:valid_time
-                      {:end_time "2535"}}])
+                      {:end_time #inst "2535-01-01T00:00:00.000-00:00"}}])
          [{:valid_time
-           {:end_time "2525"}}])))
+           {:end_time #inst "2525-01-01T00:00:00.000-00:00"}}]))
+
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])
+         [{:valid_time
+           {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])))
 
 (deftest test-migrate-store-indexes
   (helpers/set-capabilities! "foouser"

--- a/test/ctia/task/migrations_test.clj
+++ b/test/ctia/task/migrations_test.clj
@@ -1,0 +1,30 @@
+(ns ctia.task.migrations-test
+  (:require [clojure.test :refer [deftest is]]
+            [ctia.task.migrations :as sut]))
+
+(deftest add-groups-test
+  (is (= (transduce sut/add-groups conj [{}])
+         [{:groups ["tenzin"]}]))
+  (is (= (transduce sut/add-groups conj [{:groups []}])
+         [{:groups ["tenzin"]}]))
+  (is (= (transduce sut/add-groups conj [{:groups ["foo"]}])
+         [{:groups ["foo"]}])))
+
+(deftest fix-end-time-test
+  (is (= (transduce sut/fix-end-time conj [{}]) [{}]))
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:start_time "foo"}}])
+         [{:valid_time
+           {:start_time "foo"}}]))
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:end_time #inst "2535-01-01T00:00:00.000-00:00"}}])
+         [{:valid_time
+           {:end_time #inst "2525-01-01T00:00:00.000-00:00"}}]))
+
+  (is (= (transduce sut/fix-end-time conj
+                    [{:valid_time
+                      {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])
+         [{:valid_time
+           {:end_time #inst "2524-01-01T00:00:00.000-00:00"}}])))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -203,3 +203,14 @@
    (id/->id (keyword entity-name)
             (fake-short-id entity-name id)
             (get-in @properties [:ctia :http :show]))))
+
+(defmacro with-atom-logger
+  [atom-logger & body]
+  `(let [patched-log#
+         (fn [logger#
+             level#
+             throwable#
+             message#]
+           (swap! ~atom-logger conj message#))]
+     (with-redefs [clojure.tools.logging/log* patched-log#]
+       ~@body)))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -10,12 +10,13 @@
             [ctia.stores.es.store :as es-store]
             [ctia.test-helpers.core :as h]))
 
-(defn fixture-delete-store-indexes [test]
+(defn fixture-delete-store-indexes
   "walk through all the es stores delete each store indexes"
+  [t]
   (doseq [store-impls (vals @store/stores)
           {:keys [state]} store-impls]
     (es-store/delete-state-indexes state))
-  (test))
+  (t))
 
 (defn purge-event-indexes []
   (let [{:keys [conn index]} (es-store/init-store-conn
@@ -25,13 +26,14 @@
     (when conn
       (es-index/delete! conn (str index "*")))))
 
-(defn fixture-purge-event-indexes [test]
+(defn fixture-purge-event-indexes
   "walk through all producers and delete their index"
+  [t]
   (purge-event-indexes)
-  (test)
+  (t)
   (purge-event-indexes))
 
-(defn fixture-properties:es-store [test]
+(defn fixture-properties:es-store [t]
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.store.es.default.shards" 1
                       "ctia.store.es.default.replicas" 1
@@ -53,36 +55,36 @@
                       "ctia.store.relationship" "es"
                       "ctia.store.sighting" "es"
                       "ctia.store.ttp" "es"]
-    (test)))
+    (t)))
 
-(defn fixture-properties:es-hook [test]
+(defn fixture-properties:es-hook [t]
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.hook.es.enabled" true
                       "ctia.hook.es.port" 9200
                       "ctia.hook.es.indexname" "test_ctia_events"]
-    (test)))
+    (t)))
 
-(defn fixture-properties:es-hook:aliased-index [test]
+(defn fixture-properties:es-hook:aliased-index [t]
   ;; Note: These properties may be overwritten by ENV variables
   (h/with-properties ["ctia.hook.es.enabled" true
                       "ctia.hook.es.port" 9200
                       "ctia.hook.es.indexname" "test_ctia_events"
                       "ctia.hook.es.slicing.strategy" "aliased-index"
                       "ctia.hook.es.slicing.granularity" "week"]
-    (test)))
+    (t)))
 
-(defn- url-for-type [type]
+(defn- url-for-type [t]
   (assert (keyword? type) "Type must be a keyword")
   (let [{:keys [indexname host port]}
         (-> @ctia.store/stores
-            type
+            t
             first
             :state
             :props)]
     (assert (seq host) "Missing host")
     (assert (integer? port) "Missing port")
     (assert (seq indexname) "Missing index-name")
-    (str "http://" host ":" port "/" indexname "/" (name type) "/?refresh=true")))
+    (str "http://" host ":" port "/" indexname "/" (name t) "/?refresh=true")))
 
 (defn post-to-es [obj]
   (let [{:keys [status] :as response}


### PR DESCRIPTION

This PR introduces a new task to execute an ES index migration, along with migration operations for switching current deployed instances to private CTIA.

- the migration task duplicates indexes instead of modifying documents in place
- transforms are done in fixed batches
- uses ES bulk inserts for performance considerations
- migration operations are composed using clojure transducers