### PR TITLE
Report all schema errors at the end of the migration process

### DIFF
--- a/src/ctia/task/migrate_es_stores.clj
+++ b/src/ctia/task/migrate_es_stores.clj
@@ -264,8 +264,8 @@
     (check-store sr batch-size)
     (catch Exception e
       (if-let [errors (some->> (ex-data e) :error (remove nil?))]
-        (let [message (format (str "The store %s is invalid, value cannot be coerced "
-                                   "to match schema, errors: %s")
+        (let [message (format (str "The store %s is invalid, certainly a coercion issue "
+                                   "errors: %s")
                               sk
                               (pr-str errors))]
           (log/error message)


### PR DESCRIPTION
The current migration only reports schema errors with logs during the migration process. Errors are not reported at the end.

This PR changes this behaviour to report all schema errors at the end of the migration process and return the -1 status code if an error occurs.