### PR TITLE
Investigation GraphQL endpoint

### DIFF
--- a/src/ctia/schemas/graphql.clj
+++ b/src/ctia/schemas/graphql.clj
@@ -5,6 +5,9 @@
              [indicator :as indicator
               :refer [IndicatorType
                       IndicatorConnectionType]]
+             [investigation :as investigation
+              :refer [InvestigationType
+                      InvestigationConnectionType]]
              [judgement :as judgement
               :refer [JudgementType
                       JudgementConnectionType]]
@@ -40,13 +43,23 @@
    {:indicator {:type IndicatorType
                 :args search-by-id-args
                 :resolve (fn [context args _] (res/indicator-by-id
-                                              (:id args)
-                                              (:ident context)))}
+                                               (:id args)
+                                               (:ident context)))}
     :indicators {:type IndicatorConnectionType
                  :args (merge common/lucene-query-arguments
                               indicator/indicator-order-arg
                               p/connection-arguments)
                  :resolve res/search-indicators}
+    :investigation {:type InvestigationType
+                    :args search-by-id-args
+                    :resolve (fn [context args _] (res/investigation-by-id
+                                                   (:id args)
+                                                   (:ident context)))}
+    :investigations {:type InvestigationConnectionType
+                     :args (merge common/lucene-query-arguments
+                                  investigation/investigation-order-arg
+                                  p/connection-arguments)
+                     :resolve res/search-investigations}
     :judgement {:type JudgementType
                 :args search-by-id-args
                 :resolve (fn [context args _]

--- a/src/ctia/schemas/graphql/investigation.clj
+++ b/src/ctia/schemas/graphql/investigation.clj
@@ -1,0 +1,31 @@
+(ns ctia.schemas.graphql.investigation
+  (:require [ctia.schemas.graphql
+             [flanders :as flanders]
+             [helpers :as g]
+             [pagination :as pagination]
+             [refs :as refs]
+             [sorting :as sorting]]
+            [ctia.schemas.sorting :as sort-fields]
+            [ctim.schemas.investigation :as ctim-investigation]))
+
+(def InvestigationType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         ctim-investigation/Investigation
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     fields)))
+
+(def investigation-order-arg
+  (sorting/order-by-arg
+   "InvestigationOrder"
+   "investigations"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              sort-fields/investigation-sort-fields))))
+
+(def InvestigationConnectionType
+  (pagination/new-connection InvestigationType))

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -4,6 +4,7 @@
             [ctia.domain.entities
              [feedback :as ctim-feedback-entity]
              [indicator :as ctim-indicator-entity]
+             [investigation :as ctim-investigation-entity]
              [judgement :as ctim-judgement-entity]
              [relationship :as ctim-relationship-entity]
              [sighting :as ctim-sighting-entity]]
@@ -77,6 +78,25 @@
   (some-> (read-store :indicator read-indicator id ident)
           ctim-indicator-entity/with-long-id
           ctim-entities/un-store))
+
+;;---- Investigation
+
+(defn search-investigations
+  [context args src]
+  (search-entity :investigation
+                 (:query args)
+                 {}
+                 args
+                 (:ident context)
+                 ctim-investigation-entity/page-with-long-id))
+
+(s/defn investigation-by-id
+  [id :- s/Str
+   ident]
+  (some-> (read-store :investigation read-investigation id ident)
+          ctim-investigation-entity/with-long-id
+          ctim-entities/un-store))
+
 
 ;;---- Judgement
 

--- a/src/ctia/schemas/sorting.clj
+++ b/src/ctia/schemas/sorting.clj
@@ -48,6 +48,9 @@
            :likely_impact
            :confidence]))
 
+(def investigation-sort-fields
+  base-entity-sort-fields)
+
 (def relationship-sort-fields
   (concat default-entity-sort-fields
           describable-entity-sort-fields

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -102,6 +102,14 @@
    "valid_time" {"start_time" "2016-05-11T00:40:48.000Z"
                  "end_time" "2025-07-11T00:40:48.000Z"}})
 
