### PR TITLE
Add another if to check for v1.0 branch pattern names

### DIFF
--- a/build/debian-package.sh
+++ b/build/debian-package.sh
@@ -46,6 +46,12 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     echo "OK: release branch detected using regex"
     build-and-publish-package "rel"
 
+  elif [[ ${TRAVIS_BRANCH} =~ ^v[0-9]+(.[0-9]+)+$ ]]; then
+    # non-pr builds on 'v?.?' branches yield REL packages
+    # To be removed at a future date, once we're sure the process works.
+    echo "OK: v branch detected using regex"
+    build-and-publish-package "rel"
+
   else
     echo "Not on master or release branch. Not building a package."
   fi


### PR DESCRIPTION
In order to support Frank on the new release process, we'll be using versioned branch names to control release. Travis need to be aware of that to build packages whenever a merge is pushed to each of these branches.

The branch pattern regex will accept any versioning like v0.1, v1.10, v10.1, v1.2.3 and so forth.