### PR TITLE
Open Schema Version

### DIFF
--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -7,8 +7,8 @@
     [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
-    [core :refer [ACLEntity
-                  ACLStoredEntity]]
+    [core :refer [CTIAEntity
+                  CTIAStoredEntity]]
     [sorting :as sorting]]
    [ctia.schemas.graphql
     [sorting :as graphql-sorting]
@@ -28,7 +28,7 @@
    [schema.core :as s]))
 
 (s/defschema Indicator
-  (st/merge ACLEntity
+  (st/merge CTIAEntity
             (f-schema/->schema
              (fu/replace-either-with-any
               ins/Indicator))))
@@ -36,7 +36,7 @@
 (f-spec/->spec ins/Indicator "indicator")
 
 (s/defschema PartialIndicator
-  (st/merge ACLEntity
+  (st/merge CTIAEntity
             (f-schema/->schema
              (fu/optionalize-all
               (fu/replace-either-with-any
@@ -50,7 +50,7 @@
    (f-schema/->schema
     (fu/replace-either-with-any
      ins/NewIndicator))
-   ACLEntity))
+   CTIAEntity))
 
 (f-spec/->spec ins/NewIndicator "new-indicator")
 
@@ -58,7 +58,7 @@
   (st/merge (f-schema/->schema
              (fu/replace-either-with-any
               ins/StoredIndicator))
-            ACLStoredEntity))
+            CTIAStoredEntity))
 
 (f-spec/->spec ins/StoredIndicator "stored-indicator")
 
@@ -67,7 +67,7 @@
              (fu/optionalize-all
               (fu/replace-either-with-any
                ins/StoredIndicator)))
-            ACLStoredEntity))
+            CTIAStoredEntity))
 
 (def realize-indicator
   (default-realize-fn "indicator" NewIndicator StoredIndicator))

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -5,7 +5,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
-             [core :refer [ACLEntity ACLStoredEntity]]
+             [core :refer [CTIAEntity CTIAStoredEntity]]
              [sorting :as sorting]]
             [ctia.schemas.graphql
              [sorting :as graphql-sorting]
@@ -25,14 +25,14 @@
 
 (s/defschema Investigation
   (st/merge (f-schema/->schema inv/Investigation)
-            ACLEntity
+            CTIAEntity
             {s/Keyword s/Any}))
 
 (f-spec/->spec inv/Investigation "investigation")
 
 (s/defschema PartialInvestigation
   (st/merge (f-schema/->schema (fu/optionalize-all inv/Investigation))
-            ACLEntity
+            CTIAEntity
             {s/Keyword s/Any}))
 
 (s/defschema PartialInvestigationList
@@ -40,21 +40,21 @@
 
 (s/defschema NewInvestigation
   (st/merge (f-schema/->schema inv/NewInvestigation)
-            ACLEntity
+            CTIAEntity
             {s/Keyword s/Any}))
 
 (f-spec/->spec inv/NewInvestigation "new-investigation")
 
 (s/defschema StoredInvestigation
   (st/merge (f-schema/->schema inv/StoredInvestigation)
-            ACLStoredEntity
+            CTIAStoredEntity
             {s/Keyword s/Any}))
 
 (f-spec/->spec inv/StoredInvestigation "stored-investigation")
 
 (s/defschema PartialStoredInvestigation
   (st/merge (f-schema/->schema (fu/optionalize-all inv/StoredInvestigation))
-            ACLStoredEntity
+            CTIAStoredEntity
             {s/Keyword s/Any}))
 
 (def realize-investigation

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -1,23 +1,31 @@
 (ns ctia.schemas.core
-  (:require [ctim.schemas
-             [verdict :as vs]
-             [bundle :as bundle]
-             [common :as cos]
-             [vocabularies :as vocs]]
-            [flanders
-             [schema :as f-schema]
-             [spec :as f-spec]
-             [utils :as fu]]
-            [schema-tools.core :as st]
-            [schema.core :as sc :refer [Bool Str]]))
+  (:require
+   [ctim.schemas
+    [verdict :as vs]
+    [bundle :as bundle]
+    [common :as cos]
+    [vocabularies :as vocs]]
+   [flanders
+    [core :as flanders]
+    [schema :as f-schema]
+    [spec :as f-spec]
+    [utils :as fu]]
+   [schema-tools.core :as st]
+   [schema.core :as sc :refer [Bool Str]]
+   [schema.core :as s]))
 
-(sc/defschema ACLEntity
-  (st/optional-keys
-   {:authorized_users [Str]
-    :authorized_groups [Str]}))
+(sc/defschema OpenCTIMSchemaVersion
+  {(sc/optional-key :schema_version) s/Str})
 
-(sc/defschema ACLStoredEntity
-  (st/merge ACLEntity
+(sc/defschema CTIAEntity
+  (st/merge
+   OpenCTIMSchemaVersion
+   (st/optional-keys
+    {:authorized_users [Str]
+     :authorized_groups [Str]})))
+
+(sc/defschema CTIAStoredEntity
+  (st/merge CTIAEntity
             {(sc/optional-key :groups) [Str]}))
 
 (defmacro defschema [name-sym ddl spec-kw-ns]
@@ -31,7 +39,7 @@
      (sc/defschema ~name-sym
        (st/merge
         (f-schema/->schema ~ddl)
-        ACLStoredEntity))
+        CTIAStoredEntity))
      (f-spec/->spec ~ddl ~spec-kw-ns)))
 
 (defmacro def-acl-schema [name-sym ddl spec-kw-ns]
@@ -39,7 +47,7 @@
      (sc/defschema ~name-sym
        (st/merge
         (f-schema/->schema ~ddl)
-        ACLEntity))
+        CTIAEntity))
      (f-spec/->spec ~ddl ~spec-kw-ns)))
 
 ;; verdict


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/1952

Completes the `schema_version` ignore overriding the schemas exposed to the route handlers. 