### PR TITLE
Resolve transient IDs for the bulk POST route

### DIFF
--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -42,7 +42,8 @@
             NewTool
             StoredTool
             NewRelationship
-            StoredRelationship]])
+            StoredRelationship
+            TempIDs]])
   (:import [java.util UUID]))
 
 (def schema-version ctim-schema-version)
@@ -58,13 +59,13 @@
   (s/fn default-realize :- StoredModel
     ([new-object :- Model
       id :- s/Str
-      tempids :- (s/maybe {s/Str s/Str})
+      tempids :- (s/maybe TempIDs)
       owner :- s/Str
       groups :- [s/Str]]
      (default-realize new-object id tempids owner groups nil))
     ([new-object :- Model
       id :- s/Str
-      tempids :- (s/maybe {s/Str s/Str})
+      tempids :- (s/maybe TempIDs)
       owner :- s/Str
       groups :- [s/Str]
       prev-object :- (s/maybe StoredModel)]
@@ -107,7 +108,7 @@
 (s/defn realize-feedback :- StoredFeedback
   [new-feedback :- NewFeedback
    id :- s/Str
-   tempids :- {s/Str s/Str}
+   tempids :- (s/maybe TempIDs)
    owner :- s/Str
    groups :- [s/Str]]
   (assoc new-feedback
@@ -132,7 +133,7 @@
   [{:keys [source_ref target_ref]
     :as new-relationship} :- NewRelationship
    id :- s/Str
-   tempids :- (s/maybe {s/Str s/Str})
+   tempids :- (s/maybe TempIDs)
    owner :- s/Str
    groups :- [s/Str]]
 
@@ -150,7 +151,7 @@
 (s/defn realize-judgement :- StoredJudgement
   [new-judgement :- NewJudgement
    id :- s/Str
-   tempids :- (s/maybe {s/Str s/Str})
+   tempids :- (s/maybe TempIDs)
    owner :- s/Str
    groups :- [s/Str]]
   (let [now (time/now)
@@ -185,13 +186,13 @@
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting
     id :- s/Str
-    tempids :- (s/maybe {s/Str s/Str})
+    tempids :- (s/maybe TempIDs)
     owner :- s/Str
     groups :- [s/Str]]
    (realize-sighting new-sighting id tempids owner groups nil))
   ([new-sighting :- NewSighting
     id :- s/Str
-    tempids :- (s/maybe {s/Str s/Str})
+    tempids :- (s/maybe TempIDs)
     owner :- s/Str
     groups :- [s/Str]
     prev-sighting :- (s/maybe StoredSighting)]

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -58,11 +58,13 @@
   (s/fn default-realize :- StoredModel
     ([new-object :- Model
       id :- s/Str
+      tempids :- {s/Str s/Str}
       owner :- s/Str
       groups :- [s/Str]]
-     (default-realize new-object id owner groups nil))
+     (default-realize new-object id tempids owner groups nil))
     ([new-object :- Model
       id :- s/Str
+      tempids :- {s/Str s/Str}
       owner :- s/Str
       groups :- [s/Str]
       prev-object :- (s/maybe StoredModel)]
@@ -105,6 +107,7 @@
 (s/defn realize-feedback :- StoredFeedback
   [new-feedback :- NewFeedback
    id :- s/Str
+   tempids :- {s/Str s/Str}
    owner :- s/Str
    groups :- [s/Str]]
   (assoc new-feedback
@@ -126,13 +129,18 @@
   (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
 
 (s/defn realize-relationship :- StoredRelationship
-  [new-relationship :- NewRelationship
+  [{:keys [source_ref target_ref]
+    :as new-relationship} :- NewRelationship
    id :- s/Str
+   tempids :- {s/Str s/Str}
    owner :- s/Str
    groups :- [s/Str]]
+
   (assoc new-relationship
          :id id
          :type "relationship"
+         :source_ref (get tempids source_ref source_ref)
+         :target_ref (get tempids target_ref target_ref)
          :created (time/now)
          :owner owner
          :groups groups
@@ -142,6 +150,7 @@
 (s/defn realize-judgement :- StoredJudgement
   [new-judgement :- NewJudgement
    id :- s/Str
+   tempids :- {s/Str s/Str}
    owner :- s/Str
    groups :- [s/Str]]
   (let [now (time/now)
@@ -176,11 +185,13 @@
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting
     id :- s/Str
+    tempids :- {s/Str s/Str}
     owner :- s/Str
     groups :- [s/Str]]
-   (realize-sighting new-sighting id owner groups nil))
+   (realize-sighting new-sighting id tempids owner groups nil))
   ([new-sighting :- NewSighting
     id :- s/Str
+    tempids :- {s/Str s/Str}
     owner :- s/Str
     groups :- [s/Str]
     prev-sighting :- (s/maybe StoredSighting)]

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -58,13 +58,13 @@
   (s/fn default-realize :- StoredModel
     ([new-object :- Model
       id :- s/Str
-      tempids :- {s/Str s/Str}
+      tempids :- (s/maybe {s/Str s/Str})
       owner :- s/Str
       groups :- [s/Str]]
      (default-realize new-object id tempids owner groups nil))
     ([new-object :- Model
       id :- s/Str
-      tempids :- {s/Str s/Str}
+      tempids :- (s/maybe {s/Str s/Str})
       owner :- s/Str
       groups :- [s/Str]
       prev-object :- (s/maybe StoredModel)]
@@ -132,7 +132,7 @@
   [{:keys [source_ref target_ref]
     :as new-relationship} :- NewRelationship
    id :- s/Str
-   tempids :- {s/Str s/Str}
+   tempids :- (s/maybe {s/Str s/Str})
    owner :- s/Str
    groups :- [s/Str]]
 
@@ -150,7 +150,7 @@
 (s/defn realize-judgement :- StoredJudgement
   [new-judgement :- NewJudgement
    id :- s/Str
-   tempids :- {s/Str s/Str}
+   tempids :- (s/maybe {s/Str s/Str})
    owner :- s/Str
    groups :- [s/Str]]
   (let [now (time/now)
@@ -185,13 +185,13 @@
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting
     id :- s/Str
-    tempids :- {s/Str s/Str}
+    tempids :- (s/maybe {s/Str s/Str})
     owner :- s/Str
     groups :- [s/Str]]
    (realize-sighting new-sighting id tempids owner groups nil))
   ([new-sighting :- NewSighting
     id :- s/Str
-    tempids :- {s/Str s/Str}
+    tempids :- (s/maybe {s/Str s/Str})
     owner :- s/Str
     groups :- [s/Str]
     prev-sighting :- (s/maybe StoredSighting)]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -11,6 +11,7 @@
    [ctia.auth :as auth]
    [ctia.flows.hooks :as h]
    [ctia.properties :refer [properties]]
+   [ctia.schemas.core :refer [TempIDs]]
    [ctia.store :as store]
    [ctim.events.obj-to-event :refer [to-create-event
                                      to-update-event
@@ -31,7 +32,7 @@
    (s/optional-key :realize-fn) (s/pred fn?)
    (s/optional-key :results) [s/Bool]
    (s/optional-key :spec) (s/maybe s/Keyword)
-   (s/optional-key :tempids) (s/maybe {s/Str s/Str})
+   (s/optional-key :tempids) (s/maybe TempIDs)
    (s/optional-key :enveloped-result?) (s/maybe s/Bool)
    :store-fn (s/pred fn?)})
 

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -31,8 +31,8 @@
    (s/optional-key :realize-fn) (s/pred fn?)
    (s/optional-key :results) [s/Bool]
    (s/optional-key :spec) (s/maybe s/Keyword)
-   (s/optional-key :tempids) {s/Str s/Str}
-   (s/optional-key :enveloped-result?) s/Bool
+   (s/optional-key :tempids) (s/maybe {s/Str s/Str})
+   (s/optional-key :enveloped-result?) (s/maybe s/Bool)
    :store-fn (s/pred fn?)})
 
 (defn- find-id

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -31,6 +31,8 @@
    (s/optional-key :realize-fn) (s/pred fn?)
    (s/optional-key :results) [s/Bool]
    (s/optional-key :spec) (s/maybe s/Keyword)
+   (s/optional-key :tempids) {s/Str s/Str}
+   (s/optional-key :enveloped-result?) s/Bool
    :store-fn (s/pred fn?)})
 
 (defn- find-id
@@ -64,9 +66,10 @@
   (str (name entity-type) "-" (UUID/randomUUID)))
 
 (s/defn ^:private find-entity-id :- s/Str
-  [{:keys [identity entity-type prev-entity]} :- FlowMap
+  [{:keys [identity entity-type prev-entity tempids]} :- FlowMap
    entity :- {s/Keyword s/Any}]
   (or (find-id prev-entity)
+      (get tempids (:id entity))
       (when-let [entity-id (find-checked-id entity)]
         (when-not (auth/capable? identity :specify-id)
           (throw (http-response/bad-request!
@@ -96,10 +99,26 @@
                    :entity entity}))))))
   fm)
 
+(s/defn ^:private create-ids-from-transient :- FlowMap
+  "Creates IDs for entities identified by transient IDs that have not
+   yet been resolved."
+  [{:keys [entities
+           entity-type]
+    :as fm} :- FlowMap]
+  (let [newtempids
+        (->> entities
+             (map (fn [{:keys [id]}]
+                    (when (and id (re-matches id/transient-id-re id))
+                      [id (make-id entity-type)])))
+             (remove nil?)
+             (into {}))]
+    (update fm :tempids (fnil into {}) newtempids)))
+
 (s/defn ^:private realize-entities :- FlowMap
   [{:keys [entities
            flow-type
            identity
+           tempids
            prev-entity
            realize-fn] :as fm} :- FlowMap]
   (let [login (auth/login identity)
@@ -112,16 +131,19 @@
               (case flow-type
                 :create (realize-fn entity
                                     entity-id
+                                    tempids
                                     login
                                     groups)
                 :update (if prev-entity
                           (realize-fn entity
                                       entity-id
+                                      tempids
                                       login
                                       groups
                                       prev-entity)
                           (realize-fn entity
                                       entity-id
+                                      tempids
                                       login
                                       groups))
                 :delete entity))))))
@@ -204,13 +226,19 @@
               (store-fn entity))))))
 
 (s/defn ^:private apply-long-id-fn :- FlowMap
-  [{:keys [entities long-id-fn] :as fm}]
+  [{:keys [entities tempids long-id-fn] :as fm}]
   (if long-id-fn
-    (assoc fm
-           :entities
-           (doall
-            (for [entity entities]
-              (long-id-fn entity))))
+    (let [short-ids (map :id entities)
+          new-entities (map long-id-fn entities)
+          long-ids (map :id new-entities)
+          short-to-long-map (zipmap short-ids long-ids)
+          new-tempids (->> tempids
+                           (map (fn [[tempid short-id]]
+                                  [tempid (get short-to-long-map short-id short-id)]))
+                           (into {}))]
+      (assoc fm
+             :entities new-entities
+             :tempids new-tempids))
     fm))
 
 (s/defn ^:private apply-event-hooks :- FlowMap
@@ -220,11 +248,15 @@
   fm)
 
 (s/defn ^:private make-result :- s/Any
-  [{:keys [flow-type] :as fm} :- FlowMap]
+  [{:keys [flow-type entities results
+           enveloped-result? tempids] :as fm} :- FlowMap]
   (case flow-type
-    :create (:entities fm)
-    :delete (first (:results fm))
-    :update (first (:entities fm))))
+    :create (if enveloped-result?
+              (cond-> {:data entities}
+                (seq tempids) (assoc :tempids tempids))
+              entities)
+    :delete (first results)
+    :update (first entities)))
 
 (defn create-flow
   "This function centralizes the create workflow.
@@ -238,18 +270,23 @@
              store-fn
              identity
              entities
+             tempids
              long-id-fn
-             spec]}]
+             spec
+             enveloped-result?]}]
   (-> {:flow-type :create
        :entity-type entity-type
        :entities entities
+       :tempids tempids
        :identity identity
        :long-id-fn long-id-fn
        :realize-fn realize-fn
        :spec spec
        :store-fn store-fn
-       :create-event-fn to-create-event}
+       :create-event-fn to-create-event
+       :enveloped-result? enveloped-result?}
       validate-entities
