### PR TITLE
Longer timeouts for migrations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.20"]
+                 [threatgrid/clj-momo "0.2.22"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -31,7 +31,8 @@
    (str "ctia.store.es." store ".indexname") s/Str
    (str "ctia.store.es." store ".refresh") Refresh
    (str "ctia.store.es." store ".replicas") s/Num
-   (str "ctia.store.es." store ".shards") s/Num})
+   (str "ctia.store.es." store ".shards") s/Num
+   (str "ctia.store.es." store ".timeout") s/Num})
 
 (s/defschema StorePropertiesSchema
   "All entity store properties for every implementation"

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -24,7 +24,8 @@
 (s/defn init-store-conn :- ESConnState
   "initiate an ES store connection, returning a map containing a
    connection manager and dedicated store index properties"
-  [{:keys [entity indexname shards replicas] :as props} :- StoreProperties]
+  [{:keys [entity indexname shards replicas]
+    :as props} :- StoreProperties]
 
   (let [settings {:number_of_shards shards
                   :number_of_replicas replicas}]


### PR DESCRIPTION
Allow to specify an ES timeout per store, longer timeouts for migrations.

I cannot add a test easily for the timeout setting because clj-http-fake overrides the connection manager ignoring its timeout setting.