+(def investigation-1
+  {"source" "foo"
+   "title" "foo"})
+
+(def investigation-2
+  {"source" "bar"
+   "title" "foo"})
+
 (def sighting-1
   {"description" "Hostnames that have resolved to 194.87.217.88"
    "confidence" "High"
@@ -145,14 +153,16 @@
    :entity_id entity_id})
 
 (defn initialize-graphql-data []
-  (let [i1 (gh/create-object "indicator" indicator-1)
-        i2 (gh/create-object "indicator" indicator-2)
-        i3 (gh/create-object "indicator" indicator-3)
-        j1 (gh/create-object "judgement" judgement-1)
-        j2 (gh/create-object "judgement" judgement-2)
-        j3 (gh/create-object "judgement" judgement-3)
-        s1 (gh/create-object "sighting" sighting-1)
-        s2 (gh/create-object "sighting" sighting-2)]
+  (let [i1  (gh/create-object "indicator" indicator-1)
+        i2  (gh/create-object "indicator" indicator-2)
+        i3  (gh/create-object "indicator" indicator-3)
+        in1 (gh/create-object "investigation" investigation-1)
+        in2 (gh/create-object "investigation" investigation-2)
+        j1  (gh/create-object "judgement" judgement-1)
+        j2  (gh/create-object "judgement" judgement-2)
+        j3  (gh/create-object "judgement" judgement-3)
+        s1  (gh/create-object "sighting" sighting-1)
+        s2  (gh/create-object "sighting" sighting-2)]
     (gh/create-object "feedback" (feedback-1 (:id i1)))
     (gh/create-object "feedback" (feedback-2 (:id i1)))
     (gh/create-object "feedback" (feedback-1 (:id j1)))
@@ -160,40 +170,42 @@
     (gh/create-object "feedback" (feedback-1 (:id s1)))
     (gh/create-object "feedback" (feedback-2 (:id s1)))
     (gh/create-object "relationship"
-                   {:relationship_type "element-of"
-                    :target_ref (:id i1)
-                    :source_ref (:id j1)})
+                      {:relationship_type "element-of"
+                       :target_ref (:id i1)
+                       :source_ref (:id j1)})
     (gh/create-object "relationship"
-                   {:relationship_type "element-of"
-                    :target_ref (:id i2)
-                    :source_ref (:id j1)})
+                      {:relationship_type "element-of"
+                       :target_ref (:id i2)
+                       :source_ref (:id j1)})
     (gh/create-object "relationship"
-                   {:relationship_type "element-of"
-                    :target_ref (:id i1)
-                    :source_ref (:id j2)})
+                      {:relationship_type "element-of"
+                       :target_ref (:id i1)
+                       :source_ref (:id j2)})
     (gh/create-object "relationship"
-                   {:relationship_type "element-of"
-                    :target_ref (:id i1)
-                    :source_ref (:id j3)})
+                      {:relationship_type "element-of"
+                       :target_ref (:id i1)
+                       :source_ref (:id j3)})
     (gh/create-object "relationship"
-                   {:relationship_type "indicates"
-                    :target_ref (:id i1)
-                    :source_ref (:id s1)})
+                      {:relationship_type "indicates"
+                       :target_ref (:id i1)
+                       :source_ref (:id s1)})
     (gh/create-object "relationship"
                       {:relationship_type "indicates"
                        :target_ref (:id i2)
                        :source_ref (:id s1)})
     (gh/create-object "relationship"
-                   {:relationship_type "variant-of"
-                    :target_ref (:id i2)
-                    :source_ref (:id i1)})
+                      {:relationship_type "variant-of"
+                       :target_ref (:id i2)
+                       :source_ref (:id i1)})
     (gh/create-object "relationship"
-                   {:relationship_type "variant-of"
-                    :target_ref (:id i3)
-                    :source_ref (:id i1)})
+                      {:relationship_type "variant-of"
+                       :target_ref (:id i3)
+                       :source_ref (:id i1)})
     {:indicator-1 i1
      :indicator-2 i2
      :indicator-3 i3
+     :investigation-1 in1
+     :investigation-2 in2
      :judgement-1 j1
      :judgement-2 j2
      :judgement-3 j3
@@ -210,6 +222,8 @@
         indicator-1-id (get-in datamap [:indicator-1 :id])
         indicator-2-id (get-in datamap [:indicator-2 :id])
         indicator-3-id (get-in datamap [:indicator-3 :id])
+        investigation-1-id (get-in datamap [:investigation-1 :id])
+        investigation-2-id (get-in datamap [:investigation-2 :id])
         judgement-1-id (get-in datamap [:judgement-1 :id])
         judgement-2-id (get-in datamap [:judgement-2 :id])
         judgement-3-id (get-in datamap [:judgement-3 :id])
@@ -415,7 +429,6 @@
                sort-fields/feedback-sort-fields)))))
 
       (testing "indicators query"
-
         (testing "indicators connection"
           (gh/connection-test "IndicatorsQueryTest"
                               graphql-queries
@@ -445,6 +458,49 @@
             (is (= [(:indicator-1 datamap)]
                    (get-in data [:indicators :nodes]))
                 "The indicator matches the search query"))))