+      create-ids-from-transient
       realize-entities
       apply-before-hooks
       apply-store-fn

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -78,8 +78,7 @@
           :compojure.api.exception/response-validation ex/response-validation-handler
           :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
           :access-control-error ex/access-control-error-handler
-          :compojure.api.exception/default ex/default-error-handler
-          }}
+          :compojure.api.exception/default ex/default-error-handler}}
         :swagger {:ui "/"
                   :spec "/swagger.json"
                   :options {:ui {:jwtLocalStorageKey

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -78,7 +78,8 @@
           :compojure.api.exception/response-validation ex/response-validation-handler
           :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
           :access-control-error ex/access-control-error-handler
-          :compojure.api.exception/default ex/default-error-handler}}
+          :compojure.api.exception/default ex/default-error-handler
+          }}
         :swagger {:ui "/"
                   :spec "/swagger.json"
                   :options {:ui {:jwtLocalStorageKey

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -153,26 +153,59 @@
           {}
           (keys bulk)))
 
-(defn gen-create-bulk
+(defn tempids
+  "Merges tempids from all entities
+   {:entity-type1 {:data []
+                   :tempids {transientid1 id1
+                             transientid2 id2}}
+    :entity-type2 {:data []
+                   :tempids {transientid3 id3
+                             transientid4 id4}}}
+
+   ->
+
+   {transientid1 id1
+    transientid2 id2
+    transientid3 id3
+    transientid4 id4}
+
+  The create-entities set the enveloped-result? to True in the flow
+  configuration to get :data and :tempids for each entity in the result."
+  [entities]
+  (reduce (fn [acc [_ v]]
+            (into acc (:tempids v)))
+          {}
+          entities))
+
+(defn create-bulk
+  "Creates entities in bulk. To define relationships between entities,
+   transient IDs can be used. They are automatically converted into
+   real IDs.
+
+   1. Creates all entities except Relationships
+   2. Creates Relationships with mapping between transient and real IDs"
   [bulk login]
   (let [new-entities (gen-bulk-from-fn
                       create-entities
                       (dissoc bulk :relationships)
                       {}
                       login)
-        tempids (reduce (fn [acc [_ v]]
-                          (into acc (:tempids v)))
-                        {}
-                        new-entities)
+        entities-tempids (tempids new-entities)
         new-relationships (gen-bulk-from-fn
                            create-entities
                            (select-keys bulk [:relationships])
-                           tempids
-                           login)]
-    (->> (into new-entities new-relationships)
-         (map (fn [[k {:keys [data]}]]
-                {k data}))
-         (into {}))))
+                           entities-tempids
+                           login)
+        all-tempids (merge entities-tempids
+                           (tempids new-relationships))
+        ;; Extracting data from the enveloped flow result
+        ;; {:entity-type {:data [] :tempids {} :errors {}}}
+        bulk-refs (->> (into new-entities new-relationships)
+                       (map (fn [[k {:keys [data]}]]
+                              {k data}))
+                       (into {}))]
+    (cond-> bulk-refs
+      (seq all-tempids) (assoc :tempids all-tempids))))
 
 (defn bulk-size [bulk]
   (apply + (map count (vals bulk))))
