### PR TITLE
Allow to DELETE indicators, update entities valid_time field

### DIFF
--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -65,6 +65,7 @@
     :list-indicators
     :create-indicator
     :search-indicator
+    :delete-indicator
 
     ;; Investigation
     :read-investigation

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -74,6 +74,19 @@
       (contains? schema (s/required-key k))
       (contains? schema k)))
 
+(defn make-valid-time
+  "make a valid-time object from either in this order:
+  the newest value, the previous value or the default value"
+  [prev-valid-time new-valid-time now]
+  {:valid_time {:start_time
+                (or (:start_time new-valid-time)
+                    (:start_time prev-valid-time)
+                    now)
+                :end_time
+                (or (:end_time new-valid-time)
+                    (:end_time prev-valid-time)
+                    time/default-expire-date)}})
+
 (defn default-realize-fn [type-name Model StoredModel]
   (s/fn default-realize :- StoredModel
     ([new-object :- Model
@@ -100,11 +113,9 @@
                :tlp (:tlp new-object
                           (:tlp prev-object (properties-default-tlp)))}
               (when (contains-key? Model :valid_time)
-                {:valid_time (or (:valid_time prev-object)
-                                 {:end_time (or (get-in new-object [:valid_time :end_time])
-                                                time/default-expire-date)
-                                  :start_time (or (get-in new-object [:valid_time :start_time])
-                                                  now)})}))))))
+                (make-valid-time (:valid_time prev-object)
+                                 (:valid_time new-object)
+                                 now)))))))
 
 (def realize-actor
   (default-realize-fn "actor" NewActor StoredActor))

--- a/src/ctia/http/routes/indicator.clj
+++ b/src/ctia/http/routes/indicator.clj
@@ -140,4 +140,29 @@
                       with-long-id
                       ent/un-store
                       ok)
-                  (not-found)))))
+                  (not-found)))
+
+           (DELETE "/:id" []
+                   :no-doc true
+                   :path-params [id :- s/Str]
+                   :summary "Deletes an Indicator"
+                   :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                   :capabilities :delete-indicator
+                   :identity identity
+                   :identity-map identity-map
+                   (if (flows/delete-flow
+                        :get-fn #(read-store :indicator
+                                             read-indicator
+                                             %
+                                             identity-map
+                                             {})
+                        :delete-fn #(write-store :indicator
+                                                 delete-indicator
+                                                 %
+                                                 identity-map)
+                        :entity-type :indicator
+                        :entity-id id
+                        :identity identity)
+                     (no-content)
+                     (not-found)))
+           ))

