### PR TITLE
Add Version headers to Responses

### DIFF
--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -7,6 +7,7 @@
             [compojure.route :as rt]
             [ctia.http.exceptions :as ex]
             [ctia.http.middleware
+             [version :refer [wrap-version]]
              [auth :as auth]
              [cache-control :refer [wrap-cache-control]]
              [unknown :as unk]]
@@ -123,6 +124,7 @@
 
        (middleware [wrap-not-modified
                     wrap-cache-control
+                    wrap-version
                     ;; always last
                     (metrics/wrap-metrics "ctia" routes/get-routes)]
 

--- a/src/ctia/http/middleware/version.clj
+++ b/src/ctia/http/middleware/version.clj
@@ -1,0 +1,14 @@
+(ns ctia.http.middleware.version
+  (:require [ctia.version :refer [version-headers]]))
+
+(defn wrap-version
+  "appends CTIA version headers to response"
+  [handler]
+  (fn [req]
+    (let [{body :body
+           :as resp} (handler req)
+          version (version-headers)]
+
+      (if body
+        (update resp :headers into version)
+        resp))))

--- a/src/ctia/http/routes/version.clj
+++ b/src/ctia/http/routes/version.clj
@@ -1,11 +1,9 @@
 (ns ctia.http.routes.version
-  (:require [ctia.version :refer [current-version]]
-            [clojure.string :as st]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.schemas.core :refer [VersionInfo]]
-            [compojure.api.sweet :refer :all]
-            [ring.util.http-response :refer :all]
-            [clojure.string :as st]))
+  (:require
+   [compojure.api.sweet :refer :all]
+   [ctia.schemas.core :refer [VersionInfo]]
+   [ctia.version :refer [version-data]]
+   [ring.util.http-response :refer :all]))
 
 (defroutes version-routes
   (context "/version" []
@@ -13,8 +11,4 @@
            (GET "/" []
                 :return VersionInfo
                 :summary "API version details"
-                (ok {:base "/ctia"
-                     :version schema-version
-                     :beta true
-                     :build (st/replace (current-version) #"\n" "")
-                     :supported_features []}))))
+                (ok (version-data)))))

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -40,13 +40,12 @@
   (doto
       (jetty/run-jetty
        (cond-> (handler/api-handler)
-
          access-control-allow-origin
          (wrap-cors :access-control-allow-origin
                     (allow-origin-regexps access-control-allow-origin)
                     :access-control-allow-methods
                     (str->set-of-keywords access-control-allow-methods)
-                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag")
+                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version")
 
          true auth/wrap-authentication
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -575,10 +575,11 @@
 (sc/defschema VersionInfo
   "Version information for a specific instance of CTIA"
   {:base Str
-   :version Str
-   :build Str
+   :ctim-version Str
+   :ctia-build Str
    :beta Bool
-   :supported_features [Str]})
+   :ctia-config Str
+   :ctia-supported_features [Str]})
 
 ;; vocabularies
 

--- a/src/ctia/version.clj
+++ b/src/ctia/version.clj
@@ -1,7 +1,11 @@
 (ns ctia.version
   (:require [clojure.java
              [io :as io]
-             [shell :as shell]]))
+             [shell :as shell]]
+            [clojure.string :as st]
+            [ctia.domain.entities :refer [schema-version]]
+            [ctia.properties :refer [properties]]
+            [pandect.algo.sha1 :refer [sha1]]))
 
 (def version-file "ctia-version.txt")
 
@@ -10,3 +14,24 @@
               (slurp built-version)
               (str (:out (shell/sh "git" "log" "-n" "1" "--pretty=format:%H "))
                    (:out (shell/sh "git" "symbolic-ref" "--short" "HEAD"))))))
+
+(def current-config-hash
+  (memoize #(-> @properties
+                set
+                str
+                .getBytes
+                sha1)))
+
+(defn version-data []
+  {:base "/ctia"
+   :ctim-version schema-version
+   :beta true
+   :ctia-build (st/replace (current-version) #"\n" "")
+   :ctia-config (current-config-hash)
+   :ctia-supported_features []})
+
+
+(defn version-headers []
+  {"X-Ctia-Version" (st/replace (current-version) #"\n" "")
+   "X-Ctia-Config" (current-config-hash)
+   "X-Ctim-Version" schema-version})

--- a/test/ctia/http/routes/version_test.clj
+++ b/test/ctia/http/routes/version_test.clj
@@ -28,4 +28,15 @@
   (testing "GET /ctia/version"
     (let [response (get "ctia/version")]
       (is (= 200 (:status response)))
-      (is (= schema-version (get-in response [:parsed-body :version]))))))
+      (is (= schema-version (get-in response [:parsed-body :ctim-version]))))))
+
+
+(deftest-for-each-store test-version-headers
+  (testing "GET /ctia/version"
+    (let [{headers :headers
+           :as response} (get "ctia/version")]
+      (is (= 200 (:status response)))
+      (is (every? (set (keys headers))
+                  ["X-Ctia-Version"
+                   "X-Ctia-Config"
+                   "X-Ctim-Version"])))))


### PR DESCRIPTION
closes #671 
- Make CTIA Version keys more coherent
- Add a new config hash key
- Append Version Headers to responses
- Also fix caching Etag not different accross content-types