### PR TITLE
Fix duplicates when submitting bundles

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.25-SNAPSHOT"
+                 [threatgrid/ctim "0.4.25"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
                  [threatgrid/clj-momo "0.2.19"]

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  [threatgrid/ctim "0.4.24"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.18"]
+                 [threatgrid/clj-momo "0.2.19-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,7 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.24"
+                 [threatgrid/ctim "0.4.25-SNAPSHOT"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
                  [threatgrid/clj-momo "0.2.19"]

--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
                  [threatgrid/ctim "0.4.24"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.19-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.19"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -37,7 +37,7 @@ ctia.store.es.default.port=9200
 ctia.store.es.default.indexname=ctia
 ctia.store.es.default.replicas=1
 ctia.store.es.default.shards=5
-ctia.store.es.default.refresh=false
+ctia.store.es.default.refresh=wait_for
 
 ctia.store.actor=es
 ctia.store.attack-pattern=es

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -37,7 +37,7 @@ ctia.store.es.default.port=9200
 ctia.store.es.default.indexname=ctia
 ctia.store.es.default.replicas=1
 ctia.store.es.default.shards=5
-ctia.store.es.default.refresh=wait_for
+ctia.store.es.default.refresh=false
 
 ctia.store.actor=es
 ctia.store.attack-pattern=es
@@ -76,6 +76,7 @@ ctia.store.es.sighting.indexname=ctia_sighting
 ctia.store.es.tool.indexname=ctia_tool
 
 ctia.store.external-key-prefixes=cisco-,ctia-
+ctia.store.bundle-refresh=wait_for
 
 ctia.hook.redis.enabled=true
 ctia.hook.redis.host=localhost

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -9,6 +9,6 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d %p (%t) [%c] - %m%n
 log4j.appender.STDOUT=org.apache.log4j.FileAppender
 log4j.appender.STDOUT.append=false
 log4j.appender.STDOUT.file=/tmp/test.log
-log4j.appender.STDOUT.threshold=DEBUG
+log4j.appender.STDOUT.threshold=INFO
 log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
 log4j.appender.STDOUT.layout.ConversionPattern=%d %p (%t) [%c] - %m%n

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -9,6 +9,6 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d %p (%t) [%c] - %m%n
 log4j.appender.STDOUT=org.apache.log4j.FileAppender
 log4j.appender.STDOUT.append=false
 log4j.appender.STDOUT.file=/tmp/test.log
-log4j.appender.STDOUT.threshold=INFO
+log4j.appender.STDOUT.threshold=DEBUG
 log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
 log4j.appender.STDOUT.layout.ConversionPattern=%d %p (%t) [%c] - %m%n

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -98,7 +98,7 @@
 
                          :tags [{:name "Actor" :description "Actor operations"}
                                 {:name "Attack Pattern" :description "Attack Pattern operations"}
-                                {:name "Bundle" :description "Bundle import"}
+                                {:name "Bundle" :description "Bundle import (Beta)"}
                                 {:name "Campaign" :description "Campaign operations"}
                                 {:name "COA" :description "COA operations"}
                                 {:name "DataTable" :description "DataTable operations"}
@@ -130,7 +130,7 @@
                             actor-routes
                             attack-pattern-routes
                             bulk-routes
-                            (undocumented bundle-routes)
+                            bundle-routes
                             campaign-routes
                             coa-routes
                             data-table-routes

--- a/src/ctia/http/routes/actor.clj
+++ b/src/ctia/http/routes/actor.clj
@@ -37,7 +37,8 @@
                       :store-fn #(write-store :actor
                                               create-actors
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :actor
                       :identity identity

--- a/src/ctia/http/routes/attack_pattern.clj
+++ b/src/ctia/http/routes/attack_pattern.clj
@@ -37,7 +37,8 @@
                       :store-fn #(write-store :attack-pattern
                                               create-attack-patterns
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :attack-pattern
                       :identity identity

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -146,15 +146,11 @@
   ~~~~
   "
   [func bulk & args]
-  (reduce (fn [acc entity-type]
-            (assoc acc
-                   entity-type
-                   (apply func
-                          (get bulk entity-type)
-                          (singular entity-type)
-                          args)))
-          {}
-          (keys bulk)))
+  (->> bulk
+       (pmap (fn [[entity-type entities]]
+               [entity-type
+                (apply func entities (singular entity-type) args)]))
+       (into {})))
 
 (defn merge-tempids
   "Merges tempids from all entities
@@ -194,7 +190,7 @@
                        (dissoc bulk :relationships)
                        tempids
                        login
-                       {})
+                       {:refresh refresh})
          entities-tempids (merge-tempids new-entities)
          new-relationships (gen-bulk-from-fn
                             create-entities

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -50,7 +50,7 @@
 
 (defn create-fn
   "return the create function provided an entity type key"
-  [k auth-identity]
+  [k auth-identity params]
   #(write-store
     k (case k
         :actor          create-actors
@@ -67,7 +67,7 @@
         :relationship   create-relationships
         :sighting       create-sightings
         :tool           create-tools)
-    % (auth/ident->map auth-identity)))
+    % (auth/ident->map auth-identity) params))
 
 (defn read-fn
   "return the create function provided an entity type key"
@@ -111,13 +111,13 @@
 
 (defn create-entities
   "Create many entities provided their type and returns a list of ids"
-  [new-entities entity-type tempids auth-identity]
+  [new-entities entity-type tempids auth-identity params]
   (when (seq new-entities)
     (let [with-long-id (with-long-id-fn entity-type)]
       (update (flows/create-flow
                :entity-type entity-type
                :realize-fn (realize-fn entity-type)
-               :store-fn (create-fn entity-type auth-identity)
+               :store-fn (create-fn entity-type auth-identity params)
                :long-id-fn with-long-id
                :enveloped-result? true
                :identity auth-identity
@@ -186,19 +186,22 @@
 
    1. Creates all entities except Relationships
    2. Creates Relationships with mapping between transient and real IDs"
-  ([bulk login] (create-bulk bulk {} login))
-  ([bulk tempids login]
+  ([bulk login] (create-bulk bulk {} login {}))
+  ([bulk tempids login {:keys [refresh] :as params
+                        :or {refresh "false"}}]
    (let [new-entities (gen-bulk-from-fn
                        create-entities
                        (dissoc bulk :relationships)
                        tempids
-                       login)
+                       login
+                       {})
          entities-tempids (merge-tempids new-entities)
          new-relationships (gen-bulk-from-fn
                             create-entities
                             (select-keys bulk [:relationships])
                             entities-tempids
-                            login)
+                            login
+                            {:refresh refresh})
          all-tempids (merge entities-tempids
                             (merge-tempids new-relationships))
          all-entities (into new-entities new-relationships)

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -298,6 +298,10 @@
              #(dissoc % :new-entity :old-entity)
              (apply concat (vals bundle-import-data)))})
 
+(defn bulk-params []
+  {:refresh
+   (get-in @properties [:ctia :store :bundle-refresh] false)})
+
 (s/defn import-bundle :- BundleImportResult
   [bundle :- NewBundle
    external-key-prefixes :- (s/maybe s/Str)
@@ -312,7 +316,7 @@
                             (entities-import-data->tempids entities-import-data)))
                      (apply merge {}))]
     (debug "Import bundle response"
-           (->> (bulk/create-bulk bulk tempids auth-identity)
+           (->> (bulk/create-bulk bulk tempids auth-identity (bulk-params))
                 (with-bulk-result bundle-import-data)
                 build-response))))
 

--- a/src/ctia/http/routes/campaign.clj
+++ b/src/ctia/http/routes/campaign.clj
@@ -39,7 +39,8 @@
                       :store-fn #(write-store :campaign
                                               create-campaigns
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :campaign
                       :identity identity

--- a/src/ctia/http/routes/coa.clj
+++ b/src/ctia/http/routes/coa.clj
@@ -34,7 +34,8 @@
                                         :store-fn #(write-store :coa
                                                                 create-coas
                                                                 %
-                                                                identity-map)
+                                                                identity-map
+                                                                {})
                                         :long-id-fn with-long-id
                                         :entity-type :coa
                                         :identity identity

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -34,7 +34,8 @@
                       :store-fn #(write-store :data-table
                                               create-data-tables
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :data-table
                       :identity identity

--- a/src/ctia/http/routes/exploit_target.clj
+++ b/src/ctia/http/routes/exploit_target.clj
@@ -37,7 +37,8 @@
                       :store-fn #(write-store :exploit-target
                                               create-exploit-targets
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :exploit-target
                       :identity identity

--- a/src/ctia/http/routes/feedback.clj
+++ b/src/ctia/http/routes/feedback.clj
@@ -34,7 +34,8 @@
                       :store-fn #(write-store :feedback
                                               create-feedbacks
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :feedback
                       :identity identity

--- a/src/ctia/http/routes/incident.clj
+++ b/src/ctia/http/routes/incident.clj
@@ -38,7 +38,8 @@
                       :store-fn #(write-store :incident
                                               create-incidents
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :incident
                       :identity identity

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -42,7 +42,8 @@
                       :store-fn #(write-store :indicator
                                               create-indicators
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :indicator
                       :identity identity

--- a/src/ctia/http/routes/investigation.clj
+++ b/src/ctia/http/routes/investigation.clj
@@ -40,7 +40,8 @@
                       :store-fn #(write-store :investigation
                                               create-investigations
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :investigation
                       :identity identity

--- a/src/ctia/http/routes/judgement.clj
+++ b/src/ctia/http/routes/judgement.clj
@@ -42,7 +42,8 @@
                       :store-fn #(write-store :judgement
                                               create-judgements
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :judgement
                       :identity identity

--- a/src/ctia/http/routes/malware.clj
+++ b/src/ctia/http/routes/malware.clj
@@ -38,7 +38,8 @@
                       :store-fn #(write-store :malware
                                               create-malwares
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :malware
                       :identity identity

--- a/src/ctia/http/routes/relationship.clj
+++ b/src/ctia/http/routes/relationship.clj
@@ -38,7 +38,8 @@
                       :store-fn #(write-store :relationship
                                               create-relationships
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :relationship
                       :identity identity

--- a/src/ctia/http/routes/sighting.clj
+++ b/src/ctia/http/routes/sighting.clj
@@ -36,7 +36,8 @@
                       :store-fn #(write-store :sighting
                                               create-sightings
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :sighting
                       :identity identity

--- a/src/ctia/http/routes/tool.clj
+++ b/src/ctia/http/routes/tool.clj
@@ -38,7 +38,8 @@
                       :store-fn #(write-store :tool
                                               create-tools
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :tool
                       :identity identity

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -28,7 +28,7 @@
    (str "ctia.store.es." store ".port") s/Int
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
-   (str "ctia.store.es." store ".refresh") s/Bool
+   (str "ctia.store.es." store ".refresh") (s/enum "wait_for" "true" "false")
    (str "ctia.store.es." store ".replicas") s/Num
    (str "ctia.store.es." store ".shards") s/Num})
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -4,7 +4,8 @@
             alternative properties file on the classpath or by\n
             setting system properties."}
     ctia.properties
