### PR TITLE
Entity Field selection support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,9 +24,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
 
-  :jvm-opts ["-Xmx4g" ;; On some OSX VMs, this is needed to increase available memory
-             "-Djava.awt.headless=true"
-             "-XX:MaxPermSize=256m"
+  :jvm-opts ["-Djava.awt.headless=true"
              "-Dlog.console.threshold=INFO"
              "-server"]
   :pedantic? :warn
@@ -42,7 +40,10 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.23-SNAPSHOT"]
+                 [threatgrid/ctim "0.4.22"]
+                 [threatgrid/flanders "0.1.13-SNAPSHOT"
+                  :exclusions [com.google.code.findbugs/jsr305
+                               com.andrewmcveigh/cljs-time]]
                  [threatgrid/clj-momo "0.2.17-SNAPSHOT"]
 
                  ;; Web server

--- a/project.clj
+++ b/project.clj
@@ -42,8 +42,8 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.22"]
-                 [threatgrid/clj-momo "0.2.14"]
+                 [threatgrid/ctim "0.4.23-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.17-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version
@@ -63,7 +63,7 @@
 
                  ;; nREPL server
                  [org.clojure/tools.nrepl "0.2.13"]
-                 [cider/cider-nrepl "0.15.0"]
+                 [cider/cider-nrepl "0.15.1"]
 
                  ;; clients
                  [clj-http "3.4.1"]

--- a/project.clj
+++ b/project.clj
@@ -41,11 +41,25 @@
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
                  [threatgrid/ctim "0.4.22"]
-                 [threatgrid/flanders "0.1.13-SNAPSHOT"
+                 [threatgrid/flanders "0.1.13"
                   :exclusions [com.google.code.findbugs/jsr305
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/clj-momo "0.2.17-SNAPSHOT"]
-
+                 [threatgrid/clj-momo "0.2.18"
+                  ;; TODO: Please remove those exclusions once the dependency upgrade is done
+                  :exclusions [metosin/schema-tools
+                               com.fasterxml.jackson.core/*
+                               com.fasterxml.jackson.dataformat/*
+                               metrics-clojure
+                               metrics-clojure-ring
+                               cheshire
+                               metrics-clojure-jvm
+                               metrics-clojure-riemann
+                               clj-http
+                               clj-time
+                               com.andrewmcveigh/cljs-time
+                               org.apache.httpcomponents/*
+                               io.dropwizard.metrics/*
+                               prismatic/schema]]
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version
                   :exclusions [com.google.code.findbugs/jsr305

--- a/src/ctia/domain/access_control.clj
+++ b/src/ctia/domain/access_control.clj
@@ -3,6 +3,16 @@
             [ctim.schemas.common :as csc]
             [schema.core :as s]))
 
+(def acl-fields
+  "Those fields should always be retrieved from _source
+   to check access control"
+  [:id
+   :owner
+   :groups
+   :tlp
+   :authorized_users
+   :authorized_groups])
+
 (def public-tlps
   ["white" "green"])
 
@@ -13,7 +23,7 @@
       csc/default-tlp))
 
 (defn allowed-tlps []
-  (let [min-tlp (or (:min-tlp (get-access-control) "white"))]
+  (let [min-tlp (:min-tlp (get-access-control) "white")]
     (nthrest tlps
              (.indexOf tlps min-tlp))))
 

--- a/src/ctia/http/routes/attack_pattern.clj
+++ b/src/ctia/http/routes/attack_pattern.clj
@@ -114,7 +114,7 @@
                     paginated-ok))
 
            (GET "/:id" []
-                :return (s/maybe AttackPattern)
+                :return (s/maybe PartialAttackPattern)
                 :summary "Gets an Attack Pattern by ID"
                 :path-params [id :- s/Str]
                 :query [params AttackPatternGetParams]

--- a/src/ctia/http/routes/attack_pattern.clj
+++ b/src/ctia/http/routes/attack_pattern.clj
@@ -7,16 +7,18 @@
    [ctia.http.routes.common
     :refer [created
             paginated-ok
+            filter-map-search-options
+            search-options
             PagingParams
-            AttackPatternSearchParams]]
+            AttackPatternGetParams
+            AttackPatternSearchParams
+            AttackPatternByExternalIdQueryParams]]
    [ctia.store :refer :all]
-   [ctia.schemas.core :refer [NewAttackPattern AttackPattern]]
+   [ctia.schemas.core
+    :refer [NewAttackPattern AttackPattern PartialAttackPattern PartialAttackPatternList]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [schema-tools.core :as st]
    [schema.core :as s]))
-
-(s/defschema AttackPatternByExternalIdQueryParams
-  PagingParams)
 
 (defroutes attack-pattern-routes
   (context "/attack-pattern" []
@@ -58,7 +60,8 @@
                      :get-fn #(read-store :attack-pattern
                                           read-attack-pattern
                                           %
-                                          identity-map)
+                                          identity-map
+                                          {})
                      :realize-fn ent/realize-attack-pattern
                      :update-fn #(write-store :attack-pattern
                                               update-attack-pattern
@@ -75,7 +78,7 @@
                     ok))
 
            (GET "/external_id/:external_id" []
-                :return (s/maybe [AttackPattern])
+                :return PartialAttackPatternList
                 :query [q AttackPatternByExternalIdQueryParams]
                 :path-params [external_id :- s/Str]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
@@ -92,7 +95,7 @@
                     paginated-ok))
 
            (GET "/search" []
-                :return (s/maybe [AttackPattern])
+                :return PartialAttackPatternList
                 :summary "Search for an Attack Pattern using a Lucene/ES query string"
                 :query [params AttackPatternSearchParams]
                 :capabilities #{:read-attack-pattern :search-attack-pattern}
@@ -103,9 +106,9 @@
                      :attack-pattern
                      query-string-search
                      (:query params)
-                     (dissoc params :query :sort_by :sort_order :offset :limit)
+                     (apply dissoc params filter-map-search-options)
                      identity-map
-                     (select-keys params [:sort_by :sort_order :offset :limit]))
+                     (select-keys params search-options))
                     page-with-long-id
                     ent/un-store-page
                     paginated-ok))
@@ -114,14 +117,16 @@
                 :return (s/maybe AttackPattern)
                 :summary "Gets an Attack Pattern by ID"
                 :path-params [id :- s/Str]
+                :query [params AttackPatternGetParams]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :capabilities :read-attack-pattern
                 :identity identity
                 :identity-map identity-map
                 (if-let [attack-pattern (read-store :attack-pattern
-                                           read-attack-pattern
-                                           id
-                                           identity-map)]
+                                                    read-attack-pattern
+                                                    id
+                                                    identity-map
+                                                    params)]
                   (-> attack-pattern
                       with-long-id
                       ent/un-store
@@ -140,7 +145,8 @@
                         :get-fn #(read-store :attack-pattern
                                              read-attack-pattern
                                              %
-                                             identity-map)
+                                             identity-map
+                                             {})
                         :delete-fn #(write-store :attack-pattern
                                                  delete-attack-pattern
                                                  %

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -69,7 +69,7 @@
 
 (defn read-fn
   "return the create function provided an entity type key"
-  [k ident]
+  [k ident params]
   #(read-store
     k (case k
         :actor          read-actor
@@ -86,7 +86,7 @@
         :relationship   read-relationship
         :sighting       read-sighting
         :tool           read-tool)
-    % ident))
+    % ident params))
 
 (defn with-long-id-fn
   "return the with-long-id function provided an entity type key"
@@ -122,13 +122,13 @@
 (defn read-entities
   "Retrieve many entities of the same type provided their ids and common type"
   [ids entity-type ident]
-  (let [read-entity (read-fn entity-type ident)
+  (let [read-entity (read-fn entity-type ident {})
         with-long-id (with-long-id-fn entity-type)]
     (map (fn [id] (try (with-long-id
-                        (read-entity id))
-                      (catch Exception e
-                        (do (log/error (pr-str e))
-                            nil)))) ids)))
+                         (read-entity id))
+                       (catch Exception e
+                         (do (log/error (pr-str e))
+                             nil)))) ids)))
 
 (defn gen-bulk-from-fn
   "Kind of fmap but adapted for bulk

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -9,6 +9,17 @@
    [schema-tools.core :as st]
    [ring.swagger.schema :refer [describe]]))
 
+(def search-options [:sort_by
+                     :sort_order
+                     :offset
+                     :limit
+                     :fields])
+
+(def filter-map-search-options
+  (conj search-options :query))
+
+(def datatable-sort-fields
+  (apply s/enum sorting/default-entity-sort-fields))
 
 (def exploit-target-sort-fields
   (apply s/enum sorting/exploit-target-sort-fields))
@@ -24,6 +35,10 @@
 
 (def judgement-sort-fields
   (apply s/enum sorting/judgement-sort-fields))
+
+(def judgements-by-observable-sort-fields
+  (apply s/enum (map name (conj sorting/judgement-sort-fields
+                                "disposition:asc,valid_time.start_time:desc"))))
 
 (def sighting-sort-fields
   (apply s/enum sorting/sighting-sort-fields))
@@ -49,7 +64,7 @@
 (def tool-sort-fields
   (apply s/enum sorting/tool-sort-fields))
 
-(def InvestigationSortFields
+(def investigation-sort-fields
   (apply s/enum sorting/investigation-sort-fields))
 
 ;; Paging related values and code
@@ -118,19 +133,145 @@
   {(s/optional-key :source) s/Str})
 
 
+;; actor
+
+(s/defschema ActorFieldsParam
+  {(s/optional-key :fields) [actor-sort-fields]})
+
+(s/defschema ActorSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   ActorFieldsParam
+   {:query s/Str
+    (s/optional-key :actor_type) s/Str
+    (s/optional-key :motivation) s/Str
+    (s/optional-key :sophistication) s/Str
+    (s/optional-key :intended_effect) s/Str
+    (s/optional-key :confidence) s/Str
+    (s/optional-key :sort_by)  actor-sort-fields}))
+
+(def ActorGetParams ActorFieldsParam)
+
+(s/defschema ActorByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   ActorFieldsParam))
+
+;; campaign
+
+(s/defschema CampaignFieldsParam
+  {(s/optional-key :fields) [campaign-sort-fields]})
+
+(s/defschema CampaignSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   CampaignFieldsParam
+   {:query s/Str
+    (s/optional-key :campaign_type) s/Str
+    (s/optional-key :confidence) s/Str
+    (s/optional-key :activity) s/Str
+    (s/optional-key :sort_by)  campaign-sort-fields}))
+
+(def CampaignGetParams CampaignFieldsParam)
+
+(s/defschema CampaignByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   CampaignFieldsParam))
+
+;; COA
+
+(s/defschema COAFieldsParam
+  {(s/optional-key :fields) [coa-sort-fields]})
+
+(s/defschema COASearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   COAFieldsParam
+   {:query s/Str
+    (s/optional-key :stage) s/Str
+    (s/optional-key :coa_type) s/Str
+    (s/optional-key :impact) s/Str
+    (s/optional-key :objective) s/Str
+    (s/optional-key :cost) s/Str
+    (s/optional-key :efficacy) s/Str
+    (s/optional-key :structured_coa_type) s/Str
+    (s/optional-key :sort_by) coa-sort-fields}))
+
+(def COAGetParams COAFieldsParam)
+
+(s/defschema COAByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   COAFieldsParam))
+
+;; data-table
+
+(s/defschema DataTableFieldsParam
+  {(s/optional-key :fields) [datatable-sort-fields]})
+
+(def DataTableGetParams DataTableFieldsParam)
+
+(s/defschema DataTableByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   DataTableFieldsParam))
+
+;; exploit-target
+
+(s/defschema ExploitTargetFieldsParam
+  {(s/optional-key :fields) [exploit-target-sort-fields]})
+
 (s/defschema ExploitTargetSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   ExploitTargetFieldsParam
    {:query s/Str
     (s/optional-key :sort_by) exploit-target-sort-fields}))
+
+(def ExploitTargetGetParams ExploitTargetFieldsParam)
+
+(s/defschema ExploitTargetByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   ExploitTargetFieldsParam))
+
+;; feedback
+
+(s/defschema FeedbackFieldsParam
+  {(s/optional-key :fields) [feedback-sort-fields]})
+
+(s/defschema FeedbackQueryParams
+  (st/merge
+   FeedbackFieldsParam
+   PagingParams
+   {:entity_id s/Str
+    (s/optional-key :sort_by) feedback-sort-fields}))
+
+(def FeedbackGetParams FeedbackFieldsParam)
+
+(s/defschema FeedbackByExternalIdQueryParams
+  (st/dissoc FeedbackQueryParams :entity_id))
+
+;; incident
+
+(s/defschema IncidentFieldsParam
+  {(s/optional-key :fields) [incident-sort-fields]})
 
 (s/defschema IncidentSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   IncidentFieldsParam
    {:query s/Str
     (s/optional-key :confidence) s/Str
     (s/optional-key :status) s/Str
@@ -144,11 +285,24 @@
     (s/optional-key :categories) s/Str
     (s/optional-key :sort_by) incident-sort-fields}))
 
+(def IncidentGetParams IncidentFieldsParam)
+
+(s/defschema IncidentByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   IncidentFieldsParam))
+
+;; indicator
+
+(s/defschema IndicatorFieldsParam
+  {(s/optional-key :fields) [indicator-sort-fields]})
+
 (s/defschema IndicatorSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   IndicatorFieldsParam
    {:query s/Str
     (s/optional-key :indicator_type) s/Str
     (s/optional-key :tags) s/Int
@@ -158,11 +312,28 @@
     (s/optional-key :confidence) s/Str
     (s/optional-key :sort_by)  indicator-sort-fields}))
 
+(def IndicatorGetParams IndicatorFieldsParam)
+
+(s/defschema IndicatorsListQueryParams
+  (st/merge
+   PagingParams
+   IndicatorFieldsParam
+   {(s/optional-key :sort_by) indicator-sort-fields}))
+
+(s/defschema IndicatorsByExternalIdQueryParams
+  IndicatorsListQueryParams)
+
+;; judgement
+
+(s/defschema JudgementFieldsParam
+  {(s/optional-key :fields) [judgement-sort-fields]})
+
 (s/defschema JudgementSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   JudgementFieldsParam
    {:query s/Str
     (s/optional-key :disposition_name) s/Str
     (s/optional-key :disposition) s/Int
@@ -171,82 +342,109 @@
     (s/optional-key :confidence) s/Str
     (s/optional-key :sort_by)  judgement-sort-fields}))
 
+(def JudgementGetParams JudgementFieldsParam)
+
+(s/defschema FeedbacksByJudgementQueryParams
+  (st/merge
+   PagingParams
+   JudgementFieldsParam
+   {(s/optional-key :sort_by) feedback-sort-fields}))
+
+(s/defschema JudgementsQueryParams
+  (st/merge
+   PagingParams
+   JudgementFieldsParam
+   {(s/optional-key :sort_by) judgement-sort-fields}))
+
+(s/defschema JudgementsByExternalIdQueryParams
+  (st/merge
+   JudgementsQueryParams
+   JudgementFieldsParam))
+
+(s/defschema JudgementsByObservableQueryParams
+  (st/merge
+   PagingParams
+   JudgementFieldsParam
+   {(s/optional-key :sort_by) judgements-by-observable-sort-fields}))
+
+;; relationship
+
+(s/defschema RelationshipFieldsParam
+  {(s/optional-key :fields) [relationship-sort-fields]})
+
 (s/defschema RelationshipSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   RelationshipFieldsParam
    {:query s/Str
     (s/optional-key :relationship_type) s/Str
     (s/optional-key :source_ref) s/Str
     (s/optional-key :target_ref) s/Str
     (s/optional-key :sort_by)  relationship-sort-fields}))
 
+(s/defschema RelationshipGetParams RelationshipFieldsParam)
+
+(s/defschema RelationshipByExternalIdQueryParams
+  (st/merge PagingParams
+            RelationshipFieldsParam))
+
+;; sighting
+
+(s/defschema SightingFieldsParam
+  {(s/optional-key :fields) [sighting-sort-fields]})
+
 (s/defschema SightingSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   SightingFieldsParam
    {:query s/Str
     (s/optional-key :sensor) s/Str
     (s/optional-key :observables.value) s/Str
     (s/optional-key :observables.type) s/Str
     (s/optional-key :sort_by)  sighting-sort-fields}))
 
-(s/defschema ActorSearchParams
+(def SightingGetParams SightingFieldsParam)
+
+(s/defschema SightingByExternalIdQueryParams
   (st/merge
    PagingParams
-   BaseEntityFilterParams
-   SourcableEntityFilterParams
-   {:query s/Str
-    (s/optional-key :actor_type) s/Str
-    (s/optional-key :motivation) s/Str
-    (s/optional-key :sophistication) s/Str
-    (s/optional-key :intended_effect) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :sort_by)  actor-sort-fields}))
+   SightingFieldsParam))
 
-(s/defschema CampaignSearchParams
-  (st/merge
-   PagingParams
-   BaseEntityFilterParams
-   SourcableEntityFilterParams
-   {:query s/Str
-    (s/optional-key :campaign_type) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :activity) s/Str
-    (s/optional-key :sort_by)  campaign-sort-fields}))
+;; attack-pattern
 
-
-(s/defschema COASearchParams
-  (st/merge
-   PagingParams
-   BaseEntityFilterParams
-   SourcableEntityFilterParams
-   {:query s/Str
-    (s/optional-key :stage) s/Str
-    (s/optional-key :coa_type) s/Str
-    (s/optional-key :impact) s/Str
-    (s/optional-key :objective) s/Str
-    (s/optional-key :cost) s/Str
-    (s/optional-key :efficacy) s/Str
-    (s/optional-key :structured_coa_type) s/Str
-    (s/optional-key :sort_by) coa-sort-fields}))
+(s/defschema AttackPatternFieldsParam
+  {(s/optional-key :fields) [attack-pattern-sort-fields]})
 
 (s/defschema AttackPatternSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
+   AttackPatternFieldsParam
    {:query s/Str}
    (st/optional-keys
     {:kill_chain_phases.kill_chain_name s/Str
      :kill_chain_phases.phase_name s/Str
      :sort_by attack-pattern-sort-fields})))
 
+(s/defschema AttackPatternGetParams AttackPatternFieldsParam)
+
+(s/defschema AttackPatternByExternalIdQueryParams
+  (st/merge PagingParams AttackPatternFieldsParam))
+
+;; malware
+
+(s/defschema MalwareFieldsParam
+  {(s/optional-key :fields) [malware-sort-fields]})
+
 (s/defschema MalwareSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
+   MalwareFieldsParam
    {:query s/Str}
    (st/optional-keys
     {:labels s/Str
@@ -254,10 +452,22 @@
      :kill_chain_phases.phase_name s/Str
      :sort_by malware-sort-fields})))
 
+(s/defschema MalwareGetParams MalwareFieldsParam)
+
+(s/defschema MalwareByExternalIdQueryParams
+  (st/merge PagingParams
+            MalwareFieldsParam))
+
+;; tool
+
+(s/defschema ToolFieldsParam
+  {(s/optional-key :fields) [tool-sort-fields]})
+
 (s/defschema ToolSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
+   ToolFieldsParam
    {:query s/Str}
    (st/optional-keys
     {:labels s/Str
@@ -266,10 +476,29 @@
      :tool_version s/Str
      :sort_by malware-sort-fields})))
 
+(s/defschema ToolGetParams ToolFieldsParam)
+
+(s/defschema ToolByExternalIdQueryParams
+  (st/merge PagingParams
+            ToolFieldsParam))
+
+;; investigation
+
+(s/defschema InvestigationFieldsParam
+  {(s/optional-key :fields) [investigation-sort-fields]})
+
 (s/defschema InvestigationSearchParams
   (st/merge
    PagingParams
    BaseEntityFilterParams
    SourcableEntityFilterParams
+   InvestigationFieldsParam
    {:query s/Str}
    {s/Keyword s/Any}))
+
+(def InvestigationGetParams InvestigationFieldsParam)
+
+(s/defschema InvestigationsByExternalIdQueryParams
+  (st/merge
+   InvestigationFieldsParam
+   PagingParams))

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -407,6 +407,17 @@
     (s/optional-key :observables.type) s/Str
     (s/optional-key :sort_by)  sighting-sort-fields}))
 
+(s/defschema SightingsByObservableQueryParams
+  (st/merge
+   PagingParams
+   SightingFieldsParam
+   {(s/optional-key :sort_by)
+    (s/enum
+     :id
+     :timestamp
+     :confidence
+     :observed_time.start_time)}))
+
 (def SightingGetParams SightingFieldsParam)
 
 (s/defschema SightingByExternalIdQueryParams

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -5,18 +5,20 @@
    [ctia.domain.entities.exploit-target :refer [with-long-id page-with-long-id]]
    [ctia.flows.crud :as flows]
    [ctia.store :refer :all]
-   [ctia.schemas.core :refer [NewExploitTarget ExploitTarget]]
+   [ctia.schemas.core
+    :refer [NewExploitTarget ExploitTarget PartialExploitTarget PartialExploitTargetList]]
    [ctia.http.routes.common :refer [created
                                     paginated-ok
+                                    search-options
+                                    filter-map-search-options
+                                    PagingParams
+                                    ExploitTargetGetParams
                                     ExploitTargetSearchParams
-                                    PagingParams]]
+                                    ExploitTargetByExternalIdQueryParams]]
    [ring.util.http-response :refer [ok no-content not-found]]
    [schema.core :as s]
    [schema-tools.core :as st]
    [flanders.schema :as fs]))
-
-(s/defschema ExploitTargetByExternalIdQueryParams
-  PagingParams)
 
 (defroutes exploit-target-routes
   (context "/exploit-target" []
@@ -60,7 +62,8 @@
                      :get-fn #(read-store :exploit-target
                                           read-exploit-target
                                           %
-                                          identity-map)
+                                          identity-map
+                                          {})
                      :realize-fn ent/realize-exploit-target
                      :update-fn #(write-store :exploit-target
                                               update-exploit-target
@@ -77,7 +80,7 @@
                     ok))
 
            (GET "/external_id/:external_id" []
-                :return (s/maybe [ExploitTarget])
+                :return PartialExploitTargetList
                 :query [q ExploitTargetByExternalIdQueryParams]
                 :path-params [external_id :- s/Str]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
@@ -94,7 +97,7 @@
                     paginated-ok))
 
            (GET "/search" []
-                :return (s/maybe [ExploitTarget])
+                :return PartialExploitTargetList
                 :summary "Search for an ExploitTarget using a Lucene/ES query string"
                 :query [params ExploitTargetSearchParams]
                 :capabilities #{:read-exploit-target :search-exploit-target}
@@ -105,17 +108,18 @@
                      :exploit-target
                      query-string-search
                      (:query params)
-                     (dissoc params :query :sort_by :sort_order :offset :limit)
+                     (apply dissoc params filter-map-search-options)
                      identity-map
-                     (select-keys params [:sort_by :sort_order :offset :limit]))
+                     (select-keys params search-options))
                     page-with-long-id
                     ent/un-store-page
                     paginated-ok))
 
            (GET "/:id" []
-                :return (s/maybe ExploitTarget)
+                :return (s/maybe PartialExploitTarget)
                 :summary "Gets an ExploitTarget by ID"
                 :path-params [id :- s/Str]
+                :query [params ExploitTargetGetParams]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :capabilities :read-exploit-target
                 :identity identity
@@ -123,7 +127,8 @@
                 (if-let [exploit-target (read-store :exploit-target
                                                     read-exploit-target
                                                     id
-                                                    identity-map)]
+                                                    identity-map
+                                                    params)]
                   (-> exploit-target
                       with-long-id
                       ent/un-store
@@ -142,7 +147,8 @@
                         :get-fn #(read-store :exploit-target
                                              read-exploit-target
                                              %
-                                             identity-map)
+                                             identity-map
+                                             {})
                         :delete-fn #(write-store :exploit-target
                                                  delete-exploit-target
                                                  %

--- a/src/ctia/http/routes/investigation.clj
+++ b/src/ctia/http/routes/investigation.clj
@@ -17,7 +17,8 @@
             InvestigationGetParams
             InvestigationsByExternalIdQueryParams]]
    [ctia.store :refer :all]
-   [ctia.schemas.core :refer [Investigation NewInvestigation]]
+   [ctia.schemas.core
+    :refer [Investigation NewInvestigation PartialInvestigation PartialInvestigationList]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [schema-tools.core :as st]
    [schema.core :as s]))
@@ -50,7 +51,7 @@
                      created))
 
            (GET "/external_id/:external_id" []
-                :return (s/maybe [Investigation])
+                :return PartialInvestigationList
                 :query [q InvestigationsByExternalIdQueryParams]
                 :path-params [external_id :- s/Str]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
@@ -68,7 +69,7 @@
                     paginated-ok))
 
            (GET "/search" []
-                :return (s/maybe [Investigation])
+                :return PartialInvestigationList
                 :summary "Search for an Investigation using a Lucene/ES query string"
                 :query [params InvestigationSearchParams]
                 :capabilities #{:read-investigation :search-investigation}
@@ -87,7 +88,7 @@
                     paginated-ok))
 
            (GET "/:id" []
-                :return (s/maybe Investigation)
+                :return (s/maybe PartialInvestigation)
                 :summary "Gets an Investigation by ID"
                 :path-params [id :- s/Str]
                 :query [params InvestigationGetParams]

--- a/src/ctia/http/routes/malware.clj
+++ b/src/ctia/http/routes/malware.clj
@@ -2,21 +2,24 @@
   (:require
    [compojure.api.sweet :refer :all]
    [ctia.domain.entities :as ent]
-   [ctia.domain.entities.malware :refer [with-long-id page-with-long-id]]
+   [ctia.domain.entities.malware
+    :refer [with-long-id page-with-long-id]]
    [ctia.flows.crud :as flows]
    [ctia.http.routes.common
     :refer [created
             paginated-ok
+            filter-map-search-options
+            search-options
             PagingParams
-            MalwareSearchParams]]
+            MalwareGetParams
+            MalwareSearchParams
+            MalwareByExternalIdQueryParams]]
    [ctia.store :refer :all]
-   [ctia.schemas.core :refer [NewMalware Malware]]
+   [ctia.schemas.core
+    :refer [NewMalware Malware PartialMalware PartialMalwareList]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [schema-tools.core :as st]
    [schema.core :as s]))
-
-(s/defschema MalwareByExternalIdQueryParams
-  PagingParams)
 
 (defroutes malware-routes
   (context "/malware" []
@@ -58,7 +61,8 @@
                      :get-fn #(read-store :malware
                                           read-malware
                                           %
-                                          identity-map)
+                                          identity-map
+                                          {})
                      :realize-fn ent/realize-malware
                      :update-fn #(write-store :malware
                                               update-malware
@@ -75,7 +79,7 @@
                     ok))
 
            (GET "/external_id/:external_id" []
-                :return (s/maybe [Malware])
+                :return PartialMalwareList
                 :query [q MalwareByExternalIdQueryParams]
                 :path-params [external_id :- s/Str]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
@@ -92,7 +96,7 @@
                     paginated-ok))
 
            (GET "/search" []
-                :return (s/maybe [Malware])
+                :return PartialMalwareList
                 :summary "Search for a Malware using a Lucene/ES query string"
                 :query [params MalwareSearchParams]
                 :capabilities #{:read-malware :search-malware}
@@ -103,25 +107,27 @@
                      :malware
                      query-string-search
                      (:query params)
-                     (dissoc params :query :sort_by :sort_order :offset :limit)
+                     (apply dissoc params filter-map-search-options)
                      identity-map
-                     (select-keys params [:sort_by :sort_order :offset :limit]))
+                     (select-keys params search-options))
                     page-with-long-id
                     ent/un-store-page
                     paginated-ok))
 
            (GET "/:id" []
-                :return (s/maybe Malware)
+                :return PartialMalware
                 :summary "Gets a Malware by ID"
                 :path-params [id :- s/Str]
+                :query [params MalwareGetParams]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :capabilities :read-malware
                 :identity identity
                 :identity-map identity-map
                 (if-let [malware (read-store :malware
-                                           read-malware
-                                           id
-                                           identity-map)]
+                                             read-malware
+                                             id
+                                             identity-map
+                                             params)]
                   (-> malware
                       with-long-id
                       ent/un-store
@@ -140,7 +146,8 @@
                         :get-fn #(read-store :malware
                                              read-malware
                                              %
-                                             identity-map)
+                                             identity-map
+                                             {})
                         :delete-fn #(write-store :malware
                                                  delete-malware
                                                  %

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -8,12 +8,14 @@
    [ctia.http.routes.common
     :refer [paginated-ok
             PagingParams
-            JudgementsByObservableQueryParams]]
+            JudgementsByObservableQueryParams
+            SightingsByObservableQueryParams]]
    [ctia.lib.pagination :as pag]
    [ctia.properties :refer [properties]]
    [ctia.schemas.core :refer [Indicator
                               Judgement
                               PartialJudgementList
+                              PartialSightingList
                               ObservableTypeIdentifier
                               Reference
                               Sighting
@@ -28,16 +30,6 @@
 
 (s/defschema RefsByObservableQueryParams
   (st/dissoc PagingParams :sort_by :sort_order))
-
-(s/defschema SightingsByObservableQueryParams
-  (st/merge
-   PagingParams
-   {(s/optional-key :sort_by)
-    (s/enum
-     :id
-     :timestamp
-     :confidence
-     :observed_time.start_time)}))
 
 (defroutes observable-routes
   (GET "/:observable_type/:observable_value/verdict" []
@@ -101,7 +93,7 @@
                                  {:type observable_type
                                   :value observable_value}
                                  identity-map
-                                 nil))
+                                 {:fields [:id]}))
               judgement-ids (->> judgements
                                  (map :id)
                                  (map #(id/short-id->id :judgement % http-show))
@@ -111,7 +103,7 @@
                                     list-relationships
                                     {:source_ref judgement-ids}
                                     identity-map
-                                    nil))
+                                    {:fields [:target_ref]}))
               indicator-ids (->> (map :target_ref relationships)
                                  (map #(id/long-id->id %))
                                  (filter #(= "indicator" (:type %)))
@@ -132,7 +124,7 @@
        :capabilities :list-sightings
        :identity identity
        :identity-map identity-map
-       :return (s/maybe [Sighting])
+       :return PartialSightingList
        :summary "Returns Sightings associated with the specified observable."
        (-> (read-store :sighting
                        list-sightings-by-observables
@@ -163,7 +155,7 @@
                                            [{:type observable_type
                                              :value observable_value}]
                                            identity-map
-                                           nil))
+                                           {:fields [:id]}))
               sighting-ids (->> sightings
                                 (map :id)
                                 (map #(id/short-id->id :sighting % http-show))
@@ -173,7 +165,7 @@
                                     list-relationships
                                     {:source_ref sighting-ids}
                                     identity-map
-                                    nil))
+                                    {:fields [:target_ref]}))
               indicator-ids (->> (map :target_ref relationships)
                                  (map #(id/long-id->id %))
                                  (filter #(= "indicator" (:type %)))
@@ -204,7 +196,7 @@
                                            [{:type observable_type
                                              :value observable_value}]
                                            identity-map
-                                           nil))
+                                           {:fields [:id]}))
               sighting-ids (->> sightings
                                 (map :id)
                                 (map #(id/short-id->id :sighting % http-show))
@@ -214,7 +206,7 @@
                                     list-relationships
                                     {:source_ref sighting-ids}
                                     identity-map
-                                    nil))
+                                    {:fields [:target_ref]}))
               incident-ids (->> (map :target_ref relationships)
                                 (map #(id/long-id->id %))
                                 (filter #(= "incident" (:type %)))

--- a/src/ctia/http/routes/observable.clj
+++ b/src/ctia/http/routes/observable.clj
@@ -7,11 +7,13 @@
     [sighting :as sighting]]
    [ctia.http.routes.common
     :refer [paginated-ok
-            PagingParams]]
+            PagingParams
+            JudgementsByObservableQueryParams]]
    [ctia.lib.pagination :as pag]
    [ctia.properties :refer [properties]]
    [ctia.schemas.core :refer [Indicator
                               Judgement
+                              PartialJudgementList
                               ObservableTypeIdentifier
                               Reference
                               Sighting
@@ -23,19 +25,6 @@
    [schema-tools.core :as st]
    [schema.core :as s]
    [clojure.tools.logging :as log]))
-
-(s/defschema JudgementsByObservableQueryParams
-  (st/merge
-   PagingParams
-   {(s/optional-key :sort_by)
-    (s/enum
-     "id"
-     "disposition"
-     "priority"
-     "severity"
-     "confidence"
-     "valid_time.start_time"
-     "disposition:asc,valid_time.start_time:desc")}))
 
 (s/defschema RefsByObservableQueryParams
   (st/dissoc PagingParams :sort_by :sort_order))
@@ -76,7 +65,7 @@
        :query [params JudgementsByObservableQueryParams]
        :path-params [observable_type :- ObservableTypeIdentifier
                      observable_value :- s/Str]
-       :return (s/maybe [Judgement])
+       :return PartialJudgementList
        :summary "Returns the Judgements associated with the specified observable."
        :header-params [{Authorization :- (s/maybe s/Str) nil}]
        :capabilities :list-judgements

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -361,6 +361,9 @@
             ACLEntity
             {sc/Keyword sc/Any}))
 
+(sc/defschema PartialInvestigationList
+  [PartialInvestigation])
+
 (sc/defschema NewInvestigation
   (st/merge (f-schema/->schema inv/NewInvestigation)
             ACLEntity

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -1,30 +1,32 @@
 (ns ctia.schemas.core
-  (:require [ctim.schemas
-             [actor :as as]
-             [attack-pattern :as attack]
-             [campaign :as cs]
-             [coa :as coas]
-             [common :as cos]
-             [data-table :as ds]
-             [exploit-target :as es]
-             [feedback :as feedbacks]
-             [incident :as is]
-             [indicator :as ins]
-             [investigation :as inv]
-             [judgement :as js]
-             [malware :as malware]
-             [relationship :as rels]
-             [sighting :as ss]
-             [tool :as tool]
-             [verdict :as vs]
-             [vocabularies :as vocs]]
-            [flanders
-             [core :as f]
-             [schema :as f-schema]
-             [spec :as f-spec]
-             [utils :as fu]]
-            [schema.core :refer [Str Bool] :as sc]
-            [schema-tools.core :as st]))
+  (:require
+   [flanders.utils :as fu]
+   [ctim.schemas
+    [actor :as as]
+    [attack-pattern :as attack]
+    [campaign :as cs]
+    [coa :as coas]
+    [common :as cos]
+    [data-table :as ds]
+    [exploit-target :as es]
+    [feedback :as feedbacks]
+    [incident :as is]
+    [indicator :as ins]
+    [investigation :as inv]
+    [judgement :as js]
+    [malware :as malware]
+    [relationship :as rels]
+    [sighting :as ss]
+    [tool :as tool]
+    [verdict :as vs]
+    [vocabularies :as vocs]]
+   [flanders
+    [core :as f]
+    [schema :as f-schema]
+    [spec :as f-spec]
+    [utils :as fu]]
+   [schema.core :refer [Str Bool] :as sc]
+   [schema-tools.core :as st]))
 
 
 
@@ -65,6 +67,13 @@
   as/Actor
   "actor")
 
+(def-acl-schema PartialActor
+  (fu/optionalize-all as/Actor)
+  "partial-actor")
+
+(sc/defschema PartialActorList
+  [PartialActor])
+
 (def-acl-schema NewActor
   as/NewActor
   "new-actor")
@@ -73,11 +82,22 @@
   as/StoredActor
   "stored-actor")
 
+(def-stored-schema PartialStoredActor
+  (fu/optionalize-all as/StoredActor)
+  "partial-stored-actor")
+
 ;; campaign
 
 (def-acl-schema Campaign
   cs/Campaign
   "campaign")
+
+(def-acl-schema PartialCampaign
+  (fu/optionalize-all cs/Campaign)
+  "partial-campaign")
+
+(sc/defschema PartialCampaignList
+  [PartialCampaign])
 
 (def-acl-schema NewCampaign
   cs/NewCampaign
@@ -87,11 +107,22 @@
   cs/StoredCampaign
   "stored-campaign")
 
+(def-stored-schema PartialStoredCampaign
+  (fu/optionalize-all cs/StoredCampaign)
+  "partial-stored-campaign")
+
 ;; coa
 
 (def-acl-schema COA
   coas/COA
   "coa")
+
+(def-acl-schema PartialCOA
+  (fu/optionalize-all coas/COA)
+  "partial-coa")
+
+(sc/defschema PartialCOAList
+  [PartialCOA])
 
 (def-acl-schema NewCOA
   coas/NewCOA
@@ -101,12 +132,25 @@
   coas/StoredCOA
   "stored-coa")
 
+(def-stored-schema PartialStoredCOA
+  (fu/optionalize-all coas/StoredCOA)
+  "partial-stored-coa")
+
 ;; data-table
 
 (def-acl-schema DataTable
   (fu/replace-either-with-any
    ds/DataTable)
   "data-table")
+
+(def-acl-schema PartialDataTable
+  (fu/optionalize-all
+   (fu/replace-either-with-any
+    ds/DataTable))
+  "partial-data-table")
+
+(sc/defschema PartialDataTableList
+  [PartialDataTable])
 
 (def-acl-schema NewDataTable
   (fu/replace-either-with-any
@@ -118,11 +162,25 @@
    ds/StoredDataTable)
   "stored-data-table")
 
+(def-stored-schema PartialStoredDataTable
+  (fu/optionalize-all
+   (fu/replace-either-with-any
+    ds/StoredDataTable))
+  "partial-stored-data-table")
+
+
 ;; exploit-target
 
 (def-acl-schema ExploitTarget
   es/ExploitTarget
   "exploit-target")
+
+(def-acl-schema PartialExploitTarget
+  (fu/optionalize-all es/ExploitTarget)
+  "partial-exploit-target")
+
+(sc/defschema PartialExploitTargetList
+  [PartialExploitTarget])
 
 (def-acl-schema NewExploitTarget
   es/NewExploitTarget
@@ -131,6 +189,11 @@
 (def-stored-schema StoredExploitTarget
   es/StoredExploitTarget
   "stored-exploit-target")
+
+(def-stored-schema PartialStoredExploitTarget
+  (fu/optionalize-all es/StoredExploitTarget)
+  "partial-stored-exploit-target")
+
 
 ;; sighting
 
@@ -142,15 +205,33 @@
   ss/Sighting
   "sighting")
 
+(def-acl-schema PartialSighting
+  (fu/optionalize-all ss/Sighting)
+  "partial-sighting")
+
+(sc/defschema PartialSightingList
+  [PartialSighting])
+
 (def-stored-schema StoredSighting
   ss/StoredSighting
   "stored-sighting")
+
+(def-stored-schema PartialStoredSighting
+  (fu/optionalize-all ss/StoredSighting)
+  "partial-stored-sighting")
 
 ;; judgement
 
 (def-acl-schema Judgement
   js/Judgement
   "judgement")
+
+(def-acl-schema PartialJudgement
+  (fu/optionalize-all js/Judgement)
+  "partial-judgement")
+
+(sc/defschema PartialJudgementList
+  [PartialJudgement])
 
 (def-acl-schema NewJudgement
   js/NewJudgement
@@ -159,6 +240,10 @@
 (def-stored-schema StoredJudgement
   js/StoredJudgement
   "stored-judgement")
+
+(def-stored-schema PartialStoredJudgement
+  (fu/optionalize-all js/StoredJudgement)
+  "partial-stored-judgement")
 
 ;; verdict
 
@@ -172,6 +257,13 @@
   feedbacks/Feedback
   "feedback")
 
+(def-acl-schema PartialFeedback
+  (fu/optionalize-all feedbacks/Feedback)
+  "partial-feedback")
+
+(sc/defschema PartialFeedbackList
+  [PartialFeedback])
+
 (def-acl-schema NewFeedback
   feedbacks/NewFeedback
   "new-feedback")
@@ -180,11 +272,23 @@
   feedbacks/StoredFeedback
   "stored-feedback")
 
+(def-stored-schema PartialStoredFeedback
+  (fu/optionalize-all feedbacks/StoredFeedback)
+  "partial-stored-feedback")
+
 ;; incident
+
 
 (def-acl-schema Incident
   is/Incident
   "incident")
+
+(def-acl-schema PartialIncident
+  (fu/optionalize-all is/Incident)
+  "partial-incident")
+
+(sc/defschema PartialIncidentList
+  [PartialIncident])
 
 (def-acl-schema NewIncident
   is/NewIncident
@@ -193,6 +297,11 @@
 (def-stored-schema StoredIncident
   is/StoredIncident
   "stored-incident")
+
+(def-stored-schema PartialStoredIncident
+  (fu/optionalize-all is/StoredIncident)
+  "partial-stored-incident")
+
 
 ;; indicator
 
@@ -203,6 +312,16 @@
               ins/Indicator))))
 
 (f-spec/->spec ins/Indicator "indicator")
+
+(sc/defschema PartialIndicator
+  (st/merge ACLEntity
+            (f-schema/->schema
+             (fu/optionalize-all
+              (fu/replace-either-with-any
+               ins/Indicator)))))
+
+(sc/defschema PartialIndicatorList
+  [PartialIndicator])
 
 (sc/defschema NewIndicator
   (st/merge
@@ -221,6 +340,12 @@
 
 (f-spec/->spec ins/StoredIndicator "stored-indicator")
 
+(sc/defschema PartialStoredIndicator
+  (st/merge (f-schema/->schema
+             (fu/optionalize-all
+              (fu/replace-either-with-any
+               ins/StoredIndicator)))
+            ACLStoredEntity))
 
 ;; investigation
 
@@ -230,6 +355,11 @@
             {sc/Keyword sc/Any}))
 
 (f-spec/->spec inv/Investigation "investigation")
+
+(sc/defschema PartialInvestigation
+  (st/merge (f-schema/->schema (fu/optionalize-all inv/Investigation))
+            ACLEntity
+            {sc/Keyword sc/Any}))
 
 (sc/defschema NewInvestigation
   (st/merge (f-schema/->schema inv/NewInvestigation)
@@ -245,12 +375,24 @@
 
 (f-spec/->spec inv/StoredInvestigation "stored-investigation")
 
+(sc/defschema PartialStoredInvestigation
+  (st/merge (f-schema/->schema (fu/optionalize-all inv/StoredInvestigation))
+            ACLStoredEntity
+            {sc/Keyword sc/Any}))
 
 ;; relationship
+
 
 (def-acl-schema Relationship
   rels/Relationship
   "relationship")
+
+(def-acl-schema PartialRelationship
+  (fu/optionalize-all rels/Relationship)
+  "partial-relationship")
+
+(sc/defschema PartialRelationshipList
+  [PartialRelationship])
 
 (def-acl-schema NewRelationship
   rels/NewRelationship
@@ -260,11 +402,23 @@
   rels/StoredRelationship
   "stored-relationship")
 
+(def-stored-schema PartialStoredRelationship
+  (fu/optionalize-all rels/StoredRelationship)
+  "partial-stored-relationship")
+
 ;; Attack Pattern
+
 
 (def-acl-schema AttackPattern
   attack/AttackPattern
   "attack-pattern")
+
+(def-acl-schema PartialAttackPattern
+  (fu/optionalize-all attack/AttackPattern)
+  "partial-attack-pattern")
+
+(sc/defschema PartialAttackPatternList
+  [PartialAttackPattern])
 
 (def-acl-schema NewAttackPattern
   attack/NewAttackPattern
@@ -274,11 +428,22 @@
   attack/StoredAttackPattern
   "stored-attack-pattern")
 
+(def-stored-schema PartialStoredAttackPattern
+  (fu/optionalize-all attack/StoredAttackPattern)
+  "partial-stored-attack-pattern")
+
 ;; Malware
 
 (def-acl-schema Malware
   malware/Malware
   "malware")
+
+(def-acl-schema PartialMalware
+  (fu/optionalize-all malware/Malware)
+  "partial-malware")
+
+(sc/defschema PartialMalwareList
+  [PartialMalware])
 
 (def-acl-schema NewMalware
   malware/NewMalware
@@ -288,11 +453,22 @@
   malware/StoredMalware
   "stored-malware")
 
+(def-stored-schema PartialStoredMalware
+  (fu/optionalize-all malware/StoredMalware)
+  "partial-stored-malware")
+
+
 ;; Tool
 
 (def-acl-schema Tool
   tool/Tool
   "tool")
+
+(def-acl-schema PartialTool
+  (fu/optionalize-all tool/Tool)
+  "partial-tool")
+
+(sc/defschema PartialToolList [PartialTool])
 
 (def-acl-schema NewTool
   tool/NewTool
@@ -301,6 +477,10 @@
 (def-stored-schema StoredTool
   tool/StoredTool
   "stored-tool")
+
+(def-stored-schema PartialStoredTool
+  (fu/optionalize-all tool/StoredTool)
+  "partial-stored-tool")
 
 ;; common
 

--- a/src/ctia/schemas/graphql.clj
+++ b/src/ctia/schemas/graphql.clj
@@ -42,9 +42,10 @@
    []
    {:indicator {:type IndicatorType
                 :args search-by-id-args
-                :resolve (fn [context args _] (res/indicator-by-id
-                                               (:id args)
-                                               (:ident context)))}
+                :resolve (fn [context args field-selection _] (res/indicator-by-id
+                                                               (:id args)
+                                                               (:ident context)
+                                                               field-selection))}
     :indicators {:type IndicatorConnectionType
                  :args (merge common/lucene-query-arguments
                               indicator/indicator-order-arg
@@ -52,9 +53,10 @@
                  :resolve res/search-indicators}
     :investigation {:type InvestigationType
                     :args search-by-id-args
-                    :resolve (fn [context args _] (res/investigation-by-id
-                                                   (:id args)
-                                                   (:ident context)))}
+                    :resolve (fn [context args field-selection _] (res/investigation-by-id
+                                                                   (:id args)
+                                                                   (:ident context)
+                                                                   field-selection))}
     :investigations {:type InvestigationConnectionType
                      :args (merge common/lucene-query-arguments
                                   investigation/investigation-order-arg
@@ -62,9 +64,10 @@
                      :resolve res/search-investigations}
     :judgement {:type JudgementType
                 :args search-by-id-args
-                :resolve (fn [context args _]
+                :resolve (fn [context args field-selection _]
                            (res/judgement-by-id (:id args)
-                                                (:ident context)))}
+                                                (:ident context)
+                                                field-selection))}
     :judgements {:type JudgementConnectionType
                  :args (merge common/lucene-query-arguments
                               judgement/judgement-order-arg
@@ -73,12 +76,13 @@
     :observable {:type ObservableType
                  :args {:type {:type (g/non-null Scalars/GraphQLString)}
                         :value {:type (g/non-null Scalars/GraphQLString)}}
-                 :resolve (fn [_ args _] args)}
+                 :resolve (fn [_ args _ _] args)}
     :sighting {:type SightingType
                :args search-by-id-args
-               :resolve (fn [context args _]
+               :resolve (fn [context args field-selection _]
                           (res/sighting-by-id (:id args)
-                                              (:ident context)))}
+                                              (:ident context)
+                                              field-selection))}
     :sightings {:type SightingConnectionType
                 :args (merge common/lucene-query-arguments
                              sighting/sighting-order-arg

--- a/src/ctia/schemas/graphql/feedback.clj
+++ b/src/ctia/schemas/graphql/feedback.clj
@@ -1,16 +1,18 @@
 (ns ctia.schemas.graphql.feedback
-  (:require [ctia.schemas.graphql
-             [flanders :as f]
-             [helpers :as g]
-             [pagination :as pagination]
-             [resolvers :as resolvers]]
-            [ctim.schemas.feedback :as ctim-feedback]
-            [ctia.schemas.graphql.sorting :as sorting]
-            [ctia.schemas.sorting :as sort-fields]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [flanders :as f]
+    [helpers :as g]
+    [pagination :as pagination]
+    [resolvers :as resolvers]]
+   [ctim.schemas.feedback :as ctim-feedback]
+   [ctia.schemas.graphql.sorting :as sorting]
+   [ctia.schemas.sorting :as sort-fields]))
 
 (def FeedbackType
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-feedback/Feedback)]
+        (f/->graphql (fu/optionalize-all ctim-feedback/Feedback))]
     (g/new-object name description [] fields)))
 
 (def feedback-order-arg

--- a/src/ctia/schemas/graphql/feedback.clj
+++ b/src/ctia/schemas/graphql/feedback.clj
@@ -33,8 +33,9 @@
     :args (into pagination/connection-arguments
                 feedback-order-arg)
     :resolve
-    (fn [context args src]
+    (fn [context args field-selection src]
       (resolvers/search-feedbacks-by-entity-id (:id src)
                                                context
-                                               args))}})
+                                               args
+                                               field-selection))}})
 

--- a/src/ctia/schemas/graphql/indicator.clj
+++ b/src/ctia/schemas/graphql/indicator.clj
@@ -1,19 +1,21 @@
 (ns ctia.schemas.graphql.indicator
-  (:require [ctia.schemas.graphql
-             [feedback :as feedback]
-             [flanders :as f]
-             [helpers :as g]
-             [pagination :as pagination]
-             [refs :as refs]
-             [relationship :as relationship]
-             [sorting :as sorting]]
-            [ctia.schemas.sorting :as sort-fields]
-            [ctim.schemas.indicator :as ctim-indicator-schema]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [feedback :as feedback]
+    [flanders :as f]
+    [helpers :as g]
+    [pagination :as pagination]
+    [refs :as refs]
+    [relationship :as relationship]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.schemas.indicator :as ctim-indicator-schema]))
 
 (def IndicatorType
   (let [{:keys [fields name description]}
         (f/->graphql
-         ctim-indicator-schema/Indicator
+         (fu/optionalize-all ctim-indicator-schema/Indicator)
          {refs/related-judgement-type-name relationship/RelatedJudgement
           refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object name description []

--- a/src/ctia/schemas/graphql/judgement.clj
+++ b/src/ctia/schemas/graphql/judgement.clj
@@ -1,18 +1,20 @@
 (ns ctia.schemas.graphql.judgement
-  (:require [ctia.schemas.graphql
-             [feedback :as feedback]
-             [flanders :as f]
-             [helpers :as g]
-             [pagination :as pagination]
-             [refs :as refs]
-             [relationship :as relationship]
-             [sorting :as sorting]]
-            [ctia.schemas.sorting :as sort-fields]
-            [ctim.schemas.judgement :as ctim-judgement-schema]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [feedback :as feedback]
+    [flanders :as f]
+    [helpers :as g]
+    [pagination :as pagination]
+    [refs :as refs]
+    [relationship :as relationship]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.schemas.judgement :as ctim-judgement-schema]))
 
 (def JudgementType
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-judgement-schema/Judgement
+        (f/->graphql (fu/optionalize-all ctim-judgement-schema/Judgement)
                      {refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object
      name

--- a/src/ctia/schemas/graphql/observable.clj
+++ b/src/ctia/schemas/graphql/observable.clj
@@ -24,17 +24,18 @@
 
 (def observable-fields
   {:verdict {:type verdict/VerdictType
-             :resolve (fn [context _ src]
+             :resolve (fn [context _ _ src]
                         (observable-verdict (select-keys src [:type :value])
                                             (:ident context)))}
    :judgements {:type judgement/JudgementConnectionType
                 :args (into pagination/connection-arguments
                             judgement/judgement-order-arg)
-                :resolve (fn [context args src]
+                :resolve (fn [context args field-selection src]
                            (resolvers/search-judgements-by-observable
                             (select-keys src [:type :value])
                             context
-                            args))}})
+                            args
+                            field-selection))}})
 
 (def ObservableType
   (let [{:keys [fields name description]}

--- a/src/ctia/schemas/graphql/observable.clj
+++ b/src/ctia/schemas/graphql/observable.clj
@@ -1,14 +1,16 @@
 (ns ctia.schemas.graphql.observable
-  (:require [ctia.domain.entities.judgement :as ctim-judgement-entity]
-            [ctia.schemas.graphql
-             [flanders :as f]
-             [helpers :as g]
-             [judgement :as judgement]
-             [pagination :as pagination]
-             [resolvers :as resolvers]
-             [verdict :as verdict]]
-            [ctia.store :refer :all]
-            [ctim.schemas.common :as ctim-common-schema]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.domain.entities.judgement :as ctim-judgement-entity]
+   [ctia.schemas.graphql
+    [flanders :as f]
+    [helpers :as g]
+    [judgement :as judgement]
+    [pagination :as pagination]
+    [resolvers :as resolvers]
+    [verdict :as verdict]]
+   [ctia.store :refer :all]
+   [ctim.schemas.common :as ctim-common-schema]))
 
 (defn observable-verdict
   [{observable-type :type
@@ -36,6 +38,6 @@
 
 (def ObservableType
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-common-schema/Observable)]
+        (f/->graphql (fu/optionalize-all ctim-common-schema/Observable))]
     (g/new-object name description [] (into observable-fields
                                             fields))))

--- a/src/ctia/schemas/graphql/relationship.clj
+++ b/src/ctia/schemas/graphql/relationship.clj
@@ -25,9 +25,9 @@
 (def related-judgement-fields
   {:judgement {:type refs/JudgementRef
                :description "The related Judgement"
-               :resolve (fn [context _ src]
+               :resolve (fn [context _ field-selection src]
                           (when-let [id (:judgement_id src)]
-                            (res/judgement-by-id id (:ident context))))}})
+                            (res/judgement-by-id id (:ident context) field-selection)))}})
 
 (def RelatedJudgement
   (let [{:keys [fields name description]}
@@ -60,21 +60,23 @@
   (merge
    (g/non-nulls
     {:source_entity {:type Entity
-                     :resolve (fn [context args src]
+                     :resolve (fn [context args field-selection src]
                                 (log/debug "Source resolver" args src)
                                 (let [ref (:source_ref src)
                                       entity-type (ref->entity-type ref)]
                                   (entity-by-id entity-type
                                                 ref
-                                                (:ident context))))}
+                                                (:ident context)
+                                                field-selection)))}
      :target_entity {:type Entity
-                     :resolve (fn [context args src]
+                     :resolve (fn [context args field-selection src]
                                 (log/debug "Target resolver" args src)
                                 (let [ref (:target_ref src)
                                       entity-type (ref->entity-type ref)]
                                   (entity-by-id entity-type
                                                 ref
-                                                (:ident context))))}})))
+                                                (:ident context)
+                                                field-selection)))}})))
 
 (def RelationshipType
   (let [{:keys [fields name description]}

--- a/src/ctia/schemas/graphql/relationship.clj
+++ b/src/ctia/schemas/graphql/relationship.clj
@@ -1,22 +1,25 @@
 (ns ctia.schemas.graphql.relationship
-  (:require [clojure.tools.logging :as log]
-            [ctia.schemas.graphql
-             [common :as common]
-             [flanders :as f]
-             [helpers :as g]
-             [pagination :as p]
-             [refs :as refs]
-             [resolvers :as res :refer [entity-by-id search-relationships]]
-             [sorting :as sorting]]
-            [ctia.schemas.sorting :as sort-fields]
-            [ctim.domain.id :as id]
-            [ctim.schemas
-             [indicator :as ctim-ind]
-             [judgement :as ctim-j]
-             [relationship :as ctim-rel]
-             [sighting :as ctim-sig]
-             [vocabularies :as ctim-voc]]
-            [schema.core :as s])
+  (:require
+   [flanders.utils :as fu]
+   [clojure.tools.logging :as log]
+   [ctia.schemas.graphql
+    [common :as common]
+    [flanders :as f]
+    [helpers :as g]
+    [pagination :as p]
+    [refs :as refs]
+    [resolvers :as res
+     :refer [entity-by-id search-relationships]]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.domain.id :as id]
+   [ctim.schemas
+    [indicator :as ctim-ind]
+    [judgement :as ctim-j]
+    [relationship :as ctim-rel]
+    [sighting :as ctim-sig]
+    [vocabularies :as ctim-voc]]
+   [schema.core :as s])
   (:import graphql.Scalars))
 
 (def related-judgement-fields
@@ -28,7 +31,7 @@
 
 (def RelatedJudgement
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-rel/RelatedJudgement)]
+        (f/->graphql (fu/optionalize-all ctim-rel/RelatedJudgement))]
     (g/new-object name description [] (into fields
                                             related-judgement-fields))))
 
@@ -75,7 +78,7 @@
 
 (def RelationshipType
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-rel/Relationship
+        (f/->graphql (fu/optionalize-all ctim-rel/Relationship)
                      {refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object name
                   description

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -30,7 +30,8 @@
    ident
    page-with-long-id-fn]
   (let [paging-params (pagination/connection-params->paging-params args)
-        params (select-keys paging-params [:limit :offset :sort_by])]
+        params (merge (select-keys paging-params [:limit :offset :sort_by])
+                      (select-keys args [:fields]))]
     (log/debugf "Search entity %s graphql args %s" entity-type args)
     (some-> (query-string-search-store
              entity-type
@@ -75,7 +76,7 @@
 (s/defn indicator-by-id
   [id :- s/Str
    ident]
-  (some-> (read-store :indicator read-indicator id ident)
+  (some-> (read-store :indicator read-indicator id ident {})
           ctim-indicator-entity/with-long-id
           ctim-entities/un-store))
 
@@ -93,7 +94,7 @@
 (s/defn investigation-by-id
   [id :- s/Str
    ident]
-  (some-> (read-store :investigation read-investigation id ident)
+  (some-> (read-store :investigation read-investigation id ident {})
           ctim-investigation-entity/with-long-id
           ctim-entities/un-store))
 
@@ -114,7 +115,7 @@
    context :- {s/Keyword s/Any}
    args :- {s/Keyword s/Any}]
   (let [paging-params (pagination/connection-params->paging-params args)
-        params (select-keys paging-params [:limit :offset :sort_by])]
+        params (select-keys paging-params [:limit :offset :sort_by :fields])]
     (some-> (read-store :judgement
                         list-judgements-by-observable
                         observable
@@ -127,7 +128,7 @@
 (s/defn judgement-by-id
   [id :- s/Str
    ident]
-  (some-> (read-store :judgement read-judgement id ident)
+  (some-> (read-store :judgement read-judgement id ident {})
           ctim-judgement-entity/with-long-id
           ctim-entities/un-store))
 
@@ -145,7 +146,7 @@
 (s/defn sighting-by-id
   [id :- s/Str
    ident]
-  (some-> (read-store :sighting read-sighting id ident)
+  (some-> (read-store :sighting read-sighting id ident {})
           ctim-sighting-entity/with-long-id
           ctim-entities/un-store))
 

--- a/src/ctia/schemas/graphql/sighting.clj
+++ b/src/ctia/schemas/graphql/sighting.clj
@@ -1,19 +1,21 @@
 (ns ctia.schemas.graphql.sighting
-  (:require [ctia.schemas.graphql
-             [feedback :as feedback]
-             [flanders :as flanders]
-             [helpers :as g]
-             [pagination :as pagination]
-             [refs :as refs]
-             [relationship :as relationship]
-             [sorting :as sorting]]
-            [ctia.schemas.sorting :as sort-fields]
-            [ctim.schemas.sighting :as ctim-sighting]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [feedback :as feedback]
+    [flanders :as flanders]
+    [helpers :as g]
+    [pagination :as pagination]
+    [refs :as refs]
+    [relationship :as relationship]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.schemas.sighting :as ctim-sighting]))
 
 (def SightingType
   (let [{:keys [fields name description]}
         (flanders/->graphql
-         ctim-sighting/Sighting
+         (fu/optionalize-all ctim-sighting/Sighting)
          {refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object
      name

--- a/src/ctia/schemas/graphql/verdict.clj
+++ b/src/ctia/schemas/graphql/verdict.clj
@@ -1,10 +1,12 @@
 (ns ctia.schemas.graphql.verdict
-  (:require [ctia.schemas.graphql
-             [flanders :as f]
-             [helpers :as g]
-             [refs :as refs]
-             [resolvers :as resolvers]]
-            [ctim.schemas.verdict :as ctim-verdict-schema]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [flanders :as f]
+    [helpers :as g]
+    [refs :as refs]
+    [resolvers :as resolvers]]
+   [ctim.schemas.verdict :as ctim-verdict-schema]))
 
 (def verdict-fields
   {:judgement {:type refs/JudgementRef
@@ -15,7 +17,7 @@
 
 (def VerdictType
   (let [{:keys [fields name description]}
-        (f/->graphql ctim-verdict-schema/Verdict
+        (f/->graphql (fu/optionalize-all ctim-verdict-schema/Verdict)
                      {refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object name description [] (into fields
                                             verdict-fields))))

--- a/src/ctia/schemas/graphql/verdict.clj
+++ b/src/ctia/schemas/graphql/verdict.clj
@@ -11,9 +11,9 @@
 (def verdict-fields
   {:judgement {:type refs/JudgementRef
                :description "The confidence with which the judgement was made."
-               :resolve (fn [context _ src]
+               :resolve (fn [context _ field-selection src]
                           (when-let [id (:judgement_id src)]
-                            (resolvers/judgement-by-id id (:ident context))))}})
+                            (resolvers/judgement-by-id id (:ident context) field-selection)))}})
 
 (def VerdictType
   (let [{:keys [fields name description]}

--- a/src/ctia/schemas/sorting.clj
+++ b/src/ctia/schemas/sorting.clj
@@ -33,7 +33,15 @@
            :valid_time.end_time
            :confidence
            :status
-           :incident_time
+           :incident_time.first_malicious_action
+           :incident_time.initial_compromise
+           :incident_time.first_data_exfiltration
+           :incident_time.incident_discovery
+           :incident_time.incident_opened
+           :incident_time.containment_achieved
+           :incident_time.restoration_achieved
+           :incident_time.incident_reported
+           :incident_time.incident_closed
            :reporter
            :coordinator
            :victim
@@ -95,7 +103,8 @@
            :valid_time.end_time
            :campaign_type
            :status
-           :activity
+           :activity.date_time
+           :activity.description
            :confidence]))
 
 (def coa-sort-fields

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -2,15 +2,15 @@
   (:require [clojure.tools.logging :as log]))
 
 (defprotocol IActorStore
-  (read-actor [this id ident])
   (create-actors [this new-actors ident])
+  (read-actor [this id ident params])
   (update-actor [this id actor ident])
   (delete-actor [this id ident])
   (list-actors [this filtermap ident params]))
 
 (defprotocol IJudgementStore
   (create-judgements [this new-judgements ident])
-  (read-judgement [this id ident])
+  (read-judgement [this id ident params])
   (delete-judgement [this id ident])
   (list-judgements [this filter-map ident params])
   (calculate-verdict [this observable ident])
@@ -20,39 +20,39 @@
 (defprotocol IIndicatorStore
   (create-indicators [this new-indicators ident])
   (update-indicator [this id indicator ident])
-  (read-indicator [this id ident])
+  (read-indicator [this id ident params])
   (delete-indicator [this id ident])
   (list-indicators [this filtermap ident params]))
 
 (defprotocol IExploitTargetStore
-  (read-exploit-target [this id ident])
+  (read-exploit-target [this id ident params])
   (create-exploit-targets [this new-exploit-targets ident])
   (update-exploit-target [this id exploit-target ident])
   (delete-exploit-target [this id ident])
   (list-exploit-targets [this filtermap ident params]))
 
 (defprotocol IFeedbackStore
-  (read-feedback [this id ident])
+  (read-feedback [this id ident params])
   (create-feedbacks [this new-feedbacks ident])
   (delete-feedback [this id ident])
   (list-feedback [this filtermap ident params]))
 
 (defprotocol ICampaignStore
-  (read-campaign [this id ident])
+  (read-campaign [this id ident params])
   (create-campaigns [this new-campaigns ident])
   (update-campaign [this id campaign ident])
   (delete-campaign [this id ident])
   (list-campaigns [this filtermap ident params]))
 
 (defprotocol ICOAStore
-  (read-coa [this id ident])
+  (read-coa [this id ident params])
   (create-coas [this new-coas ident])
   (update-coa [this id coa ident])
   (delete-coa [this id ident])
   (list-coas [this filtermap ident params]))
 
 (defprotocol ISightingStore
-  (read-sighting [this id ident])
+  (read-sighting [this id ident params])
   (create-sightings [this new-sightings ident])
   (update-sighting [this id sighting ident])
   (delete-sighting [this id ident])
@@ -60,14 +60,14 @@
   (list-sightings-by-observables [this observable ident params]))
 
 (defprotocol IIncidentStore
-  (read-incident [this id ident])
+  (read-incident [this id ident params])
   (create-incidents [this new-incidents ident])
   (update-incident [this id incident ident])
   (delete-incident [this id ident])
   (list-incidents [this filtermap ident params]))
 
 (defprotocol IRelationshipStore
-  (read-relationship [this id ident])
+  (read-relationship [this id ident params])
   (create-relationships [this new-relations ident])
   (delete-relationship [this id ident])
   (list-relationships [this filtermap ident params]))
@@ -78,27 +78,27 @@
   (delete-identity [this org-id role]))
 
 (defprotocol IDataTableStore
-  (read-data-table [this id ident])
+  (read-data-table [this id ident params])
   (create-data-tables [this new-data-tables ident])
   (delete-data-table [this id ident])
   (list-data-tables [this filtermap ident params]))
 
 (defprotocol IAttackPatternStore
-  (read-attack-pattern [this id ident])
+  (read-attack-pattern [this id ident params])
   (create-attack-patterns [this new-attack-patterns ident])
   (update-attack-pattern [this id attack-pattern ident])
   (delete-attack-pattern [this id ident])
   (list-attack-patterns [this filtermap ident params]))
 
 (defprotocol IMalwareStore
-  (read-malware [this id ident])
+  (read-malware [this id ident params])
   (create-malwares [this new-malwares ident])
   (update-malware [this id malware ident])
   (delete-malware [this id ident])
   (list-malwares [this filtermap ident params]))
 
 (defprotocol IToolStore
-  (read-tool [this id ident])
+  (read-tool [this id ident params])
   (create-tools [this new-tools ident])
   (update-tool [this id tool ident])
   (delete-tool [this id ident])
@@ -109,7 +109,7 @@
   (list-events [this filtermap ident params]))
 
 (defprotocol IInvestigationStore
-  (read-investigation [this id ident])
+  (read-investigation [this id ident params])
   (create-investigations [this new-investigations ident])
   (update-investigation [this id investigation ident])
   (delete-investigation [this id ident])

--- a/src/ctia/stores/es/actor.clj
+++ b/src/ctia/stores/es/actor.clj
@@ -1,10 +1,11 @@
 (ns ctia.stores.es.actor
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredActor]]))
+            [ctia.schemas.core
+             :refer [StoredActor PartialStoredActor]]))
 
 (def handle-create (crud/handle-create :actor StoredActor))
-(def handle-read (crud/handle-read :actor StoredActor))
+(def handle-read (crud/handle-read :actor PartialStoredActor))
 (def handle-update (crud/handle-update :actor StoredActor))
 (def handle-delete (crud/handle-delete :actor StoredActor))
-(def handle-list (crud/handle-find :actor StoredActor))
-(def handle-query-string-search (crud/handle-query-string-search :actor StoredActor))
+(def handle-list (crud/handle-find :actor PartialStoredActor))
+(def handle-query-string-search (crud/handle-query-string-search :actor PartialStoredActor))

--- a/src/ctia/stores/es/attack_pattern.clj
+++ b/src/ctia/stores/es/attack_pattern.clj
@@ -1,10 +1,10 @@
 (ns ctia.stores.es.attack-pattern
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredAttackPattern]]))
+            [ctia.schemas.core :refer [StoredAttackPattern PartialStoredAttackPattern]]))
 
 (def handle-create (crud/handle-create :attack-pattern StoredAttackPattern))
-(def handle-read (crud/handle-read :attack-pattern StoredAttackPattern))
+(def handle-read (crud/handle-read :attack-pattern PartialStoredAttackPattern))
 (def handle-update (crud/handle-update :attack-pattern StoredAttackPattern))
 (def handle-delete (crud/handle-delete :attack-pattern StoredAttackPattern))
-(def handle-list (crud/handle-find :attack-pattern StoredAttackPattern))
-(def handle-query-string-search (crud/handle-query-string-search :attack-pattern StoredAttackPattern))
+(def handle-list (crud/handle-find :attack-pattern PartialStoredAttackPattern))
+(def handle-query-string-search (crud/handle-query-string-search :attack-pattern PartialStoredAttackPattern))

--- a/src/ctia/stores/es/campaign.clj
+++ b/src/ctia/stores/es/campaign.clj
@@ -1,10 +1,10 @@
 (ns ctia.stores.es.campaign
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredCampaign]]))
+            [ctia.schemas.core :refer [StoredCampaign PartialStoredCampaign]]))
 
 (def handle-create (crud/handle-create :campaign StoredCampaign))
-(def handle-read (crud/handle-read :campaign StoredCampaign))
+(def handle-read (crud/handle-read :campaign PartialStoredCampaign))
 (def handle-update (crud/handle-update :campaign StoredCampaign))
 (def handle-delete (crud/handle-delete :campaign StoredCampaign))
-(def handle-list (crud/handle-find :campaign StoredCampaign))
-(def handle-query-string-search (crud/handle-query-string-search :campaign StoredCampaign))
+(def handle-list (crud/handle-find :campaign PartialStoredCampaign))
+(def handle-query-string-search (crud/handle-query-string-search :campaign PartialStoredCampaign))

--- a/src/ctia/stores/es/coa.clj
+++ b/src/ctia/stores/es/coa.clj
@@ -1,10 +1,11 @@
 (ns ctia.stores.es.coa
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredCOA]]))
+            [ctia.schemas.core
+             :refer [StoredCOA PartialStoredCOA]]))
 
 (def handle-create (crud/handle-create :coa StoredCOA))
-(def handle-read (crud/handle-read :coa StoredCOA))
+(def handle-read (crud/handle-read :coa PartialStoredCOA))
 (def handle-update (crud/handle-update :coa StoredCOA))
 (def handle-delete (crud/handle-delete :coa StoredCOA))
-(def handle-list (crud/handle-find :coa StoredCOA))
-(def handle-query-string-search (crud/handle-query-string-search :coa StoredCOA))
+(def handle-list (crud/handle-find :coa PartialStoredCOA))
+(def handle-query-string-search (crud/handle-query-string-search :coa PartialStoredCOA))

--- a/src/ctia/stores/es/exploit_target.clj
+++ b/src/ctia/stores/es/exploit_target.clj
@@ -1,10 +1,11 @@
 (ns ctia.stores.es.exploit-target
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredExploitTarget]]))
+            [ctia.schemas.core
+             :refer [StoredExploitTarget PartialStoredExploitTarget]]))
 
 (def handle-create (crud/handle-create :exploit-target StoredExploitTarget))
-(def handle-read (crud/handle-read :exploit-target StoredExploitTarget))
+(def handle-read (crud/handle-read :exploit-target PartialStoredExploitTarget))
 (def handle-update (crud/handle-update :exploit-target StoredExploitTarget))
 (def handle-delete (crud/handle-delete :exploit-target StoredExploitTarget))
-(def handle-list (crud/handle-find :exploit-target StoredExploitTarget))
-(def handle-query-string-search (crud/handle-query-string-search :exploit-target StoredExploitTarget))
+(def handle-list (crud/handle-find :exploit-target PartialStoredExploitTarget))
+(def handle-query-string-search (crud/handle-query-string-search :exploit-target PartialStoredExploitTarget))

--- a/src/ctia/stores/es/feedback.clj
+++ b/src/ctia/stores/es/feedback.clj
@@ -1,9 +1,9 @@
 (ns ctia.stores.es.feedback
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredFeedback]]))
+            [ctia.schemas.core :refer [StoredFeedback PartialStoredFeedback]]))
 
 (def handle-create (crud/handle-create :feedback StoredFeedback))
-(def handle-read (crud/handle-read :feedback StoredFeedback))
+(def handle-read (crud/handle-read :feedback PartialStoredFeedback))
 (def handle-update (crud/handle-update :feedback StoredFeedback))
 (def handle-delete (crud/handle-delete :feedback StoredFeedback))
-(def handle-list (crud/handle-find :feedback StoredFeedback))
+(def handle-list (crud/handle-find :feedback PartialStoredFeedback))

--- a/src/ctia/stores/es/identity.clj
+++ b/src/ctia/stores/es/identity.clj
@@ -38,7 +38,8 @@
   (some-> (get-doc (:conn state)
                    (:index state)
                    mapping
-                   login)
+                   login
+                   {})
           (update-in [:capabilities] capabilities->capabilities-set)
           (dissoc :id)))
 

--- a/src/ctia/stores/es/incident.clj
+++ b/src/ctia/stores/es/incident.clj
@@ -1,10 +1,11 @@
 (ns ctia.stores.es.incident
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredIncident]]))
+            [ctia.schemas.core
+             :refer [StoredIncident PartialStoredIncident]]))
 
 (def handle-create (crud/handle-create :incident StoredIncident))
-(def handle-read (crud/handle-read :incident StoredIncident))
+(def handle-read (crud/handle-read :incident PartialStoredIncident))
 (def handle-update (crud/handle-update :incident StoredIncident))
 (def handle-delete (crud/handle-delete :incident StoredIncident))
-(def handle-list (crud/handle-find :incident StoredIncident))
-(def handle-query-string-search (crud/handle-query-string-search :incident StoredIncident))
+(def handle-list (crud/handle-find :incident PartialStoredIncident))
+(def handle-query-string-search (crud/handle-query-string-search :incident PartialStoredIncident))

--- a/src/ctia/stores/es/indicator.clj
+++ b/src/ctia/stores/es/indicator.clj
@@ -1,12 +1,13 @@
 (ns ctia.stores.es.indicator
-  (:require [ctia.schemas.core :refer [StoredIndicator]]
+  (:require [ctia.schemas.core
+             :refer [StoredIndicator PartialStoredIndicator]]
             [ctia.stores.es.crud :as crud]))
 
 (def handle-create (crud/handle-create :indicator StoredIndicator))
-(def handle-read (crud/handle-read :indicator StoredIndicator))
+(def handle-read (crud/handle-read :indicator PartialStoredIndicator))
 (def handle-update (crud/handle-update :indicator StoredIndicator))
 (def handle-delete (crud/handle-delete :indicator StoredIndicator))
-(def handle-list (crud/handle-find :indicator StoredIndicator))
-(def handle-query-string-search (crud/handle-query-string-search :indicator StoredIndicator))
+(def handle-list (crud/handle-find :indicator PartialStoredIndicator))
+(def handle-query-string-search (crud/handle-query-string-search :indicator PartialStoredIndicator))
 
 (def ^{:private true} mapping "indicator")

--- a/src/ctia/stores/es/investigation.clj
+++ b/src/ctia/stores/es/investigation.clj
@@ -1,12 +1,13 @@
 (ns ctia.stores.es.investigation
   (:require
    [ctia.stores.es.crud :as crud]
-   [ctia.schemas.core :refer [StoredInvestigation]]))
+   [ctia.schemas.core
+    :refer [StoredInvestigation PartialStoredInvestigation]]))
 
 (def handle-create (crud/handle-create :investigation StoredInvestigation))
-(def handle-read (crud/handle-read :investigation StoredInvestigation))
+(def handle-read (crud/handle-read :investigation PartialStoredInvestigation))
 (def handle-update (crud/handle-update :investigation StoredInvestigation))
 (def handle-delete (crud/handle-delete :investigation StoredInvestigation))
-(def handle-list (crud/handle-find :investigation StoredInvestigation))
+(def handle-list (crud/handle-find :investigation PartialStoredInvestigation))
 (def handle-query-string-search (crud/handle-query-string-search
-                                 :investigation StoredInvestigation))
+                                 :investigation PartialStoredInvestigation))

--- a/src/ctia/stores/es/malware.clj
+++ b/src/ctia/stores/es/malware.clj
@@ -1,10 +1,10 @@
 (ns ctia.stores.es.malware
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredMalware]]))
+            [ctia.schemas.core :refer [StoredMalware PartialStoredMalware]]))
 
 (def handle-create (crud/handle-create :malware StoredMalware))
-(def handle-read (crud/handle-read :malware StoredMalware))
+(def handle-read (crud/handle-read :malware PartialStoredMalware))
 (def handle-update (crud/handle-update :malware StoredMalware))
 (def handle-delete (crud/handle-delete :malware StoredMalware))
-(def handle-list (crud/handle-find :malware StoredMalware))
-(def handle-query-string-search (crud/handle-query-string-search :malware StoredMalware))
+(def handle-list (crud/handle-find :malware PartialStoredMalware))
+(def handle-query-string-search (crud/handle-query-string-search :malware PartialStoredMalware))

--- a/src/ctia/stores/es/relationship.clj
+++ b/src/ctia/stores/es/relationship.clj
@@ -1,9 +1,10 @@
 (ns ctia.stores.es.relationship
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredRelationship]]))
+            [ctia.schemas.core
+             :refer [StoredRelationship PartialStoredRelationship]]))
 
 (def handle-create (crud/handle-create :relationship StoredRelationship))
-(def handle-read (crud/handle-read :relationship StoredRelationship))
+(def handle-read (crud/handle-read :relationship PartialStoredRelationship))
 (def handle-delete (crud/handle-delete :relationship StoredRelationship))
-(def handle-list (crud/handle-find :relationship StoredRelationship))
-(def handle-query-string-search (crud/handle-query-string-search :relationship StoredRelationship))
+(def handle-list (crud/handle-find :relationship PartialStoredRelationship))
+(def handle-query-string-search (crud/handle-query-string-search :relationship PartialStoredRelationship))

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -21,7 +21,7 @@
 (def es-coerce! (crud/coerce-to-fn [(s/maybe ESPartialStoredSighting)]))
 
 (def create-fn (crud/handle-create :sighting ESStoredSighting))
-(def read-fn (crud/handle-read :sighting ESStoredSighting))
+(def read-fn (crud/handle-read :sighting ESPartialStoredSighting))
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
 (def list-fn (crud/handle-find :sighting ESPartialStoredSighting))
 (def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
@@ -55,15 +55,15 @@
       s)))
 
 (s/defn es-stored-sighting->stored-sighting
-  :- (s/maybe PartialStoredSighting)
+  :- (s/maybe StoredSighting)
   "remove the computed observables hash from a sighting"
-  [s :- (s/maybe ESPartialStoredSighting)]
+  [s :- (s/maybe ESStoredSighting)]
   (when s (dissoc s :observables_hash)))
 
 (s/defn es-partial-stored-sighting->partial-stored-sighting
   :- (s/maybe PartialStoredSighting)
   "remove the computed observables hash from a sighting"
-  [s :- (s/maybe ESStoredSighting)]
+  [s :- (s/maybe ESPartialStoredSighting)]
   (when s (dissoc s :observables_hash)))
 
 (s/defn handle-create :- [StoredSighting]
@@ -94,7 +94,7 @@
   [paginated-list :- ESPartialStoredSightingList]
   (update-in paginated-list
              [:data]
-             #(map es-stored-sighting->stored-sighting (es-coerce! %))))
+             #(map es-partial-stored-sighting->partial-stored-sighting (es-coerce! %))))
 
 (s/defn handle-list :- PartialStoredSightingList
   [state filter-map ident params]

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -1,7 +1,7 @@
 (ns ctia.stores.es.sighting
   (:require [clj-momo.lib.es.schemas :refer [ESConnState]]
             [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.schemas.core :refer [Observable StoredSighting]]
+            [ctia.schemas.core :refer [Observable StoredSighting PartialStoredSighting]]
             [ctia.stores.es.crud :as crud]
             [schema-tools.core :as st]
             [schema.core :as s]))
@@ -9,14 +9,22 @@
 (s/defschema ESStoredSighting
   (st/assoc StoredSighting :observables_hash [s/Str]))
 
+(s/defschema ESPartialStoredSighting
+  (st/assoc PartialStoredSighting (s/optional-key :observables_hash) [s/Str]))
+
 (def ESStoredSightingList (list-response-schema ESStoredSighting))
+(def ESPartialStoredSightingList (list-response-schema ESPartialStoredSighting))
+
 (def StoredSightingList (list-response-schema StoredSighting))
-(def es-coerce! (crud/coerce-to-fn [(s/maybe ESStoredSighting)]))
+(def PartialStoredSightingList (list-response-schema PartialStoredSighting))
+
+(def es-coerce! (crud/coerce-to-fn [(s/maybe ESPartialStoredSighting)]))
+
 (def create-fn (crud/handle-create :sighting ESStoredSighting))
 (def read-fn (crud/handle-read :sighting ESStoredSighting))
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
-(def list-fn (crud/handle-find :sighting ESStoredSighting))
-(def handle-query-string-search (crud/handle-query-string-search :sighting ESStoredSighting))
+(def list-fn (crud/handle-find :sighting ESPartialStoredSighting))
+(def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
 
 (s/defn observable->observable-hash :- s/Str
   "transform an observable to a hash of the form type:value"
@@ -28,14 +36,32 @@
   [observables :- [Observable]]
   (map observable->observable-hash observables))
 
-(s/defn stored-sighting->es-stored-sighting :- (s/maybe ESStoredSighting)
+(s/defn stored-sighting->es-stored-sighting
+  :- (s/maybe ESStoredSighting)
   "adds an observables hash to a sighting"
   [{:keys [observables] :as s :- (s/maybe StoredSighting)}]
   (when s
     (assoc s :observables_hash
            (map observable->observable-hash observables))))
 
-(s/defn es-stored-sighting->stored-sighting :- (s/maybe StoredSighting)
+(s/defn partial-stored-sighting->es-partial-stored-sighting
+  :- (s/maybe ESPartialStoredSighting)
+  "adds an observables hash to a partial-sighting"
+  [{:keys [observables] :as s :- (s/maybe PartialStoredSighting)}]
+  (when s
+    (if observables
+      (assoc s :observables_hash
+             (map observable->observable-hash observables))
+      s)))
+
+(s/defn es-stored-sighting->stored-sighting
+  :- (s/maybe PartialStoredSighting)
+  "remove the computed observables hash from a sighting"
+  [s :- (s/maybe ESPartialStoredSighting)]
+  (when s (dissoc s :observables_hash)))
+
+(s/defn es-partial-stored-sighting->partial-stored-sighting
+  :- (s/maybe PartialStoredSighting)
   "remove the computed observables hash from a sighting"
   [s :- (s/maybe ESStoredSighting)]
   (when s (dissoc s :observables_hash)))
@@ -50,10 +76,10 @@
      (create-fn state $ ident)
      (map es-stored-sighting->stored-sighting $))))
 
-(s/defn handle-read :- (s/maybe StoredSighting)
-  [state id ident]
-  (es-stored-sighting->stored-sighting
-   (read-fn state id ident)))
+(s/defn handle-read :- (s/maybe PartialStoredSighting)
+  [state id ident params]
+  (es-partial-stored-sighting->partial-stored-sighting
+   (read-fn state id ident params)))
 
 (s/defn handle-update :- StoredSighting
   [state id realized ident]
@@ -63,24 +89,26 @@
 
 (def handle-delete (crud/handle-delete :sighting StoredSighting))
 
-(s/defn es-paginated-list->paginated-list :- StoredSightingList
-  [paginated-list :- ESStoredSightingList]
+(s/defn es-paginated-list->paginated-list
+  :- PartialStoredSightingList
+  [paginated-list :- ESPartialStoredSightingList]
   (update-in paginated-list
              [:data]
              #(map es-stored-sighting->stored-sighting (es-coerce! %))))
 
-(s/defn handle-list :- StoredSightingList
+(s/defn handle-list :- PartialStoredSightingList
   [state filter-map ident params]
   (es-paginated-list->paginated-list
    (list-fn state filter-map ident params)))
 
-
-(s/defn handle-query-string-search-sightings :- StoredSightingList
+(s/defn handle-query-string-search-sightings
+  :- PartialStoredSightingList
   [state query filter-map ident params]
   (es-paginated-list->paginated-list
    (handle-query-string-search state query filter-map ident params)))
 
-(s/defn handle-list-by-observables :- StoredSightingList
+(s/defn handle-list-by-observables
+  :- PartialStoredSightingList
   [state observables :- [Observable] ident params]
   (handle-list state
                {:observables_hash

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -51,8 +51,8 @@
     (ju/handle-create state new-judgements ident))
   (add-indicator-to-judgement [_ judgement-id indicator-rel ident]
     (ju/handle-add-indicator-to state judgement-id indicator-rel ident))
-  (read-judgement [_ id ident]
-    (ju/handle-read state id ident))
+  (read-judgement [_ id ident params]
+    (ju/handle-read state id ident params))
   (delete-judgement [_ id ident]
     (ju/handle-delete state id ident))
   (list-judgements [_ filter-map ident params]
@@ -70,8 +70,8 @@
   IRelationshipStore
   (create-relationships [_ new-relationships ident]
     (rel/handle-create state new-relationships ident))
-  (read-relationship [_ id ident]
-    (rel/handle-read state id ident))
+  (read-relationship [_ id ident params]
+    (rel/handle-read state id ident params))
   (delete-relationship [_ id ident]
     (rel/handle-delete state id ident))
   (list-relationships [_ filter-map ident params]
@@ -84,8 +84,8 @@
   IFeedbackStore
   (create-feedbacks [_ new-feedbacks ident]
     (fe/handle-create state new-feedbacks ident))
-  (read-feedback [_ id ident]
-    (fe/handle-read state id ident))
+  (read-feedback [_ id ident params]
+    (fe/handle-read state id ident params))
   (delete-feedback [_ id ident]
     (fe/handle-delete state id ident))
   (list-feedback [_ filter-map ident params]
@@ -97,8 +97,8 @@
     (in/handle-create state new-indicators ident))
   (update-indicator [_ id new-indicator ident]
     (in/handle-update state id new-indicator ident))
-  (read-indicator [_ id ident]
-    (in/handle-read state id ident))
+  (read-indicator [_ id ident params]
+    (in/handle-read state id ident params))
   (delete-indicator [_ id ident]
     (in/handle-delete state id ident))
   (list-indicators [_ filter-map ident params]
@@ -109,8 +109,8 @@
 
 (defrecord ActorStore [state]
   IActorStore
-  (read-actor [_ id ident]
-    (ac/handle-read state id ident))
+  (read-actor [_ id ident params]
+    (ac/handle-read state id ident params))
   (create-actors [_ new-actors ident]
     (ac/handle-create state new-actors ident))
   (update-actor [_ id actor ident]
@@ -125,8 +125,8 @@
 
 (defrecord CampaignStore [state]
   ICampaignStore
-  (read-campaign [_ id ident]
-    (ca/handle-read state id ident))
+  (read-campaign [_ id ident params]
+    (ca/handle-read state id ident params))
   (create-campaigns [_ new-campaigns ident]
     (ca/handle-create state new-campaigns ident))
   (update-campaign [_ id new-campaign ident]
@@ -141,8 +141,8 @@
 
 (defrecord COAStore [state]
   ICOAStore
-  (read-coa [_ id ident]
-    (coa/handle-read state id ident))
+  (read-coa [_ id ident params]
+    (coa/handle-read state id ident params))
   (create-coas [_ new-coas ident]
     (coa/handle-create state new-coas ident))
   (update-coa [_ id new-coa ident]
@@ -157,8 +157,8 @@
 
 (defrecord DataTableStore [state]
   IDataTableStore
-  (read-data-table [_ id ident]
-    (dt/handle-read state id ident))
+  (read-data-table [_ id ident params]
+    (dt/handle-read state id ident params))
   (create-data-tables [_ new-data-tables ident]
     (dt/handle-create state new-data-tables ident))
   (delete-data-table [_ id ident]
@@ -168,8 +168,8 @@
 
 (defrecord IncidentStore [state]
   IIncidentStore
-  (read-incident [_ id ident]
-    (inc/handle-read state id ident))
+  (read-incident [_ id ident params]
+    (inc/handle-read state id ident params))
   (create-incidents [_ new-incidents ident]
     (inc/handle-create state new-incidents ident))
   (update-incident [_ id new-incident ident]
@@ -184,8 +184,8 @@
 
 (defrecord ExploitTargetStore [state]
   IExploitTargetStore
-  (read-exploit-target [_ id ident]
-    (et/handle-read state id ident))
+  (read-exploit-target [_ id ident params]
+    (et/handle-read state id ident params))
   (create-exploit-targets [_ new-exploit-targets ident]
     (et/handle-create state new-exploit-targets ident))
   (update-exploit-target [_ id new-exploit-target ident]
@@ -205,12 +205,12 @@
   (create-identity [_ new-identity]
     (id/handle-create state new-identity))
   (delete-identity [_ org-id role]
-    (id/handle-delete state org-id role)))
+    (id/handle-delete state org-id)))
 
 (defrecord SightingStore [state]
   ISightingStore
-  (read-sighting [_ id ident]
-    (sig/handle-read state id ident))
+  (read-sighting [_ id ident params]
+    (sig/handle-read state id ident params))
   (create-sightings [_ new-sightings ident]
     (sig/handle-create state new-sightings ident))
   (update-sighting [_ id sighting ident]
@@ -227,8 +227,8 @@
 
 (defrecord AttackPatternStore [state]
   IAttackPatternStore
-  (read-attack-pattern [_ id ident]
-    (attack/handle-read state id ident))
+  (read-attack-pattern [_ id ident params]
+    (attack/handle-read state id ident params))
   (create-attack-patterns [_ new-attack-patterns ident]
     (attack/handle-create state new-attack-patterns ident))
   (update-attack-pattern [_ id attack-pattern ident]
@@ -243,8 +243,8 @@
 
 (defrecord MalwareStore [state]
   IMalwareStore
-  (read-malware [_ id ident]
-    (malware/handle-read state id ident))
+  (read-malware [_ id ident params]
+    (malware/handle-read state id ident params))
   (create-malwares [_ new-malwares ident]
     (malware/handle-create state new-malwares ident))
   (update-malware [_ id malware ident]
@@ -259,8 +259,8 @@
 
 (defrecord ToolStore [state]
   IToolStore
-  (read-tool [_ id ident]
-    (tool/handle-read state id ident))
+  (read-tool [_ id ident params]
+    (tool/handle-read state id ident params))
   (create-tools [_ new-tools ident]
     (tool/handle-create state new-tools ident))
   (update-tool [_ id tool ident]
@@ -282,8 +282,8 @@
 
 (defrecord InvestigationStore [state]
   IInvestigationStore
-  (read-investigation [_ id ident]
-    (inv/handle-read state id ident))
+  (read-investigation [_ id ident params]
+    (inv/handle-read state id ident params))
   (create-investigations [_ new-investigations ident]
     (inv/handle-create state new-investigations ident))
   (update-investigation [_ id investigation ident]

--- a/src/ctia/stores/es/tool.clj
+++ b/src/ctia/stores/es/tool.clj
@@ -1,10 +1,10 @@
 (ns ctia.stores.es.tool
   (:require [ctia.stores.es.crud :as crud]
-            [ctia.schemas.core :refer [StoredTool]]))
+            [ctia.schemas.core :refer [StoredTool PartialStoredTool]]))
 
 (def handle-create (crud/handle-create :tool StoredTool))
-(def handle-read (crud/handle-read :tool StoredTool))
+(def handle-read (crud/handle-read :tool PartialStoredTool))
 (def handle-update (crud/handle-update :tool StoredTool))
 (def handle-delete (crud/handle-delete :tool StoredTool))
-(def handle-list (crud/handle-find :tool StoredTool))
-(def handle-query-string-search (crud/handle-query-string-search :tool StoredTool))
+(def handle-list (crud/handle-find :tool PartialStoredTool))
+(def handle-query-string-search (crud/handle-query-string-search :tool PartialStoredTool))

--- a/test/ctia/http/routes/actor_test.clj
+++ b/test/ctia/http/routes/actor_test.clj
@@ -1,6 +1,9 @@
 (ns ctia.http.routes.actor-test
   (:refer-clojure :exclude [get])
-  (:require [ctia.schemas.sorting
+  (:require [ctim.examples.actors
+             :refer [new-actor-minimal
+                     new-actor-maximal]]
+            [ctia.schemas.sorting
              :refer [actor-sort-fields]]
             [clj-momo.test-helpers
              [core :as mth]
@@ -20,8 +23,7 @@
              [field-selection :refer [field-selection-tests]]
              [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.actors :as ex]))
+            [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -191,7 +193,7 @@
     (let [{status :status
            body :body}
           (post "ctia/actor"
-                :body (assoc ex/new-actor-minimal
+                :body (assoc new-actor-minimal
                              ;; This field has an invalid length
                              :title (clojure.string/join (repeatedly 1025 (constantly \0))))
                 :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -208,22 +210,10 @@
   (let [posted-docs
         (doall (map #(:parsed-body
                       (post "ctia/actor"
-                            :body {:external_ids ["http://ex.tld/ctia/actor/actor-123"
-                                                  "http://ex.tld/ctia/actor/actor-456"]
-                                   :title "actor"
-                                   :description "description"
-                                   :actor_type "Hacker"
-                                   :source (str "dotimes " %)
-                                   :confidence "High"
-                                   :motivation "Opportunistic"
-                                   :revision 1
-                                   :language "elvish"
-                                   :sophistication "Innovator"
-                                   :source_uri "http://foo.bar"
-                                   :intended_effect "Destruction"
-                                   :timestamp "2016-02-11T00:40:48.212-00:00"
-                                   :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
-                                                :end_time "2016-07-11T00:40:48.212-00:00"}}
+                            :body (-> new-actor-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)
+                                             :title "foo"))
                             :headers {"Authorization" "45c1f5e3f05d0"}))
                     (range 0 30)))]
 
@@ -240,6 +230,6 @@
 
 (deftest-for-each-store test-actor-routes-access-control
   (access-control-test "actor"
-                       ex/new-actor-minimal
+                       new-actor-minimal
                        true
                        true))

--- a/test/ctia/http/routes/campaign_test.clj
+++ b/test/ctia/http/routes/campaign_test.clj
@@ -1,6 +1,11 @@
 (ns ctia.http.routes.campaign-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers
+  (:require [ctim.examples.campaigns
+             :refer [new-campaign-minimal
+                     new-campaign-maximal]]
+            [ctia.schemas.sorting
+             :refer [campaign-sort-fields]]
+            [clj-momo.test-helpers
              [core :as mth]
              [http :refer [encode]]]
             [clojure
@@ -9,9 +14,13 @@
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
+             [http :refer [doc-id->rel-url]]
+             [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
+             [pagination :refer [pagination-test]]
+             [field-selection :refer [field-selection-tests]]
              [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
             [ctim.domain.id :as id]
@@ -181,3 +190,36 @@
                 :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= status 400))
       (is (re-find #"error.*in.*title" (str/lower-case body))))))
+
+(deftest-for-each-store test-campaign-pagination-field-selection
+  (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (let [posted-docs
+        (doall (map #(:parsed-body
+                      (post "ctia/campaign"
+                            :body (-> new-campaign-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)))
+                            :headers {"Authorization" "45c1f5e3f05d0"}))
+                    (range 0 30)))]
+
+    (pagination-test
+     "ctia/campaign/search?query=*"
+     {"Authorization" "45c1f5e3f05d0"}
+     campaign-sort-fields)
+
+    (field-selection-tests
+     ["ctia/campaign/search?query=*"
+      (-> posted-docs first :id doc-id->rel-url)]
+     {"Authorization" "45c1f5e3f05d0"}
+     campaign-sort-fields)))
+
+(deftest-for-each-store test-campaign-routes-access-control
+  (access-control-test "campaign"
+                       ex/new-campaign-minimal
+                       true
+                       true))

--- a/test/ctia/http/routes/exploit_target_test.clj
+++ b/test/ctia/http/routes/exploit_target_test.clj
@@ -1,22 +1,30 @@
 (ns ctia.http.routes.exploit-target-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
-            [ctia.test-helpers
-             [search :refer [test-query-string-search]]
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.exploit-targets :as ex]))
+  (:require
+   [ctim.examples.exploit-targets
+    :refer [new-exploit-target-maximal
+            new-exploit-target-minimal]]
+   [ctia.schemas.sorting
+    :refer [exploit-target-sort-fields]]
+   [clj-momo.test-helpers
+    [core :as mth]
+    [http :refer [encode]]]
+   [clojure
+    [string :as str]
+    [test :refer [is join-fixtures testing use-fixtures]]]
+   [ctia.domain.entities :refer [schema-version]]
+   [ctia.properties :refer [get-http-show]]
+   [ctia.test-helpers
+    [http :refer [doc-id->rel-url]]
+    [search :refer [test-query-string-search]]
+    [access-control :refer [access-control-test]]
+    [auth :refer [all-capabilities]]
+    [core :as helpers :refer [delete get post put]]
+    [fake-whoami-service :as whoami-helpers]
+    [pagination :refer [pagination-test]]
+    [field-selection :refer [field-selection-tests]]
+    [store :refer [deftest-for-each-store]]]
+   [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -172,15 +180,42 @@
     (let [{status :status
            body :body}
           (post "ctia/exploit-target"
-                :body (assoc ex/new-exploit-target-minimal
+                :body (assoc new-exploit-target-minimal
                              ;; This field has an invalid length
                              :title (clojure.string/join (repeatedly 1025 (constantly \0))))
                 :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= status 400))
       (is (re-find #"error.*in.*title" (str/lower-case body))))))
 
+(deftest-for-each-store test-exploit-target-pagination-field-selection
+  (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (let [posted-docs
+        (doall (map #(:parsed-body
+                      (post "ctia/exploit-target"
+                            :body (-> new-exploit-target-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)))
+                            :headers {"Authorization" "45c1f5e3f05d0"}))
+                    (range 0 30)))]
+
+    (pagination-test
+     "ctia/exploit-target/search?query=*"
+     {"Authorization" "45c1f5e3f05d0"}
+     exploit-target-sort-fields)
+
+    (field-selection-tests
+     ["ctia/exploit-target/search?query=*"
+      (-> posted-docs first :id doc-id->rel-url)]
+     {"Authorization" "45c1f5e3f05d0"}
+     exploit-target-sort-fields)))
+
 (deftest-for-each-store test-exploit-target-routes-access-control
   (access-control-test "exploit-target"
-                       ex/new-exploit-target-minimal
+                       new-exploit-target-minimal
                        true
                        true))

--- a/test/ctia/http/routes/judgement_test.clj
+++ b/test/ctia/http/routes/judgement_test.clj
@@ -1,6 +1,8 @@
 (ns ctia.http.routes.judgement-test
   (:refer-clojure :exclude [get])
-  (:require [ctia.schemas.sorting
+  (:require [ctim.examples.judgements
+             :refer [new-judgement-maximal]]
+            [ctia.schemas.sorting
              :refer [judgement-sort-fields]]
             [clj-momo.lib.clj-time.core :as time]
             [clj-momo.test-helpers
@@ -469,23 +471,12 @@
   (let [posted-docs
         (doall (map #(:parsed-body
                       (post "ctia/judgement"
-                            :body {:observable {:value "1.2.3.4"
-                                                :type "ip"}
-                                   :disposition 5
-                                   :disposition_name "Unknown"
-                                   :source (str "dotimes " %)
-                                   :priority 100
-                                   :severity "High"
-                                   :confidence "Low"
-                                   :revision 1
-                                   :language "fr"
-                                   :source_uri "http://foo.bar"
-                                   :reason "foo"
-                                   :timestamp "2016-02-11T00:40:48.212-00:00"
-                                   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"}}
+                            :body (-> new-judgement-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)
+                                             :observable {:value "1.2.3.4", :type "ip"}))
                             :headers {"Authorization" "45c1f5e3f05d0"}))
                     (range 0 30)))]
-
     (pagination-test
      "ctia/ip/1.2.3.4/judgements"
      {"Authorization" "45c1f5e3f05d0"}

--- a/test/ctia/http/routes/judgement_test.clj
+++ b/test/ctia/http/routes/judgement_test.clj
@@ -199,33 +199,6 @@
                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}]
                judgements))))
 
-      (testing "GET /ctia/judgement/:id with query-param Authorization"
-        (let [{status :status
-               judgement :parsed-body
-               :as response}
-              (get (str "ctia/judgement/" (:short-id judgement-id))
-                   :query-params {:Authorization "45c1f5e3f05d0"})]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id judgement-id)
-                :type "judgement"
-                :observable {:value "1.2.3.4"
-                             :type "ip"}
-                :external_ids ["http://ex.tld/ctia/judgement/judgement-123"
-                               "http://ex.tld/ctia/judgement/judgement-456"]
-                :disposition 2
-                :disposition_name "Malicious"
-                :priority 100
-                :severity "High"
-                :confidence "Low"
-                :source "test"
-                :tlp "green"
-                :schema_version schema-version
-                :reason "This is a bad IP address that talked to some evil servers"
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-               judgement))))
-
       (testing "GET /ctia/judgement/:id authentication failures"
         (testing "no Authorization"
           (let [{body :parsed-body status :status}

--- a/test/ctia/http/routes/malware_test.clj
+++ b/test/ctia/http/routes/malware_test.clj
@@ -1,6 +1,10 @@
 (ns ctia.http.routes.malware-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers
+  (:require [ctim.examples.malwares
+             :refer [new-malware-maximal]]
+            [ctia.schemas.sorting
+             :refer [malware-sort-fields]]
+            [clj-momo.test-helpers
              [core :as mth]
              [http :refer [encode]]]
             [clojure
@@ -9,10 +13,13 @@
             [ctia.domain.entities :refer [schema-version]]
             [ctia.properties :refer [get-http-show]]
             [ctia.test-helpers
+             [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]
+             [pagination :refer [pagination-test]]
+             [field-selection :refer [field-selection-tests]]
              [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
             [ctim.domain.id :as id]
@@ -163,6 +170,32 @@
                 :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= status 400))
       (is (re-find #"error.*in.*name" (str/lower-case body))))))
+
+(deftest-for-each-store test-malware-pagination-field-selection
+  (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (let [posted-docs
+        (doall (map #(:parsed-body
+                      (post "ctia/malware"
+                            :body (-> new-malware-maximal
+                                      (dissoc :id)
+                                      (assoc :description (str "dotimes " %)))
+                            :headers {"Authorization" "45c1f5e3f05d0"}))
+                    (range 0 30)))]
+    (pagination-test
+     "ctia/malware/search?query=*"
+     {"Authorization" "45c1f5e3f05d0"}
+     malware-sort-fields)
+
+    (field-selection-tests
+     ["ctia/malware/search?query=*"
+      (-> posted-docs first :id doc-id->rel-url)]
+     {"Authorization" "45c1f5e3f05d0"}
+     malware-sort-fields)))
 
 (deftest-for-each-store test-malware-routes-access-control
   (access-control-test "malware"

--- a/test/ctia/http/routes/relationship_test.clj
+++ b/test/ctia/http/routes/relationship_test.clj
@@ -1,21 +1,28 @@
 (ns ctia.http.routes.relationship-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure.test :refer [is join-fixtures testing use-fixtures]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
-            [ctia.test-helpers
-             [search :refer [test-query-string-search]]
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.relationships
-             :refer [new-relationship-minimal]]))
+  (:require
+   [ctim.examples.relationships
+    :refer [new-relationship-maximal
+            new-relationship-minimal]]
+   [ctia.schemas.sorting
+    :refer [relationship-sort-fields]]
+   [clj-momo.test-helpers
+    [core :as mth]
+    [http :refer [encode]]]
+   [clojure.test :refer [is join-fixtures testing use-fixtures]]
+   [ctia.domain.entities :refer [schema-version]]
+   [ctia.properties :refer [get-http-show]]
+   [ctia.test-helpers
+    [http :refer [doc-id->rel-url]]
+    [search :refer [test-query-string-search]]
+    [access-control :refer [access-control-test]]
+    [auth :refer [all-capabilities]]
+    [core :as helpers :refer [delete get post]]
+    [fake-whoami-service :as whoami-helpers]
+    [pagination :refer [pagination-test]]
+    [field-selection :refer [field-selection-tests]]
+    [store :refer [deftest-for-each-store]]]
+   [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -179,6 +186,33 @@
           (let [response (get (str "ctia/relationship/" (:short-id relationship-id))
                               :headers {"Authorization" "45c1f5e3f05d0"})]
             (is (= 404 (:status response)))))))))
+
+(deftest-for-each-store test-relationship-pagination-field-selection
+  (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (let [posted-docs
+        (doall (map #(:parsed-body
+                      (post "ctia/relationship"
+                            :body (-> new-relationship-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)))
+                            :headers {"Authorization" "45c1f5e3f05d0"}))
+                    (range 0 30)))]
+
+    (pagination-test
+     "ctia/relationship/search?query=*"
+     {"Authorization" "45c1f5e3f05d0"}
+     relationship-sort-fields)
+
+    (field-selection-tests
+     ["ctia/relationship/search?query=*"
+      (-> posted-docs first :id doc-id->rel-url)]
+     {"Authorization" "45c1f5e3f05d0"}
+     relationship-sort-fields)))
 
 (deftest-for-each-store test-relationship-routes-access-control
   (access-control-test "relationship"

--- a/test/ctia/test_helpers/field_selection.clj
+++ b/test/ctia/test_helpers/field_selection.clj
@@ -1,0 +1,41 @@
+(ns ctia.test-helpers.field-selection
+  (:refer-clojure :exclude [get])
+  (:require [clojure.test :refer [is testing]]
+            [ctia.test-helpers [core :as helpers :refer [get]]]))
+
+(def default-fields
+  #{:id
+    :tlp
+    :authorized_groups
+    :authorized_users})
+
+(defn testable-fields [fields]
+  (remove default-fields fields))
+
+(defn expected-field [field]
+  (-> field
+      name
+      (clojure.string/split #"\.")
+      first
+      keyword))
+
+(defn field-selection-test [route headers fields]
+  "all field selection related tests for given routes and fields"
+  (testing (str "field selection tests for: " route)
+    (doseq [field (testable-fields fields)]
+      (let [{:keys [status parsed-body]}
+            (get route
+                 :headers headers
+                 :query-params {:fields [(name field)]})
+            response-fields (if (vector? parsed-body)
+                              (->> parsed-body
+                                   (mapcat keys)
+                                   set
+                                   testable-fields)
+                              (testable-fields (keys parsed-body)))]
+        (is (= 200 status))
+        (is (= [(expected-field field)] response-fields))))))
+
+(defn field-selection-tests [routes headers fields]
+  (doseq [route routes]
+    (field-selection-test route headers fields)))

--- a/test/ctia/test_helpers/graphql.clj
+++ b/test/ctia/test_helpers/graphql.clj
@@ -133,9 +133,9 @@
   ;; page 1
   (let [{:keys [data errors status]}
         (query graphql-query
-                  (into variables
-                        {:first 1})
-                  operation-name)]
+               (into variables
+                     {:first 1})
+               operation-name)]
     (is (= 200 status))
     (is (empty? errors) "No errors")
     (let [{nodes-p1 :nodes

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -4,6 +4,10 @@
 
 (def api-key "45c1f5e3f05d0")
 
+(defn doc-id->rel-url [doc-id]
+  "given a doc id (url) make a relative url for test queries"
+  (clojure.string/replace doc-id #".*(?=ctia)" ""))
+
 (def test-post
   (mthh/with-port-fn-and-api-key th/get-http-port api-key mthh/test-post))
 

--- a/test/ctia/test_helpers/pagination.clj
+++ b/test/ctia/test_helpers/pagination.clj
@@ -79,19 +79,21 @@
 
   (testing (str route " with sort")
     (doall (map (fn [field]
-                  (is (deep=
-                       (->> (get route :headers headers)
-                            :parsed-body
-                            (sort-by field)
-                            (map field)
-                            (remove nil?))
-                       (->> (get route
-                                 :headers headers
-                                 :query-params {:sort_by (name field)
-                                                :sort_order "asc"})
-                            :parsed-body
-                            (map field)
-                            (remove nil?)))))
+                  (let [manually-sorted (->> (get route :headers headers)
+                                             :parsed-body
+                                             (sort-by field)
+                                             (map field)
+                                             (remove nil?))
+                        route-sorted (->> (get route
+                                               :headers headers
+                                               :query-params {:sort_by (name field)
+                                                              :sort_order "asc"})
+                                          :parsed-body
+                                          (map field)
+                                          (remove nil?))]
+                    (is (deep=
+                         manually-sorted
+                         route-sorted) field)))
                 sort-fields))))
 
 (defn edge-cases-test [route headers]


### PR DESCRIPTION
## Overall description

Querying for snapshots we concluded that CTIA is currently not optimal when used from a single page application because it is not possible to select only fields that are needed while doing queries,
this leads many time a client app to over consume data.

This change enables many optimisations:

- a `REST` client can now select the retrieved fields for each documents on any GET request, wether it's a list, a search or a read-only operation.

- all `Store` read operations have now a `fields` param as a list, allowing to select only what's needed down to the data store implementation.

- all graphql and REST endpoints use this field when querying data, allowing to optimise queries down to the datastore layer.

- all routes requiring intermediary store queries now also use this field to fetch only ids when relevant.

## Functional description

- For every entity `GET` request, a new `fields` query param is available
- Only sorting choices are available for use on this param
- if this field is not used used, the full documents are returned
- if this field is used, only those selected + some mandatory fields are returned (:id  & access control related)
- all swagger `GET` routes have this field documented, enabling to easily compose queries.

## Misc

I also added a lot of missing tests on various entities, especially those related to sorting, this uncovered many hidden bugs that I also fixed in the process

## Screenshots

<img width="853" alt="screen shot 2018-01-15 at 18 28 56" src="https://user-images.githubusercontent.com/1433542/34954841-39e49672-fa22-11e7-881d-b228a38fa773.png">

<img width="859" alt="screen shot 2018-01-15 at 18 30 02" src="https://user-images.githubusercontent.com/1433542/34954875-5c24051a-fa22-11e7-8a9f-b23b35510809.png">

