### PR TITLE
Pagination stateless cursor using search_after

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,40 @@ or from source with leiningen:
 |          1.0.0 | 1.1.0                         | `java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores 1.0.0 1.0.0 200 true`   |
 
 
+#### API
+
+##### List Pagination
+
+HTTP routes providing a list use a default limit of 100 records.
+An API client can change this parameter up to 10 0000 records.
+
+when a limit is applied to the response, pagination headers are returned:
+
+| header     | description                                                                    | example                                        |
+|------------|--------------------------------------------------------------------------------|------------------------------------------------|
+| X-TOTAL    | total number of hits in the data store                                         | 5000                                           |
+| X-OFFSET   | the current pagination offset                                                  | 200                                            |
+| X-NEXT     | ready made parameters to fetch the next results page                           | limit=100&offset=100&search_after=foo          |
+| X-PREVIOUS | ready made parameters to fetch the previous results page                       | limit=100&offset=0                             |
+| X-SORT     | the sort parameter for use with `search_after`, the id of the last result page | ["actor-77b01a42-6d2b-4081-8fd0-c887bf54140c"] |
+|            |                                                                                |                                                |
+
+
+To easily scroll through all results of a list, just iterate, appending `X-Next` to your base query URL.
+if no `X-Next` header is present, you have reached the last page.
+
+##### Offset Pagination
+
+To be used for simple matters, when the result window is inferior to 10 000 (`offset` + `limit`)
+use a combination of `offset` and `limit` parameters to paginate results.
+
+
+#### Stateless Cursor Pagination
+
+To be used when the result window is superior to `10 000`, allows to easily loop across all pages of a query response.
+use `limit` and `offset` along with `search_after` filled with the value from the `X-Sort` response header to get the next page.
+
+
 ## License
 
 Copyright © 2015-2016 Cisco Systems

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.23-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.23"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.22"]
+                 [threatgrid/clj-momo "0.2.23-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/lib/pagination.clj
+++ b/src/ctia/lib/pagination.clj
@@ -3,30 +3,11 @@
 
 (def default-limit 100)
 
-(defn list-response-schema [Model]
+(defn list-response-schema
   "generate a list response schema for a model"
+  [Model]
   {:data [Model]
    :paging {s/Any s/Any}})
-
-(defn response
-  "Make a paginated response adding summary info as metas"
-  [results offset limit hits]
-  (let [offset (or offset 0)
-        limit (or limit default-limit)
-        previous-offset (- offset limit)
-        next-offset (+ offset limit)
-        previous? (pos? offset)
-        next? (> hits next-offset)
-        previous {:previous {:limit limit
-                             :offset (if (> previous-offset 0)
-                                       previous-offset 0)}}
-        next {:next {:limit limit
-                     :offset next-offset}}]
-    {:data results
-     :paging (merge
-              {:total-hits hits}
-              (when previous? previous)
-              (when next? next))}))
 
 (defn paginate
   [data {:keys [sort_by sort_order offset limit]

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -13,7 +13,7 @@
    [ctia.entity.judgement.schemas :refer [PartialJudgementList]]
    [ctia.entity.sighting.schemas :refer [PartialSightingList]]
    [ctia.http.routes.common :refer [paginated-ok PagingParams]]
-   [ctia.lib.pagination :as pag]
+   [clj-momo.lib.es.pagination :as pag]
    [ctia.schemas.core :refer [ObservableTypeIdentifier Reference Verdict]]
    [ctim.domain.id :as id]
    [ring.util.http-response :refer [not-found ok]]
@@ -105,6 +105,8 @@
               (pag/paginate params)
               (pag/response (:offset params)
                             (:limit params)
+                            nil
+                            nil
                             (count indicator-ids))))))
 
   (GET "/:observable_type/:observable_value/sightings" []
@@ -167,6 +169,8 @@
               (pag/paginate params)
               (pag/response (:offset params)
                             (:limit params)
+                            nil
+                            nil
                             (count indicator-ids))))))
 
   (GET "/:observable_type/:observable_value/sightings/incidents" []
@@ -208,4 +212,6 @@
               (pag/paginate params)
               (pag/response (:offset params)
                             (:limit params)
+                            nil
+                            nil
                             (count incident-ids)))))))

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -103,11 +103,9 @@
                                  set)]
           (-> indicator-ids
               (pag/paginate params)
-              (pag/response (:offset params)
-                            (:limit params)
-                            nil
-                            nil
-                            (count indicator-ids))))))
+              (pag/response {:offset (:offset params)
+                             :limit (:limit params)
+                             :hits (count indicator-ids)})))))
 
   (GET "/:observable_type/:observable_value/sightings" []
        :tags ["Sighting"]
@@ -167,11 +165,9 @@
                                  set)]
           (-> indicator-ids
               (pag/paginate params)
-              (pag/response (:offset params)
-                            (:limit params)
-                            nil
-                            nil
-                            (count indicator-ids))))))
+              (pag/response {:offset (:offset params)
+                             :limit (:limit params)
+                             :hits (count indicator-ids)})))))
 
   (GET "/:observable_type/:observable_value/sightings/incidents" []
        :tags ["Incident"]
@@ -210,8 +206,6 @@
                                 set)]
           (-> incident-ids
               (pag/paginate params)
-              (pag/response (:offset params)
-                            (:limit params)
-                            nil
-                            nil
-                            (count incident-ids)))))))
+              (pag/response {:offset (:offset params)
+                             :limit (:limit params)
+                             :hits (count incident-ids)}))))))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -89,15 +89,15 @@
        ident
        {:keys [refresh] :as params}]
       (try
-        (->> (bulk-create-doc (:conn state)
+        (map #(build-create-result % coerce!)
+             (bulk-create-doc (:conn state)
                               (map #(assoc %
                                            :_id (:id %)
                                            :_index (:index state)
                                            :_type (name mapping))
                                    models)
                               (or refresh
-                                  (get-in state [:props :refresh] false)))
-             (map #(build-create-result % coerce!)))
+                                  (get-in state [:props :refresh] false))))
         (catch Exception e
           (throw
            (if-let [ex-data (ex-data e)]

--- a/test/ctia/http/routes/actor_test.clj
+++ b/test/ctia/http/routes/actor_test.clj
@@ -49,7 +49,7 @@
      (let [ids (post-entity-bulk
                 (assoc new-actor-maximal :title "foo")
                 :actors
-                30
+                345
                 {"Authorization" "45c1f5e3f05d0"})]
 
        (field-selection-tests

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -7,7 +7,8 @@
             [ctia.test-helpers
              [core :as helpers :refer [url-id]]
              [http :refer [assert-post]]
-             [pagination :refer [pagination-test pagination-test-no-sort]]
+             [pagination :refer [pagination-test
+                                 pagination-test-no-sort]]
              [store :refer [test-for-each-store]]]
             [ctim.domain.id :as id]))
 
@@ -80,8 +81,7 @@
 
        (testing "sightings/indicators by observable"
          (pagination-test-no-sort (str route-pref "/sightings/indicators")
-                                  {"Authorization" "45c1f5e3f05d0"}
-                                  []))
+                                  {"Authorization" "45c1f5e3f05d0"}))
 
        (testing "judgements by observable"
          (pagination-test (str route-pref "/judgements")
@@ -95,5 +95,4 @@
 
        (testing "judgements/indicators by observable"
          (pagination-test-no-sort (str route-pref "/judgements/indicators")
-                                  {"Authorization" "45c1f5e3f05d0"}
-                                  []))))))
+                                  {"Authorization" "45c1f5e3f05d0"}))))))

