### PR TITLE
Scratchpad Entity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,9 +40,10 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/flanders "0.1.15"]
+                 [threatgrid/flanders "0.1.16-SNAPSHOT"]
                  [threatgrid/ctim "0.4.26"
-                  :exclusions [metosin/ring-swagger
+                  :exclusions [threatgrid/flanders
+                               metosin/ring-swagger
                                com.google.guava/guava]]
                  [threatgrid/clj-momo "0.2.20-SNAPSHOT"]
 

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.20-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.20"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,8 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/ctim "0.4.25"
+                 [threatgrid/flanders "0.1.15-SNAPSHOT"]
+                 [threatgrid/ctim "0.4.25-SNAPSHOT"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
                  [threatgrid/clj-momo "0.2.19"]

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,10 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/flanders "0.1.16-SNAPSHOT"]
+                 [threatgrid/flanders "0.1.16"
+                  :exclusions [prismatic/plumbing
+                               potemkin
+                               com.andrewmcveigh/cljs-time]]
                  [threatgrid/ctim "0.4.26"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
@@ -152,7 +155,7 @@
                                    [org.clojure/test.check "0.9.0"]
                                    [com.gfredericks/test.chuck "0.2.8"]
                                    [prismatic/schema-generators "0.1.1"]]
-                    :pedantic? :warn
+                    :pedantic? :abort
                     :java-source-paths ["hooks/ctia"
                                         "test/java"]
                     :resource-paths ["test/resources"

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                  [threatgrid/ctim "0.4.25-SNAPSHOT"
                   :exclusions [metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.19"]
+                 [threatgrid/clj-momo "0.2.20-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version
@@ -151,7 +151,7 @@
                                    [org.clojure/test.check "0.9.0"]
                                    [com.gfredericks/test.chuck "0.2.8"]
                                    [prismatic/schema-generators "0.1.1"]]
-                    :pedantic? :abort
+                    :pedantic? :warn
                     :java-source-paths ["hooks/ctia"
                                         "test/java"]
                     :resource-paths ["test/resources"

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -54,6 +54,7 @@ ctia.store.investigation=es
 ctia.store.judgement=es
 ctia.store.malware=es
 ctia.store.relationship=es
+ctia.store.scratchpad = es
 ctia.store.sighting=es
 ctia.store.tool=es
 
@@ -72,6 +73,7 @@ ctia.store.es.investigation.indexname=ctia_investigation
 ctia.store.es.judgement.indexname=ctia_judgement
 ctia.store.es.malware.indexname=ctia_malware
 ctia.store.es.relationship.indexname=ctia_relationship
+ctia.store.es.scratchpad.indexname = ctia_scratchpad
 ctia.store.es.sighting.indexname=ctia_sighting
 ctia.store.es.tool.indexname=ctia_tool
 

--- a/resources/swagger-ui/index.html
+++ b/resources/swagger-ui/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>IROH - Swagger UI</title>
+  <title>Intel - Swagger UI</title>
   <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
   <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -93,6 +93,13 @@
     :delete-relationship
     :search-relationship
 
+    ;; Scratchpad
+    :create-scratchpad
+    :read-scratchpad
+    :list-scratchpads
+    :delete-scratchpad
+    :search-scratchpad
+
     ;; Sighting
     :create-sighting
     :read-sighting

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -37,6 +37,8 @@
             StoredJudgement
             NewMalware
             StoredMalware
+            NewScratchpad
+            StoredScratchpad
             NewSighting
             StoredSighting
             NewTool
@@ -128,6 +130,9 @@
 
 (def realize-investigation
   (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
+
+(def realize-scratchpad
+  (default-realize-fn "scratchpad" NewScratchpad StoredScratchpad))
 
 (s/defn realize-relationship :- StoredRelationship
   [{:keys [source_ref target_ref]

--- a/src/ctia/domain/entities/scratchpad.clj
+++ b/src/ctia/domain/entities/scratchpad.clj
@@ -1,0 +1,13 @@
+(ns ctia.domain.entities.scratchpad
+  (:require
+   [ctia.properties :refer [get-http-show]]
+   [ctim.domain.id :as id]))
+
+(def short-id->long-id
+  (id/factory:short-id->long-id :scratchpad get-http-show))
+
+(defn with-long-id [entity]
+  (update entity :id short-id->long-id))
+
+(defn page-with-long-id [m]
+  (update m :data (partial map with-long-id)))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -300,20 +300,28 @@
     :delete (first results)
     :update (first entities)))
 
-(defn recast [orig-coll new-coll]
+(defn recast
+  "given a source collection and the target one,
+   cast target the same as source"
+  [orig-coll new-coll]
   (cond
     (vector? orig-coll) (vec new-coll)
     (set? orig-coll) (set new-coll)
     :else new-coll))
 
 (defn add-colls [& args]
+  "given many collections as argument
+   concat them keeping the first argument type"
   (let [new-coll
         (->> args
              (map #(or % []))
              (apply into))]
     (recast (first args) new-coll)))
 
-(defn remove-colls [& args]
+(defn remove-colls
+  "given many collections as argument
+   remove items on a from b successively"
+  [& args]
   (let [new-coll
         (reduce
          (fn [a b]
@@ -321,7 +329,10 @@
                    (or a []))) args)]
     (recast (first args) new-coll)))
 
-(defn replace-colls [& args]
+(defn replace-colls
+  "given many collections as argument
+   replace a from b successively"
+  [& args]
   (let [new-coll (last args)]
     (recast (first args) new-coll)))
 
@@ -394,7 +405,6 @@
              realize-fn
              update-fn
              entity-id
-             partial-entity
              identity
              entity
              long-id-fn
@@ -404,7 +414,6 @@
          :entity-type entity-type
          :entities [entity]
          :prev-entity prev-entity
-         :partial-entity partial-entity
          :identity identity
          :long-id-fn long-id-fn
          :realize-fn realize-fn

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -315,7 +315,7 @@
   (let [new-coll
         (->> args
              (map #(or % []))
-             (apply into))]
+             (reduce into))]
     (recast (first args) new-coll)))
 
 (defn remove-colls

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -16,7 +16,9 @@
             [ctim.domain.id :as id]
             [ctim.events.obj-to-event
              :refer
-             [to-create-event to-delete-event to-update-event]]
+             [to-create-event
+              to-delete-event
+              to-update-event]]
             [ring.util.http-response :as http-response]
             [schema.core :as s])
   (:import java.util.UUID))
@@ -297,7 +299,6 @@
               entities)
     :delete (first results)
     :update (first entities)))
-
 
 (defn recast [orig-coll new-coll]
   (cond

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -1,25 +1,25 @@
 (ns ctia.flows.crud
   "This namespace handle all necessary flows for creating, updating
   and deleting entities."
-  (:import java.util.UUID)
-  (:require
-   [ctia.domain.access-control
-    :refer [allowed-tlps
-            allowed-tlp?]]
-   [clojure.spec.alpha :as cs]
-   [clojure.tools.logging :as log]
-   [ctia.auth :as auth]
-   [ctia.flows.hooks :as h]
-   [ctia.properties :refer [properties]]
-   [ctia.schemas.core :refer [TempIDs]]
-   [ctia.store :as store]
-   [ctim.events.obj-to-event :refer [to-create-event
-                                     to-update-event
-                                     to-delete-event]]
-   [ctim.domain.id :as id]
-   [ring.util.http-response :as http-response]
-   [schema.core :as s]
-   [clojure.set :as set]))
+  (:require [clj-momo.lib.map :refer [deep-merge]]
+            [clojure.spec.alpha :as cs]
+            [clojure.tools.logging :as log]
+            [ctia
+             [auth :as auth]
+             [properties :refer [properties]]
+             [store :as store]]
+            [ctia.domain
+             [access-control :refer [allowed-tlp? allowed-tlps]]
+             [entities :refer [un-store]]]
+            [ctia.flows.hooks :as h]
+            [ctia.schemas.core :refer [TempIDs]]
+            [ctim.domain.id :as id]
+            [ctim.events.obj-to-event
+             :refer
+             [to-create-event to-delete-event to-update-event]]
+            [ring.util.http-response :as http-response]
+            [schema.core :as s])
+  (:import java.util.UUID))
 
 (s/defschema FlowMap
   {:create-event-fn (s/pred fn?)
@@ -352,6 +352,48 @@
              long-id-fn
              spec]}]
   (let [prev-entity (get-fn entity-id)]
+    (-> {:flow-type :update
+         :entity-type entity-type
+         :entities [entity]
+         :prev-entity prev-entity
+         :identity identity
+         :long-id-fn long-id-fn
+         :realize-fn realize-fn
+         :spec spec
+         :store-fn update-fn
+         :create-event-fn to-update-event}
+        validate-entities
+        realize-entities
+        apply-before-hooks
+        apply-store-fn
+        apply-long-id-fn
+        create-events
+        write-events
+        apply-event-hooks
+        apply-after-hooks
+        make-result)))
+
+(defn patch-flow
+  "This function centralizes the patch workflow.
+  It is helpful to easily add new hooks name
+
+  To be noted:
+    - `:before-update` hooks can modify the entity stored.
+    - `:after-update` hooks are read only"
+  [& {:keys [entity-type
+             get-fn
+             realize-fn
+             update-fn
+             entity-id
+             identity
+             partial-entity
+             long-id-fn
+             spec]}]
+  (let [prev-entity (get-fn entity-id)
+        entity (-> prev-entity
+                   (deep-merge partial-entity)
+                   un-store
+                   (dissoc :id))]
     (-> {:flow-type :update
          :entity-type entity-type
          :entities [entity]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -30,6 +30,7 @@
              [observable :refer [observable-routes]]
              [properties :refer [properties-routes]]
              [relationship :refer [relationship-routes]]
+             [scratchpad :refer [scratchpad-routes]]
              [sighting :refer [sighting-routes]]
              [tool :refer [tool-routes]]
              [graphql :refer [graphql-routes
@@ -112,6 +113,7 @@
                                 {:name "Malware", :description "Malware operations"}
                                 {:name "Relationship", :description "Relationship operations"}
                                 {:name "Properties", :description "Properties operations"}
+                                {:name "Scratchpad", :description "Scratchpad operations"}
                                 {:name "Sighting", :description "Sighting operations"}
                                 {:name "Bulk", :description "Bulk operations"}
                                 {:name "Metrics", :description "Performance Statistics"}
@@ -145,9 +147,10 @@
                             observable-routes
                             properties-routes
                             sighting-routes
+                            scratchpad-routes
                             tool-routes
                             relationship-routes
                             graphql-routes
                             version-routes))
        (undocumented
-         (rt/not-found (ok (unk/err-html))))))
+        (rt/not-found (ok (unk/err-html))))))

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -13,9 +13,11 @@
              [feedback :as fbk-ent]
              [incident :as inc-ent]
              [indicator :as ind-ent]
+             [investigation :as inv-ent]
              [judgement :as jud-ent]
              [malware :as malware-ent]
              [relationship :as rel-ent]
+             [scratchpad :as scr-ent]
              [sighting :as sig-ent]
              [tool :as tool-ent]]
             [ctia.flows.crud :as flows]
@@ -41,10 +43,12 @@
     :exploit-target ent/realize-exploit-target
     :feedback       ent/realize-feedback
     :incident       ent/realize-incident
+    :investigation  ent/realize-investigation
     :indicator      ent/realize-indicator
     :judgement      ent/realize-judgement
     :malware        ent/realize-malware
     :relationship   ent/realize-relationship
+    :scratchpad     ent/realize-scratchpad
     :sighting       ent/realize-sighting
     :tool           ent/realize-tool))
 
