### PR TITLE
Fix migration from 0.4.28 to 1.0.0

### DIFF
--- a/src/ctia/task/migrations.clj
+++ b/src/ctia/task/migrations.clj
@@ -123,7 +123,7 @@
            ("judgement"
             "verdict") (rename-judgement-observable-type doc old new)
            "casebook" (rename-casebook-observable-types doc old new)
-           identity))))
+           doc))))
 
 ;;--- Simplify incident model
 

--- a/src/ctia/task/migrations.clj
+++ b/src/ctia/task/migrations.clj
@@ -1,7 +1,8 @@
 (ns ctia.task.migrations
   (:require [clj-momo.lib.clj-time
              [coerce :as time-coerce]
-             [core :as time-core]]))
+             [core :as time-core]]
+            [clojure.set :as set]))
 
 (def add-groups
   "set a document group to [\"tenzin\"] if unset"
@@ -55,6 +56,98 @@
                (dissoc :target))
            doc))))
 
+;;-- Rename observable type
+
+(defn with-renamed-observable-type
+  [observable old new]
+  (update observable
+          :type
+          (fn [obs-type]
+            (if (= obs-type old)
+              new
+              obs-type))))
+
+(defn with-renamed-observable-types
+  [c old new]
+  (mapv #(with-renamed-observable-type % old new)
+        c))
+
+(defn rename-sighting-relations-observable-types
+  [relation old new]
+  (-> relation
+      (update :source with-renamed-observable-type old new)
+      (update :related with-renamed-observable-type old new)))
+
+(defn rename-sighting-observable-types
+  [sighting old new]
+  (-> sighting
+      (update :observables with-renamed-observable-types old new)
+      (update :relations
+              (fn [relations]
+                (mapv #(rename-sighting-relations-observable-types % old new)
+                      relations)))))
+
+(defn rename-judgement-observable-type
+  [judgement old new]
+  (update judgement
+          :observable
+          with-renamed-observable-type
+          old
+          new))
+
+(defn rename-bundle-observable-types
+  [bundle old new]
+  (-> bundle
+      (update :sightings (fn [sightings]
+                           (mapv #(rename-sighting-observable-types % old new)
+                                 sightings)))
+      (update :judgements (fn [judgements]
+                            (mapv #(rename-judgement-observable-type % old new)
+                                  judgements)))
+      (update :verdicts (fn [verdicts]
+                          (mapv #(rename-judgement-observable-type % old new)
+                                verdicts)))))
+
+(defn rename-casebook-observable-types
+  [{:keys [observables bundle] :as casebook} old new]
+  (cond-> casebook
+    (seq observables) (update :observables with-renamed-observable-types old new)
+    bundle (update :bundle rename-bundle-observable-types old new)))
+
+(defn rename-observable-type
+  [old new]
+  (map (fn [{observable-type :type
+             :as doc}]
+         (case observable-type
+           "sighting" (rename-sighting-observable-types doc old new)
+           ("judgement"
+            "verdict") (rename-judgement-observable-type doc old new)
+           "casebook" (rename-casebook-observable-types doc old new)
+           identity))))
+
+;;--- Simplify incident model
+
+(defn simplify-incident-time
+  [incident-time]
+  (-> incident-time
+      (dissoc :first_malicious_action :initial_compromise :first_data_exfiltration
+              :containment_achieved :restoration_achieved)
+      (set/rename-keys {:incident_discovery :discovered
+                        :incident_opened :opened
+                        :incident_reported :reported
+                        :incident_closed :closed})))
+
+(def simplify-incident
+  (map (fn [{entity-type :type :as doc}]
+         (if (= entity-type "incident")
+           (-> doc
+               (dissoc :valid_time :reporter :responder :coordinator :victim
+                       :affected_assets :impact_assessment :security_compromise
+                       :COA_requested :COA_taken :contact :history :related_indicators
+                       :related_observables :attributed_actors :related_incidents)
+               (update :incident_time simplify-incident-time))
+           doc))))
+
 (def available-migrations
   {:__test (map #(assoc % :groups ["migration-test"]))
    :0.4.16 (comp (append-version "0.4.16")
@@ -65,4 +158,6 @@
                  add-groups
                  target-observed_time
                  pluralize-target)
-   :1.0.0 (comp (append-version "1.0.0"))})
+   :1.0.0 (comp (append-version "1.0.0")
+                (rename-observable-type "pki-serial" "pki_serial")
+                simplify-incident)})

