### PR TITLE
Malware abstraction level support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,10 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "0.4.29"
-                  :exclusions [threatgrid/flanders
-                               metosin/ring-swagger
-                               com.google.guava/guava]]
+                 [threatgrid/ctim "0.4.29"]
                  [threatgrid/clj-momo "0.2.20"]
 
                  ;; Web server

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,10 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "0.4.29"]
+                 [threatgrid/ctim "0.4.30"
+                  :exclusions [threatgrid/flanders
+                               metosin/ring-swagger
+                               com.google.guava/guava]]
                  [threatgrid/clj-momo "0.2.20"]
 
                  ;; Web server

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -46,7 +46,7 @@
 
 (def actor-mapping
   {"actor"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -59,7 +59,7 @@
 
 (def attack-pattern-mapping
   {"attack-pattern"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -56,7 +56,7 @@
 
 (def campaign-mapping
   {"campaign"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -43,7 +43,7 @@
 
 (def coa-mapping
   {"coa"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -72,7 +72,7 @@
 
 (def data-table-mapping
   {"data-table"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/exploit_target.clj
+++ b/src/ctia/entity/exploit_target.clj
@@ -43,7 +43,7 @@
 
 (def exploit-target-mapping
   {"exploit-target"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -16,7 +16,7 @@
 
 (def feedback-mapping
   {"feedback"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -44,7 +44,7 @@
 
 (def incident-mapping
   {"incident"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -74,7 +74,7 @@
 
 (def indicator-mapping
   {"indicator"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -22,7 +22,7 @@
 
 (def judgement-mapping-def
   {"judgement"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -50,7 +50,7 @@
 
 (def malware-mapping
   {"malware"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge
@@ -61,7 +61,8 @@
       :description em/all_text
       :labels em/token
       :kill_chain_phases em/kill-chain-phase
-      :x_mitre_aliases em/token})}})
+      :x_mitre_aliases em/token
+      :abstraction_level token})}})
 
 (def-es-store MalwareStore :malware StoredMalware PartialStoredMalware)
 

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -62,7 +62,7 @@
       :labels em/token
       :kill_chain_phases em/kill-chain-phase
       :x_mitre_aliases em/token
-      :abstraction_level token})}})
+      :abstraction_level em/token})}})
 
 (def-es-store MalwareStore :malware StoredMalware PartialStoredMalware)
 

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -13,7 +13,7 @@
 
 (def relationship-mapping
   {"relationship"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -14,7 +14,7 @@
 
 (def sighting-mapping
   {"sighting"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -12,7 +12,7 @@
 
 (def tool-mapping
   {"tool"
-   {:dynamic "strict"
+   {:dynamic false
     :include_in_all false
     :properties
     (merge

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -292,7 +292,7 @@
     :modifiers modifier-type}})
 
 (def observed-relation
-  {:dynamic "strict"
+  {:dynamic false
    :properties
    {:id token
     :timestamp ts
@@ -306,7 +306,7 @@
     :related observable}})
 
 (def sighting-target
-  {:dynamic "strict"
+  {:dynamic false
    :properties
    {:type token
     :observed_time valid-time

--- a/test/data/malware.graphql
+++ b/test/data/malware.graphql
@@ -87,4 +87,5 @@ fragment malwareFields on Malware {
     ...killChainPhaseFields
   }
   x_mitre_aliases
+  abstraction_level
 }


### PR DESCRIPTION
Also set entity mappings to use `dynamic: false` to avoid useless migrations in the future