@@ -62,9 +66,11 @@
         :feedback       create-feedbacks
         :incident       create-incidents
         :indicator      create-indicators
+        :investigation  create-investigations
         :judgement      create-judgements
         :malware        create-malwares
         :relationship   create-relationships
+        :scratchpad     create-scratchpads
         :sighting       create-sightings
         :tool           create-tools)
     % (auth/ident->map auth-identity) params))
@@ -83,9 +89,11 @@
         :feedback       read-feedback
         :incident       read-incident
         :indicator      read-indicator
+        :investigation  read-investigation
         :judgement      read-judgement
         :malware        read-malware
         :relationship   read-relationship
+        :scratchpad     read-scratchpad
         :sighting       read-sighting
         :tool           read-tool)
     % (auth/ident->map auth-identity) params))
@@ -103,9 +111,11 @@
     :feedback       fbk-ent/with-long-id
     :incident       inc-ent/with-long-id
     :indicator      ind-ent/with-long-id
+    :investigation  inv-ent/with-long-id
     :judgement      jud-ent/with-long-id
     :malware        malware-ent/with-long-id
     :relationship   rel-ent/with-long-id
+    :scratchpad     scr-ent/with-long-id
     :sighting       sig-ent/with-long-id
     :tool           tool-ent/with-long-id))
 
@@ -233,10 +243,12 @@
                                  :create-exploit-target
                                  :create-feedback
                                  :create-incident
+                                 :create-investigation
                                  :create-indicator
                                  :create-judgement
                                  :create-malware
                                  :create-relationship
+                                 :create-scratchpad
                                  :create-sighting
                                  :create-tool}
                  (if (> (bulk-size bulk)
@@ -256,9 +268,11 @@
                                {feedbacks       :- [Reference] []}
                                {incidents       :- [Reference] []}
                                {indicators      :- [Reference] []}
+                               {investigations  :- [Reference] []}
                                {judgements      :- [Reference] []}
                                {malwares        :- [Reference] []}
                                {relationships   :- [Reference] []}
+                               {scratchpads     :- [Reference] []}
                                {sightings       :- [Reference] []}
                                {tools           :- [Reference] []}]
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
@@ -271,9 +285,11 @@
                                 :read-feedback
                                 :read-incident
                                 :read-indicator
+                                :read-investigation
                                 :read-judgement
                                 :read-malware
                                 :read-relationship
+                                :read-scratchpad
                                 :read-sighting
                                 :read-tool}
                 :identity auth-identity
@@ -286,10 +302,12 @@
                                              :exploit-targets exploit-targets
                                              :feedbacks       feedbacks
                                              :incidents       incidents
+                                             :investigations  investigations
                                              :indicators      indicators
                                              :judgements      judgements
                                              :malwares        malwares
                                              :relationships   relationships
+                                             :scratchpads     scratchpads
                                              :sightings       sightings
                                              :tools           tools}))]
                   (if (> (bulk-size bulk) (get-bulk-max-size))

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -75,6 +75,9 @@
                          :short_description
                          :created_at])))
 
+(def scratchpad-sort-fields
+  (apply s/enum sorting/scratchpad-sort-fields))
+
 ;; Paging related values and code
 
 (s/defschema PagingParams
@@ -397,6 +400,28 @@
 (s/defschema RelationshipByExternalIdQueryParams
   (st/merge PagingParams
             RelationshipFieldsParam))
+
+;; scratchpad
+
+(s/defschema ScratchpadFieldsParam
+  {(s/optional-key :fields) [scratchpad-sort-fields]})
+
+(s/defschema ScratchpadSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   ScratchpadFieldsParam
+   {:query s/Str
+    (s/optional-key :texts.text) s/Str
+    (s/optional-key :sort_by) scratchpad-sort-fields}))
+
+(def ScratchpadGetParams ScratchpadFieldsParam)
+
+(s/defschema ScratchpadByExternalIdQueryParams
+  (st/merge
+   PagingParams
+   ScratchpadFieldsParam))
 
 ;; sighting
 

