### PR TITLE
Fix PATCH route schema version issues

### DIFF
--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -349,7 +349,7 @@
                                     prev-entity
                                     partial-entity)
                    un-store
-                   (dissoc :id))]
+                   (dissoc :id :schema_version))]
     (assoc fm :entities [entity])))
 
 (defn create-flow
@@ -370,7 +370,7 @@
              enveloped-result?]}]
   (-> {:flow-type :create
        :entity-type entity-type
-       :entities entities
+       :entities (map #(dissoc % :schema_version) entities)
        :tempids tempids
        :identity identity
        :long-id-fn long-id-fn
@@ -410,7 +410,8 @@
   (let [prev-entity (get-fn entity-id)]
     (-> {:flow-type :update
          :entity-type entity-type
-         :entities [entity]
+         :entities [(dissoc entity
+                            :schema_version)]
          :prev-entity prev-entity
          :identity identity
          :long-id-fn long-id-fn


### PR DESCRIPTION
This is an attempt to be more flexible regarding the `schema_version` field value on `PATCH` and `PUT` operations.

The `PATCH` behavior fetches the record from the DS, apply the patch, validates the entity and realize it before submitting it again to the store.

the target  behavior is to clear the `schema_version` field after fetching it from the DS, the field will be populated again by the realize function.

same behavior is applied on the `PUT` operations except we clear that value from the client request for convenience.

This improved behavior will enable `PATCH` and `PUT` operations to still work when CTIA is updated but the migration is not done.