-  (:require [clj-momo.lib.schema :as mls]
+  (:require [clj-momo.lib.es.schemas :refer [Refresh]]
+            [clj-momo.lib.schema :as mls]
             [clj-momo.properties :as mp]
             [ctia.store :as store]
             [schema-tools.core :as st]
@@ -28,7 +29,7 @@
    (str "ctia.store.es." store ".port") s/Int
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
-   (str "ctia.store.es." store ".refresh") (s/enum "wait_for" "true" "false")
+   (str "ctia.store.es." store ".refresh") Refresh
    (str "ctia.store.es." store ".replicas") s/Num
    (str "ctia.store.es." store ".shards") s/Num})
 
@@ -113,6 +114,7 @@
                       "ctia.metrics.riemann.interval" s/Int
 
                       "ctia.store.external-key-prefixes" s/Str
+                      "ctia.store.bundle-refresh" Refresh
 
                       "ctia.store.es.event.slicing.strategy"
                       (s/maybe (s/enum :aliased-index))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -2,14 +2,14 @@
   (:require [clojure.tools.logging :as log]))
 
 (defprotocol IActorStore
-  (create-actors [this new-actors ident])
+  (create-actors [this new-actors ident params])
   (read-actor [this id ident params])
   (update-actor [this id actor ident])
   (delete-actor [this id ident])
   (list-actors [this filtermap ident params]))
 
 (defprotocol IJudgementStore
-  (create-judgements [this new-judgements ident])
+  (create-judgements [this new-judgements ident params])
   (read-judgement [this id ident params])
   (delete-judgement [this id ident])
   (list-judgements [this filter-map ident params])
@@ -18,7 +18,7 @@
   (add-indicator-to-judgement [this judgement-id indicator-relationship ident]))
 
 (defprotocol IIndicatorStore
-  (create-indicators [this new-indicators ident])
+  (create-indicators [this new-indicators ident params])
   (update-indicator [this id indicator ident])
   (read-indicator [this id ident params])
   (delete-indicator [this id ident])
@@ -26,34 +26,34 @@
 
 (defprotocol IExploitTargetStore
   (read-exploit-target [this id ident params])
-  (create-exploit-targets [this new-exploit-targets ident])
+  (create-exploit-targets [this new-exploit-targets ident params])
   (update-exploit-target [this id exploit-target ident])
   (delete-exploit-target [this id ident])
   (list-exploit-targets [this filtermap ident params]))
 
 (defprotocol IFeedbackStore
   (read-feedback [this id ident params])
-  (create-feedbacks [this new-feedbacks ident])
+  (create-feedbacks [this new-feedbacks ident params])
   (delete-feedback [this id ident])
   (list-feedback [this filtermap ident params]))
 
 (defprotocol ICampaignStore
   (read-campaign [this id ident params])
-  (create-campaigns [this new-campaigns ident])
+  (create-campaigns [this new-campaigns ident params])
   (update-campaign [this id campaign ident])
   (delete-campaign [this id ident])
   (list-campaigns [this filtermap ident params]))
 
 (defprotocol ICOAStore
   (read-coa [this id ident params])
-  (create-coas [this new-coas ident])
+  (create-coas [this new-coas ident params])
   (update-coa [this id coa ident])
   (delete-coa [this id ident])
   (list-coas [this filtermap ident params]))
 
 (defprotocol ISightingStore
   (read-sighting [this id ident params])
-  (create-sightings [this new-sightings ident])
+  (create-sightings [this new-sightings ident params])
   (update-sighting [this id sighting ident])
   (delete-sighting [this id ident])
   (list-sightings [this filtermap ident params])
@@ -61,14 +61,14 @@
 
 (defprotocol IIncidentStore
   (read-incident [this id ident params])
-  (create-incidents [this new-incidents ident])
+  (create-incidents [this new-incidents ident params])
   (update-incident [this id incident ident])
   (delete-incident [this id ident])
   (list-incidents [this filtermap ident params]))
 
 (defprotocol IRelationshipStore
   (read-relationship [this id ident params])
-  (create-relationships [this new-relations ident])
+  (create-relationships [this new-relations ident params])
   (delete-relationship [this id ident])
   (list-relationships [this filtermap ident params]))
 
@@ -79,27 +79,27 @@
 
 (defprotocol IDataTableStore
   (read-data-table [this id ident params])
-  (create-data-tables [this new-data-tables ident])
+  (create-data-tables [this new-data-tables ident params])
   (delete-data-table [this id ident])
   (list-data-tables [this filtermap ident params]))
 
 (defprotocol IAttackPatternStore
   (read-attack-pattern [this id ident params])
-  (create-attack-patterns [this new-attack-patterns ident])
+  (create-attack-patterns [this new-attack-patterns ident params])
   (update-attack-pattern [this id attack-pattern ident])
   (delete-attack-pattern [this id ident])
   (list-attack-patterns [this filtermap ident params]))
 
 (defprotocol IMalwareStore
   (read-malware [this id ident params])
-  (create-malwares [this new-malwares ident])
+  (create-malwares [this new-malwares ident params])
   (update-malware [this id malware ident])
   (delete-malware [this id ident])
   (list-malwares [this filtermap ident params]))
 
 (defprotocol IToolStore
   (read-tool [this id ident params])
-  (create-tools [this new-tools ident])
+  (create-tools [this new-tools ident params])
   (update-tool [this id tool ident])
   (delete-tool [this id ident])
   (list-tools [this filtermap ident params]))
@@ -110,7 +110,7 @@
 
 (defprotocol IInvestigationStore
   (read-investigation [this id ident params])
-  (create-investigations [this new-investigations ident])
+  (create-investigations [this new-investigations ident params])
   (update-investigation [this id investigation ident])
   (delete-investigation [this id ident])
   (list-investigations [this filtermap ident params]))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -16,7 +16,8 @@
             [schema
              [coerce :as c]
              [core :as s]]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [clojure.tools.logging :as log]))
 
 (defn make-es-read-params
   "Prepare ES Params for read operations, setting the _source field
@@ -176,6 +177,10 @@
         (throw (ex-info "You are not allowed to delete this document"
                         {:type :access-control-error}))))))
 