--- a/src/ctia/http/routes/scratchpad.clj
+++ b/src/ctia/http/routes/scratchpad.clj
@@ -1,0 +1,158 @@
+(ns ctia.http.routes.scratchpad
+  (:require
+   [compojure.api.sweet :refer :all]
+   [ctia.domain.entities :as ent]
+   [ctia.domain.entities.scratchpad :refer [with-long-id page-with-long-id]]
+   [ctia.flows.crud :as flows]
+   [ctia.http.routes.common
+    :refer [created
+            search-options
+            filter-map-search-options
+            paginated-ok
+            PagingParams
+            ScratchpadGetParams
+            ScratchpadSearchParams
+            ScratchpadByExternalIdQueryParams]]
+   [ctia.store :refer :all]
+   [ctia.schemas.core
+    :refer [NewScratchpad Scratchpad PartialScratchpad PartialScratchpadList]]
+   [ring.util.http-response :refer [no-content not-found ok]]
+   [schema-tools.core :as st]
+   [schema.core :as s]))
+
+(defroutes scratchpad-routes
+  (context "/scratchpad" []
+           :tags ["Scratchpad"]
+           (POST "/" []
+                 :return Scratchpad
+                 :body [scratchpad NewScratchpad {:description "a new Scratchpad"}]
+                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                 :summary "Adds a new Scratchpad"
+                 :capabilities :create-scratchpad
+                 :identity identity
+                 :identity-map identity-map
+                 (-> (flows/create-flow
+                      :entity-type :scratchpad
+                      :realize-fn ent/realize-scratchpad
+                      :store-fn #(write-store :scratchpad
+                                              create-scratchpads
+                                              %
+                                              identity-map)
+                      :long-id-fn with-long-id
+                      :entity-type :scratchpad
+                      :identity identity
+                      :entities [scratchpad]
+                      :spec :new-scratchpad/map)
+                     first
+                     ent/un-store
+                     created))
+
+           (PUT "/:id" []
+                :return Scratchpad
+                :body [scratchpad NewScratchpad {:description "an updated Scratchpad"}]
+                :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                :summary "Updates an Scratchpad"
+                :path-params [id :- s/Str]
+                :capabilities :create-scratchpad
+                :identity identity
+                :identity-map identity-map
+                (-> (flows/update-flow
+                     :get-fn #(read-store :scratchpad
+                                          read-scratchpad
+                                          %
+                                          identity-map
+                                          {})
+                     :realize-fn ent/realize-scratchpad
+                     :update-fn #(write-store :scratchpad
+                                              update-scratchpad
+                                              (:id %)
+                                              %
+                                              identity-map)
+                     :long-id-fn with-long-id
+                     :entity-type :scratchpad
+                     :entity-id id
+                     :identity identity
+                     :entity scratchpad
+                     :spec :new-scratchpad/map)
+                    ent/un-store
+                    ok))
+
+           (GET "/external_id/:external_id" []
+                :return PartialScratchpadList
+                :query [q ScratchpadByExternalIdQueryParams]
+                :path-params [external_id :- s/Str]
+                :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                :summary "List scratchpads by external id"
+                :capabilities #{:read-scratchpad :external-id}
+                :identity identity
+                :identity-map identity-map
+                (-> (read-store :scratchpad list-scratchpads
+                                {:external_ids external_id}
+                                identity-map
+                                q)
+                    page-with-long-id
+                    ent/un-store-page
+                    paginated-ok))
+
+           (GET "/search" []
+                :return PartialScratchpadList
+                :summary "Search for an Scratchpad using a Lucene/ES query string"
+                :query [params ScratchpadSearchParams]
+                :capabilities #{:read-scratchpad :search-scratchpad}
+                :identity identity
+                :identity-map identity-map
+                :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                (-> (query-string-search-store
+                     :scratchpad
+                     query-string-search
+                     (:query params)
+                     (apply dissoc params filter-map-search-options)
+                     identity-map
+                     (select-keys params search-options))
+                    page-with-long-id
+                    ent/un-store-page
+                    paginated-ok))
+
+           (GET "/:id" []
+                :return (s/maybe PartialScratchpad)
+                :summary "Gets an Scratchpad by ID"
+                :path-params [id :- s/Str]
+                :query [params ScratchpadGetParams]
+                :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                :capabilities :read-scratchpad
+                :identity identity
+                :identity-map identity-map
+                (if-let [scratchpad (read-store :scratchpad
+                                                read-scratchpad
+                                                id
+                                                identity-map
+                                                params)]
+                  (-> scratchpad
+                      with-long-id
+                      ent/un-store
+                      ok)
+                  (not-found)))
+
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes an Scratchpad"
+                   :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                   :capabilities :delete-scratchpad
+                   :identity identity
+                   :identity-map identity-map
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :scratchpad
+                                             read-scratchpad
+                                             %
+                                             identity-map
+                                             {})
+                        :delete-fn #(write-store :scratchpad
+                                                 delete-scratchpad
+                                                 %
+                                                 identity-map)
+                        :entity-type :scratchpad
+                        :entity-id id
+                        :identity identity)
+                     (no-content)
+                     (not-found)))))

--- a/src/ctia/http/routes/scratchpad.clj
+++ b/src/ctia/http/routes/scratchpad.clj
@@ -24,7 +24,8 @@
      PartialScratchpadList
      Scratchpad
      ScratchpadObservablesUpdate
-     ScratchpadTextsUpdate]]
+     ScratchpadTextsUpdate
+     ScratchpadBundleUpdate]]
    [ctia.store :refer :all]
    [ring.util.http-response :refer [no-content not-found ok]]
    [schema.core :as s]))
@@ -238,6 +239,40 @@
                                :spec :new-scratchpad/map)
                               ent/un-store
                               ok)))
+
+           (context "/:id/bundle" []
+                    (POST "/" []
+                          :return Scratchpad
+                          :body [operation ScratchpadBundleUpdate
+                                 {:description "A scratchpad Bundle operation"}]
+                          :path-params [id :- s/Str]
+                          :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                          :summary "Edit a Bundle on a scratchpad"
+                          :capabilities :create-scratchpad
+                          :identity identity
+                          :identity-map identity-map
+                          (-> (flows/patch-flow
+                               :get-fn #(read-store :scratchpad
+                                                    read-scratchpad
+                                                    %
+                                                    identity-map
+                                                    {})
+                               :realize-fn ent/realize-scratchpad
+                               :update-fn #(write-store :scratchpad
+                                                        update-scratchpad
+                                                        (:id %)
+                                                        %
+                                                        identity-map)
+                               :long-id-fn with-long-id
+                               :entity-type :scratchpad
+                               :entity-id id
+                               :identity identity
+                               :patch-operation (:operation operation)
+                               :partial-entity {:bundle (:bundle operation)}
+                               :spec :new-scratchpad/map)
+                              ent/un-store
+                              ok)))
+
            (DELETE "/:id" []
                    :no-doc true
                    :path-params [id :- s/Str]

--- a/src/ctia/http/routes/scratchpad.clj
+++ b/src/ctia/http/routes/scratchpad.clj
@@ -47,7 +47,8 @@
                       :store-fn #(write-store :scratchpad
                                               create-scratchpads
                                               %
-                                              identity-map)
+                                              identity-map
+                                              {})
                       :long-id-fn with-long-id
                       :entity-type :scratchpad
                       :identity identity

--- a/src/ctia/schemas/bulk.clj
+++ b/src/ctia/schemas/bulk.clj
@@ -19,9 +19,11 @@
     :feedbacks       [(s/maybe Feedback)]
     :incidents       [(s/maybe Incident)]
     :indicators      [(s/maybe Indicator)]