--- a/test/ctia/task/migrations_test.clj
+++ b/test/ctia/task/migrations_test.clj
@@ -1,6 +1,8 @@
 (ns ctia.task.migrations-test
   (:require [clojure.test :refer [deftest is]]
-            [ctia.task.migrations :as sut]))
+            [ctia.entity.incident :refer [StoredIncident]]
+            [ctia.task.migrations :as sut]
+            [schema.core :as s]))
 
 (deftest add-groups-test
   (is (= (transduce sut/add-groups conj [{}])
@@ -130,3 +132,179 @@
             :end_time "2018-03-15T02:36:00.632Z"},
            :observables_hash ["ip:22.11.22.11"],
            :owner "b3eab96a-ed74-4195-9c2b-f8b3dd447ccd"}])))
+
+(def old-incident
+  {:id "http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+   :external_ids ["http://ex.tld/ctia/incident/incident-e1b8afdf-e3dd-45d9-961c-dd84f37a8587"
+                  "http://ex.tld/ctia/incident/incident-456"]
+   :external_references
+   [{:source_name "source"
+     :external_id "T1067"
+     :url "https://ex.tld/wiki/T1067"
+     :hashes ["#section1"]
+     :description "Description text"}]
+   :type "incident"
+   :title "incident"
+   :description "description"
+   :short_description "short desc"
+   :tlp "green"
+   :schema_version "0.4.28"
+   :revision 1
+   :timestamp #inst "2016-02-11T00:40:48.212-00:00"
+   :language "language"
+   :source "source"
+   :source_uri "http://example.com"
+   :confidence "High"
+   :categories ["Denial of Service"
+                "Improper Usage"]
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+                :end_time #inst "2525-01-01T00:00:00.000-00:00"}
+   :status "Open"
+   :incident_time {:first_malicious_action #inst "2016-02-11T00:40:48.212-00:00"
+                   :initial_compromise #inst "2016-02-11T00:40:48.212-00:00"
+                   :first_data_exfiltration #inst "2016-02-11T00:40:48.212-00:00"
+                   :incident_discovery #inst "2016-02-11T00:40:48.212-00:00"
+                   :incident_opened #inst "2016-02-11T00:40:48.212-00:00"
+                   :containment_achieved #inst "2016-02-11T00:40:48.212-00:00"
+                   :restoration_achieved #inst "2016-02-11T00:40:48.212-00:00"
+                   :incident_reported #inst "2016-02-11T00:40:48.212-00:00"
+                   :incident_closed #inst "2016-02-11T00:40:48.212-00:00"}
+   :reporter "reporter"
+   :responder "responder"
+   :coordinator "coordinator"
+   :victim "victim"
+   :affected_assets [{:type "thing"
+                      :description "description"
+                      :ownership_class "Partner-Owned"
+                      :management_class "CO-Management"
+                      :location_class "Mobile"
+                      :property_affected {:property "Non-Repudiation"
+                                          :description_of_effect "foo"
+                                          :type_of_availability_loss "foo"
+                                          :duration_of_availability_loss "Seconds"
+                                          :non_public_data_compromised {:security_compromise "Yes"
+                                                                        :data_encrypted false}}
+                      :identifying_observables [{:type "domain" :value "foo.com"}]}]
+   :impact_assessment {:direct_impact_summary {:asset_losses "Moderate"
+                                               :business_mission_distruption "Major"
+                                               :response_and_recovery_costs "Minor"}
+                       :indirect_impact_summary {:loss_of_competitive_advantage "Yes"
+                                                 :brand_and_market_damage "No"
+                                                 :increased_operating_costs "Yes"
+                                                 :local_and_regulatory_costs "Yes"}
+                       :total_loss_estimation {:initial_reported_total_loss_estimation {:amount 100
+                                                                                        :iso_currency_code "foo"}
+                                               :actual_total_loss_estimation {:amount 100
+                                                                              :iso_currency_code "foo"}}
+                       :impact_qualification "Painful"
+                       :effects ["Data Breach or Compromise"]}
+   :security_compromise "Yes"
+   :discovery_method "Log Review"
+   :contact "contact"
+   :history [{:action_entry [{:COA "http://example.com/ctia/coa/coa-2e4eb53f-cfa3-4957-86ab-6eaf02fd0587"
+                              :time #inst "2016-02-11T00:40:48.212-00:00"
+                              :contributors [{:role "role"
+                                              :name "name"
+                                              :email "email"
+                                              :phone "phone"
+                                              :organization "org"
+                                              :date #inst "2016-02-11T00:40:48.212-00:00"
+                                              :contribution_location "location"}]}]
+              :journal_entry "history"}]
+   :intended_effect "Extortion"
+   :related_indicators [{:confidence "High"
+                         :source "source"
+                         :relationship "related-to"
+                         :indicator_id "http://example.com/ctia/indicator/indicator-6e279a0d-6788-4cdf-957f-4e4b73823d6c"}]
+   :related_incidents [{:confidence "High"
+                        :source "source"
+                        :relationship "related-to"
+                        :incident_id "http://example.com/ctia/incident/incident-6e279a0d-6788-4cdf-957f-4e4b73823d6f"}]
+   :related_observables [{:type "domain" :value "example.com"}]
+   :attributed_actors [{:confidence "High"
+                        :source "source"
+                        :relationship "attributed-to"
+                        :actor_id "http://example.com/ctia/actor/actor-6e279a0d-6788-4cdf-957f-4e4b73823d6d"}]
+   :COA_taken [{:COA "http://example.com/ctia/coa/coa-6e279a0d-6788-4cdf-957f-4e4b73823f6d"
+                :time #inst "2016-02-11T00:40:48.212-00:00"
+                :contributors [{:role "role"
+                                :name "name"
+                                :email "name@foo.com"
+                                :phone "+33 82222"
+                                :organization "org"
+                                :date #inst "2016-02-11T00:40:48.212-00:00"
+                                :contribution_location "location"}]}]
+   :COA_requested [{:COA "http://example.com/ctia/coa/coa-6e279a0d-6788-4ddf-957f-4e4b73823f6d"
+                    :time #inst "2016-02-11T00:40:48.212-00:00"
+                    :contributors [{:role "role"
+                                    :name "name"
+                                    :email "name@foo.com"
+                                    :phone "+33 82222"
+                                    :organization "org"
+                                    :date #inst "2016-02-11T00:40:48.212-00:00"
+                                    :contribution_location "location"}]}]
+   :owner "foouser"
+   :groups ["bar"]
+   :created #inst "2016-02-11T00:40:48.212-00:00"
+   :modified #inst "2016-02-11T00:40:48.212-00:00"})
+
+(deftest simplify-incident-model-test
+  (is (nil? (->> (transduce sut/simplify-incident
+                            conj
+                            [old-incident])
+                 first
+                 (s/check StoredIncident)))))
+
+(deftest rename-observable-type-test
+  (let [sighting {:type "sighting"
+                  :observables [{:type "domain" :value "example.com"}
+                                {:type "pki-serial" :value "12345"}]
+                  :relations [{:source {:type "pki-serial" :value "12345"}
+                               :related {:type "pki-serial" :value "12345"}}]}
+        judgement {:type "judgement"
+                   :observable {:type "pki-serial" :value "12345"}}
+        verdict {:type "verdict"
+                 :observable {:type "pki-serial" :value "12345"}}
+        casebook {:type "casebook"
+                  :observables (:observables sighting)
+                  :bundle {:type "bundle"
+                           :sightings [sighting]
+                           :judgements [judgement]
+                           :verdicts [verdict]}}]
+    (is (= [{:type "sighting",
+            :observables
+            [{:type "domain", :value "example.com"}
+             {:type "pki_serial", :value "12345"}],
+            :relations
+            [{:source {:type "pki_serial", :value "12345"},
+              :related {:type "pki_serial", :value "12345"}}]}
+           {:type "judgement",
+            :observable {:type "pki_serial", :value "12345"}}
+           {:type "verdict",
+            :observable {:type "pki_serial", :value "12345"}}
+           {:type "casebook",
+            :observables
+            [{:type "domain", :value "example.com"}
+             {:type "pki_serial", :value "12345"}],
+            :bundle
+            {:type "bundle",
+             :sightings
+             [{:type "sighting",
+               :observables
+               [{:type "domain", :value "example.com"}
+                {:type "pki_serial", :value "12345"}],
+               :relations
+               [{:source {:type "pki_serial", :value "12345"},
+                 :related {:type "pki_serial", :value "12345"}}]}],
+             :judgements
+             [{:type "judgement",
+               :observable {:type "pki_serial", :value "12345"}}],
+             :verdicts
+             [{:type "verdict",
+               :observable {:type "pki_serial", :value "12345"}}]}}]
+           (transduce (sut/rename-observable-type "pki-serial" "pki_serial")
+                      conj
+                      [sighting
+                       judgement
+                       verdict
+                       casebook])))))


### PR DESCRIPTION
Closes #702

- Rename pki-serial observable type to pki_serial
- Update simplified incident model
- Add a default catch clause for the whole migration process
- Improve the display of coercion errors

When a validation error occurs, the whole process is not stopped. Is this the expected behaviour?