@@ -184,7 +217,7 @@
   (context "/bulk" []
            :tags ["Bulk"]
            (POST "/" []
-                 :return s/Any
+                 :return BulkRefs
                  :body [bulk NewBulk {:description "a new Bulk object"}]
                  :header-params [{Authorization :- (s/maybe s/Str) nil}]
                  :summary "POST many new entities using a single HTTP call"
@@ -206,7 +239,7 @@
                  (if (> (bulk-size bulk)
                         (get-bulk-max-size))
                    (bad-request (str "Bulk max nb of entities: " (get-bulk-max-size)))
-                   (common/created (gen-create-bulk bulk login))))
+                   (common/created (create-bulk bulk login))))
 
            (GET "/" []
                 :return (s/maybe Bulk)

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -172,10 +172,9 @@
   The create-entities set the enveloped-result? to True in the flow
   configuration to get :data and :tempids for each entity in the result."
   [entities]
-  (reduce (fn [acc [_ v]]
-            (into acc (:tempids v)))
-          {}
-          entities))
+  (->> entities
+       (map (fn [[_ v]] (:tempids v)))
+       (reduce into {})))
 
 (defn create-bulk
   "Creates entities in bulk. To define relationships between entities,

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -153,27 +153,22 @@
           {}
           (keys bulk)))
 