+    :investigations  [(s/maybe Investigation)]
     :judgements      [(s/maybe Judgement)]
     :malwares        [(s/maybe Malware)]
     :relationships   [(s/maybe Relationship)]
+    :scratchpads     [(s/maybe Scratchpad)]
     :sightings       [(s/maybe Sighting)]
     :tools           [(s/maybe Tool)]}))
 
@@ -35,10 +37,12 @@
     :exploit-targets [(s/maybe StoredExploitTarget)]
     :feedbacks       [(s/maybe StoredFeedback)]
     :incidents       [(s/maybe StoredIncident)]
+    :investigations  [(s/maybe StoredInvestigation)]
     :indicators      [(s/maybe StoredIndicator)]
     :judgements      [(s/maybe StoredJudgement)]
     :malwares        [(s/maybe StoredMalware)]
     :relationships   [(s/maybe StoredRelationship)]
+    :scratchpads     [(s/maybe StoredScratchpad)]
     :sightings       [(s/maybe StoredSighting)]
     :tools           [(s/maybe StoredTool)]}))
 
@@ -53,9 +57,11 @@
     :feedbacks       [(s/maybe Reference)]
     :incidents       [(s/maybe Reference)]
     :indicators      [(s/maybe Reference)]
+    :investigations  [(s/maybe Reference)]
     :judgements      [(s/maybe Reference)]
     :malwares        [(s/maybe Reference)]
     :relationships   [(s/maybe Reference)]
+    :scratchpads     [(s/maybe Reference)]
     :sightings       [(s/maybe Reference)]
     :tools           [(s/maybe Reference)]
     :tempids         TempIDs}))
@@ -71,8 +77,10 @@
     :feedbacks       [NewFeedback]
     :incidents       [NewIncident]
     :indicators      [NewIndicator]
+    :investigations  [NewInvestigation]
     :judgements      [NewJudgement]
     :malwares        [NewMalware]
     :relationships   [NewRelationship]
+    :scratchpads     [NewScratchpad]
     :sightings       [NewSighting]
     :tools           [NewTool]}))

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -410,53 +410,6 @@
   "partial-stored-relationship")
 
 
-;; Scratchpad
-
-
-(def-acl-schema Scratchpad
-  (fu/replace-either-with-any
-   scr/Scratchpad)
-  "scratchpad")
-
-(def-acl-schema PartialScratchpad
-  (fu/replace-either-with-any
-   (fu/optionalize-all scr/Scratchpad))
-  "partial-scratchpad")
-
-(sc/defschema PartialScratchpadList
-  [PartialScratchpad])
-
-(def-acl-schema NewScratchpad
-  (fu/replace-either-with-any
-   scr/NewScratchpad)
-  "new-scratchpad")
-
-(def-acl-schema PartialNewScratchpad
-  (fu/replace-either-with-any
-   (fu/optionalize-all scr/NewScratchpad))
-  "new-scratchpad")
-
-(def-stored-schema StoredScratchpad
-  (fu/replace-either-with-any
-   scr/StoredScratchpad)
-  "stored-scratchpad")
-
-(def-stored-schema PartialStoredScratchpad
-  (fu/replace-either-with-any
-   (fu/optionalize-all scr/StoredScratchpad))
-  "partial-stored-scratchpad")
-
-(sc/defschema ScratchpadObservablesUpdate
-  (st/merge
-   {:operation (sc/enum :add :remove :replace)}
-   (st/select-keys Scratchpad [:observables])))
-
-(sc/defschema ScratchpadTextsUpdate
-  (st/merge
-   {:operation (sc/enum :add :remove :replace)}
-   (st/select-keys Scratchpad [:texts])))
-
-
 ;; Attack Pattern
 
 
@@ -542,6 +495,58 @@
 (def-acl-schema Bundle
   bundle/Bundle
   "bundle")
+
+
+;; Scratchpad
+
+
+(def-acl-schema Scratchpad
+  (fu/replace-either-with-any
+   scr/Scratchpad)
+  "scratchpad")
+
+(def-acl-schema PartialScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/Scratchpad))
+  "partial-scratchpad")
+
+(sc/defschema PartialScratchpadList
+  [PartialScratchpad])
+
+(def-acl-schema NewScratchpad
+  (fu/replace-either-with-any
+   scr/NewScratchpad)
+  "new-scratchpad")
+
+(def-acl-schema PartialNewScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/NewScratchpad))
+  "new-scratchpad")
+
+(def-stored-schema StoredScratchpad
+  (fu/replace-either-with-any
+   scr/StoredScratchpad)
+  "stored-scratchpad")
+
+(def-stored-schema PartialStoredScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/StoredScratchpad))
+  "partial-stored-scratchpad")
+
+(sc/defschema ScratchpadObservablesUpdate
+  (st/merge
+   {:operation (sc/enum :add :remove :replace)}
+   (st/select-keys Scratchpad [:observables])))
+
+(sc/defschema ScratchpadTextsUpdate
+  (st/merge
+   {:operation (sc/enum :add :remove :replace)}
+   (st/select-keys Scratchpad [:texts])))
+
+(sc/defschema ScratchpadBundleUpdate
+  {:operation (sc/enum :add :remove :replace)
+   :bundle (st/optional-keys Bundle)})
+
 
 ;; common
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -446,6 +446,16 @@
    (fu/optionalize-all scr/StoredScratchpad))
   "partial-stored-scratchpad")
 
+(sc/defschema ScratchpadObservablesUpdate
+  (st/merge
+   {:operation (sc/enum :add :remove :replace)}
+   (st/select-keys Scratchpad [:observables])))
+
+(sc/defschema ScratchpadTextsUpdate
+  (st/merge
+   {:operation (sc/enum :add :remove :replace)}
+   (st/select-keys Scratchpad [:texts])))
+
 
 ;; Attack Pattern
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -17,6 +17,7 @@
     [judgement :as js]
     [malware :as malware]
     [relationship :as rels]
+    [scratchpad :as scr]
     [sighting :as ss]
     [tool :as tool]
     [verdict :as vs]
@@ -382,7 +383,7 @@
             ACLStoredEntity
             {sc/Keyword sc/Any}))
 
-;; relationship
+;; Relationship
 
 
 (def-acl-schema Relationship
@@ -407,6 +408,39 @@
 (def-stored-schema PartialStoredRelationship
   (fu/optionalize-all rels/StoredRelationship)
   "partial-stored-relationship")
+
+
+;; Scratchpad
+
+
+(def-acl-schema Scratchpad
+  (fu/replace-either-with-any
+   scr/Scratchpad)
+  "scratchpad")
+
+(def-acl-schema PartialScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/Scratchpad))
+  "partial-scratchpad")
+
+(sc/defschema PartialScratchpadList
+  [PartialScratchpad])
+
+(def-acl-schema NewScratchpad
+  (fu/replace-either-with-any
+   scr/NewScratchpad)
+  "new-scratchpad")
+
+(def-stored-schema StoredScratchpad
+  (fu/replace-either-with-any
+   scr/StoredScratchpad)
+  "stored-scratchpad")
+
+(def-stored-schema PartialStoredScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/StoredScratchpad))
+  "partial-stored-scratchpad")
+
 
 ;; Attack Pattern
 
@@ -545,4 +579,6 @@
    :malware StoredMalware
    :relationship StoredRelationship
    :sighting StoredSighting
-   :tool StoredTool})
+   :tool StoredTool
+   :investigation StoredInvestigation
+   :scratchpad StoredScratchpad})

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -431,6 +431,11 @@
    scr/NewScratchpad)
   "new-scratchpad")
 
