### PR TITLE
fix bad root-scopes initialisation

### DIFF
--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -10,11 +10,11 @@
     [auth :as auth :refer [IIdentity]]
     [properties :as prop]]))
 
-(def entity-root-scope
+(defn entity-root-scope []
   (get-in @prop/properties [:ctia :auth :entities :scope]
           "private-intel"))
 
-(def casebook-root-scope
+(defn casebook-root-scope []
   (get-in @prop/properties [:ctia :auth :casebook :scope]
           "casebook"))
 
@@ -93,8 +93,8 @@
   [scope]
   (let [scope-repr (mid/to-scope-repr scope)]
     (condp = (first (:path scope-repr))
-      entity-root-scope   (gen-entity-capabilities scope-repr)
-      casebook-root-scope (gen-casebook-capabilities scope-repr)
+      (entity-root-scope)   (gen-entity-capabilities scope-repr)
+      (casebook-root-scope) (gen-casebook-capabilities scope-repr)
       #{})))
 
 (defn scopes-to-capabilities

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -33,45 +33,45 @@
 
 
 (deftest scopes-to-capapbilities-test
-  (is (= "private-intel" sut/entity-root-scope)
+  (is (= "private-intel" (sut/entity-root-scope))
       "entity root scope default value is private-intel")
-  (is (= "casebook" sut/casebook-root-scope)
+  (is (= "casebook" (sut/casebook-root-scope))
       "casebook root scope default value is casebook")
   (is (= #{:search-casebook :create-casebook :list-casebooks :read-casebook
            :delete-casebook}
-         (sut/scope-to-capabilities sut/casebook-root-scope))
+         (sut/scope-to-capabilities (sut/casebook-root-scope)))
       "Check the casebook capabilities from the casebook scope")
   (is  (= #{:developer :specify-id :external-id}
           (set/difference caps/all-capabilities
-                          (sut/scopes-to-capabilities #{sut/entity-root-scope
-                                                        sut/casebook-root-scope})))
+                          (sut/scopes-to-capabilities #{(sut/entity-root-scope)
+                                                        (sut/casebook-root-scope)})))
        "with all scopes you should have most capabilities except some very
        specific ones")
   (is (= #{:import-bundle}
          (sut/scopes-to-capabilities
-          #{(str sut/entity-root-scope "/import-bundle")})))
+          #{(str (sut/entity-root-scope) "/import-bundle")})))
   (is (= #{}
          (sut/scopes-to-capabilities
-          #{(str sut/entity-root-scope "/import-bundle:read")})))
-  (is (contains? (sut/scopes-to-capabilities #{(str sut/entity-root-scope ":write")})
+          #{(str (sut/entity-root-scope) "/import-bundle:read")})))
+  (is (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope) ":write")})
                  :import-bundle))
-  (is (not (contains? (sut/scopes-to-capabilities #{(str sut/entity-root-scope ":read")})
+  (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope) ":read")})
                       :import-bundle)))
   (is (= #{:read-sighting :list-sightings :search-sighting :create-sighting
            :delete-sighting}
          (sut/scopes-to-capabilities
-          #{(str sut/entity-root-scope "/sighting")}))
+          #{(str (sut/entity-root-scope) "/sighting")}))
       "Scopes can be limited to some entity")
   (is (= #{:create-sighting :delete-sighting}
          (sut/scopes-to-capabilities
-          #{(str sut/entity-root-scope "/sighting:write")}))
+          #{(str (sut/entity-root-scope) "/sighting:write")}))
       "Scopes can be limited to some entity and for write-only")
   (is (= #{:read-sighting :list-sightings :search-sighting}
          (sut/scopes-to-capabilities
-          #{(str sut/entity-root-scope "/sighting:read")}))
+          #{(str (sut/entity-root-scope) "/sighting:read")}))
       "Scopes can be limited to some entity and for read-only")
   (is (= #{:search-casebook :read-sighting :list-sightings :search-sighting
            :list-casebooks :read-casebook}
-         (sut/scopes-to-capabilities #{(str sut/entity-root-scope "/sighting:read")
-                                       (str sut/casebook-root-scope ":read")}))
+         (sut/scopes-to-capabilities #{(str (sut/entity-root-scope) "/sighting:read")
+                                       (str (sut/casebook-root-scope) ":read")}))
       "Scopes can compose"))


### PR DESCRIPTION
Close #713 
Close https://github.com/threatgrid/iroh/issues/1949

Root scopes properties wasn't correctly set due to bad init ordering.

_We should think about using TK or a similar project to handle init order and prevent future errors like these._