+(defn debug [msg v]
+  (log/debug msg v)
+  v)
+
 (defn handle-find
   "Generate an ES find/list handler using some mapping and schema"
   [mapping Model]
@@ -187,12 +192,13 @@
        ident
        params]
       (update
-       (coerce! (search-docs (:conn state)
-                             (:index state)
-                             (name mapping)
-                             (find-restriction-query-part ident)
-                             filter-map
-                             (make-es-read-params params)))
+       (coerce! (debug "Search docs"
+                 (search-docs (:conn state)
+                              (:index state)
+                              (name mapping)
+                              (find-restriction-query-part ident)
+                              filter-map
+                              (make-es-read-params params))))
        :data access-control-filter-list ident))))
 
 (defn handle-query-string-search

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -86,7 +86,8 @@
     (s/fn :- (s/maybe [Model])
       [state :- ESConnState
        models :- [Model]
-       ident]
+       ident
+       {:keys [refresh] :as params}]
       (try
         (->> (bulk-create-doc (:conn state)
                               (map #(assoc %
@@ -94,7 +95,8 @@
                                            :_index (:index state)
                                            :_type (name mapping))
                                    models)
-                              (get-in state [:props :refresh] false))
+                              (or refresh
+                                  (get-in state [:props :refresh] false)))
              (map #(build-create-result % coerce!)))
         (catch Exception e
           (throw

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -16,8 +16,7 @@
             [schema
              [coerce :as c]
              [core :as s]]
-            [clojure.set :as set]
-            [clojure.tools.logging :as log]))
+            [clojure.set :as set]))
 
 (defn make-es-read-params
   "Prepare ES Params for read operations, setting the _source field
@@ -177,10 +176,6 @@
         (throw (ex-info "You are not allowed to delete this document"
                         {:type :access-control-error}))))))
 