-(defn debug [msg v]
-  (println msg v)
-  v)
-
 (defn gen-create-bulk
   [bulk login]
-  (let [new-entities (debug "new entities" (gen-bulk-from-fn
-                                            create-entities
-                                            (dissoc bulk :relationships)
-                                            {}
-                                            login))
-        tempids (debug "tempids" (reduce (fn [acc [_ v]]
-                                           (into acc (:tempids v)))
-                                         {}
-                                         new-entities))
-        new-relationships (debug "new relationships" (gen-bulk-from-fn
-                                                      create-entities
-                                                      (select-keys bulk [:relationships])
-                                                      tempids
-                                                      login))
-        ]
+  (let [new-entities (gen-bulk-from-fn
+                      create-entities
+                      (dissoc bulk :relationships)
+                      {}
+                      login)
+        tempids (reduce (fn [acc [_ v]]
+                          (into acc (:tempids v)))
+                        {}
+                        new-entities)
+        new-relationships (gen-bulk-from-fn
+                           create-entities
+                           (select-keys bulk [:relationships])
+                           tempids
+                           login)]
     (->> (into new-entities new-relationships)
          (map (fn [[k {:keys [data]}]]
                 {k data}))

--- a/src/ctia/schemas/bulk.clj
+++ b/src/ctia/schemas/bulk.clj
@@ -53,7 +53,8 @@
     :malwares        [(s/maybe Reference)]
     :relationships   [(s/maybe Reference)]
     :sightings       [(s/maybe Reference)]
-    :tools           [(s/maybe Reference)]}))
+    :tools           [(s/maybe Reference)]
+    :tempids         TempIDs}))
 
 (s/defschema NewBulk
   (st/optional-keys

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -26,8 +26,6 @@
             [schema.core :refer [Str Bool] :as sc]
             [schema-tools.core :as st]))
 
