### PR TITLE
Replacing short IDs by URL IDs in tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.19"]
+                 [threatgrid/ctim "0.4.20-SNAPSHOT"]
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version
                   :exclusions [com.google.code.findbugs/jsr305
@@ -85,7 +85,7 @@
                  [ring-cors "0.1.8"]
 
                  ;; Hooks
-                 [redismq "0.1.0"]
+                 [redismq "0.1.0-SNAPSHOT"]
 
                  ;; GraphQL
                  [base64-clj "0.1.1"]

--- a/test/ctia/http/routes/observable/judgements_indicators_test.clj
+++ b/test/ctia/http/routes/observable/judgements_indicators_test.clj
@@ -41,7 +41,7 @@
     (testing "test setup: create judgement-1"
       (let [{status :status}
             (post "ctia/judgement"
-                  :body {:id (:short-id judgement-1-id)
+                  :body {:id (id/long-id judgement-1-id)
                          :observable observable-1
                          :source "source"
                          :priority 99
@@ -55,7 +55,7 @@
     (testing "test setup: create judgement-2"
       (let [{status :status}
             (post "ctia/judgement"
-                  :body {:id (:short-id judgement-2-id)
+                  :body {:id (id/long-id judgement-2-id)
                          :observable observable-1
                          :source "source"
                          :priority 99
@@ -80,7 +80,7 @@
     (testing "test setup: create judgement-3"
       (let [{status :status}
             (post "ctia/judgement"
-                  :body {:id (:short-id judgement-3-id)
+                  :body {:id (id/long-id judgement-3-id)
                          :observable observable-2
                          :source "source"
                          :priority 99
@@ -94,7 +94,7 @@
     (testing "test setup: create indicator-1"
       (let [{status :status}
             (post "ctia/indicator"
-                  :body {:id (:short-id indicator-1-id)
+                  :body {:id (id/long-id indicator-1-id)
                          :producer "producer"
                          :external_ids ["indicator-1"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -104,7 +104,7 @@
     (testing "test setup: create indicator-2"
       (let [{status :status}
             (post "ctia/indicator"
-                  :body {:id (:short-id indicator-2-id)
+                  :body {:id (id/long-id indicator-2-id)
                          :producer "producer"
                          :external_ids ["indicator-2"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -115,7 +115,7 @@
                   "based on indicator-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-1-id)
+                  :body {:id (id/long-id relationship-1-id)
                          :source_ref (id/long-id judgement-1-id)
                          :relationship_type "based-on"
                          :target_ref (id/long-id indicator-1-id)
@@ -128,7 +128,7 @@
                   "based on indicator-2")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-2-id)
+                  :body {:id (id/long-id relationship-2-id)
                          :source_ref (id/long-id judgement-3-id)
                          :relationship_type "based-on"
                          :target_ref (id/long-id indicator-2-id)
@@ -141,7 +141,7 @@
                   "based on sighting-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-3-id)
+                  :body {:id (id/long-id relationship-3-id)
                          :source_ref (id/long-id judgement-1-id)
                          :relationship_type "based-on"
                          :target_ref (id/long-id sighting-1-id)

--- a/test/ctia/http/routes/observable/sightings_incidents_test.clj
+++ b/test/ctia/http/routes/observable/sightings_incidents_test.clj
@@ -41,7 +41,7 @@
     (testing "test setup: create sighting-1"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-1-id)
+                  :body {:id (id/long-id sighting-1-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-1]
@@ -53,7 +53,7 @@
     (testing "test setup: create sighting-2"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-2-id)
+                  :body {:id (id/long-id sighting-2-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-1]
@@ -65,7 +65,7 @@
     (testing "test setup: create sighting-3"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-3-id)
+                  :body {:id (id/long-id sighting-3-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-2]
@@ -91,7 +91,7 @@
     (testing "test setup: create incident-1"
       (let [{status :status}
             (post "ctia/incident"
-                  :body {:id (:short-id incident-1-id)
+                  :body {:id (id/long-id incident-1-id)
                          :confidence "High"
                          :external_ids ["incident-1"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -101,7 +101,7 @@
     (testing "test setup: create incident-1"
       (let [{status :status}
             (post "ctia/incident"
-                  :body {:id (:short-id incident-2-id)
+                  :body {:id (id/long-id incident-2-id)
                          :confidence "High"
                          :external_ids ["incident-2"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -112,7 +112,7 @@
                   "member of incident-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-1-id)
+                  :body {:id (id/long-id relationship-1-id)
                          :source_ref (id/long-id sighting-1-id)
                          :relationship_type "member-of"
                          :target_ref (id/long-id incident-1-id)
@@ -125,7 +125,7 @@
                   "member of incident-2")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-2-id)
+                  :body {:id (id/long-id relationship-2-id)
                          :source_ref (id/long-id sighting-3-id)
                          :relationship_type "member-of"
                          :target_ref (id/long-id incident-2-id)
@@ -138,7 +138,7 @@
                   "based on judgement-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-3-id)
+                  :body {:id (id/long-id relationship-3-id)
                          :source_ref (id/long-id sighting-3-id)
                          :relationship_type "based-on"
                          :target_ref (id/long-id judgement-1-id)

--- a/test/ctia/http/routes/observable/sightings_indicators_test.clj
+++ b/test/ctia/http/routes/observable/sightings_indicators_test.clj
@@ -41,7 +41,7 @@
     (testing "test setup: create sighting-1"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-1-id)
+                  :body {:id (id/long-id sighting-1-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-1]
@@ -53,7 +53,7 @@
     (testing "test setup: create sighting-2"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-2-id)
+                  :body {:id (id/long-id sighting-2-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-1]
@@ -65,7 +65,7 @@
     (testing "test setup: create sighting-3"
       (let [{status :status}
             (post "ctia/sighting"
-                  :body {:id (:short-id sighting-3-id)
+                  :body {:id (id/long-id sighting-3-id)
                          :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                          :end_time #inst "2016-02-11T00:40:48.212-00:00"}
                          :observables [observable-2]
@@ -90,7 +90,7 @@
     (testing "test setup: create indicator-1"
       (let [{status :status}
             (post "ctia/indicator"
-                  :body {:id (:short-id indicator-1-id)
+                  :body {:id (id/long-id indicator-1-id)
                          :producer "producer"
                          :external_ids ["indicator-1"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -100,7 +100,7 @@
     (testing "test setup: create indicator-2"
       (let [{status :status}
             (post "ctia/indicator"
-                  :body {:id (:short-id indicator-2-id)
+                  :body {:id (id/long-id indicator-2-id)
                          :producer "producer"
                          :external_ids ["indicator-2"]}
                   :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -111,7 +111,7 @@
                   "indication of indicator-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-1-id)
+                  :body {:id (id/long-id relationship-1-id)
                          :source_ref (id/long-id sighting-1-id)
                          :relationship_type "indicates"
                          :target_ref (id/long-id indicator-1-id)
@@ -124,7 +124,7 @@
                   "indication of indicator-2")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-2-id)
+                  :body {:id (id/long-id relationship-2-id)
                          :source_ref (id/long-id sighting-3-id)
                          :relationship_type "indicates"
                          :target_ref (id/long-id indicator-2-id)
@@ -137,7 +137,7 @@
                   "based on judgement-1")
       (let [{status :status}
             (post "ctia/relationship"
-                  :body {:id (:short-id relationship-3-id)
+                  :body {:id (id/long-id relationship-3-id)
                          :source_ref (id/long-id sighting-3-id)
                          :relationship_type "based-on"
                          :target_ref (id/long-id judgement-1-id)

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -8,7 +8,7 @@
             [ctia.properties :refer [properties]]
             [ctia.schemas.core] ;; for spec side-effects
             [ctia.test-helpers
-             [core :as helpers]
+             [core :as helpers :refer [url-id]]
              [http :refer [assert-post]]
              [pagination :refer [pagination-test
                                  pagination-test-no-sort]]
@@ -27,18 +27,21 @@
                     :value "1.2.3.4"}
         title "test"
         new-indicators (->> (csg/sample (cs/gen :new-indicator/map 5))
-                            (map #(assoc % :title title)))
+                            (map #(assoc % :title title))
+                            (map #(assoc % :id (url-id :indicator))))
         created-indicators (map #(assert-post "ctia/indicator" %)
                                 new-indicators)
         new-judgements (->> (csg/sample (cs/gen :new-judgement/map) 5)
                             (map #(assoc %
                                          :observable observable
                                          :disposition 5
-                                         :disposition_name "Unknown")))
+                                         :disposition_name "Unknown"))
+                            (map #(assoc % :id (url-id :judgement))))
         new-sightings (->> (csg/sample (cs/gen :new-sighting/map) 5)
                            (map #(-> (assoc %
                                             :observables [observable])
-                                     (dissoc % :relations))))
+                                     (dissoc % :relations)))
+                           (map #(assoc % :id (url-id :sighting))))
         route-pref (str "ctia/" (:type observable) "/" (:value observable))]
 
     (testing "setup: create sightings and their relationships with indicators"

--- a/test/ctia/http/routes/sighting_test.clj
+++ b/test/ctia/http/routes/sighting_test.clj
@@ -11,7 +11,7 @@
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [access-control :refer [access-control-test]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [delete get post put url-id]]
              [fake-whoami-service :as whoami-helpers]
              [http :refer [api-key]]
              [search :refer [test-query-string-search]]
@@ -35,7 +35,7 @@
     (let [{status :status
            sighting :parsed-body}
           (post "ctia/sighting"
-                :body {:id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c"
+                :body {:id (url-id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c" :sighting)
                        :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                                       "http://ex.tld/ctia/sighting/sighting-345"]
                        :timestamp "2016-02-11T00:40:48.212-00:00"
@@ -124,7 +124,7 @@
         (let [{status :status
                updated-sighting :parsed-body}
               (put (str "ctia/sighting/" (:short-id sighting-id))
-                   :body {:id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c"
+                   :body {:id (url-id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c" :sighting)
                           :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                                          "http://ex.tld/ctia/sighting/sighting-345"]
                           :timestamp "2016-02-11T00:40:48.212-00:00"
@@ -157,7 +157,7 @@
         (let [{status :status
                body :body}
               (put (str "ctia/sighting/" (:short-id sighting-id))
-                   :body {:id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c"
+                   :body {:id (url-id "sighting-7d24c22a-96e3-40fb-81d3-eae158f0770c" :sighting)
                           :external_ids ["http://ex.tld/ctia/sighting/sighting-123"
                                          "http://ex.tld/ctia/sighting/sighting-345"]
                           :timestamp "2016-02-11T00:40:48.212-00:00"

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -183,6 +183,15 @@
            (crud/make-id (name type-kw))
            (get-in @properties [:ctia :http :show])))
 
+(defn url-id
+  ([type-kw]
+   (url-id (crud/make-id (name type-kw)) type-kw))
+  ([short-id type-kw]
+   (id/long-id
+    (id/short-id->id (name type-kw)
+                     short-id
+                     (get-in @properties [:ctia :http :show])))))
+
 (def zero-uuid "00000000-0000-0000-0000-000000000000")
 
 (defn fake-short-id


### PR DESCRIPTION
Short IDs are no more valid for entities. See [CTIM](https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/common.cljc#L60) for more information

All short IDs in the tests have been replaced with URL IDs