### PR TITLE
HTTP CRUD tests refactor

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -114,7 +114,8 @@
   :test-selectors {:es-store :es-store
                    :disabled :disabled
                    :default #(not (or (:disabled %)
-                                      (:sleepy %)))
+                                      (:sleepy %)
+                                      (:generative %)))
                    :integration #(or (:es-store %)
                                      (:integration %)
                                      (:es-aliased-index %))

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -81,6 +81,7 @@ ctia.store.es.tool.indexname=ctia_tool
 
 ctia.store.external-key-prefixes=cisco-,ctia-
 ctia.store.bundle-refresh=wait_for
+ctia.store.bulk-refresh=false
 
 ctia.hook.redis.enabled=true
 ctia.hook.redis.host=localhost

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -42,6 +42,7 @@
     :create-data-table
     :read-data-table
     :delete-data-table
+    :search-data-table
 
     ;; Exploit-Target
     :create-exploit-target

--- a/src/ctia/http/routes/bulk.clj
+++ b/src/ctia/http/routes/bulk.clj
@@ -117,6 +117,13 @@
        (map (fn [[_ v]] (:tempids v)))
        (reduce into {})))
 
+(defn bulk-refresh? []
+  (get-in
+   @properties [:ctia
+                :store
+                :bulk-refresh]
+   "false"))
+
 (defn create-bulk
   "Creates entities in bulk. To define relationships between entities,
    transient IDs can be used. They are automatically converted into
@@ -126,7 +133,7 @@
    2. Creates Relationships with mapping between transient and real IDs"
   ([bulk login] (create-bulk bulk {} login {}))
   ([bulk tempids login {:keys [refresh] :as params
-                        :or {refresh "false"}}]
+                        :or {refresh (bulk-refresh?)}}]
    (let [new-entities (gen-bulk-from-fn
                        create-entities
                        (dissoc bulk :relationships)

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -318,7 +318,7 @@
 
 (defn bulk-params []
   {:refresh
-   (get-in @properties [:ctia :store :bundle-refresh] false)})
+   (get-in @properties [:ctia :store :bundle-refresh] "false")})
 
 (s/defn import-bundle :- BundleImportResult
   [bundle :- NewBundle

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -227,6 +227,15 @@
 (s/defschema DataTableFieldsParam
   {(s/optional-key :fields) [datatable-sort-fields]})
 
+(s/defschema DataTableSearchParams
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   DataTableFieldsParam
+   {:query s/Str
+    (s/optional-key :sort_by) datatable-sort-fields}))
+
 (def DataTableGetParams DataTableFieldsParam)
 
 (s/defschema DataTableByExternalIdQueryParams

--- a/src/ctia/http/routes/data_table.clj
+++ b/src/ctia/http/routes/data_table.clj
@@ -8,6 +8,7 @@
     :refer [created
             paginated-ok
             PagingParams
+            DataTableSearchParams
             DataTableGetParams
             DataTableByExternalIdQueryParams]]
    [ctia.store :refer :all]

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -116,6 +116,7 @@
                       "ctia.metrics.riemann.interval" s/Int
 
                       "ctia.store.external-key-prefixes" s/Str
+                      "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
 
                       "ctia.store.es.event.slicing.strategy"

--- a/test/ctia/http/routes/actor_test.clj
+++ b/test/ctia/http/routes/actor_test.clj
@@ -1,30 +1,18 @@
 (ns ctia.http.routes.actor-test
-  (:refer-clojure :exclude [get])
-  (:require [ctim.examples.actors
-             :refer [new-actor-minimal
-                     new-actor-maximal]]
-            [ctia.schemas.sorting
-             :refer [actor-sort-fields]]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [actor-sort-fields]]
             [ctia.test-helpers
-             [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
-             [search :refer [test-query-string-search]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]))
-
+            [ctim.examples.actors :refer [new-actor-maximal new-actor-minimal]]))
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
@@ -43,94 +31,10 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/actor"
-    (let [new-actor (-> new-actor-maximal
-                        (dissoc :id)
-                        (assoc :description "description"))
-          {status :status
-           actor :parsed-body}
-          (post "ctia/actor"
-                :body new-actor
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          actor-id
-          (id/long-id->id (:id actor))
-
-          actor-external-ids
-          (:external_ids actor)]
-      (is (= 201 status))
-      (is (deep=
-           (assoc new-actor :id (id/long-id actor-id)) actor))
-
-      (testing "the actor ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    actor-id)      (:hostname    show-props)))
-          (is (= (:protocol    actor-id)      (:protocol    show-props)))
-          (is (= (:port        actor-id)      (:port        show-props)))
-          (is (= (:path-prefix actor-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/actor/:id"
-        (let [response (get (str "ctia/actor/" (:short-id actor-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              actor (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               (assoc new-actor :id (id/long-id actor-id)) actor))))
-
-      (test-query-string-search :actor "description" :description)
-
-      (testing "GET /ctia/actor/external_id/:external_id"
-        (let [response (get (format "ctia/actor/external_id/%s"
-                                    (encode (rand-nth actor-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              actors (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc actor :id (id/long-id actor-id))]
-               actors))))
-
-      (testing "PUT /ctia/actor/:id"
-        (let [with-updates (assoc actor
-                                  :title "modified actor")
-              response (put (str "ctia/actor/" (:short-id actor-id))
-                            :body with-updates
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-actor (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               with-updates
-               updated-actor))))
-
-      (testing "PUT invalid /ctia/actor/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/actor/" (:short-id actor-id))
-                   :body (assoc actor
-                                :title (clojure.string/join
-                                        (repeatedly 1025 (constantly \0))))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/actor/:id"
-        (let [response (delete (str "ctia/actor/" (:short-id actor-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/actor/" (:short-id actor-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/actor"
-    (let [{status :status
-           body :body}
-          (post "ctia/actor"
-                ;; This field has an invalid length
-                :body (assoc new-actor-minimal
-                             :title (clojure.string/join (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test
+   {:entity "actor"
+    :example new-actor-maximal
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-actor-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -139,26 +43,21 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/actor"
-                            :body (-> new-actor-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)
-                                             :title "foo"))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
-    (pagination-test
-     "ctia/actor/search?query=*"
-     {"Authorization" "45c1f5e3f05d0"}
-     actor-sort-fields)
-
+  (let [ids (post-entity-bulk
+             (assoc new-actor-maximal :title "foo")
+             :actors
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (field-selection-tests
      ["ctia/actor/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
-     actor-sort-fields)))
+     actor-sort-fields))
+
+  (pagination-test
+   "ctia/actor/search?query=*"
+   {"Authorization" "45c1f5e3f05d0"}
+   actor-sort-fields))
 
 (deftest-for-each-store test-actor-routes-access-control
   (access-control-test "actor"

--- a/test/ctia/http/routes/attack_pattern_test.clj
+++ b/test/ctia/http/routes/attack_pattern_test.clj
@@ -1,30 +1,21 @@
 (ns ctia.http.routes.attack-pattern-test
   (:refer-clojure :exclude [get])
-  (:require
-   [ctim.examples.attack-patterns
-    :refer [new-attack-pattern-minimal
-            new-attack-pattern-maximal]]
-   [ctia.schemas.sorting
-    :refer [attack-pattern-sort-fields]]
-   [clj-momo.test-helpers
-    [core :as mth]
-    [http :refer [encode]]]
-   [clojure
-    [string :as str]
-    [test :refer [is join-fixtures testing use-fixtures]]]
-   [ctia.domain.entities :refer [schema-version]]
-   [ctia.properties :refer [get-http-show]]
-   [ctia.test-helpers
-    [http :refer [doc-id->rel-url]]
-    [access-control :refer [access-control-test]]
-    [auth :refer [all-capabilities]]
-    [core :as helpers :refer [delete get post put]]
-    [fake-whoami-service :as whoami-helpers]
-    [pagination :refer [pagination-test]]
-    [field-selection :refer [field-selection-tests]]
-    [search :refer [test-query-string-search]]
-    [store :refer [deftest-for-each-store]]]
-   [ctim.domain.id :as id]))
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [attack-pattern-sort-fields]]
+            [ctia.test-helpers
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
+             [fake-whoami-service :as whoami-helpers]
+             [field-selection :refer [field-selection-tests]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.attack-patterns
+             :refer
+             [new-attack-pattern-maximal new-attack-pattern-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -43,128 +34,11 @@
                                       "foogroup"
                                       "user")
 
-  (testing "POST /ctia/attack-pattern"
-    (let [{status :status
-           attack-pattern :parsed-body}
-          (post "ctia/attack-pattern"
-                :body {:external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                                      "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                       :name "attack-pattern-name"
-                       :description "description"}
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          attack-pattern-id
-          (id/long-id->id (:id attack-pattern))
-
-          attack-pattern-external-ids
-          (:external_ids attack-pattern)]
-      (is (= 201 status))
-      (is (deep=
-           {:external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                           "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-            :type "attack-pattern"
-            :name "attack-pattern-name"
-            :description "description",
-            :schema_version schema-version
-            :tlp "green"}
-           (dissoc attack-pattern
-                   :id)))
-
-      (testing "the attack-pattern ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    attack-pattern-id)      (:hostname    show-props)))
-          (is (= (:protocol    attack-pattern-id)      (:protocol    show-props)))
-          (is (= (:port        attack-pattern-id)      (:port        show-props)))
-          (is (= (:path-prefix attack-pattern-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/attack-pattern/:id"
-        (let [response (get (str "ctia/attack-pattern/" (:short-id attack-pattern-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              attack-pattern (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id attack-pattern-id)
-                :external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                               "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                :type "attack-pattern"
-                :name "attack-pattern-name"
-                :description "description"
-                :schema_version schema-version
-                :tlp "green"}
-               attack-pattern))))
-
-      (test-query-string-search :attack-pattern "description" :description)
-
-      (testing "GET /ctia/attack-pattern/external_id/:external_id"
-        (let [response (get (format "ctia/attack-pattern/external_id/%s"
-                                    (encode (rand-nth attack-pattern-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              attack-patterns (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id attack-pattern-id)
-                 :external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                                "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                 :type "attack-pattern"
-                 :name "attack-pattern-name"
-                 :description "description",
-                 :schema_version schema-version
-                 :tlp "green"}]
-               attack-patterns))))
-
-      (testing "PUT /ctia/attack-pattern/:id"
-        (let [response (put (str "ctia/attack-pattern/" (:short-id attack-pattern-id))
-                            :body {:external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                                                  "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                                   :name "modified attack-pattern"
-                                   :description "updated description"
-                                   :type "attack-pattern"}
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-attack-pattern (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id attack-pattern-id)
-                :external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                               "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                :type "attack-pattern"
-                :name "modified attack-pattern"
-                :description "updated description"
-                :schema_version schema-version
-                :tlp "green"}
-               updated-attack-pattern))))
-
-      (testing "PUT invalid /ctia/attack-pattern/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/attack-pattern/" (:short-id attack-pattern-id))
-                   :body {:external_ids ["http://ex.tld/ctia/attack-pattern/attack-pattern-123"
-                                         "http://ex.tld/ctia/attack-pattern/attack-pattern-456"]
-                          ;; This field has an invalid length
-                          :name (apply str (repeatedly 1025 (constantly \0)))
-                          :description "updated description"
-                          :type "attack-pattern"}
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*name" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/attack-pattern/:id"
-        (let [response (delete (str "ctia/attack-pattern/" (:short-id attack-pattern-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/attack-pattern/" (:short-id attack-pattern-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/attack-pattern"
-    (let [{status :status
-           body :body}
-          (post "ctia/attack-pattern"
-                :body (assoc new-attack-pattern-minimal
-                             ;; This field has an invalid length
-                             :name (clojure.string/join (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*name" (str/lower-case body))))))
+  (entity-crud-test {:entity "attack-pattern"
+                     :example new-attack-pattern-maximal
+                     :headers {:Authorization "45c1f5e3f05d0"}
+                     :update-field :name
+                     :invalid-test-field :name}))
 
 (deftest-for-each-store test-attack-pattern-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -173,15 +47,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/attack-pattern"
-                            :body (-> new-attack-pattern-maximal
-                                      (dissoc :id)
-                                      (assoc :description (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             new-attack-pattern-maximal
+             :attack_patterns
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/attack-pattern/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -189,7 +59,7 @@
 
     (field-selection-tests
      ["ctia/attack-pattern/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      attack-pattern-sort-fields)))
 

--- a/test/ctia/http/routes/campaign_test.clj
+++ b/test/ctia/http/routes/campaign_test.clj
@@ -1,30 +1,18 @@
 (ns ctia.http.routes.campaign-test
-  (:refer-clojure :exclude [get])
-  (:require [ctim.examples.campaigns
-             :refer [new-campaign-minimal
-                     new-campaign-maximal]]
-            [ctia.schemas.sorting
-             :refer [campaign-sort-fields]]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [campaign-sort-fields]]
             [ctia.test-helpers
-             [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
-             [search :refer [test-query-string-search]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.campaigns :as ex]))
+            [ctim.examples.campaigns :as ex :refer [new-campaign-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -39,157 +27,9 @@
                                       "foogroup"
                                       "user")
 
-  (testing "POST /ctia/campaign"
-    (let [{status :status
-           campaign :parsed-body}
-          (post "ctia/campaign"
-                :body {:external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                                      "http://ex.tld/ctia/campaign/campaign-456"]
-                       :title "campaign"
-                       :description "description"
-                       :tlp "green"
-                       :campaign_type "anything goes here"
-                       :intended_effect ["Theft"]
-                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
-                                    :end_time "2016-07-11T00:40:48.212-00:00"}}
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          campaign-id (id/long-id->id (:id campaign))
-          campaign-external-ids (:external_ids campaign)]
-      (is (= 201 status))
-      (is (deep=
-           {:id (id/long-id campaign-id)
-            :type "campaign"
-            :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                           "http://ex.tld/ctia/campaign/campaign-456"]
-            :title "campaign"
-            :description "description"
-            :tlp "green"
-            :schema_version schema-version
-            :campaign_type "anything goes here"
-            :intended_effect ["Theft"]
-            :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                         :end_time #inst "2016-07-11T00:40:48.212-00:00"}}
-           campaign))
-
-      (testing "the campaign ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    campaign-id)      (:hostname    show-props)))
-          (is (= (:protocol    campaign-id)      (:protocol    show-props)))
-          (is (= (:port        campaign-id)      (:port        show-props)))
-          (is (= (:path-prefix campaign-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/campaign/external_id/:external_id"
-        (let [response (get (format "ctia/campaign/external_id/%s"
-                                    (encode (rand-nth campaign-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              campaigns (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id campaign-id)
-                 :type "campaign"
-                 :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                                "http://ex.tld/ctia/campaign/campaign-456"]
-                 :title "campaign"
-                 :description "description"
-                 :tlp "green"
-                 :schema_version schema-version
-                 :campaign_type "anything goes here"
-                 :intended_effect ["Theft"]
-                 :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                              :end_time #inst "2016-07-11T00:40:48.212-00:00"}}]
-               campaigns))))
-
-      (test-query-string-search :campaign "description" :description)
-
-      (testing "GET /ctia/campaign/:id"
-        (let [response (get (str "ctia/campaign/" (:short-id campaign-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              campaign (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id campaign-id)
-                :type "campaign"
-                :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                               "http://ex.tld/ctia/campaign/campaign-456"]
-                :title "campaign"
-                :description "description"
-                :tlp "green"
-                :schema_version schema-version
-                :campaign_type "anything goes here"
-                :intended_effect ["Theft"]
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2016-07-11T00:40:48.212-00:00"}}
-               campaign))))
-
-      (testing "PUT /ctia/campaign/:id"
-        (let [{status :status
-               updated-campaign :parsed-body}
-              (put (str "ctia/campaign/" (:short-id campaign-id))
-                   :body {:title "modified campaign"
-                          :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                                         "http://ex.tld/ctia/campaign/campaign-456"]
-                          :description "different description"
-                          :tlp "amber"
-                          :campaign_type "anything goes here"
-                          :intended_effect ["Brand Damage"]
-                          :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
-                                       :end_time "2016-07-11T00:40:48.212-00:00"}}
-                   :headers {"Authorization" "45c1f5e3f05d0"})
-
-              updated-campaign-id (id/long-id->id (:id updated-campaign))]
-          (is (= 200 status))
-          (is (deep=
-               {:id (id/long-id updated-campaign-id)
-                :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                               "http://ex.tld/ctia/campaign/campaign-456"]
-                :type "campaign"
-                :title "modified campaign"
-                :description "different description"
-                :tlp "amber"
-                :schema_version schema-version
-                :campaign_type "anything goes here"
-                :intended_effect ["Brand Damage"]
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2016-07-11T00:40:48.212-00:00"}}
-               updated-campaign))))
-
-      (testing "PUT invalid /ctia/campaign/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/campaign/" (:short-id campaign-id))
-                   :body {;; This field has an invalid length
-                          :title (apply str (repeatedly 1025 (constantly \0)))
-                          :external_ids ["http://ex.tld/ctia/campaign/campaign-123"
-                                         "http://ex.tld/ctia/campaign/campaign-456"]
-                          :description "different description"
-                          :tlp "amber"
-                          :campaign_type "anything goes here"
-                          :intended_effect ["Brand Damage"]
-                          :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
-                                       :end_time "2016-07-11T00:40:48.212-00:00"}}
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/campaign/:id"
-        (let [response (delete (str "ctia/campaign/" (:short-id campaign-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/campaign/" (:short-id campaign-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/campaign"
-    (let [{status :status
-           body :body}
-          (post "ctia/campaign"
-                :body (assoc ex/new-campaign-minimal
-                             ;; This field has an invalid length
-                             :title (apply str (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test {:entity "campaign"
+                     :example (assoc new-campaign-maximal :tlp "green")
+                     :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-campaign-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -198,15 +38,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/campaign"
-                            :body (-> new-campaign-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             (assoc new-campaign-maximal :title "foo")
+             :campaigns
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/campaign/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -214,7 +50,7 @@
 
     (field-selection-tests
      ["ctia/campaign/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      campaign-sort-fields)))
 

--- a/test/ctia/http/routes/casebook_test.clj
+++ b/test/ctia/http/routes/casebook_test.clj
@@ -1,34 +1,173 @@
 (ns ctia.http.routes.casebook-test
   (:refer-clojure :exclude [get])
-  (:require
-   [ctim.schemas.common
-    :refer [ctim-schema-version]]
-   [clojure.set :refer [subset?]]
-   [ctim.examples.casebooks
-    :refer [new-casebook-minimal
-            new-casebook-maximal]]
-   [ctia.schemas.sorting
-    :refer [casebook-sort-fields]]
-   [clj-momo.test-helpers
-    [core :as mth]
-    [http :refer [encode]]]
-   [clojure
-    [string :as str]
-    [test :refer [is join-fixtures testing use-fixtures]]]
-   [ctia.domain.entities :refer [schema-version]]
-   [ctia.properties :refer [get-http-show]]
-   [ctia.test-helpers
-    [http :refer [doc-id->rel-url]]
-    [access-control :refer [access-control-test]]
-    [auth :refer [all-capabilities]]
-    [core :as helpers :refer [delete get post put patch]]
-    [fake-whoami-service :as whoami-helpers]
-    [pagination :refer [pagination-test]]
-    [field-selection :refer [field-selection-tests]]
-    [search :refer [test-query-string-search]]
-    [store :refer [deftest-for-each-store]]]
-   [ctim.domain.id :as id]))
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure
+             [set :refer [subset?]]
+             [test :refer [is join-fixtures testing use-fixtures]]]
+            [ctia.schemas.sorting :refer [casebook-sort-fields]]
+            [ctia.test-helpers
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
+             [fake-whoami-service :as whoami-helpers]
+             [field-selection :refer [field-selection-tests]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.casebooks
+             :refer
+             [new-casebook-maximal new-casebook-minimal]]
+            [ctim.schemas.common :refer [ctim-schema-version]]))
 
+(defn partial-operations-tests [casebook-id casebook]
+  ;; observables
+  (testing "POST /ctia/casebook/:id/observables :add"
+    (let [new-observables [{:type "ip" :value "42.42.42.42"}]
+          expected-entity (update casebook :observables concat new-observables)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
+                         :body {:operation :add
+                                :observables new-observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/observables :remove"
+    (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
+                               {:value "42.42.42.42" :type "ip"}]
+          expected-entity (update casebook :observables #(remove (set deleted-observables) %))
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
+                         :body {:operation :remove
+                                :observables deleted-observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity
+                 updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/observables :replace"
+    (let [observables [{:value "42.42.42.42" :type "ip"}]
+          expected-entity (assoc casebook :observables observables)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
+                         :body {:operation :replace
+                                :observables observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity
+                 updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/observables :replace"
+    (let [observables (:observables new-casebook-maximal)
+          expected-entity (assoc casebook :observables observables)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
+                         :body {:operation :replace
+                                :observables observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity
+                 updated-casebook))))
+
+
+  ;; texts
+  (testing "POST /ctia/casebook/:id/texts :add"
+    (let [new-texts [{:type "some" :text "text"}]
+          expected-entity (update casebook :texts concat new-texts)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
+                         :body {:operation :add
+                                :texts new-texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+
+
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/texts :remove"
+    (let [deleted-texts [{:type "some" :text "text"}]
+          expected-entity (update casebook :texts #(remove (set deleted-texts) %))
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
+                         :body {:operation :remove
+                                :texts deleted-texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= expected-entity updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/texts :replace"
+    (let [texts [{:type "text" :text "text"}]
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
+                         :body {:operation :replace
+                                :texts texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (= texts (:texts updated-casebook)))))
+
+  (testing "POST /ctia/casebook/:id/texts :replace"
+    (let [texts (:texts new-casebook-maximal)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
+                         :body {:operation :replace
+                                :texts texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (= texts (:texts updated-casebook)))))
+
+  ;; bundle
+  (testing "POST /ctia/casebook/:id/bundle :add"
+    (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                            :type "malware"
+                                            :schema_version ctim-schema-version
+                                            :name "TEST"
+                                            :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                         :body {:operation :add
+                                :bundle new-bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+
+      (is (= 200 (:status response)))
+      (is (not= (:malwares updated-casebook)
+                (:malwares new-bundle-entities)))
+      (is (subset? (set (:malwares new-bundle-entities))
+                   (set (-> updated-casebook :bundle :malwares))))))
+
+  (testing "POST /ctia/casebook/:id/bundle :remove"
+    (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                                :type "malware"
+                                                :schema_version ctim-schema-version
+                                                :name "TEST"
+                                                :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                         :body {:operation :remove
+                                :bundle deleted-bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= (update casebook :bundle dissoc :malwares)
+                 (update updated-casebook :bundle dissoc :malwares)))
+      (is (not (subset? (set (:malwares deleted-bundle-entities))
+                        (set (-> updated-casebook :bundle :malwares)))))))
+
+  (testing "POST /ctia/casebook/:id/bundle :replace"
+    (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                        :type "malware"
+                                        :schema_version ctim-schema-version
+                                        :name "TEST"
+                                        :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                         :body {:operation :replace
+                                :bundle bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep= (update casebook :bundle dissoc :malwares)
+                 (update updated-casebook :bundle dissoc :malwares)))
+      (is (= (:malwares bundle-entities)
+             (-> updated-casebook :bundle :malwares))))))
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
@@ -48,247 +187,10 @@
                                       "foogroup"
                                       "user")
 
-  (testing "POST /ctia/casebook"
-    (let [new-casebook (-> new-casebook-maximal
-                           (dissoc :id)
-                           (assoc :description "description"))
-          {status :status
-           casebook :parsed-body}
-          (post "ctia/casebook"
-                :body new-casebook
-                :headers {"Authorization" "45c1f5e3f05d0"})
-          casebook-id
-          (id/long-id->id (:id casebook))
-
-          casebook-external-ids
-          (:external_ids casebook)]
-      (is (= 201 status))
-      (is (deep=
-           (assoc new-casebook :id (id/long-id casebook-id)) casebook))
-
-      (testing "the casebook ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    casebook-id)      (:hostname    show-props)))
-          (is (= (:protocol    casebook-id)      (:protocol    show-props)))
-          (is (= (:port        casebook-id)      (:port        show-props)))
-          (is (= (:path-prefix casebook-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/casebook/:id"
-        (let [response (get (str "ctia/casebook/" (:short-id casebook-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               (assoc new-casebook :id (id/long-id casebook-id)) casebook))))
-
-      (test-query-string-search :casebook "description" :description)
-
-      (testing "GET /ctia/casebook/external_id/:external_id"
-        (let [response (get (format "ctia/casebook/external_id/%s"
-                                    (encode (rand-nth casebook-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              casebooks (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc casebook :id (id/long-id casebook-id))]
-               casebooks))))
-
-      (testing "PUT /ctia/casebook/:id"
-        (let [with-updates (assoc casebook
-                                  :title "modified casebook")
-              response (put (str "ctia/casebook/" (:short-id casebook-id))
-                            :body with-updates
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               with-updates
-               updated-casebook))))
-
-      (testing "PATCH /ctia/casebook/:id"
-        (let [updates {:title "patched casebook"}
-              response (patch (str "ctia/casebook/" (:short-id casebook-id))
-                              :body updates
-                              :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (= "patched casebook"
-                 (:title updated-casebook)))
-
-          (patch (str "ctia/casebook/" (:short-id casebook-id))
-                 :body {:title "casebook"}
-                 :headers {"Authorization" "45c1f5e3f05d0"})))
-      
-      ;; -------- partial update operation tests ------------
-
-      ;; observables
-      (testing "POST /ctia/casebook/:id/observables :add"
-        (let [new-observables [{:type "ip" :value "42.42.42.42"}]
-              expected-entity (update casebook :observables concat new-observables)
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
-                             :body {:operation :add
-                                    :observables new-observables}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity updated-casebook))))
-
-      (testing "POST /ctia/casebook/:id/observables :remove"
-        (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
-                                   {:value "42.42.42.42" :type "ip"}]
-              expected-entity (update casebook :observables #(remove (set deleted-observables) %))
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
-                             :body {:operation :remove
-                                    :observables deleted-observables}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity
-                     updated-casebook))))
-
-      (testing "POST /ctia/casebook/:id/observables :replace"
-        (let [observables [{:value "42.42.42.42" :type "ip"}]
-              expected-entity (assoc casebook :observables observables)
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
-                             :body {:operation :replace
-                                    :observables observables}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity
-                     updated-casebook))))
-
-      (testing "POST /ctia/casebook/:id/observables :replace"
-        (let [observables (:observables new-casebook-maximal)
-              expected-entity (assoc casebook :observables observables)
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/observables")
-                             :body {:operation :replace
-                                    :observables observables}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity
-                     updated-casebook))))
-
-
-      ;; texts
-      (testing "POST /ctia/casebook/:id/texts :add"
-        (let [new-texts [{:type "some" :text "text"}]
-              expected-entity (update casebook :texts concat new-texts)
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
-                             :body {:operation :add
-                                    :texts new-texts}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-
-
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity updated-casebook))))
-
-      (testing "POST /ctia/casebook/:id/texts :remove"
-        (let [deleted-texts [{:type "some" :text "text"}]
-              expected-entity (update casebook :texts #(remove (set deleted-texts) %))
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
-                             :body {:operation :remove
-                                    :texts deleted-texts}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= expected-entity updated-casebook))))
-
-      (testing "POST /ctia/casebook/:id/texts :replace"
-        (let [texts [{:type "text" :text "text"}]
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
-                             :body {:operation :replace
-                                    :texts texts}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (= texts (:texts updated-casebook)))))
-
-      (testing "POST /ctia/casebook/:id/texts :replace"
-        (let [texts (:texts new-casebook-maximal)
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/texts")
-                             :body {:operation :replace
-                                    :texts texts}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (= texts (:texts updated-casebook)))))
-
-      ;; bundle
-      (testing "POST /ctia/casebook/:id/bundle :add"
-        (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                                :type "malware"
-                                                :schema_version ctim-schema-version
-                                                :name "TEST"
-                                                :labels ["malware"]}}}
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                             :body {:operation :add
-                                    :bundle new-bundle-entities}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-
-          (is (= 200 (:status response)))
-          (is (not= (:malwares updated-casebook)
-                    (:malwares new-bundle-entities)))
-          (is (subset? (set (:malwares new-bundle-entities))
-                       (set (-> updated-casebook :bundle :malwares))))))
-
-      (testing "POST /ctia/casebook/:id/bundle :remove"
-        (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                                    :type "malware"
-                                                    :schema_version ctim-schema-version
-                                                    :name "TEST"
-                                                    :labels ["malware"]}}}
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                             :body {:operation :remove
-                                    :bundle deleted-bundle-entities}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= (update casebook :bundle dissoc :malwares)
-                     (update updated-casebook :bundle dissoc :malwares)))
-          (is (not (subset? (set (:malwares deleted-bundle-entities))
-                            (set (-> updated-casebook :bundle :malwares)))))))
-
-      (testing "POST /ctia/casebook/:id/bundle :replace"
-        (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                            :type "malware"
-                                            :schema_version ctim-schema-version
-                                            :name "TEST"
-                                            :labels ["malware"]}}}
-              response (post (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                             :body {:operation :replace
-                                    :bundle bundle-entities}
-                             :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-casebook (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep= (update casebook :bundle dissoc :malwares)
-                     (update updated-casebook :bundle dissoc :malwares)))
-          (is (= (:malwares bundle-entities)
-                 (-> updated-casebook :bundle :malwares)))))
-
-
-      (testing "DELETE /ctia/casebook/:id"
-        (let [response (delete (str "ctia/casebook/" (:short-id casebook-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/casebook/" (:short-id casebook-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-
-  (testing "POST invalid /ctia/casebook"
-    (let [{status :status
-           body :body}
-          (post "ctia/casebook"
-                ;; This field has an invalid length
-                :body (assoc new-casebook-minimal
-                             :title (clojure.string/join (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test {:entity "casebook"
+                     :example new-casebook-maximal
+                     :headers {:Authorization "45c1f5e3f05d0"}
+                     :additional-tests partial-operations-tests}))
 
 (deftest-for-each-store test-casebook-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -297,15 +199,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/casebook"
-                            :body (-> new-casebook-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)
-                                             :title "foo"))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
+  (let [ids (post-entity-bulk
+             (assoc new-casebook-maximal :title "foo")
+             :casebooks
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
 
     (pagination-test
      "ctia/casebook/search?query=*"
@@ -314,7 +212,7 @@
 
     (field-selection-tests
      ["ctia/casebook/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      casebook-sort-fields)))
 

--- a/test/ctia/http/routes/coa_test.clj
+++ b/test/ctia/http/routes/coa_test.clj
@@ -1,28 +1,18 @@
 (ns ctia.http.routes.coa-test
-  (:refer-clojure :exclude [get])
-  (:require [ctim.examples.coas
-             :refer [new-coa-minimal new-coa-maximal]]
-            [ctia.schemas.sorting
-             :refer [coa-sort-fields]]
-            [clj-momo.test-helpers.core :as mth]
-            [clj-momo.test-helpers.http :refer [encode]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [coa-sort-fields]]
             [ctia.test-helpers
-             [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
-             [search :refer [test-query-string-search]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
-             [store :refer [deftest-for-each-store]]]))
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.coas :refer [new-coa-maximal new-coa-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -37,88 +27,9 @@
                                       "foogroup"
                                       "user")
 
-  (testing "POST /ctia/coa"
-    (let [{status :status
-           coa :parsed-body}
-          (post "ctia/coa"
-                :body (dissoc new-coa-maximal :id)
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          coa-id (id/long-id->id (:id coa))
-          coa-external-ids (:external_ids coa)]
-      (is (= 201 status))
-      (is (deep= (assoc new-coa-maximal :id (id/long-id coa-id)) coa))
-
-      (testing "the coa ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    coa-id)      (:hostname    show-props)))
-          (is (= (:protocol    coa-id)      (:protocol    show-props)))
-          (is (= (:port        coa-id)      (:port        show-props)))
-          (is (= (:path-prefix coa-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/coa/external_id/:external_id"
-        (let [response (get (format "ctia/coa/external_id/%s" (encode (rand-nth coa-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              coas (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc new-coa-maximal :id (id/long-id coa-id))]
-               coas))))
-
-      (testing "GET /ctia/coa/:id"
-        (let [response (get (str "ctia/coa/" (:short-id coa-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              coa (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               (assoc new-coa-maximal :id (id/long-id coa-id))
-               coa))))
-
-      (test-query-string-search :coa "description" :description)
-
-      (testing "PUT /ctia/coa/:id"
-        (let [with-updates (assoc coa
-                                  :title "updated coa"
-                                  :description "updated description")
-              {updated-coa :parsed-body
-               status :status}
-              (put (str "ctia/coa/" (:short-id coa-id))
-                   :body with-updates
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 200 status))
-          (is (deep= with-updates updated-coa))))
-
-      (testing "PUT invalid /ctia/coa/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/coa/" (:short-id coa-id))
-                   ;; use an invalid length
-                   :body (assoc coa
-                                :title (clojure.string/join
-                                        (repeatedly 1025 (constantly \0))))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/coa/:id"
-        (let [response (delete (str "/ctia/coa/" (:short-id coa-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "/ctia/coa/" (:short-id coa-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/coa"
-    (let [{status :status
-           body :body}
-          (post "ctia/coa"
-                ;; This field has an invalid length
-                :body (assoc new-coa-minimal
-                             :title (clojure.string/join
-                                     (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test {:entity "coa"
+                     :example new-coa-maximal
+                     :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-coa-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -127,16 +38,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/coa"
-                            :body
-                            (-> new-coa-maximal
-                                (dissoc :id)
-                                (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             new-coa-maximal
+             :coas
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/coa/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -144,7 +50,7 @@
 
     (field-selection-tests
      ["ctia/coa/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      coa-sort-fields)))
 

--- a/test/ctia/http/routes/data_table_test.clj
+++ b/test/ctia/http/routes/data_table_test.clj
@@ -1,16 +1,13 @@
 (ns ctia.http.routes.data-table-test
-  (:refer-clojure :exclude [get])
   (:require [clj-momo.test-helpers.core :as mth]
-            [clj-momo.test-helpers.http :refer [encode]]
-            [clojure.test :refer [is join-fixtures testing use-fixtures]]
-            [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
+            [clojure.test :refer [join-fixtures use-fixtures]]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [store :refer [deftest-for-each-store]]]
+            [ctim.schemas.common :as c]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -18,109 +15,30 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
+(def new-data-table
+  {:type "data-table"
+   :row_count 1
+   :external_ids ["http://ex.tld/ctia/data-table/data-table-123"
+                  "http://ex.tld/ctia/data-table/data-table-456"]
+   :schema_version c/ctim-schema-version
+   :tlp "green"
+   :columns [{:name "Column1"
+              :type "string"}
+             {:name "Column2"
+              :type "string"}]
+   :rows [["foo"] ["bar"]]
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+
 (deftest-for-each-store test-data-table-routes
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
   (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/data-table"
-    (let [{status :status
-           d :body
-           data-table :parsed-body}
-          (post "ctia/data-table"
-                :body {:type "data-table"
-                       :row_count 1
-                       :external_ids ["http://ex.tld/ctia/data-table/data-table-123"
-                                      "http://ex.tld/ctia/data-table/data-table-456"]
-                       :schema_version c/ctim-schema-version
-                       :tlp "green"
-                       :columns [{:name "Column1"
-                                  :type "string"}
-                                 {:name "Column2"
-                                  :type "string"}]
-                       :rows [["foo"] ["bar"]]
-                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"
-                                    :end_time "2016-07-11T00:40:48.212-00:00"}}
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          data-table-id (id/long-id->id (:id data-table))
-          data-table-external-ids (:external_ids data-table)]
-
-      (is (= 201 status))
-      (is (deep=
-           {:type "data-table"
-            :row_count 1
-            :external_ids ["http://ex.tld/ctia/data-table/data-table-123"
-                           "http://ex.tld/ctia/data-table/data-table-456"]
-            :schema_version c/ctim-schema-version
-            :tlp "green"
-            :columns [{:name "Column1"
-                       :type "string"}
-                      {:name "Column2"
-                       :type "string"}]
-            :rows [["foo"] ["bar"]]
-            :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                         :end_time #inst "2016-07-11T00:40:48.212-00:00"}}
-           (dissoc data-table :id)))
-
-      (testing "the data-table ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    data-table-id)      (:hostname    show-props)))
-          (is (= (:protocol    data-table-id)      (:protocol    show-props)))
-          (is (= (:port        data-table-id)      (:port        show-props)))
-          (is (= (:path-prefix data-table-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/data-table/:id"
-        (let [response (get (str "ctia/data-table/" (:short-id data-table-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              data-table (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id data-table-id)
-                :type "data-table"
-                :row_count 1
-                :external_ids ["http://ex.tld/ctia/data-table/data-table-123"
-                               "http://ex.tld/ctia/data-table/data-table-456"]
-                :schema_version c/ctim-schema-version
-                :tlp "green"
-                :columns [{:name "Column1"
-                           :type "string"}
-                          {:name "Column2"
-                           :type "string"}]
-                :rows [["foo"] ["bar"]]
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2016-07-11T00:40:48.212-00:00"}}
-               data-table))))
-
-      (testing "GET /ctia/data-table/external_id/:external_id"
-        (let [response (get (format "ctia/data-table/external_id/%s"
-                                    (encode (rand-nth data-table-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              data-tables (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id data-table-id)
-                 :type "data-table"
-                 :row_count 1
-                 :external_ids ["http://ex.tld/ctia/data-table/data-table-123"
-                                "http://ex.tld/ctia/data-table/data-table-456"]
-                 :schema_version c/ctim-schema-version
-                 :tlp "green"
-                 :columns [{:name "Column1"
-                            :type "string"}
-                           {:name "Column2"
-                            :type "string"}]
-                 :rows [["foo"] ["bar"]]
-                 :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                              :end_time #inst "2016-07-11T00:40:48.212-00:00"}}]
-               data-tables))))
-
-      (testing "DELETE /ctia/data-table/:id"
-        (let [response (delete (str "ctia/data-table/" (:short-id data-table-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/data-table/" (:short-id data-table-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response)))))))))
+  (entity-crud-test {:entity "data-table"
+                     :example new-data-table
+                     :invalid-tests? false
+                     :update-tests? false
+                     :search-tests? false
+                     :headers {:Authorization "45c1f5e3f05d0"}}))

--- a/test/ctia/http/routes/exploit_target_test.clj
+++ b/test/ctia/http/routes/exploit_target_test.clj
@@ -1,30 +1,20 @@
 (ns ctia.http.routes.exploit-target-test
-  (:refer-clojure :exclude [get])
-  (:require
-   [ctim.examples.exploit-targets
-    :refer [new-exploit-target-maximal
-            new-exploit-target-minimal]]
-   [ctia.schemas.sorting
-    :refer [exploit-target-sort-fields]]
-   [clj-momo.test-helpers
-    [core :as mth]
-    [http :refer [encode]]]
-   [clojure
-    [string :as str]
-    [test :refer [is join-fixtures testing use-fixtures]]]
-   [ctia.domain.entities :refer [schema-version]]
-   [ctia.properties :refer [get-http-show]]
-   [ctia.test-helpers
-    [http :refer [doc-id->rel-url]]
-    [search :refer [test-query-string-search]]
-    [access-control :refer [access-control-test]]
-    [auth :refer [all-capabilities]]
-    [core :as helpers :refer [delete get post put]]
-    [fake-whoami-service :as whoami-helpers]
-    [pagination :refer [pagination-test]]
-    [field-selection :refer [field-selection-tests]]
-    [store :refer [deftest-for-each-store]]]
-   [ctim.domain.id :as id]))
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [exploit-target-sort-fields]]
+            [ctia.test-helpers
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
+             [fake-whoami-service :as whoami-helpers]
+             [field-selection :refer [field-selection-tests]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.exploit-targets
+             :refer
+             [new-exploit-target-maximal new-exploit-target-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -38,154 +28,9 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/exploit-target"
-    (let [{status :status
-           exploit-target :parsed-body}
-          (post "ctia/exploit-target"
-                :body {:external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                                      "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                       :title "exploit-target"
-                       :description "description"
-                       :vulnerability [{:title "vulnerability"
-                                        :description "description"}]
-                       :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          exploit-target-id (id/long-id->id (:id exploit-target))
-          exploit-targets-external-ids (:external_ids exploit-target)]
-      (is (= 201 status))
-      (is (deep=
-           {:id (id/long-id exploit-target-id)
-            :type "exploit-target"
-            :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                           "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-            :title "exploit-target"
-            :description "description"
-            :tlp "green"
-            :schema_version schema-version
-            :vulnerability [{:title "vulnerability"
-                             :description "description"}]
-            :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                         :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-           exploit-target))
-
-      (testing "the exploit-target ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    exploit-target-id)      (:hostname    show-props)))
-          (is (= (:protocol    exploit-target-id)      (:protocol    show-props)))
-          (is (= (:port        exploit-target-id)      (:port        show-props)))
-          (is (= (:path-prefix exploit-target-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/exploit-target/external_id/:external_id"
-        (let [response (get (format "ctia/exploit-target/external_id/%s"
-                                    (encode (rand-nth exploit-targets-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              exploit-targets (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id exploit-target-id)
-                 :type "exploit-target"
-                 :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                                "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                 :title "exploit-target"
-                 :description "description"
-                 :tlp "green"
-                 :schema_version schema-version
-                 :vulnerability [{:title "vulnerability"
-                                  :description "description"}]
-                 :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                              :end_time #inst "2525-01-01T00:00:00.000-00:00"}}]
-               exploit-targets))))
-
-      (test-query-string-search :exploit-target "description" :description)
-
-      (testing "GET /ctia/exploit-target/:id"
-        (let [response (get (str "ctia/exploit-target/" (:short-id exploit-target-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              exploit-target (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id exploit-target-id)
-                :type "exploit-target"
-                :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                               "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                :title "exploit-target"
-                :description "description"
-                :tlp "green"
-                :schema_version schema-version
-                :vulnerability [{:title "vulnerability"
-                                 :description "description"}]
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-               exploit-target))))
-
-      (testing "PUT /ctia/exploit-target/:id"
-        (let [{updated-exploit-target :parsed-body
-               status :status}
-              (put (str "ctia/exploit-target/" (:short-id exploit-target-id))
-                   :body {:title "updated exploit-target"
-                          :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                                         "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                          :description "updated description"
-                          :tlp "red"
-                          :vulnerability [{:title "vulnerability"
-                                           :description "description"}]
-                          :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 200 status))
-          (is (deep=
-               {:id (id/long-id exploit-target-id)
-                :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                               "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                :type "exploit-target"
-                :title "updated exploit-target"
-                :description "updated description"
-                :tlp "red"
-                :schema_version schema-version
-                :vulnerability [{:title "vulnerability"
-                                 :description "description"}]
-                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                             :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-               updated-exploit-target))))
-
-      (testing "PUT invalid /ctia/exploit-target/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/exploit-target/" (:short-id exploit-target-id))
-                   :body {;; This field has an invalid length
-                          :title (apply str (repeatedly 1025 (constantly \0)))
-                          :external_ids ["http://ex.tld/ctia/exploit-target/exploit-target-123"
-                                         "http://ex.tld/ctia/exploit-target/exploit-target-345"]
-                          :description "updated description"
-                          :tlp "red"
-                          :vulnerability [{:title "vulnerability"
-                                           :description "description"}]
-                          :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/exploit-target/:id"
-        (let [response (delete (str "ctia/exploit-target/"
-                                    (:short-id exploit-target-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/exploit-target/"
-                                   (:short-id exploit-target-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/exploit-target"
-    (let [{status :status
-           body :body}
-          (post "ctia/exploit-target"
-                :body (assoc new-exploit-target-minimal
-                             ;; This field has an invalid length
-                             :title (clojure.string/join (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test {:entity "exploit-target"
+                     :example new-exploit-target-maximal
+                     :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-exploit-target-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -194,15 +39,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/exploit-target"
-                            :body (-> new-exploit-target-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             (assoc new-exploit-target-maximal :title "foo")
+             :exploit_targets
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/exploit-target/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -210,7 +51,7 @@
 
     (field-selection-tests
      ["ctia/exploit-target/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      exploit-target-sort-fields)))
 

--- a/test/ctia/http/routes/feedback_test.clj
+++ b/test/ctia/http/routes/feedback_test.clj
@@ -1,17 +1,37 @@
 (ns ctia.http.routes.feedback-test
   (:refer-clojure :exclude [get])
   (:require [clj-momo.test-helpers.core :as mth]
-            [clj-momo.test-helpers.http :refer [encode]]
             [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
-            [ctim.domain.id :as id]
-            [ctim.schemas.common :as c]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post]]
+             [core :as helpers :refer [get]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [deftest-for-each-store]]]))
+             [store :refer [deftest-for-each-store]]]
+            [ctim.domain.id :as id]))
+
+(def new-feedback
+  {:feedback -1
+   :schema_version schema-version
+   :entity_id "judgement-123"
+   :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
+                  "http://ex.tld/ctia/feedback/feedback-456"]
+   :type "feedback"
+   :reason "false positive"
+   :tlp "green"})
+
+(defn feedback-by-entity-id-test
+  [feedback-id feedback]
+  (testing "GET /ctia/feedback?entity_id="
+    (let [response (get (str "ctia/feedback")
+                        :query-params {:entity_id "judgement-123"}
+                        :headers {"Authorization" "45c1f5e3f05d0"})
+          feedbacks (:parsed-body response)]
+      (is (= 200 (:status response)))
+      (is (deep=
+           [(assoc new-feedback :id (id/long-id feedback-id))]
+           feedbacks)))))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -32,107 +52,12 @@
                                       "bargroup"
                                       "user")
 
-  (testing "POST /ctia/feedback"
-    (let [{feedback :parsed-body
-           status :status}
-          (post "ctia/feedback"
-                :body {:feedback -1,
-                       :entity_id "judgement-123"
-                       :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
-                                      "http://ex.tld/ctia/feedback/feedback-456"]
-                       :type "feedback"
-                       :reason "false positive"
-                       :tlp "green"}
-                :headers {"Authorization" "45c1f5e3f05d0"})
+  (entity-crud-test
+   {:entity "feedback"
+    :example new-feedback
+    :update-tests? false
+    :invalid-tests? false
+    :search-tests? false
+    :additional-tests feedback-by-entity-id-test
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
-          feedback-id (id/long-id->id (:id feedback))
-          feedback-external-ids (:external_ids feedback)]
-      (is (= 201 status))
-      (is (deep=
-           {:id (id/long-id feedback-id)
-            :feedback -1,
-            :entity_id "judgement-123"
-            :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
-                           "http://ex.tld/ctia/feedback/feedback-456"]
-            :type "feedback"
-            :reason "false positive"
-            :schema_version schema-version
-            :tlp "green"}
-           feedback))
-
-      (testing "the feedback ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    feedback-id)      (:hostname    show-props)))
-          (is (= (:protocol    feedback-id)      (:protocol    show-props)))
-          (is (= (:port        feedback-id)      (:port        show-props)))
-          (is (= (:path-prefix feedback-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/feedback/:id"
-        (let [response (get (str "ctia/feedback/" (:short-id feedback-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              feedback (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id feedback-id)
-                :feedback -1,
-                :entity_id "judgement-123"
-                :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
-                               "http://ex.tld/ctia/feedback/feedback-456"]
-                :reason "false positive"
-                :type "feedback"
-                :schema_version schema-version
-                :tlp "green"}
-               feedback))))
-
-      (testing "GET /ctia/feedback?entity_id="
-        (let [response (get (str "ctia/feedback")
-                            :query-params {:entity_id "judgement-123"}
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              feedbacks (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id feedback-id)
-                 :feedback -1,
-                 :entity_id "judgement-123"
-                 :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
-                                "http://ex.tld/ctia/feedback/feedback-456"]
-                 :type "feedback"
-                 :reason "false positive"
-                 :schema_version schema-version
-                 :tlp "green"}]
-               feedbacks))))
-
-      (testing "GET /ctia/feedback/external_id/:external_id"
-        (let [response (get (format "ctia/feedback/external_id/%s"
-                                    (encode (rand-nth feedback-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              feedback (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id feedback-id)
-                 :feedback -1,
-                 :entity_id "judgement-123"
-                 :external_ids ["http://ex.tld/ctia/feedback/feedback-123"
-                                "http://ex.tld/ctia/feedback/feedback-456"]
-                 :type "feedback"
-                 :reason "false positive"
-                 :schema_version schema-version
-                 :tlp "green"}]
-               feedback))))
-
-      (testing "DELETE /ctia/feedback/:id"
-        (let [temp-feedback (-> (post "ctia/feedback"
-                                      :body {:feedback -1,
-                                             :entity_id "judgement-42"
-                                             :reason "false positive"
-                                             :tlp "green"}
-                                      :headers {"Authorization" "45c1f5e3f05d0"})
-                                :parsed-body)
-
-              temp-feedback-id (id/long-id->id (:id temp-feedback))
-              response (delete (str "ctia/feedback/" (:short-id temp-feedback-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/feedback/" (:short-id temp-feedback-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response)))))))))

--- a/test/ctia/http/routes/indicator_test.clj
+++ b/test/ctia/http/routes/indicator_test.clj
@@ -1,26 +1,17 @@
 (ns ctia.http.routes.indicator-test
   (:refer-clojure :exclude [get])
-  (:require [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia
-             [auth :as auth]
-             [properties :refer [get-http-show]]]
-            [ctia.domain.entities :refer [schema-version]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.auth :as auth]
             [ctia.test-helpers
-             [core :as helpers :refer [delete get post put fake-long-id]]
-             [access-control
-              :refer [access-control-test]]
+             [access-control :refer [access-control-test]]
+             [core :as helpers]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [search :refer [test-query-string-search]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.indicators :refer [new-indicator-maximal
-                                              new-indicator-minimal]]
-            [ring.util.codec :refer [url-encode]]))
+            [ctim.examples.indicators
+             :refer
+             [new-indicator-maximal new-indicator-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -34,102 +25,10 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/indicator"
-    (let [new-indicator (-> new-indicator-maximal
-                            (dissoc :id)
-                            (assoc
-                             :external_ids ["http://ex.tld/ctia/indicator/indicator-123"
-                                            "http://ex.tld/ctia/indicator/indicator-345"]
-                             :composite_indicator_expression
-                             {:operator "and"
-                              :indicator_ids [(fake-long-id 'indicator 1)
-                                              (fake-long-id 'indicator 2)]}))
-          {status :status
-           indicator :parsed-body}
-          (post "ctia/indicator"
-                :body new-indicator
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          indicator-id (id/long-id->id (:id indicator))
-          indicator-external-ids (:external_ids indicator)]
-      (is (= 201 status))
-      (is (deep=
-           (assoc new-indicator :id (id/long-id indicator-id))
-           indicator))
-
-      (testing "the indicator ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    indicator-id)      (:hostname    show-props)))
-          (is (= (:protocol    indicator-id)      (:protocol    show-props)))
-          (is (= (:port        indicator-id)      (:port        show-props)))
-          (is (= (:path-prefix indicator-id) (seq (:path-prefix show-props))))))
-
-      (test-query-string-search :indicator "description" :description)
-
-      (testing "GET /ctia/indicator/external_id/:external_id"
-        (let [response (get (format "ctia/indicator/external_id/%s"
-                                    (encode (rand-nth indicator-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              indicators (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc new-indicator :id (id/long-id indicator-id))]
-               indicators))))
-
-      (testing "GET /ctia/indicator/:id"
-        (let [response (get (str "ctia/indicator/" (:short-id indicator-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              indicator (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               (assoc new-indicator :id (id/long-id indicator-id))
-               indicator))))
-
-      (testing "PUT /ctia/indicator/:id"
-        (let [with-updates (-> indicator
-                               (assoc :title "modified indicator")
-                               (assoc-in [:valid_time :end_time]
-                                         #inst "2042-02-12T00:00:00.000-00:00"))
-              {status :status
-               updated-indicator :parsed-body}
-              (put (str "ctia/indicator/" (:short-id indicator-id))
-                   :body with-updates
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 200 status))
-          (is (deep=
-               with-updates
-               updated-indicator))))
-
-      (testing "PUT invalid /ctia/indicator/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/indicator/" (:short-id indicator-id))
-                   :body (assoc indicator
-                                :title (clojure.string/join
-                                        (repeatedly 1025 (constantly \0))))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/indicator/:id"
-        (let [response (delete (str "ctia/indicator/" (:short-id indicator-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/indicator/" (:short-id indicator-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/indicator"
-    (let [{status :status
-           body :body}
-          (post "ctia/indicator"
-                :body (assoc new-indicator-minimal
-                             ;; This field has an invalid length
-                             :title (apply str (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test
+   {:entity "indicator"
+    :example new-indicator-maximal
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-indicator-routes-access-control
   (access-control-test "indicator"

--- a/test/ctia/http/routes/investigation_test.clj
+++ b/test/ctia/http/routes/investigation_test.clj
@@ -1,31 +1,20 @@
 (ns ctia.http.routes.investigation-test
-  (:refer-clojure :exclude [get])
-  (:require
-   [ctim.examples.investigations
-    :refer [new-investigation-minimal
-            new-investigation-maximal
-            investigation-maximal]]
-   [ctia.schemas.sorting
-    :refer [investigation-sort-fields]]
-   [clj-momo.test-helpers
-    [core :as mth]
-    [http :refer [encode]]]
-   [clojure
-    [string :as str]
-    [test :refer [is join-fixtures testing use-fixtures]]]
-   [ctia.domain.entities :refer [schema-version]]
-   [ctia.properties :refer [get-http-show]]
-   [ctia.test-helpers
-    [http :refer [doc-id->rel-url]]
-    [access-control :refer [access-control-test]]
-    [auth :refer [all-capabilities]]
-    [core :as helpers :refer [delete get post put]]
-    [fake-whoami-service :as whoami-helpers]
-    [pagination :refer [pagination-test]]
-    [field-selection :refer [field-selection-tests]]
-    [search :refer [test-query-string-search]]
-    [store :refer [deftest-for-each-store]]]
-   [ctim.domain.id :as id]))
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [investigation-sort-fields]]
+            [ctia.test-helpers
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
+             [fake-whoami-service :as whoami-helpers]
+             [field-selection :refer [field-selection-tests]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.investigations
+             :refer
+             [new-investigation-maximal new-investigation-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -44,75 +33,12 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/investigation"
-    (let [{status :status
-           investigation :parsed-body}
-          (post "ctia/investigation"
-                :body (-> investigation-maximal
-                          (dissoc :id)
-                          (merge {:foo "foo"
-                                  :bar "bar"}))
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          investigation-id
-          (id/long-id->id (:id investigation))]
-
-      (is (= 201 status))
-      (is (deep=
-           (-> investigation-maximal
-               (dissoc :id)
-               (merge {:foo "foo"
-                       :bar "bar"}))
-           (dissoc investigation :id)))
-
-      (testing "the Investigation ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    investigation-id)      (:hostname    show-props)))
-          (is (= (:protocol    investigation-id)      (:protocol    show-props)))
-          (is (= (:port        investigation-id)      (:port        show-props)))
-          (is (= (:path-prefix investigation-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/investigation/:id"
-        (let [{status :status
-               investigation :parsed-body}
-              (get (str "ctia/investigation/" (:short-id investigation-id))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 200 status))
-          (is (deep=
-               (-> investigation-maximal
-                   (dissoc :id)
-                   (merge {:foo "foo"
-                           :bar "bar"}))
-               (dissoc investigation :id)))))
-
-      (test-query-string-search :investigation "description" :description)
-
-      (testing "GET /ctia/investigation/external_id/:external_id"
-        (let [ext-id (-> investigation-maximal :external_ids first)
-
-              {status :status
-               investigations :parsed-body}
-              (get (str "ctia/investigation/external_id/" (encode ext-id))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 200 status))
-          (is (deep=
-               [(-> investigation-maximal
-                    (dissoc :id)
-                    (merge {:foo "foo"
-                            :bar "bar"}))]
-               (map #(dissoc % :id) investigations)))))
-
-      (testing "DELETE /ctia/investigation/:id"
-        (let [{status :status
-               :as response}
-              (delete (str "ctia/investigation/" (:short-id investigation-id))
-                      :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 status))
-          (let [{status :status}
-                (get (str "ctia/investigation/" (:short-id investigation-id))
-                     :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 status))))))))
+  (entity-crud-test
+   {:entity "investigation"
+    :example new-investigation-maximal
+    :update-tests? false
+    :invalid-tests? false
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-investigation-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -121,15 +47,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/investigation"
-                            :body (-> new-investigation-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             (assoc new-investigation-maximal :title "foo")
+             :investigations
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/investigation/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -137,7 +59,7 @@
 
     (field-selection-tests
      ["ctia/investigation/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      investigation-sort-fields)))
 

--- a/test/ctia/http/routes/malware_test.clj
+++ b/test/ctia/http/routes/malware_test.clj
@@ -1,29 +1,19 @@
 (ns ctia.http.routes.malware-test
-  (:refer-clojure :exclude [get])
-  (:require [ctim.examples.malwares
-             :refer [new-malware-maximal]]
-            [ctia.schemas.sorting
-             :refer [malware-sort-fields]]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [malware-sort-fields]]
             [ctia.test-helpers
-             [http :refer [doc-id->rel-url]]
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [delete get post put]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
-             [search :refer [test-query-string-search]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
-            [ctim.examples.malwares :as ex]))
+            [ctim.examples.malwares :refer [new-malware-minimal
+                                            new-malware-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -41,135 +31,14 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/malware"
-    (let [{status :status
-           malware :parsed-body}
-          (post "ctia/malware"
-                :body {:external_ids ["http://ex.tld/ctia/malware/malware-123"
-                                      "http://ex.tld/ctia/malware/malware-456"]
-                       :name "malware"
-                       :description "description"
-                       :labels ["malware"]}
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-          malware-id
-          (id/long-id->id (:id malware))
-
-          malware-external-ids
-          (:external_ids malware)]
-      (is (= 201 status))
-      (is (deep=
-           {:external_ids ["http://ex.tld/ctia/malware/malware-123"
-                           "http://ex.tld/ctia/malware/malware-456"]
-            :type "malware"
-            :name "malware"
-            :description "description"
-            :labels ["malware"]
-            :schema_version schema-version
-            :tlp "green"}
-           (dissoc malware
-                   :id)))
-
-      (testing "the malware ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    malware-id)      (:hostname    show-props)))
-          (is (= (:protocol    malware-id)      (:protocol    show-props)))
-          (is (= (:port        malware-id)      (:port        show-props)))
-          (is (= (:path-prefix malware-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/malware/:id"
-        (let [response (get (str "ctia/malware/" (:short-id malware-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              malware (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id malware-id)
-                :external_ids ["http://ex.tld/ctia/malware/malware-123"
-                               "http://ex.tld/ctia/malware/malware-456"]
-                :type "malware"
-                :name "malware"
-                :description "description"
-                :labels ["malware"]
-                :schema_version schema-version
-                :tlp "green"}
-               malware))))
-
-      (test-query-string-search :malware "description" :description)
-
-      (testing "GET /ctia/malware/external_id/:external_id"
-        (let [response (get (format "ctia/malware/external_id/%s"
-                                    (encode (rand-nth malware-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              malwares (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [{:id (id/long-id malware-id)
-                 :external_ids ["http://ex.tld/ctia/malware/malware-123"
-                                "http://ex.tld/ctia/malware/malware-456"]
-                 :type "malware"
-                 :name "malware"
-                 :description "description"
-                 :labels ["malware"]
-                 :schema_version schema-version
-                 :tlp "green"}]
-               malwares))))
-
-      (testing "PUT /ctia/malware/:id"
-        (let [response (put (str "ctia/malware/" (:short-id malware-id))
-                            :body {:external_ids ["http://ex.tld/ctia/malware/malware-123"
-                                                  "http://ex.tld/ctia/malware/malware-456"]
-                                   :name "modified malware"
-                                   :description "modified description"
-                                   :labels ["modified label"]}
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-malware (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               {:id (id/long-id malware-id)
-                :external_ids ["http://ex.tld/ctia/malware/malware-123"
-                               "http://ex.tld/ctia/malware/malware-456"]
-                :type "malware"
-                :name "modified malware"
-                :description "modified description"
-                :labels ["modified label"]
-                :schema_version schema-version
-                :tlp "green"}
-               updated-malware))))
-
-      (testing "PUT invalid /ctia/malware/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/malware/" (:short-id malware-id))
-                   :body {:external_ids ["http://ex.tld/ctia/malware/malware-123"
-                                         "http://ex.tld/ctia/malware/malware-456"]
-                          ;; This field has an invalid length
-                          :name (apply str (repeatedly 1025 (constantly \0)))
-                          :description "updated description"
-                          :labels ["modified label"]
-                          :type "malware"}
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*name" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/malware/:id"
-        (let [response (delete (str "ctia/malware/" (:short-id malware-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/malware/" (:short-id malware-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response))))))))
-
-  (testing "POST invalid /ctia/malware"
-    (let [{status :status
-           body :body}
-          (post "ctia/malware"
-                :body (assoc ex/new-malware-minimal
-                             ;; This field has an invalid length
-                             :name (clojure.string/join (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*name" (str/lower-case body))))))
+  (entity-crud-test
+   {:entity "malware"
+    :example new-malware-maximal
+    ;; TODO seems like we forgot to add restrictions on ctim
+    :invalid-tests? false
+    :update-field :description
+    :search-field :title
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-malware-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -178,14 +47,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/malware"
-                            :body (-> new-malware-maximal
-                                      (dissoc :id)
-                                      (assoc :description (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
+  (let [ids (post-entity-bulk
+             new-malware-maximal
+             :malwares
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/malware/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
@@ -193,12 +59,12 @@
 
     (field-selection-tests
      ["ctia/malware/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      malware-sort-fields)))
 
 (deftest-for-each-store test-malware-routes-access-control
   (access-control-test "malware"
-                       ex/new-malware-minimal
+                       new-malware-minimal
                        true
                        true))

--- a/test/ctia/http/routes/relationship_test.clj
+++ b/test/ctia/http/routes/relationship_test.clj
@@ -1,37 +1,38 @@
 (ns ctia.http.routes.relationship-test
-  (:refer-clojure :exclude [get])
-  (:require
-   [clojure.string :as str]
-   [ctim.examples.relationships
-    :refer [new-relationship-maximal
-            new-relationship-minimal]]
-   [ctia.schemas.sorting
-    :refer [relationship-sort-fields]]
-   [clj-momo.test-helpers
-    [core :as mth]
-    [http :refer [encode]]]
-   [clojure.test :refer [is join-fixtures testing use-fixtures]]
-   [ctia.domain.entities :refer [schema-version]]
-   [ctia.properties :refer [get-http-show]]
-   [ctia.test-helpers
-    [http :refer [doc-id->rel-url]]
-    [search :refer [test-query-string-search]]
-    [access-control :refer [access-control-test]]
-    [auth :refer [all-capabilities]]
-    [core :as helpers :refer [delete get post put]]
-    [fake-whoami-service :as whoami-helpers]
-    [pagination :refer [pagination-test]]
-    [field-selection :refer [field-selection-tests]]
-    [store :refer [deftest-for-each-store]]]
-   [ctim.domain.id :as id]
-   [ctim.examples.relationships :refer [new-relationship-minimal
-                                        new-relationship-maximal]]))
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [is join-fixtures testing use-fixtures]]
+            [ctia.schemas.sorting :refer [relationship-sort-fields]]
+            [ctia.test-helpers
+             [access-control :refer [access-control-test]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
+             [fake-whoami-service :as whoami-helpers]
+             [field-selection :refer [field-selection-tests]]
+             [http :refer [doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
+             [store :refer [deftest-for-each-store]]]
+            [ctim.examples.relationships
+             :refer
+             [new-relationship-maximal new-relationship-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
+
+(def new-relationship
+  (-> new-relationship-maximal
+      (assoc
+       :source_ref (str "http://example.com/ctia/judgement/judgement-"
+                        "f9832ac2-ee90-4e18-9ce6-0c4e4ff61a7a")
+       :target_ref (str "http://example.com/ctia/indicator/indicator-"
+                        "8c94ca8d-fb2b-4556-8517-8e6923d8d3c7")
+       :external_ids
+       ["http://ex.tld/ctia/relationship/relationship-123"
+        "http://ex.tld/ctia/relationship/relationship-456"])
+      (dissoc :id)))
 
 (deftest-for-each-store test-relationship-routes-bad-reference
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -62,91 +63,10 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
-  (testing "POST /ctia/relationship"
-    (let [new-relationship
-          (-> new-relationship-maximal
-              (assoc
-               :source_ref (str "http://example.com/ctia/judgement/judgement-"
-                                "f9832ac2-ee90-4e18-9ce6-0c4e4ff61a7a")
-               :target_ref (str "http://example.com/ctia/indicator/indicator-"
-                                "8c94ca8d-fb2b-4556-8517-8e6923d8d3c7")
-               :external_ids
-               ["http://ex.tld/ctia/relationship/relationship-123"
-                "http://ex.tld/ctia/relationship/relationship-456"])
-              (dissoc :id))
-          {status :status
-           relationship :parsed-body}
-          (post "ctia/relationship"
-                :body new-relationship
-                :headers {"Authorization" "45c1f5e3f05d0"})
-          relationship-id (id/long-id->id (:id relationship))
-          relationship-external-ids
-          (:external_ids relationship)]
-      (is (= 201 status))
-      (is (deep=
-           (assoc new-relationship :id (id/long-id relationship-id))
-           relationship))
-
-      (testing "the relationship ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    relationship-id)      (:hostname    show-props)))
-          (is (= (:protocol    relationship-id)      (:protocol    show-props)))
-          (is (= (:port        relationship-id)      (:port        show-props)))
-          (is (= (:path-prefix relationship-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/relationship/:id"
-        (let [response (get (str "ctia/relationship/" (:short-id relationship-id))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              relationship (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               (assoc new-relationship :id (id/long-id relationship-id))
-               relationship))))
-
-      (test-query-string-search :relationship "description" :description)
-
-      (testing "GET /ctia/relationship/external_id/:external_id"
-        (let [response (get (format "ctia/relationship/external_id/%s"
-                                    (encode (rand-nth relationship-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              relationships (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc new-relationship :id (id/long-id relationship-id))]
-               relationships))))
-
-      (testing "PUT /ctia/relationship/:id"
-        (let [with-updates (assoc relationship
-                                  :title "modified relationship")
-              response (put (str "ctia/relationship/" (:short-id relationship-id))
-                            :body with-updates
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              updated-relationship (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               with-updates
-               updated-relationship))))
-
-      (testing "PUT invalid /ctia/relationship/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/relationship/" (:short-id relationship-id))
-                   :body (assoc relationship
-                                :title (clojure.string/join
-                                        (repeatedly 1025 (constantly \0))))
-                   :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-
-      (testing "DELETE /ctia/relationship/:id"
-        (let [response (delete (str "ctia/relationship/" (:short-id relationship-id))
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
-          (is (= 204 (:status response)))
-          (let [response (get (str "ctia/relationship/" (:short-id relationship-id))
-                              :headers {"Authorization" "45c1f5e3f05d0"})]
-            (is (= 404 (:status response)))))))))
+  (entity-crud-test
+   {:entity "relationship"
+    :example new-relationship
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-relationship-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -155,23 +75,18 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/relationship"
-                            :body (-> new-relationship-maximal
-                                      (dissoc :id)
-                                      (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
-
+  (let [ids (post-entity-bulk
+             new-relationship-maximal
+             :relationships
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
     (pagination-test
      "ctia/relationship/search?query=*"
      {"Authorization" "45c1f5e3f05d0"}
      relationship-sort-fields)
-
     (field-selection-tests
      ["ctia/relationship/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      relationship-sort-fields)))
 

--- a/test/ctia/http/routes/sighting_test.clj
+++ b/test/ctia/http/routes/sighting_test.clj
@@ -1,32 +1,21 @@
 (ns ctia.http.routes.sighting-test
   (:refer-clojure :exclude [get])
-  (:require [ctim.examples.sightings
-             :refer [new-sighting-maximal]]
-            [ctia.schemas.sorting
-             :refer [sighting-sort-fields]]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [string :as str]
-             [test :refer [is join-fixtures testing use-fixtures]]]
-            [ctia.domain.entities :refer [schema-version]]
-            [ctia.properties :refer [get-http-show]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [join-fixtures use-fixtures]]
+            [ctia.schemas.sorting :refer [sighting-sort-fields]]
             [ctia.test-helpers
-             [http :refer [doc-id->rel-url]]
-             [auth :refer [all-capabilities]]
              [access-control :refer [access-control-test]]
-             [core :as helpers :refer [delete get post put url-id]]
+             [auth :refer [all-capabilities]]
+             [core :as helpers :refer [post-entity-bulk]]
+             [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
-             [pagination :refer [pagination-test]]
              [field-selection :refer [field-selection-tests]]
-             [http :refer [api-key]]
-             [search :refer [test-query-string-search]]
+             [http :refer [api-key doc-id->rel-url]]
+             [pagination :refer [pagination-test]]
              [store :refer [deftest-for-each-store]]]
-            [ctim.domain.id :as id]
             [ctim.examples.sightings
-             :refer [new-sighting-minimal
-                     new-sighting-maximal]]))
+             :refer
+             [new-sighting-maximal new-sighting-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -34,107 +23,25 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
+(def new-sighting
+  (-> new-sighting-maximal
+      (dissoc :id)
+      (assoc
+       :tlp "green"
+       :external_ids
+       ["http://ex.tld/ctia/sighting/sighting-123"
+        "http://ex.tld/ctia/sighting/sighting-345"])))
+
 (deftest-for-each-store test-sighting-routes
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
   (whoami-helpers/set-whoami-response api-key
                                       "foouser"
                                       "foogroup"
                                       "user")
-  (testing "POST /ctia/sighting"
-    (let [new-sighting (-> new-sighting-maximal
-                           (dissoc :id)
-                           (assoc
-                            :tlp "green"
-                            :external_ids
-                            ["http://ex.tld/ctia/sighting/sighting-123"
-                             "http://ex.tld/ctia/sighting/sighting-345"]))
-          {status :status
-           sighting :parsed-body}
-          (post "ctia/sighting"
-                :body new-sighting
-                :headers {"Authorization" api-key})
-
-          sighting-id (id/long-id->id (:id sighting))
-          sighting-external-ids (:external_ids sighting)]
-      (is (empty? (:errors sighting)) "No errors when")
-      (is (= 201 status))
-      (is (deep=
-           (assoc new-sighting :id (id/long-id sighting-id))
-           sighting))
-
-      (testing "the sighting ID has correct fields"
-        (let [show-props (get-http-show)]
-          (is (= (:hostname    sighting-id)      (:hostname    show-props)))
-          (is (= (:protocol    sighting-id)      (:protocol    show-props)))
-          (is (= (:port        sighting-id)      (:port        show-props)))
-          (is (= (:path-prefix sighting-id) (seq (:path-prefix show-props))))))
-
-      (testing "GET /ctia/sighting/external_id/:external_id"
-        (let [response (get (format "ctia/sighting/external_id/%s"
-                                    (encode (rand-nth sighting-external-ids)))
-                            :headers {"Authorization" "45c1f5e3f05d0"})
-              sightings (:parsed-body response)]
-          (is (= 200 (:status response)))
-          (is (deep=
-               [(assoc new-sighting :id (id/long-id sighting-id))]
-               sightings))))
-
-      (test-query-string-search :sighting "a sighting" :description)
-
-      (testing "GET /ctia/sighting/:id"
-        (let [{status :status
-               sighting :parsed-body}
-              (get (str "ctia/sighting/" (:short-id sighting-id))
-                   :headers {"Authorization" api-key})]
-          (is (empty? (:errors sighting)) "No errors when")
-          (is (= 200 status))
-          (is (deep=
-               (assoc new-sighting :id (id/long-id sighting-id))
-               sighting))))
-
-      (testing "PUT /ctia/sighting/:id"
-        (let [with-updates (assoc sighting :title "updated sighting")
-              {status :status
-               updated-sighting :parsed-body}
-              (put (str "ctia/sighting/" (:short-id sighting-id))
-                   :body with-updates
-                   :headers {"Authorization" api-key})]
-          (is (empty? (:errors sighting)) "No errors when updating sighting")
-          (is (= 200 status))
-          (is (deep=
-               with-updates
-               updated-sighting))))
-
-      (testing "PUT invalid /ctia/sighting/:id"
-        (let [{status :status
-               body :body}
-              (put (str "ctia/sighting/" (:short-id sighting-id))
-                   :body
-                   (assoc sighting
-                          :title (clojure.string/join
-                                  (repeatedly 1025 (constantly \0))))
-                   :headers {"Authorization" api-key})]
-          (is (= status 400))
-          (is (re-find #"error.*in.*title" (str/lower-case body)))))
-
-      (testing "DELETE /ctia/sighting/:id"
-        (let [{status :status} (delete (str "ctia/sighting/" (:short-id sighting-id))
-                                       :headers {"Authorization" api-key})]
-          (is (= 204 status))
-          (let [{status :status} (get (str "ctia/sighting/" (:short-id sighting-id))
-                                      :headers {"Authorization" api-key})]
-            (is (= 404 status)))))))
-
-  (testing "POST invalid /ctia/sighting"
-    (let [{status :status
-           body :body}
-          (post "ctia/sighting"
-                :body (assoc new-sighting-minimal
-                             ;; This field has an invalid length
-                             :title (apply str (repeatedly 1025 (constantly \0))))
-                :headers {"Authorization" "45c1f5e3f05d0"})]
-      (is (= status 400))
-      (is (re-find #"error.*in.*title" (str/lower-case body))))))
+  (entity-crud-test
+   {:entity "sighting"
+    :example new-sighting-maximal
+    :headers {:Authorization "45c1f5e3f05d0"}}))
 
 (deftest-for-each-store test-sighting-pagination-field-selection
   (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -143,14 +50,11 @@
                                       "foogroup"
                                       "user")
 
-  (let [posted-docs
-        (doall (map #(:parsed-body
-                      (post "ctia/sighting"
-                            :body (-> new-sighting-maximal
-                                      (dissoc :id :relations)
-                                      (assoc :source (str "dotimes " %)))
-                            :headers {"Authorization" "45c1f5e3f05d0"}))
-                    (range 0 30)))]
+  (let [ids (post-entity-bulk
+             new-sighting-maximal
+             :sightings
+             30
+             {"Authorization" "45c1f5e3f05d0"})]
 
     (pagination-test
      "ctia/sighting/search?query=*"
@@ -159,7 +63,7 @@
 
     (field-selection-tests
      ["ctia/sighting/search?query=*"
-      (-> posted-docs first :id doc-id->rel-url)]
+      (doc-id->rel-url (first ids))]
      {"Authorization" "45c1f5e3f05d0"}
      sighting-sort-fields)))
 

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -2,8 +2,6 @@
   (:require [ctia.stores.es.crud :as sut]
             [clojure.test :as t :refer [is testing deftest]]))
 
-
-
 (deftest partial-results-test
   (is (= {:data [{:error "Exception"}
                  {:id "124"}]}

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -98,9 +98,10 @@
   ([test enable-http?]
    ;; Start CTIA
    ;; This starts the server on an available port (if enabled)
-   (let [http-port (if enable-http?
-                     (net/available-port)
-                     3000)]
+   (let [http-port
+         (if enable-http?
+           (net/available-port)
+           3000)]
      (with-properties ["ctia.http.enabled" enable-http?
                        "ctia.http.port" http-port
                        "ctia.http.show.port" http-port]
@@ -150,6 +151,18 @@
 
 (def post
   (mthh/with-port-fn get-http-port mthh/post))
+
+(defn post-entity-bulk [example plural x headers]
+  (let [new-records
+        (for [x (range 0 x)]
+          (-> example
+              (assoc :source (str "dotimes " x))
+              (dissoc :id)))]
+    (-> (post "ctia/bulk"
+              :body {plural new-records}
+              :headers headers)
+        :parsed-body
+        plural)))
 
 (def delete
   (mthh/with-port-fn get-http-port mthh/delete))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -12,6 +12,11 @@
              [store :as es-store]]
             [ctia.test-helpers.core :as h]))
 
+(defn refresh-indices [entity]
+  (let [{:keys [type host port]}
+        (es-init/get-store-properties entity)]
+    (http/post (format "http://%s:%s/_refresh" host port))))
+
 (defn fixture-delete-store-indexes
   "walk through all the es stores delete each store indexes"
   [t]
@@ -58,7 +63,8 @@
                       "ctia.store.relationship" "es"
                       "ctia.store.casebook" "es"
                       "ctia.store.sighting" "es"
-                      "ctia.store.tool" "es"]
+                      "ctia.store.tool" "es"
+                      "ctia.store.bulk-refresh" "true"]
     (t)))
 
 (defn fixture-properties:es-hook [t]

--- a/test/ctia/test_helpers/field_selection.clj
+++ b/test/ctia/test_helpers/field_selection.clj
@@ -19,8 +19,9 @@
       first
       keyword))
 
-(defn field-selection-test [route headers fields]
+(defn field-selection-test
   "all field selection related tests for given routes and fields"
+  [route headers fields]
   (testing (str "field selection tests for: " route)
     (doseq [field (testable-fields fields)]
       (let [{:keys [status parsed-body]}

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -7,7 +7,6 @@
 (defn doc-id->rel-url [doc-id]
   "given a doc id (url) make a relative url for test queries"
   (clojure.string/replace doc-id #".*(?=ctia)" ""))
-
 (def test-post
   (mthh/with-port-fn-and-api-key th/get-http-port api-key mthh/test-post))
 

--- a/test/ctia/test_helpers/pagination.clj
+++ b/test/ctia/test_helpers/pagination.clj
@@ -3,15 +3,17 @@
   (:require [clojure.test :refer [is join-fixtures testing use-fixtures]]
             [ctia.test-helpers [core :as helpers :refer [get]]]))
 
-(defn total->limit [total offset]
+(defn total->limit
   "make a limit from a full list total and offset"
+  [total offset]
   (-> (/ total 2)
       Math/ceil
       Math/round
       (- offset)))
 
-(defn limit-test [route headers]
+(defn limit-test
   "test a list route with limit query param"
+  [route headers]
   (headers (str route " with a limit")
            (let [{full-status :status
                   full-res :parsed-body
@@ -35,9 +37,9 @@
              (is (= (clojure.core/get limited-headers "X-Total-Hits")
                     (clojure.core/get full-headers "X-Total-Hits"))))))
 
-(defn offset-test [route headers]
+(defn offset-test
   "test a list route with offset and limit query params"
-
+  [route headers]
   (testing (str route " with limit and offset")
     (let [offset 1
           {full-status :status
@@ -74,9 +76,9 @@
                clojure.walk/keywordize-keys
                (select-keys [:X-Total-Hits :X-Previous :X-Next])))))))
 
-(defn sort-test [route headers sort-fields]
+(defn sort-test
   "test a list route with all sort options"
-
+  [route headers sort-fields]
   (testing (str route " with sort")
     (doall (map (fn [field]
                   (let [manually-sorted (->> (get route :headers headers)
@@ -96,8 +98,9 @@
                          route-sorted) field)))
                 sort-fields))))
 
-(defn edge-cases-test [route headers]
+(defn edge-cases-test
   "miscellaneous test which may expose small caveats"
+  [route headers]
 
   (testing (str route " with invalid offset")
     (let [total (-> (get route :headers headers) :parsed-body count)
@@ -124,16 +127,18 @@
       (is (= 200 status))
       (is (deep= body [])))))
 
-(defn pagination-test [route headers sort-fields]
+(defn pagination-test
   "all pagination related tests for a list route"
+  [route headers sort-fields]
   (testing (str "pagination tests for: " route)
     (do (limit-test route headers)
         (offset-test route headers)
         (sort-test route headers sort-fields)
         (edge-cases-test route headers))))
 
-(defn pagination-test-no-sort [route headers sort-fields]
+(defn pagination-test-no-sort
   "all pagination related tests for a list route"
+  [route headers sort-fields]
   (testing (str "paginations tests for: " route)
     (do (limit-test route headers)
         (offset-test route headers))))


### PR DESCRIPTION
Adds a new `crud` test helper to test common behaviors across our entity routes.
This PR allows to remove a lot of duplicated test code.

Also:
- put generative tests under a selector disabled by default.
- Enable to set the default refresh behavior for bulk inserts using properties