+(def-acl-schema PartialNewScratchpad
+  (fu/replace-either-with-any
+   (fu/optionalize-all scr/NewScratchpad))
+  "new-scratchpad")
+
 (def-stored-schema StoredScratchpad
   (fu/replace-either-with-any
    scr/StoredScratchpad)

--- a/src/ctia/schemas/graphql.clj
+++ b/src/ctia/schemas/graphql.clj
@@ -8,6 +8,9 @@
              [investigation :as investigation
               :refer [InvestigationType
                       InvestigationConnectionType]]
+             [scratchpad :as scratchpad
+              :refer [ScratchpadType
+                      ScratchpadConnectionType]]
              [judgement :as judgement
               :refer [JudgementType
                       JudgementConnectionType]]
@@ -62,6 +65,18 @@
                                   investigation/investigation-order-arg
                                   p/connection-arguments)
                      :resolve res/search-investigations}
+    :scratchpad {:type ScratchpadType
+                 :args search-by-id-args
+                 :resolve (fn [context args field-selection _] (res/scratchpad-by-id
+                                                                (:id args)
+                                                                (:ident context)
+                                                                field-selection))}
+    :scratchpads {:type ScratchpadConnectionType
+                  :args (merge common/lucene-query-arguments
+                               scratchpad/scratchpad-order-arg
+                               p/connection-arguments)
+                  :resolve res/search-scratchpads}
+
     :judgement {:type JudgementType
                 :args search-by-id-args
                 :resolve (fn [context args field-selection _]

--- a/src/ctia/schemas/graphql/investigation.clj
+++ b/src/ctia/schemas/graphql/investigation.clj
@@ -1,17 +1,19 @@
 (ns ctia.schemas.graphql.investigation
-  (:require [ctia.schemas.graphql
-             [flanders :as flanders]
-             [helpers :as g]
-             [pagination :as pagination]
-             [refs :as refs]
-             [sorting :as sorting]]
-            [ctia.schemas.sorting :as sort-fields]
-            [ctim.schemas.investigation :as ctim-investigation]))
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [flanders :as flanders]
+    [helpers :as g]
+    [pagination :as pagination]
+    [refs :as refs]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.schemas.investigation :as ctim-investigation]))
 
 (def InvestigationType
   (let [{:keys [fields name description]}
         (flanders/->graphql
-         ctim-investigation/Investigation
+         (fu/optionalize-all ctim-investigation/Investigation)
          {})]
     (g/new-object
      name

--- a/src/ctia/schemas/graphql/refs.clj
+++ b/src/ctia/schemas/graphql/refs.clj
@@ -11,18 +11,25 @@
 (def JudgementRef
   (g/new-ref judgement-type-name))
 
-;---- Observable
+;;---- Observable
 (def observable-type-name "Observable")
 (def ObservableTypeRef (g/new-ref observable-type-name))
 
-;---- Relationship
+;;---- Relationship
 (def relationship-connection-type-name "RelationshipConnection")
 (def relationship-type-name "Relationship")
+(def RelationshipRef
+  (g/new-ref relationship-type-name))
 
 (def related-judgement-type-name "RelatedJudgement")
 
-;---- Sighting
+;;---- Sighting
 (def sighting-type-name "Sighting")
 (def SightingRef
   (g/new-ref sighting-type-name))
+
+;;---- Verdict
+(def verdict-type-name "Verdict")
+(def VerdictRef
+  (g/new-ref verdict-type-name))
 

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -5,6 +5,7 @@
              [feedback :as ctim-feedback-entity]
              [indicator :as ctim-indicator-entity]
              [investigation :as ctim-investigation-entity]
+             [scratchpad :as ctim-scratchpad-entity]
              [judgement :as ctim-judgement-entity]
              [relationship :as ctim-relationship-entity]
              [sighting :as ctim-sighting-entity]]
@@ -112,6 +113,30 @@
                       ident
                       {:fields field-selection})
           ctim-investigation-entity/with-long-id
+          ctim-entities/un-store))
+
+;;---- Scratchpad
+
+(defn search-scratchpads
+  [context args field-selection src]
+  (search-entity :scratchpad
+                 (:query args)
+                 {}
+                 args
+                 (:ident context)
+                 field-selection
+                 ctim-scratchpad-entity/page-with-long-id))
+
+(s/defn scratchpad-by-id
+  [id :- s/Str
+   ident
+   field-selection :- (s/maybe [s/Keyword])]
+  (some-> (read-store :scratchpad
+                      read-scratchpad
+                      id
+                      ident
+                      {:fields field-selection})
+          ctim-scratchpad-entity/with-long-id
           ctim-entities/un-store))
 
 

--- a/src/ctia/schemas/graphql/scratchpad.clj
+++ b/src/ctia/schemas/graphql/scratchpad.clj
@@ -1,0 +1,37 @@
+(ns ctia.schemas.graphql.scratchpad
+  (:require
+   [flanders.utils :as fu]
+   [ctia.schemas.graphql
+    [flanders :as flanders]
+    [helpers :as g]
+    [pagination :as pagination]
+    [refs :as refs]
+    [sorting :as sorting]]
+   [ctia.schemas.sorting :as sort-fields]
+   [ctim.schemas.scratchpad :as ctim-scratchpad]))
+
+(def ScratchpadType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all ctim-scratchpad/Scratchpad)
+         {refs/observable-type-name refs/ObservableTypeRef
+          refs/judgement-type-name refs/JudgementRef
+          refs/sighting-type-name refs/SightingRef
+          refs/verdict-type-name refs/VerdictRef
+          })]
+    (g/new-object
+     name
+     description
+     []
+     fields)))
+
+(def scratchpad-order-arg
+  (sorting/order-by-arg
+   "ScratchpadOrder"
+   "scratchpads"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              sort-fields/scratchpad-sort-fields))))
+
+(def ScratchpadConnectionType
+  (pagination/new-connection ScratchpadType))

--- a/src/ctia/schemas/sorting.clj
+++ b/src/ctia/schemas/sorting.clj
@@ -144,3 +144,8 @@
   (concat default-entity-sort-fields
           describable-entity-sort-fields
           sourcable-entity-sort-fields))
+
+(def scratchpad-sort-fields
+  (concat default-entity-sort-fields
+          describable-entity-sort-fields
+          sourcable-entity-sort-fields))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -115,6 +115,13 @@
   (delete-investigation [this id ident])
   (list-investigations [this filtermap ident params]))
 
+(defprotocol IScratchpadStore
+  (read-scratchpad [this id ident params])
+  (create-scratchpads [this new-scratchpads ident])
+  (update-scratchpad [this id scratchpad ident])
+  (delete-scratchpad [this id ident])
+  (list-scratchpads [this filtermap ident params]))
+
 (defprotocol IQueryStringSearchableStore
   (query-string-search [this query filtermap ident params]))
 
@@ -134,7 +141,8 @@
                    :malware []
                    :tool []
                    :event []
-                   :investigation []})
+                   :investigation []
+                   :scratchpad []})
 
 (defonce stores (atom empty-stores))
 

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -117,7 +117,7 @@
 
 (defprotocol IScratchpadStore
   (read-scratchpad [this id ident params])
-  (create-scratchpads [this new-scratchpads ident])
+  (create-scratchpads [this new-scratchpads ident params])
   (update-scratchpad [this id scratchpad ident])
   (delete-scratchpad [this id ident])
   (list-scratchpads [this filtermap ident params]))

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -79,6 +79,7 @@
    :judgement      (make-factory es-store/->JudgementStore)
    :malware        (make-factory es-store/->MalwareStore)
    :relationship   (make-factory es-store/->RelationshipStore)
+   :scratchpad     (make-factory es-store/->ScratchpadStore)
    :sighting       (make-factory es-store/->SightingStore)
    :tool           (make-factory es-store/->ToolStore)})
 

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -572,6 +572,23 @@
       :kill_chain_phases kill-chain-phase
       :x_mitre_aliases token})}})
 