--- a/test/ctia/http/routes/indicator_test.clj
+++ b/test/ctia/http/routes/indicator_test.clj
@@ -18,7 +18,8 @@
              [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
             [ctim.domain.id :as id]
-            [ctim.examples.indicators :as ex]
+            [ctim.examples.indicators :refer [new-indicator-maximal
+                                              new-indicator-minimal]]
             [ring.util.codec :refer [url-encode]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -35,41 +36,26 @@
                                       "user")
 
   (testing "POST /ctia/indicator"
-    (let [{status :status
+    (let [new-indicator (-> new-indicator-maximal
+                            (dissoc :id)
+                            (assoc
+                             :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
+                                            "http://ex.tld/ctia/indicator/indicator-345"]
+                             :composite_indicator_expression
+                             {:operator "and"
+                              :indicator_ids [(fake-long-id 'indicator 1)
+                                              (fake-long-id 'indicator 2)]}))
+          {status :status
            indicator :parsed-body}
           (post "ctia/indicator"
-                :body {:external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                                      "http://ex.tld/ctia/indicator/indicator-345"]
-                       :title "indicator-title"
-                       :description "description"
-                       :producer "producer"
-                       :indicator_type ["C2" "IP Watchlist"]
-                       :valid_time {:start_time "2016-05-11T00:40:48.212-00:00"
-                                    :end_time "2016-07-11T00:40:48.212-00:00"}
-                       :composite_indicator_expression {:operator "and"
-                                                        :indicator_ids [(fake-long-id 'indicator 1)
-                                                                        (fake-long-id 'indicator 2)]}}
+                :body new-indicator
                 :headers {"Authorization" "45c1f5e3f05d0"})
 
           indicator-id (id/long-id->id (:id indicator))
           indicator-external-ids (:external_ids indicator)]
       (is (= 201 status))
       (is (deep=
-           {:id (id/long-id indicator-id)
-            :type "indicator"
-            :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                           "http://ex.tld/ctia/indicator/indicator-345"]
-            :title "indicator-title"
-            :description "description"
-            :producer "producer"
-            :tlp "green"
-            :schema_version schema-version
-            :indicator_type ["C2" "IP Watchlist"]
-            :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
-                         :end_time #inst "2016-07-11T00:40:48.212-00:00"}
-            :composite_indicator_expression {:operator "and"
-                                             :indicator_ids [(fake-long-id 'indicator 1)
-                                                             (fake-long-id 'indicator 2)]}}
+           (assoc new-indicator :id (id/long-id indicator-id))
            indicator))
 
       (testing "the indicator ID has correct fields"
@@ -88,21 +74,7 @@
               indicators (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
-               [{:id (id/long-id indicator-id)
-                 :type "indicator"
-                 :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                                "http://ex.tld/ctia/indicator/indicator-345"]
-                 :title "indicator-title"
-                 :description "description"
-                 :producer "producer"
-                 :tlp "green"
-                 :schema_version schema-version
-                 :indicator_type ["C2" "IP Watchlist"]
-                 :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
-                              :end_time #inst "2016-07-11T00:40:48.212-00:00"}
-                 :composite_indicator_expression {:operator "and"
-                                                  :indicator_ids [(fake-long-id 'indicator 1)
-                                                                  (fake-long-id 'indicator 2)]}}]
+               [(assoc new-indicator :id (id/long-id indicator-id))]
                indicators))))
 
       (testing "GET /ctia/indicator/:id"
@@ -111,76 +83,31 @@
               indicator (:parsed-body response)]
           (is (= 200 (:status response)))
           (is (deep=
-               {:id (id/long-id indicator-id)
-                :type "indicator"
-                :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                               "http://ex.tld/ctia/indicator/indicator-345"]
-                :title "indicator-title"
-                :description "description"
-                :producer "producer"
-                :tlp "green"
-                :schema_version schema-version
-                :indicator_type ["C2" "IP Watchlist"]
-                :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
-                             :end_time #inst "2016-07-11T00:40:48.212-00:00"}
-                :composite_indicator_expression {:operator "and"
-                                                 :indicator_ids [(fake-long-id 'indicator 1)
-                                                                 (fake-long-id 'indicator 2)]}}
+               (assoc new-indicator :id (id/long-id indicator-id))
                indicator))))
 
       (testing "PUT /ctia/indicator/:id"
-        (let [{status :status
+        (let [with-updates (-> indicator
+                               (assoc :title "modified indicator")
+                               (assoc-in [:valid_time :end_time]
+                                         #inst "2042-02-12T00:00:00.000-00:00"))
+              {status :status
                updated-indicator :parsed-body}
               (put (str "ctia/indicator/" (:short-id indicator-id))
-                   :body {:external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                                         "http://ex.tld/ctia/indicator/indicator-345"]
-                          :title "updated indicator"
-                          :description "updated description"
-                          :producer "producer"
-                          :tlp "amber"
-                          :indicator_type ["IP Watchlist"]
-                          :valid_time {:start_time "2016-05-11T00:40:48.212-00:00"
-                                       :end_time "2016-07-11T00:40:48.212-00:00"}
-                          :composite_indicator_expression {:operator "and"
-                                                           :indicator_ids [(fake-long-id 'indicator 1)
-                                                                           (fake-long-id 'indicator 2)]}}
+                   :body with-updates
                    :headers {"Authorization" "45c1f5e3f05d0"})]
           (is (= 200 status))
           (is (deep=
-               {:id (id/long-id indicator-id)
-                :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                               "http://ex.tld/ctia/indicator/indicator-345"]
-                :type "indicator"
-                :title "updated indicator"
-                :description "updated description"
-                :producer "producer"
-                :tlp "amber"
-                :schema_version schema-version
-                :indicator_type ["IP Watchlist"]
-                :valid_time {:start_time #inst "2016-05-11T00:40:48.212-00:00"
-                             :end_time #inst "2016-07-11T00:40:48.212-00:00"}
-                :composite_indicator_expression {:operator "and"
-                                                 :indicator_ids [(fake-long-id 'indicator 1)
-                                                                 (fake-long-id 'indicator 2)]}}
+               with-updates
                updated-indicator))))
 
       (testing "PUT invalid /ctia/indicator/:id"
         (let [{status :status
                body :body}
               (put (str "ctia/indicator/" (:short-id indicator-id))
-                   :body {:external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                                         "http://ex.tld/ctia/indicator/indicator-345"]
-                          ;; This field has an invalid length
-                          :title (apply str (repeatedly 1025 (constantly \0)))
-                          :description "updated description"
-                          :producer "producer"
-                          :tlp "amber"
-                          :indicator_type ["IP Watchlist"]
-                          :valid_time {:start_time "2016-05-11T00:40:48.212-00:00"
-                                       :end_time "2016-07-11T00:40:48.212-00:00"}
-                          :composite_indicator_expression {:operator "and"
-                                                           :indicator_ids [(fake-long-id 'indicator 1)
-                                                                           (fake-long-id 'indicator 2)]}}
+                   :body (assoc indicator
+                                :title (clojure.string/join
+                                        (repeatedly 1025 (constantly \0))))
                    :headers {"Authorization" "45c1f5e3f05d0"})]
           (is (= status 400))
           (is (re-find #"error.*in.*title" (str/lower-case body)))))
@@ -188,14 +115,16 @@
       (testing "DELETE /ctia/indicator/:id"
         (let [response (delete (str "ctia/indicator/" (:short-id indicator-id))
                                :headers {"Authorization" "45c1f5e3f05d0"})]
-          ;; Deleting indicators is not allowed
-          (is (= 404 (:status response)))))))
+          (is (= 204 (:status response)))
+          (let [response (get (str "ctia/indicator/" (:short-id indicator-id))
+                              :headers {"Authorization" "45c1f5e3f05d0"})]
+            (is (= 404 (:status response))))))))
 
   (testing "POST invalid /ctia/indicator"
     (let [{status :status
            body :body}
           (post "ctia/indicator"
-                :body (assoc ex/new-indicator-minimal
+                :body (assoc new-indicator-minimal
                              ;; This field has an invalid length
                              :title (apply str (repeatedly 1025 (constantly \0))))
                 :headers {"Authorization" "45c1f5e3f05d0"})]
@@ -204,6 +133,6 @@
 
 (deftest-for-each-store test-indicator-routes-access-control
   (access-control-test "indicator"
-                       ex/new-indicator-minimal
+                       new-indicator-minimal
                        true
                        false))


### PR DESCRIPTION
- Add a Swagger undocumented `DELETE` route for `indicators`
- Break down `valid_time` computation logic from `default-realize`
- Change `valid_time` computation so that one may edit the dates
