### PR TITLE
Incident PATCH

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -35,6 +35,10 @@
   is/StoredIncident
   "stored-incident")
 
+(def-stored-schema PartialNewIncident
+  (fu/optionalize-all is/NewIncident)
+  "partial-new-incident")
+
 (def-stored-schema PartialStoredIncident
   (fu/optionalize-all is/StoredIncident)
   "partial-stored-incident")
@@ -112,13 +116,16 @@
     :get-params IncidentGetParams
     :list-schema PartialIncidentList
     :search-schema PartialIncidentList
+    :patch-schema PartialNewIncident
     :external-id-q-params IncidentByExternalIdQueryParams
     :search-q-params IncidentSearchParams
     :new-spec :new-incident/map
+    :can-patch? true
     :realize-fn realize-incident
     :get-capabilities :read-incident
     :post-capabilities :create-incident
     :put-capabilities :create-incident
+    :patch-capabilities :create-incident
     :delete-capabilities :delete-incident
     :search-capabilities :search-incident
     :external-id-capabilities #{:read-incident :external-id}}))

--- a/test/ctia/http/routes/casebook_test.clj
+++ b/test/ctia/http/routes/casebook_test.clj
@@ -23,22 +23,6 @@
    [ctim.schemas.common :refer [ctim-schema-version]]))
 
 (defn partial-operations-tests [casebook-id casebook]
-  ;; patch
-  (testing "PATCH /ctia/casebook/:id"
-    (let [teardown {:description (:description casebook)}
-          change {:description "updated"}
-          expected-entity (merge casebook change)
-          response (patch (str "ctia/casebook/" (:short-id casebook-id))
-                          :body change
-                          :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 200 (:status response)))
-      (is (deep= expected-entity updated-casebook))
-
-      (patch (str "ctia/casebook/" (:short-id casebook-id))
-             :body teardown
-             :headers {"Authorization" "45c1f5e3f05d0"})))
-
   ;; observables
   (testing "POST /ctia/casebook/:id/observables :add"
     (let [new-observables [{:type "ip" :value "42.42.42.42"}]
@@ -236,6 +220,7 @@
      (entity-crud-test {:entity "casebook"
                         :example new-casebook-maximal
                         :headers {:Authorization "45c1f5e3f05d0"}
+                        :patch-tests? true
                         :additional-tests partial-operations-tests}))))
 
 (deftest test-casebook-pagination-field-selection

--- a/test/ctia/http/routes/incident_test.clj
+++ b/test/ctia/http/routes/incident_test.clj
@@ -29,6 +29,7 @@
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
      (entity-crud-test
       {:entity "incident"
+       :patch-tests? true
        :example new-incident-maximal
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -8,7 +8,7 @@
     [test :refer [is testing]]]
    [ctia.properties :refer [get-http-show]]
    [ctia.test-helpers
-    [core :as helpers :refer [delete get post put]]
+    [core :as helpers :refer [delete get post put patch]]
     [search :refer [test-query-string-search]]]
    [ctim.domain.id :as id]))
 
@@ -21,6 +21,7 @@
            invalid-tests?
            invalid-test-field
            update-tests?
+           patch-tests?
            search-tests?
            additional-tests]
     :or {invalid-tests? true
@@ -28,6 +29,7 @@
          update-field :title
          search-field :description
          update-tests? true
+         patch-tests? false
          search-tests? true}}]
   (testing (str "POST /ctia/" entity)
     (let [new-record (dissoc example :id)
@@ -76,6 +78,18 @@
           (is (deep=
                [(assoc record :id (id/long-id record-id))]
                records))))
+
+      (testing (format "PATCH /ctia/%s/:id" entity)
+        (let [updates {update-field "patch"}
+              response (patch (format "ctia/%s/%s" entity (:short-id record-id))
+                              :body updates
+                              :headers headers)
+              updated-record (:parsed-body response)]
+          (when patch-tests?
+            (is (= 200 (:status response)))
+            (is (deep=
+                 (merge record updates)
+                 updated-record)))))
 
       (testing (format "PUT /ctia/%s/:id" entity)
         (let [with-updates (assoc record


### PR DESCRIPTION
close https://github.com/threatgrid/iroh/issues/1962

Make the `PATCH`api feature available to any entity, enable it only for Casebook and Incident. 