+(def texts
+  {:properties {:type token
+                :text text}})
+
+(def scratchpad-mapping
+  {"scratchpad"
+   {:dynamic false
+    :properties
+    (merge
+     base-entity-mapping
+     describable-entity-mapping
+     sourcable-entity-mapping
+     stored-entity-mapping
+     {:observables observable
+      :bundle {:enabled false}
+      :texts texts})}})
+
 (def tool-mapping
   {"tool"
    {:dynamic "strict"
@@ -665,4 +682,5 @@
    :malware malware-mapping
    :tool tool-mapping
    :event event-mapping
-   :investigation investigation-mapping})
+   :investigation investigation-mapping
+   :scratchpad scratchpad-mapping})

--- a/src/ctia/stores/es/scratchpad.clj
+++ b/src/ctia/stores/es/scratchpad.clj
@@ -1,0 +1,13 @@
+(ns ctia.stores.es.scratchpad
+  (:require [ctia.schemas.core
+             :refer [StoredScratchpad PartialStoredScratchpad]]
+            [ctia.stores.es.crud :as crud]))
+
+(def handle-create (crud/handle-create :scratchpad StoredScratchpad))
+(def handle-read (crud/handle-read :scratchpad PartialStoredScratchpad))
+(def handle-update (crud/handle-update :scratchpad StoredScratchpad))
+(def handle-delete (crud/handle-delete :scratchpad StoredScratchpad))
+(def handle-list (crud/handle-find :scratchpad PartialStoredScratchpad))
+(def handle-query-string-search (crud/handle-query-string-search :scratchpad PartialStoredScratchpad))
+
+(def ^{:private true} mapping "scratchpad")

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -18,6 +18,7 @@
               IMalwareStore
               IQueryStringSearchableStore
               IRelationshipStore
+              IScratchpadStore
               ISightingStore
               IToolStore]]
             [ctia.stores.es
@@ -33,6 +34,7 @@
              [incident :as inc]
              [indicator :as in]
              [investigation :as inv]
+             [scratchpad :as scr]
              [judgement :as ju]
              [malware :as malware]
              [mapping :refer [store-mappings store-settings]]
@@ -295,3 +297,19 @@
   IQueryStringSearchableStore
   (query-string-search [_ query filtermap ident params]
     (inv/handle-query-string-search state query filtermap ident params)))
+
+(defrecord ScratchpadStore [state]
+  IScratchpadStore
+  (read-scratchpad [_ id ident params]
+    (scr/handle-read state id ident params))
+  (create-scratchpads [_ new-scratchpads ident]
+    (scr/handle-create state new-scratchpads ident))
+  (update-scratchpad [_ id scratchpad ident]
+    (scr/handle-update state id scratchpad ident))
+  (delete-scratchpad [this id ident]
+    (scr/handle-delete state id ident))
+  (list-scratchpads [this filtermap ident params]
+    (scr/handle-list state filtermap ident params))
+  IQueryStringSearchableStore
+  (query-string-search [_ query filtermap ident params]
+    (scr/handle-query-string-search state query filtermap ident params)))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -302,8 +302,8 @@
   IScratchpadStore
   (read-scratchpad [_ id ident params]
     (scr/handle-read state id ident params))