+
+      (testing "investigation query"
+        (let [{:keys [data errors status]}
+              (gh/query graphql-queries
+                        {:id investigation-1-id}
+                        "InvestigationQueryTest")]
+
+          (is (= 200 status))
+          (is (empty? errors) "No errors")
+
+          (testing "the investigation"
+            (is (= (:investigation-1 datamap)
+                   (:investigation data))))))
+
+      (testing "investigations query"
+        (testing "investigations connection"
+          (gh/connection-test "InvestigationsQueryTest"
+                              graphql-queries
+                              {"query" "*"}
+                              [:investigations]
+                              [(:investigation-1 datamap)
+                               (:investigation-2 datamap)])
+
+          (testing "sorting"
+            (gh/connection-sort-test
+             "InvestigationsQueryTest"
+             graphql-queries
+             {:query "*"}
+             [:investigations]
+             sort-fields/investigation-sort-fields)))
+
+        (testing "query argument"
+          (let [{:keys [data errors status]}
+                (gh/query graphql-queries
+                          {:query "source:\"foo\""}
+                          "InvestigationsQueryTest")]
+            (is (= 200 status))
+            (is (empty? errors) "No errors")
+            (is (= 1 (get-in data [:investigations :totalCount]))
+                "Only one investigation matches to the query")
+            (is (= [(:investigation-1 datamap)]
+                   (get-in data [:investigations :nodes]))
+                "The investigation matches the search query"))))
 
       (testing "sighting query"
         (let [{:keys [data errors status]}

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -239,6 +239,38 @@ fragment indicatorFields on Indicator {
   }
 }
 
+query InvestigationQueryTest($id: String!) {
+  investigation(id: $id) {
+    ...investigationFields
+  }
+}
+
+query InvestigationsQueryTest($query: String, $after: String, $first: Int, $sort_field:InvestigationOrderField = ID, $sort_direction: OrderDirection = asc) {
+  investigations(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...investigationFields
+    }
+    edges {
+      node {
+        ...investigationFields
+      }
+    }
+  }
+}
+
+fragment investigationFields on Investigation {
+  id
+  type
+  schema_version
+  title
+  tlp
+  source
+}
+
 fragment relationshipBaseFields on Relationship {
   relationship_type
   target_ref


### PR DESCRIPTION
As Investigations could turn to be very large records, I Added an Investigation GraphQL endpoint.
This should provide more efficient Investigation listing capabilities and significantly reduce Investigation API list load times.