### PR TITLE
Set the correct KMS Key to be used on S3 uploads

### DIFF
--- a/build/debian-package.sh
+++ b/build/debian-package.sh
@@ -39,7 +39,7 @@ function build-and-publish-package {
   export PATH=$PATH:$HOME/.local/bin
   export AWS_ACCESS_KEY_ID=$DEB_ACCESS_KEY
   export AWS_SECRET_ACCESS_KEY=$DEB_SECRET_KEY
-  aws s3 cp ./target/ctia.jar s3://${ARTIFACTS_BUCKET}/artifacts/ctia/${ARTIFACT_NAME} --sse aws:kms
+  aws s3 cp ./target/ctia.jar s3://${ARTIFACTS_BUCKET}/artifacts/ctia/${ARTIFACT_NAME} --sse aws:kms --sse-kms-key-id alias/kms-s3
 }
 
 if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then


### PR DESCRIPTION
If we don't specify the correct KMS Key alias for the S3 encryption, the Travis upload will use the generic default KMS key from AWS. Since we are using our own KMS Keys, we need to specify which KMS key should be used to encrypt the artifact on S3.

Tested and validated in an isolated environment.