### PR TITLE
Fix private CTIA migration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.22-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.22"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.20"]
+                 [threatgrid/clj-momo "0.2.22-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -104,6 +104,8 @@
      {}
      params)))
 
+(def bulk-max-size (* 5 1024 1024)) ;; 5Mo
+
 (defn store-batch
   "store a batch of documents using a bulk operation"
   [{:keys [conn indexname mapping type]} batch]
@@ -116,10 +118,12 @@
                      :_index indexname
                      :_type mapping)
              batch)]
+
     (es-doc/bulk-create-doc
      conn
      prepared-docs
-     "false")))
+     "false"
+     bulk-max-size)))
 
 (defn create-target-store
   "create the target store, pushing its template"
@@ -291,5 +295,6 @@
         (check-store-indexes batch-size prefix))
       (log/info "migration complete")
       (catch Exception e
-        (log/error e "Unexpected error during migration")))
+        (log/error e "Unexpected error during migration")
+        (System/exit -1)))
     (System/exit 0)))


### PR DESCRIPTION
Closes #705

The private CTIA migration fails on the Investigation index. Investigations can be very large (> 5M). We need to split the payload when we post these docs to ES using the bulk API. The `bulk-create-doc` fn from cli-momo has been updated to take a `max-size` option. If the given collection of documents exceed this `max-size`, they are split into multiple bulk operations.