### PR TITLE
Use the right authentication identity data structure

### DIFF
--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -1,4 +1,5 @@
-(ns ctia.auth)
+(ns ctia.auth
+  (:require [schema.core :as s]))
 
 (defprotocol IIdentity
   (authenticated? [this])
@@ -155,3 +156,10 @@
     false))
 
 (def denied-identity-singleton (->DeniedIdentity))
+
+(s/defn ident->map :- (s/maybe {:login (s/maybe s/Str)
+                                :groups (s/maybe [s/Str])})
+  [ident]
+  (when ident
+    {:login (login ident)
+     :groups (groups ident)}))

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -44,14 +44,6 @@
                                     :capabilities required-capability
                                     :owner (auth/login id)}))))
 
-
-(s/defn ident->map :- (s/maybe {:login (s/maybe s/Str)
-                                :groups (s/maybe [s/Str])})
-  [ident]
-  (when ident
-    {:login (auth/login ident)
-     :groups (auth/groups ident)}))
-
 ;; Create a compojure-api meta-data handler for capability-based
 ;; security. The :identity field must by on the request object
 ;; already, put there by the wrap-authentication middleware. This
@@ -77,5 +69,5 @@
 
 (defmethod meta/restructure-param :identity-map [_ bind-to acc]
   (update acc :lets into
-          [bind-to `(ident->map
+          [bind-to `(auth/ident->map
                      (:identity ~'+compojure-api-request+))]))


### PR DESCRIPTION
Closes #643 

Two data structure are used for authentication identity in CTIA:
- An `IIdentity` protocol (used by the create and update flows)
- A map `{:login login :groups groups}` (used by stores)

The bundle importers was only using the map form.

Changes:
- The `ident->map` helper has been moved to `ctia.auth`
- Usage of the appropriate form in the bulk and bundle importer routes