### PR TITLE
changed jwt field name

### DIFF
--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -15,7 +15,7 @@
   (login [_]
     (:sub jwt))
   (groups [_]
-    (remove nil? [(:business_guid jwt)]))
+    (remove nil? [(get jwt "cisco.com/iroh/org/id")]))
   (allowed-capabilities [_]
     write-capabilities)
   (capable? [this required-capabilities]

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -11,7 +11,7 @@
                         :url "http://localhost:8080/foo"}
         request-jwt (assoc request-no-jwt
                            :jwt {:sub "subject name"
-                                 :business_guid "organization-id"})
+                                 "cisco.com/iroh/org/id" "organization-id"})
         response-no-jwt (wrapped-handler request-no-jwt)
         response-jwt (wrapped-handler request-jwt)]
     (is (= {:body {:body "foo"
@@ -21,9 +21,9 @@
     (is (= {:body {:body "foo"
                    :url "http://localhost:8080/foo"
                    :jwt {:sub "subject name"
-                         :business_guid "organization-id"}
+                         "cisco.com/iroh/org/id" "organization-id"}
                    :identity #ctia.auth.jwt.Identity{:jwt {:sub "subject name"
-                                                           :business_guid "organization-id"}}
+                                                           "cisco.com/iroh/org/id" "organization-id"}}
                    :groups ["organization-id"]
                    :login  "subject name"}
             :status 200}


### PR DESCRIPTION
Epic https://github.com/threatgrid/iroh/issues/1707

change the default jwt field from business_guid to "cisco.com/iroh/org/id"

⚠️  to merge after https://github.com/threatgrid/iroh/pull/1709
  
  