-
-
 (sc/defschema ACLEntity
   (st/optional-keys
    {:authorized_users [Str]
@@ -319,6 +317,12 @@
 (defschema ID
   cos/ID
   "common.id")
+
+(def TransientID sc/Str)
+
+(sc/defschema TempIDs
+  "Mapping table between transient and permanent IDs"
+  {TransientID ID})
 
 (sc/defschema VersionInfo
   "Version information for a specific instance of CTIA"

--- a/test/ctia/http/routes/bulk_test.clj
+++ b/test/ctia/http/routes/bulk_test.clj
@@ -323,10 +323,16 @@
         {status-get :status
          {:keys [relationships tools]} :parsed-body}
         (get (str "ctia/bulk?"
-                  (make-get-query-str-from-bulkrefs bulk-ids))
+                  (make-get-query-str-from-bulkrefs (dissoc bulk-ids :tempids)))
              :headers {"Authorization" "45c1f5e3f05d0"})
-        {:keys [target_ref source_ref]} (first relationships)]
+        {:keys [target_ref source_ref]} (first relationships)
+        stored-tool-1 (get-entity tools target_ref)
+        stored-tool-2 (get-entity tools source_ref)]
     (is (= 201 status-create))
     (is (= 200 status-get))
-    (is (= (:name tool1) (:name (get-entity tools target_ref))))
-    (is (= (:name tool2) (:name (get-entity tools source_ref))))))
+    (is (= (:name tool1) (:name stored-tool-1)))
+    (is (= (:name tool2) (:name stored-tool-2)))
+    (is (= (hash-map (:id tool1) (:id stored-tool-1)
+                     (:id tool2) (:id stored-tool-2)
+                     (:id relationship) (:id (first relationships)))
+           (:tempids bulk-ids)))))


### PR DESCRIPTION
Closes #610 

It is now possible to create entities with relationships in a single POST request. 

Ex: 
```clojure
{:sightings
 [{:id "transient:f48a3768-07d6-46c9-bc8d-ff2093d10826"
   :title "sighting-title"
   :observed_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                   :end_time #inst "2016-02-11T00:40:48.212-00:00"}
   :confidence "High"
   :count 1}]
 :indicators
 [{:id "transient:41c4ebba-241a-4e2a-b17f-feb90897f614"
   :title "indicator-title"
   :producer "producer"
   :valid_time {}}]
 :relationships
 [{:relationship_type "indicates"
   :source_ref "transient:41c4ebba-241a-4e2a-b17f-feb90897f614"
   :target_ref "transient:f48a3768-07d6-46c9-bc8d-ff2093d10826"}]}
```

The route `POST /ctia/bulk` will:
- Create the sighting
- Create the indicator
- Converts all transient IDs in the relationship and create the entity
- Return a `BulkRefs` with all new IDs and a `:tempids` field which contains the mapping table between transient and real IDs

Response:

```clojure
{:indicators
 ["http://example.com/ctia/indicator/indicator-991d8dfb-b54e-4435-ac58-2297b4d886c1"]
 :sightings
 ["http://example.com/ctia/sighting/sighting-71205a63-a9f3-4576-b2a1-3179587dbaa9"]
 :relationships
 ["http://example.com/ctia/relationship/relationship-5ab99ba5-ce4f-4c51-9f3e-8916d1665a4b"]
 :tempids
 {"transient:41c4ebba-241a-4e2a-b17f-feb90897f614"
  "http://example.com/ctia/indicator/indicator-991d8dfb-b54e-4435-ac58-2297b4d886c1"
  "transient:f48a3768-07d6-46c9-bc8d-ff2093d10826"
  "http://example.com/ctia/sighting/sighting-71205a63-a9f3-4576-b2a1-3179587dbaa9"}}
```