### PR TITLE
New Incident model

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "0.4.30"
+                 [threatgrid/ctim "1.0.0-SNAPSHOT"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.0-SNAPSHOT"
+                 [threatgrid/ctim "1.0.0"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -52,27 +52,11 @@
      em/describable-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:valid_time em/valid-time
-      :confidence em/token
+     {:confidence em/token
       :status em/token
       :incident_time em/incident-time
       :categories em/token
-      :reporter em/token
-      :responder em/token
-      :coordinator em/token
-      :victim em/token
-      :affected_assets em/affected-asset
-      :impact_assessment em/impact-assessment
-      :security_compromise em/token
       :discovery_method em/token
-      :COA_requested em/coa-requested
-      :COA_taken em/coa-requested
-      :contact em/token
-      :history em/history
-      :related_indicators em/related-indicators
-      :related_observables em/observable
-      :attributed_actors em/related-actors
-      :related_incidents em/related-incidents
       :intended_effect em/token})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
@@ -81,25 +65,15 @@
   (concat default-entity-sort-fields
           describable-entity-sort-fields
           sourcable-entity-sort-fields
-          [:valid_time.start_time
-           :valid_time.end_time
-           :confidence
+          [:confidence
            :status
-           :incident_time.first_malicious_action
-           :incident_time.initial_compromise
-           :incident_time.first_data_exfiltration
-           :incident_time.incident_discovery
-           :incident_time.incident_opened
-           :incident_time.containment_achieved
-           :incident_time.restoration_achieved
-           :incident_time.incident_reported
-           :incident_time.incident_closed
-           :reporter
-           :coordinator
-           :victim
-           :security_compromise
+           :incident_time.opened
+           :incident_time.discovered
+           :incident_time.reported
+           :incident_time.remediated
+           :incident_time.closed
+           :incident_time.rejected
            :discovery_method
-           :contact
            :intended_effect]))
 
 (def incident-sort-fields
@@ -117,12 +91,7 @@
    {:query s/Str
     (s/optional-key :confidence) s/Str
     (s/optional-key :status) s/Str
-    (s/optional-key :reporter) s/Str
-    (s/optional-key :coordinator) s/Str
-    (s/optional-key :victim) s/Str
-    (s/optional-key :security_compromise) s/Str
     (s/optional-key :discovery_method) s/Str
-    (s/optional-key :contact) s/Str
     (s/optional-key :intended_effect) s/Str
     (s/optional-key :categories) s/Str
     (s/optional-key :sort_by) incident-sort-fields}))

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -134,15 +134,12 @@
 
 (def incident-time
   {:properties
-   {:first_malicious_action ts
-    :initial_compromise ts
-    :first_data_exfiltration ts
-    :incident_discovery ts
-    :incident_opened ts
-    :containment_achieved ts
-    :restoration_achieved ts
-    :incident_reported ts
-    :incident_closed ts}})
+   {:opened ts
+    :discovered ts
+    :reported ts
+    :remediated ts
+    :closed ts
+    :rejected ts}})
 
 (def non-public-data-compromised
   {:properties

--- a/src/ctia/task/migrations.clj
+++ b/src/ctia/task/migrations.clj
@@ -64,4 +64,5 @@
                  fix-end-time
                  add-groups
                  target-observed_time
-                 pluralize-target)})
+                 pluralize-target)
+   :1.0.0 (comp (append-version "1.0.0"))})

--- a/test/ctia/http/routes/bulk_test.clj
+++ b/test/ctia/http/routes/bulk_test.clj
@@ -19,7 +19,8 @@
              [core :as helpers :refer [get post]]
              [fake-whoami-service :as whoami-helpers]
              [store :refer [test-for-each-store]]]
-            [ctim.domain.id :as id]))
+            [ctim.domain.id :as id]
+            [ctim.examples.incidents :refer [new-incident-maximal]]))
 
 (defn fixture-properties:small-max-bulk-size [t]
   ;; Note: These properties may be overwritten by ENV variables
@@ -83,11 +84,10 @@
    :reason "false positive"})
 
 (defn mk-new-incident [n]
-  {:title (str "incident-" n)
-   :description (str "description: incident-" n)
-   :confidence "Low"
-   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
+  (-> new-incident-maximal
+      (dissoc :id :schema_version :tlp :type)
+      (into {:title (str "incident-" n)
+             :description (str "description: incident-" n)})))
 
 (defn mk-new-indicator [n]
   {:title (str "indicator-" n)

--- a/test/ctia/http/routes/observable/sightings_incidents_test.clj
+++ b/test/ctia/http/routes/observable/sightings_incidents_test.clj
@@ -95,6 +95,8 @@
                (post "ctia/incident"
                      :body {:id (id/long-id incident-1-id)
                             :confidence "High"
+                            :status "Open"
+                            :incident_time {:opened #inst "2016-02-11T00:40:48.212-00:00"}
                             :external_ids ["incident-1"]}
                      :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 201 status))))
@@ -105,6 +107,8 @@
                (post "ctia/incident"
                      :body {:id (id/long-id incident-2-id)
                             :confidence "High"
+                            :status "Open"
+                            :incident_time {:opened #inst "2016-02-11T00:40:48.212-00:00"}
                             :external_ids ["incident-2"]}
                      :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 201 status))))

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -244,9 +244,15 @@
               :headers {"Authorization" "player-3-token"})]
 
     (testing "green test setup is successful"
-      (is (= 201 (:status player-1-entity-post)))
-      (is (= 201 (:status player-2-entity-post)))
-      (is (= 201 (:status player-3-entity-post))))
+      (is (= 201 (:status player-1-entity-post))
+          (str "HTTP status should be 201 "
+               (pr-str player-1-entity-post)))
+      (is (= 201 (:status player-2-entity-post))
+          (str "HTTP status should be 201 "
+               (pr-str player-2-entity-post)))
+      (is (= 201 (:status player-3-entity-post))
+          (str "HTTP status should be 201 "
+               (pr-str player-3-entity-post))))
 
     (crud-access-control-test entity
                               can-update?


### PR DESCRIPTION
Closes #697

Depends on threatgrid/ctim#191

A migration is needed to:

- Change the schema_version of all entities
- Update all mappings (#684)