-(defn debug [msg v]
-  (log/debug msg v)
-  v)
-
 (defn handle-find
   "Generate an ES find/list handler using some mapping and schema"
   [mapping Model]
@@ -192,13 +187,12 @@
        ident
        params]
       (update
-       (coerce! (debug "Search docs"
-                 (search-docs (:conn state)
-                              (:index state)
-                              (name mapping)
-                              (find-restriction-query-part ident)
-                              filter-map
-                              (make-es-read-params params))))
+       (coerce! (search-docs (:conn state)
+                             (:index state)
+                             (name mapping)
+                             (find-restriction-query-part ident)
+                             filter-map
+                             (make-es-read-params params)))
        :data access-control-filter-list ident))))
 
 (defn handle-query-string-search

--- a/src/ctia/stores/es/sighting.clj
+++ b/src/ctia/stores/es/sighting.clj
@@ -69,11 +69,12 @@
 (s/defn handle-create :- [StoredSighting]
   [state :- ESConnState
    new-sightings :- [StoredSighting]
-   ident]
+   ident
+   params]
   (doall
    (as-> new-sightings $
      (map stored-sighting->es-stored-sighting $)
-     (create-fn state $ ident)
+     (create-fn state $ ident params)
      (map es-stored-sighting->stored-sighting $))))
 
 (s/defn handle-read :- (s/maybe PartialStoredSighting)

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -47,8 +47,8 @@
 
 (defrecord JudgementStore [state]
   IJudgementStore
-  (create-judgements [_ new-judgements ident]
-    (ju/handle-create state new-judgements ident))
+  (create-judgements [_ new-judgements ident params]
+    (ju/handle-create state new-judgements ident params))
   (add-indicator-to-judgement [_ judgement-id indicator-rel ident]
     (ju/handle-add-indicator-to state judgement-id indicator-rel ident))
   (read-judgement [_ id ident params]
@@ -68,8 +68,8 @@
 
 (defrecord RelationshipStore [state]
   IRelationshipStore
-  (create-relationships [_ new-relationships ident]
-    (rel/handle-create state new-relationships ident))
+  (create-relationships [_ new-relationships ident params]
+    (rel/handle-create state new-relationships ident params))
   (read-relationship [_ id ident params]
     (rel/handle-read state id ident params))
   (delete-relationship [_ id ident]
@@ -82,8 +82,8 @@
 
 (defrecord FeedbackStore [state]
   IFeedbackStore
-  (create-feedbacks [_ new-feedbacks ident]
-    (fe/handle-create state new-feedbacks ident))
+  (create-feedbacks [_ new-feedbacks ident params]
+    (fe/handle-create state new-feedbacks ident params))
   (read-feedback [_ id ident params]
     (fe/handle-read state id ident params))
   (delete-feedback [_ id ident]
@@ -93,8 +93,8 @@
 
 (defrecord IndicatorStore [state]
   IIndicatorStore
-  (create-indicators [_ new-indicators ident]
-    (in/handle-create state new-indicators ident))
+  (create-indicators [_ new-indicators ident params]
+    (in/handle-create state new-indicators ident params))
   (update-indicator [_ id new-indicator ident]
     (in/handle-update state id new-indicator ident))
   (read-indicator [_ id ident params]
@@ -111,8 +111,8 @@
   IActorStore
   (read-actor [_ id ident params]
     (ac/handle-read state id ident params))
-  (create-actors [_ new-actors ident]
-    (ac/handle-create state new-actors ident))
+  (create-actors [_ new-actors ident params]
+    (ac/handle-create state new-actors ident params))
   (update-actor [_ id actor ident]
     (ac/handle-update state id actor ident))
   (delete-actor [_ id ident]
@@ -127,8 +127,8 @@
   ICampaignStore
   (read-campaign [_ id ident params]
     (ca/handle-read state id ident params))
-  (create-campaigns [_ new-campaigns ident]
-    (ca/handle-create state new-campaigns ident))
+  (create-campaigns [_ new-campaigns ident params]
+    (ca/handle-create state new-campaigns ident params))
   (update-campaign [_ id new-campaign ident]
     (ca/handle-update state id new-campaign ident))
   (delete-campaign [_ id ident]
@@ -143,8 +143,8 @@
   ICOAStore
   (read-coa [_ id ident params]
     (coa/handle-read state id ident params))
-  (create-coas [_ new-coas ident]
-    (coa/handle-create state new-coas ident))
+  (create-coas [_ new-coas ident params]
+    (coa/handle-create state new-coas ident params))
   (update-coa [_ id new-coa ident]
     (coa/handle-update state id new-coa ident))
   (delete-coa [_ id ident]
@@ -159,8 +159,8 @@
   IDataTableStore
   (read-data-table [_ id ident params]
     (dt/handle-read state id ident params))
-  (create-data-tables [_ new-data-tables ident]
-    (dt/handle-create state new-data-tables ident))
+  (create-data-tables [_ new-data-tables ident params]
+    (dt/handle-create state new-data-tables ident params))
   (delete-data-table [_ id ident]
     (dt/handle-delete state id ident))
   (list-data-tables [_ filter-map ident params]
@@ -170,8 +170,8 @@
   IIncidentStore
   (read-incident [_ id ident params]
     (inc/handle-read state id ident params))
-  (create-incidents [_ new-incidents ident]
-    (inc/handle-create state new-incidents ident))
+  (create-incidents [_ new-incidents ident params]
+    (inc/handle-create state new-incidents ident params))
   (update-incident [_ id new-incident ident]
     (inc/handle-update state id new-incident ident))
   (delete-incident [_ id ident]
@@ -186,8 +186,8 @@
   IExploitTargetStore
   (read-exploit-target [_ id ident params]
     (et/handle-read state id ident params))
-  (create-exploit-targets [_ new-exploit-targets ident]
-    (et/handle-create state new-exploit-targets ident))
+  (create-exploit-targets [_ new-exploit-targets ident params]
+    (et/handle-create state new-exploit-targets ident params))
   (update-exploit-target [_ id new-exploit-target ident]
     (et/handle-update state id new-exploit-target ident))
   (delete-exploit-target [_ id ident]
@@ -211,8 +211,8 @@
   ISightingStore
   (read-sighting [_ id ident params]
     (sig/handle-read state id ident params))
-  (create-sightings [_ new-sightings ident]
-    (sig/handle-create state new-sightings ident))
+  (create-sightings [_ new-sightings ident params]
+    (sig/handle-create state new-sightings ident params))
   (update-sighting [_ id sighting ident]
     (sig/handle-update state id sighting ident))
   (delete-sighting [_ id ident]
@@ -229,8 +229,8 @@
   IAttackPatternStore
   (read-attack-pattern [_ id ident params]
     (attack/handle-read state id ident params))
-  (create-attack-patterns [_ new-attack-patterns ident]
-    (attack/handle-create state new-attack-patterns ident))
+  (create-attack-patterns [_ new-attack-patterns ident params]
+    (attack/handle-create state new-attack-patterns ident params))
   (update-attack-pattern [_ id attack-pattern ident]
     (attack/handle-update state id attack-pattern ident))
   (delete-attack-pattern [_ id ident]
@@ -245,8 +245,8 @@
   IMalwareStore
   (read-malware [_ id ident params]
     (malware/handle-read state id ident params))
-  (create-malwares [_ new-malwares ident]
-    (malware/handle-create state new-malwares ident))
+  (create-malwares [_ new-malwares ident params]
+    (malware/handle-create state new-malwares ident params))
   (update-malware [_ id malware ident]
     (malware/handle-update state id malware ident))
   (delete-malware [_ id ident]
@@ -261,8 +261,8 @@
   IToolStore
   (read-tool [_ id ident params]
     (tool/handle-read state id ident params))
-  (create-tools [_ new-tools ident]
-    (tool/handle-create state new-tools ident))
+  (create-tools [_ new-tools ident params]
+    (tool/handle-create state new-tools ident params))
   (update-tool [_ id tool ident]
     (tool/handle-update state id tool ident))
   (delete-tool [_ id ident]
@@ -284,8 +284,8 @@
   IInvestigationStore
   (read-investigation [_ id ident params]
     (inv/handle-read state id ident params))
-  (create-investigations [_ new-investigations ident]
-    (inv/handle-create state new-investigations ident))
+  (create-investigations [_ new-investigations ident params]
+    (inv/handle-create state new-investigations ident params))
   (update-investigation [_ id investigation ident]
     (inv/handle-update state id investigation ident))
   (delete-investigation [this id ident]

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -145,7 +145,7 @@
     (es-doc/bulk-create-doc
      conn
      prepared-docs
-     false)))
+     "false")))
 
 (defn create-target-store
   "create the target store, pushing its template"

--- a/test/ctia/http/routes/bundle_test.clj
+++ b/test/ctia/http/routes/bundle_test.clj
@@ -277,7 +277,8 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-  (let [nb-entities (+ sut/find-by-external-ids-limit 5)
+  (let [;; See fixture-find-by-external-ids-limit
+        nb-entities (+ sut/find-by-external-ids-limit 5)
         bundle {:type "bundle"
                 :source "source"
                 :indicators (set (map mk-indicator (range nb-entities)))}

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -87,7 +87,7 @@
     (assert (seq host) "Missing host")
     (assert (integer? port) "Missing port")
     (assert (seq indexname) "Missing index-name")
-    (str "http://" host ":" port "/" indexname "/" (name t) "/?refresh=true")))
+    (str "http://" host ":" port "/" indexname "/" (name t) "/")))
 
 (defn post-to-es [obj]
   (let [{:keys [status] :as response}


### PR DESCRIPTION
Closes #645 

- [x] Use the ElasticSearch wait_for param for the bundle import endpoint (See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html)
When a bundle is imported there are three steps:
  * All entities except relationships are created and stored
  * The source_ref and the target_ref in the relationships are set with entities final IDs
  * Relationships are created and stored (The wait_for param is only used at this step)

- [x] Paginate results when searching entities by external_ids
- [x] Display Swagger UI for the bundle routes