-  (create-scratchpads [_ new-scratchpads ident]
-    (scr/handle-create state new-scratchpads ident))
+  (create-scratchpads [_ new-scratchpads ident params]
+    (scr/handle-create state new-scratchpads ident params))
   (update-scratchpad [_ id scratchpad ident]
     (scr/handle-update state id scratchpad ident))
   (delete-scratchpad [this id ident]

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -145,7 +145,7 @@
     (es-doc/bulk-create-doc
      conn
      prepared-docs
-     "false")))
+     "wait_for")))
 
 (defn create-target-store
   "create the target store, pushing its template"

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -145,7 +145,7 @@
     (es-doc/bulk-create-doc
      conn
      prepared-docs
-     "wait_for")))
+     "false")))
 
 (defn create-target-store
   "create the target store, pushing its template"

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -1,0 +1,48 @@
+(ns ctia.flows.crud-test
+  (:require [ctia.flows.crud :as sut]
+            [clj-momo.test-helpers
+             [core :as mth]]
+            [clj-momo.lib.map :refer [deep-merge-with]]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest add-colls-test
+  (let [input [#{:a :b} [:c :d] nil [:e]]]
+    (is (deep= #{:a :b :c :d :e}
+               (apply sut/add-colls input)))))
+
+(deftest remove-colls-test
+  (let [input [[:a :b :c :d :e] #{:c :d} [:e] nil]]
+    (is (deep= [:a :b]
+               (apply sut/remove-colls input)))))
+
+(deftest replace-colls-test
+  (let [input [#{:a :b} [:c :d] nil [:e :f]]]
+    (is (deep= #{:e :f}
+               (apply sut/replace-colls input)))))
+
+(deftest deep-merge-with-add-colls-test
+  (let [fixture {:foo {:bar ["one" "two" "three"]
+                       :lorem ["ipsum" "dolor"]}}]
+    (is (deep= {:foo {:bar ["one" "two" "three" "four"]
+                      :lorem ["ipsum" "dolor"]}}
+               (deep-merge-with sut/add-colls
+                                fixture
+                                {:foo {:bar ["four"]}})))))
+
+(deftest deep-merge-with-remove-colls-test
+  (let [fixture {:foo {:bar #{"one" "two" "three"}
+                       :lorem ["ipsum" "dolor"]}}]
+    (is (deep= {:foo {:bar #{"one" "three"}
+                      :lorem ["ipsum" "dolor"]}}
+               (deep-merge-with sut/remove-colls
+                                fixture
+                                {:foo {:bar ["two"]}})))))
+
+(deftest deep-merge-with-replace-colls-test
+  (let [fixture {:foo {:bar {:foo {:bar ["something" "or" "something" "else"]}}
+                       :lorem ["ipsum" "dolor"]}}]
+    (is (deep= {:foo {:bar {:foo {:bar ["else"]}}
+                      :lorem ["ipsum" "dolor"]}}
+               (deep-merge-with sut/replace-colls
+                                fixture
+                                {:foo  {:bar {:foo {:bar #{"else"}}}}})))))

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -57,5 +57,5 @@
 (defspec ^:generative api-for-tool-routes-es-store
   prop/api-for-tool-routes)
 
-(defspec ^:disabled api-for-scratchpad-routes-es-store
-  prop/api-for-scratchpad-routes)
+#_(defspec ^:disabled api-for-scratchpad-routes-es-store
+    prop/api-for-scratchpad-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -57,5 +57,7 @@
 (defspec ^:generative api-for-tool-routes-es-store
   prop/api-for-tool-routes)
 
+;; TODO this test is disabled for now as this entity contains
+;; data-table which triggers a StackOverflow Exception, find a wat to enable it again
 #_(defspec ^:disabled api-for-scratchpad-routes-es-store
     prop/api-for-scratchpad-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -56,3 +56,6 @@
 
 (defspec ^:generative api-for-tool-routes-es-store
   prop/api-for-tool-routes)
+
+(defspec ^:disabled api-for-scratchpad-routes-es-store
+  prop/api-for-scratchpad-routes)

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -23,6 +23,7 @@
              [judgement :refer [NewJudgement] :as csj]
              [malware :refer [NewMalware]]
              [relationship :refer [NewRelationship]]
+             [scratchpad :refer [NewScratchpad]]
              [sighting :refer [NewSighting]]
              [tool :refer [NewTool]]]
             [flanders
@@ -76,7 +77,8 @@
                         [NewMalware "max-new-malware"]
                         [NewRelationship "max-new-relationship"]
                         [NewSighting "max-new-sighting"]
-                        [NewTool "max-new-tool"]]]
+                        [NewTool "max-new-tool"]
+                        [NewScratchpad "max-new-scratchpad"]]]
   (fs/->spec (fu/require-all entity)
              kw-ns))
 
@@ -136,3 +138,7 @@
 (def api-for-tool-routes
   (api-for-route 'tool
                  (spec-gen "max-new-tool")))
+
+(def api-for-scratchpad-routes
+  (api-for-route 'scratchpad
+                 (spec-gen "max-new-scratchpad")))

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -65,20 +65,24 @@
           (common= post-entity
                    (dissoc get-entity :id)))))))
 
-(doseq [[entity kw-ns] [[NewActor "max-new-actor"]
-                        [NewAttackPattern "max-new-attack-pattern"]
-                        [NewCampaign "max-new-campaign"]
-                        [NewCOA "max-new-coa"]
-                        [NewExploitTarget "max-new-exploit-target"]
-                        [NewFeedback "max-new-feedback"]
-                        [NewIncident "max-new-incident"]
-                        [NewIndicator "max-new-indicator"]
-                        [NewJudgement "max-new-judgement"]
-                        [NewMalware "max-new-malware"]
-                        [NewRelationship "max-new-relationship"]
-                        [NewSighting "max-new-sighting"]
-                        [NewTool "max-new-tool"]
-                        [NewScratchpad "max-new-scratchpad"]]]
+(doseq [[entity kw-ns]
+        [[NewActor "max-new-actor"]
+         [NewAttackPattern "max-new-attack-pattern"]
+         [NewCampaign "max-new-campaign"]
+         [NewCOA "max-new-coa"]
+         [NewExploitTarget "max-new-exploit-target"]
+         [NewFeedback "max-new-feedback"]
+         [NewIncident "max-new-incident"]
+         [NewIndicator "max-new-indicator"]
+         [NewJudgement "max-new-judgement"]
+         [NewMalware "max-new-malware"]
+         [NewRelationship "max-new-relationship"]
+         [NewSighting "max-new-sighting"]
+         [NewTool "max-new-tool"]
+         ;; TODO enable again once scratchpad/bundle/data_table
+         ;;does not trigger StackOverFlow Exception
+         ;;[NewScratchpad "max-new-scratchpad"]
+         ]]
   (fs/->spec (fu/require-all entity)
              kw-ns))
 
@@ -139,6 +143,6 @@
   (api-for-route 'tool
                  (spec-gen "max-new-tool")))
 
-(def api-for-scratchpad-routes
-  (api-for-route 'scratchpad
-                 (spec-gen "max-new-scratchpad")))
+#_(def api-for-scratchpad-routes
+    (api-for-route 'scratchpad
+                   (spec-gen "max-new-scratchpad")))

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -143,6 +143,7 @@
   (api-for-route 'tool
                  (spec-gen "max-new-tool")))
 
+;; TODO: uncomment that when we figure out why generative tests fail on data-table
 #_(def api-for-scratchpad-routes
     (api-for-route 'scratchpad
                    (spec-gen "max-new-scratchpad")))

--- a/test/ctia/http/routes/scratchpad_test.clj
+++ b/test/ctia/http/routes/scratchpad_test.clj
@@ -1,0 +1,155 @@
+(ns ctia.http.routes.scratchpad-test
+  (:refer-clojure :exclude [get])
+  (:require [ctim.examples.scratchpads
+             :refer [new-scratchpad-minimal
+                     new-scratchpad-maximal]]
+            [ctia.schemas.sorting
+             :refer [scratchpad-sort-fields]]
+            [clj-momo.test-helpers
+             [core :as mth]
+             [http :refer [encode]]]
+            [clojure
+             [string :as str]
+             [test :refer [is join-fixtures testing use-fixtures]]]
+            [ctia.domain.entities :refer [schema-version]]
+            [ctia.properties :refer [get-http-show]]
+            [ctia.test-helpers
+             [http :refer [doc-id->rel-url]]
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [delete get post put]]
+             [fake-whoami-service :as whoami-helpers]
+             [pagination :refer [pagination-test]]
+             [field-selection :refer [field-selection-tests]]
+             [search :refer [test-query-string-search]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
+
+
+(use-fixtures :once
+  (join-fixtures [mth/fixture-schema-validation
+                  helpers/fixture-properties:clean
+                  whoami-helpers/fixture-server]))
+
+(use-fixtures :each
+  whoami-helpers/fixture-reset-state)
+
+(deftest-for-each-store test-scratchpad-routes
+  (helpers/set-capabilities! "foouser"
+                             ["foogroup"]
+                             "user"
+                             all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (testing "POST /ctia/scratchpad"
+    (let [new-scratchpad (-> new-scratchpad-maximal
+                             (dissoc :id)
+                             (assoc :description "description"))
+          {status :status
+           scratchpad :parsed-body}
+          (post "ctia/scratchpad"
+                :body new-scratchpad
+                :headers {"Authorization" "45c1f5e3f05d0"})
+          scratchpad-id
+          (id/long-id->id (:id scratchpad))
+
+          scratchpad-external-ids
+          (:external_ids scratchpad)]
+      (is (= 201 status))
+      (is (deep=
+           (assoc new-scratchpad :id (id/long-id scratchpad-id)) scratchpad))
+
+      (testing "the scratchpad ID has correct fields"
+        (let [show-props (get-http-show)]
+          (is (= (:hostname    scratchpad-id)      (:hostname    show-props)))
+          (is (= (:protocol    scratchpad-id)      (:protocol    show-props)))
+          (is (= (:port        scratchpad-id)      (:port        show-props)))
+          (is (= (:path-prefix scratchpad-id) (seq (:path-prefix show-props))))))
+
+      (testing "GET /ctia/scratchpad/:id"
+        (let [response (get (str "ctia/scratchpad/" (:short-id scratchpad-id))
+                            :headers {"Authorization" "45c1f5e3f05d0"})
+              scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (deep=
+               (assoc new-scratchpad :id (id/long-id scratchpad-id)) scratchpad))))
+
+      (test-query-string-search :scratchpad "description" :description)
+
+      (testing "GET /ctia/scratchpad/external_id/:external_id"
+        (let [response (get (format "ctia/scratchpad/external_id/%s"
+                                    (encode (rand-nth scratchpad-external-ids)))
+                            :headers {"Authorization" "45c1f5e3f05d0"})
+              scratchpads (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (deep=
+               [(assoc scratchpad :id (id/long-id scratchpad-id))]
+               scratchpads))))
+
+      (testing "PUT /ctia/scratchpad/:id"
+        (let [with-updates (assoc scratchpad
+                                  :title "modified scratchpad")
+              response (put (str "ctia/scratchpad/" (:short-id scratchpad-id))
+                            :body with-updates
+                            :headers {"Authorization" "45c1f5e3f05d0"})
+              updated-scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (deep=
+               with-updates
+               updated-scratchpad))))
+
+      (testing "DELETE /ctia/scratchpad/:id"
+        (let [response (delete (str "ctia/scratchpad/" (:short-id scratchpad-id))
+                               :headers {"Authorization" "45c1f5e3f05d0"})]
+          (is (= 204 (:status response)))
+          (let [response (get (str "ctia/scratchpad/" (:short-id scratchpad-id))
+                              :headers {"Authorization" "45c1f5e3f05d0"})]
+            (is (= 404 (:status response))))))))
+
+  (testing "POST invalid /ctia/scratchpad"
+    (let [{status :status
+           body :body}
+          (post "ctia/scratchpad"
+                ;; This field has an invalid length
+                :body (assoc new-scratchpad-minimal
+                             :title (clojure.string/join (repeatedly 1025 (constantly \0))))
+                :headers {"Authorization" "45c1f5e3f05d0"})]
+      (is (= status 400))
+      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+
+(deftest-for-each-store test-scratchpad-pagination-field-selection
+  (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                      "foouser"
+                                      "foogroup"
+                                      "user")
+
+  (let [posted-docs
+        (doall (map #(:parsed-body
+                      (post "ctia/scratchpad"
+                            :body (-> new-scratchpad-maximal
+                                      (dissoc :id)
+                                      (assoc :source (str "dotimes " %)
+                                             :title "foo"))
+                            :headers {"Authorization" "45c1f5e3f05d0"}))
+                    (range 0 30)))]
+
+    (pagination-test
+     "ctia/scratchpad/search?query=*"
+     {"Authorization" "45c1f5e3f05d0"}
+     scratchpad-sort-fields)
+
+    (field-selection-tests
+     ["ctia/scratchpad/search?query=*"
+      (-> posted-docs first :id doc-id->rel-url)]
+     {"Authorization" "45c1f5e3f05d0"}
+     scratchpad-sort-fields)))
+
+(deftest-for-each-store test-scratchpad-routes-access-control
+  (access-control-test "scratchpad"
+                       new-scratchpad-minimal
+                       true
+                       true))

--- a/test/ctia/http/routes/scratchpad_test.clj
+++ b/test/ctia/http/routes/scratchpad_test.clj
@@ -17,7 +17,7 @@
              [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [delete get post put patch]]
              [fake-whoami-service :as whoami-helpers]
              [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
@@ -100,6 +100,16 @@
           (is (deep=
                with-updates
                updated-scratchpad))))
+
+      (testing "PATCH /ctia/scratchpad/:id"
+        (let [updates {:title "patched scratchpad"}
+              response (patch (str "ctia/scratchpad/" (:short-id scratchpad-id))
+                              :body updates
+                              :headers {"Authorization" "45c1f5e3f05d0"})
+              updated-scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (= "patched scratchpad"
+                 (:title updated-scratchpad)))))
 
       (testing "DELETE /ctia/scratchpad/:id"
         (let [response (delete (str "ctia/scratchpad/" (:short-id scratchpad-id))

--- a/test/ctia/http/routes/scratchpad_test.clj
+++ b/test/ctia/http/routes/scratchpad_test.clj
@@ -115,7 +115,7 @@
           (is (= "patched scratchpad"
                  (:title updated-scratchpad)))))
 
-      ;; -------- atomic operation tests ------------
+      ;; -------- partial update operation tests ------------
 
       ;; observables
       (testing "POST /ctia/scratchpad/:id/observables :add"

--- a/test/ctia/http/routes/scratchpad_test.clj
+++ b/test/ctia/http/routes/scratchpad_test.clj
@@ -113,7 +113,9 @@
           (is (= "patched scratchpad"
                  (:title updated-scratchpad)))))
 
-      ;; atomic operation tests
+      ;; -------- atomic operation tests ------------
+
+      ;; observables
       (testing "POST /ctia/scratchpad/:id/observables :add"
         (let [new-observables [{:type "ip" :value "42.42.42.42"}]
               response (post (str "ctia/scratchpad/" (:short-id scratchpad-id) "/observables")
@@ -146,6 +148,41 @@
               updated-scratchpad (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (= observables (:observables updated-scratchpad)))))
+
+      ;; texts
+      (testing "POST /ctia/scratchpad/:id/texts :add"
+        (let [new-texts [{:type "some" :text "text"}]
+              response (post (str "ctia/scratchpad/" (:short-id scratchpad-id) "/texts")
+                             :body {:operation :add
+                                    :texts new-texts}
+                             :headers {"Authorization" "45c1f5e3f05d0"})
+              updated-scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (subset? (set new-texts)
+                       (set (:texts updated-scratchpad))))))
+
+      (testing "POST /ctia/scratchpad/:id/observables :remove"
+        (let [deleted-texts [{:type "some" :text "text"}]
+              response (post (str "ctia/scratchpad/" (:short-id scratchpad-id) "/texts")
+                             :body {:operation :remove
+                                    :texts deleted-texts}
+                             :headers {"Authorization" "45c1f5e3f05d0"})
+              updated-scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (not (subset? (set deleted-texts)
+                            (set (:texts updated-scratchpad)))))))
+
+      (testing "POST /ctia/scratchpad/:id/observables :replace"
+        (let [texts [{:type "text" :text "text"}]
+              response (post (str "ctia/scratchpad/" (:short-id scratchpad-id) "/texts")
+                             :body {:operation :replace
+                                    :texts texts}
+                             :headers {"Authorization" "45c1f5e3f05d0"})
+              updated-scratchpad (:parsed-body response)]
+          (is (= 200 (:status response)))
+          (is (= texts (:texts updated-scratchpad)))))
+
+
 
       (testing "DELETE /ctia/scratchpad/:id"
         (let [response (delete (str "ctia/scratchpad/" (:short-id scratchpad-id))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -2,6 +2,8 @@
   (:require [ctia.stores.es.crud :as sut]
             [clojure.test :as t :refer [is testing deftest]]))
 
+
+
 (deftest partial-results-test
   (is (= {:data [{:error "Exception"}
                  {:id "124"}]}

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -156,6 +156,9 @@
 (def put
   (mthh/with-port-fn get-http-port mthh/put))
 
+(def patch
+  (mthh/with-port-fn get-http-port mthh/patch))
+
 (defn fixture-spec-validation [t]
   (with-redefs [cs/registry-ref (atom (cs/registry))]
     (cs/check-asserts true)

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -56,6 +56,7 @@
                       "ctia.store.judgement" "es"
                       "ctia.store.malware" "es"
                       "ctia.store.relationship" "es"
+                      "ctia.store.scratchpad" "es"
                       "ctia.store.sighting" "es"
                       "ctia.store.tool" "es"]
     (t)))

--- a/test/ctia/test_helpers/graphql.clj
+++ b/test/ctia/test_helpers/graphql.clj
@@ -12,11 +12,11 @@
                       :body obj
                       :headers {"Authorization" "45c1f5e3f05d0"})]
     (when (not= status 201)
-      (throw (Exception. (format "Failed to create %s obj: %s Status: %s Response:%s"
+      (throw (Exception. (format "Failed to create %s Status: %s Response: %s obj: %s"
                                  (pr-str type)
-                                 (pr-str obj)
                                  status
-                                 body))))
+                                 body
+                                 (pr-str obj)))))
     body))
 
 (defn query

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -271,6 +271,49 @@ fragment investigationFields on Investigation {
   source
 }
 
+query ScratchpadQueryTest($id: String!) {
+  scratchpad(id: $id) {
+    ...scratchpadFields
+  }
+}
+
+query ScratchpadsQueryTest($query: String, $after: String, $first: Int, $sort_field:ScratchpadOrderField = ID, $sort_direction: OrderDirection = asc) {
+  scratchpads(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...scratchpadFields
+    }
+    edges {
+      node {
+        ...scratchpadFields
+      }
+    }
+  }
+}
+
+fragment scratchpadFields on Scratchpad {
+  id
+  type
+  schema_version
+  revision
+  external_ids
+  timestamp
+  language
+  title
+  description
+  short_description
+  tlp
+  source
+  source_uri
+  observables {
+    ...observableBaseFields
+  }
+}
+
+
 fragment relationshipBaseFields on Relationship {
   relationship_type
   target_ref


### PR DESCRIPTION
Add CTIM Scratchpad entity support as well as a new `PATCH` flow intended for partial updates
- [x] Store
- [x] Basic CRUD routes
- [x] Atomic operation routes
- [x] Graphql
- [x] migration support

Misc: 
- added support to migrate `Investigation`entities
- added `abstraction_level` to `AttackPattern`entity mapping 
- Fixed Swagger page title