--- a/test/ctia/schemas/graphql/pagination_test.clj
+++ b/test/ctia/schemas/graphql/pagination_test.clj
@@ -88,7 +88,9 @@
 (defn gen-result
   [{:keys [offset limit]} hits]
   (let [data (range offset (+ offset limit))]
-    (pag/response data offset limit nil nil hits)))
+    (pag/response data {:offset offset
+                        :limit limit
+                        :hits hits})))
 
 (deftest result->connection-response
   (testing "Forwards paging"

--- a/test/ctia/schemas/graphql/pagination_test.clj
+++ b/test/ctia/schemas/graphql/pagination_test.clj
@@ -2,7 +2,7 @@
   (:require [ctia.schemas.graphql.pagination :as sut]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [schema.test :as st]
-            [ctia.lib.pagination :as pag]
+            [clj-momo.lib.es.pagination :as pag]
             [clojure.tools.logging :as log]))
 
 (use-fixtures :once st/validate-schemas)
@@ -88,7 +88,7 @@
 (defn gen-result
   [{:keys [offset limit]} hits]
   (let [data (range offset (+ offset limit))]
-    (pag/response data offset limit hits)))
+    (pag/response data offset limit nil nil hits)))
 
 (deftest result->connection-response
   (testing "Forwards paging"

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -53,6 +53,7 @@
                     "ctia.http.show.path-prefix"      ""
                     "ctia.http.jwt.enabled"           true
                     "ctia.http.jwt.public-key-path"   "resources/cert/ctia-jwt.pub"
+                    "ctia.http.bulk.max-size"         30000
                     "ctia.nrepl.enabled"              false
                     "ctia.hook.redis.enabled"         false
                     "ctia.hook.redis.channel-name"    "events-test"
@@ -155,7 +156,8 @@
               (dissoc :id)))]
     (-> (post "ctia/bulk"
               :body {plural new-records}
-              :headers headers)
+              :headers headers
+              :socket-timeout (* 5 60000))
         :parsed-body
         plural)))
 


### PR DESCRIPTION
closes https://github.com/threatgrid/ctia/issues/687

Update CTIA pagination management to make use of the ES `search_after` functionality, enabling us to get results beyond 10 000 elements.

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html