### PR TITLE
Fix the function that count the max number of entities in a bundle

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,11 +40,11 @@
                  ;; Schemas
                  [prismatic/schema ~schema-version]
                  [metosin/schema-tools ~schema-tools-version]
-                 [threatgrid/flanders "0.1.16"
+                 [threatgrid/flanders "0.1.17"
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "0.4.28"
+                 [threatgrid/ctim "0.4.29-SNAPSHOT"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "0.4.29-SNAPSHOT"
+                 [threatgrid/ctim "0.4.29"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -372,7 +372,8 @@
                                  :create-sighting
                                  :create-tool
                                  :import-bundle}
-                 (if (> (bundle-size bundle)
-                        (bundle-max-size))
-                   (bad-request (str "Bundle max nb of entities: " (bundle-max-size)))
-                   (ok (import-bundle bundle external-key-prefixes auth-identity))))))
+                 (let [max-size (bundle-max-size)]
+                   (if (> (bundle-size bundle)
+                          max-size)
+                     (bad-request (str "Bundle max nb of entities: " max-size))
+                     (ok (import-bundle bundle external-key-prefixes auth-identity)))))))

--- a/src/ctia/http/routes/bundle.clj
+++ b/src/ctia/http/routes/bundle.clj
@@ -338,6 +338,12 @@
                 (with-bulk-result bundle-import-data)
                 build-response))))
 
+(def bundle-max-size bulk/get-bulk-max-size)
+
+(defn bundle-size
+  [bundle]
+  (bulk/bulk-size (select-keys bundle bundle-entity-keys)))
+
 (defroutes bundle-routes
   (context "/bundle" []
            :tags ["Bundle"]
@@ -366,7 +372,7 @@
                                  :create-sighting
                                  :create-tool
                                  :import-bundle}
-                 (if (> (bulk/bulk-size bundle)
-                        (bulk/get-bulk-max-size))
-                   (bad-request (str "Bundle max nb of entities: " (bulk/get-bulk-max-size)))
+                 (if (> (bundle-size bundle)
+                        (bundle-max-size))
+                   (bad-request (str "Bundle max nb of entities: " (bundle-max-size)))
                    (ok (import-bundle bundle external-key-prefixes auth-identity))))))

--- a/test/ctia/http/routes/bundle_test.clj
+++ b/test/ctia/http/routes/bundle_test.clj
@@ -12,7 +12,7 @@
             [ctia.store :refer [stores]]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [get post deep-dissoc]]
+             [core :as helpers :refer [get post deep-dissoc-entity-ids]]
              [fake-whoami-service :as whoami-helpers]
              [store :refer [deftest-for-each-store]]]
             [clojure.set :as set]
@@ -187,7 +187,8 @@
                            indicators
                            sightings)]
     (testing "Import bundle with all entity types"
-      (let [new-bundle (deep-dissoc bundle-maximal :id)
+      (let [new-bundle (-> bundle-maximal
+                           deep-dissoc-entity-ids)
             response (post "ctia/bundle/import"
                            :body new-bundle
                            :headers {"Authorization" "45c1f5e3f05d0"})

--- a/test/ctia/http/routes/bundle_test.clj
+++ b/test/ctia/http/routes/bundle_test.clj
@@ -187,8 +187,7 @@
                            indicators
                            sightings)]
     (testing "Import bundle with all entity types"
-      (let [new-bundle (-> bundle-maximal
-                           deep-dissoc-entity-ids)
+      (let [new-bundle (deep-dissoc-entity-ids bundle-maximal)
             response (post "ctia/bundle/import"
                            :body new-bundle
                            :headers {"Authorization" "45c1f5e3f05d0"})

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -240,10 +240,12 @@
      (with-redefs [clojure.tools.logging/log* patched-log#]
        ~@body)))
 
-(defn deep-dissoc
-  "Dissoc a key in the given map recursively"
-  [m k]
-  (prewalk #(if (map? %)
-              (dissoc % k)
+(defn deep-dissoc-entity-ids
+  "Dissoc all entity ID in the given map recursively"
+  [m]
+  (prewalk #(if (and (map? %)
+                     ;; Do not remove the id of a nested openc2 coa
+                     (not= (:type %) "structured_coa"))
+              (dissoc % :id)
               %)
            m))

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -300,6 +300,9 @@ fragment casebookFields on Casebook {
   schema_version
   revision
   external_ids
+  external_references {
+    ...externalReferenceFields
+  }
   timestamp
   language
   title
@@ -313,6 +316,13 @@ fragment casebookFields on Casebook {
   }
 }
 
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
 
 fragment relationshipBaseFields on Relationship {
   relationship_type


### PR DESCRIPTION
Closes threatgrid/iroh#1825

The fix is tested using the updated `bundle-maximal` example (which contains a `:timestamp` field)