### PR TITLE
Add missing capabilities for the GraphQL endpoint

### DIFF
--- a/src/ctia/graphql/routes.clj
+++ b/src/ctia/graphql/routes.clj
@@ -31,6 +31,40 @@
         :header-params [{Authorization :- (s/maybe s/Str) nil}]
         :body [body gql/RelayGraphQLQuery {:description "a Relay compatible GraphQL body"}]
         :summary "EXPERIMENTAL: Executes a Relay compatible GraphQL query"
+        :capabilities
+        #{:list-campaigns
+          :read-actor
+          :read-malware
+          :read-exploit-target
+          :read-attack-pattern
+          :read-judgement
+          :read-sighting
+                  :list-sightings
+          :list-relationships
+          :read-coa
+          :read-indicator
+          :list-exploit-targets
+          :list-judgements
+          :list-tools
+          :list-indicators
+          :read-feedback
+          :list-verdicts
+          :list-casebooks
+          :list-feedbacks
+          :list-malwares
+          :list-data-tables
+          :list-incidents
+          :read-campaign
+          :list-attack-patterns
+          :read-relationship
+          :list-actors
+          :read-investigation
+          :read-incident
+          :list-coas
+          :read-tool
+          :read-casebook
+          :list-investigations
+          :read-data-table}
         :identity-map identity-map
         (let [request-context {:ident identity-map}
               {:keys [query operationName variables]} body]

--- a/src/ctia/graphql/routes.clj
+++ b/src/ctia/graphql/routes.clj
@@ -39,7 +39,7 @@
           :read-attack-pattern
           :read-judgement
           :read-sighting
-                  :list-sightings
+          :list-sightings
           :list-relationships
           :read-coa
           :read-indicator

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -131,20 +131,23 @@
                    (graphql-ui-routes)
                    (context
                     "/ctia" []
-                    (entity-routes entities)
-                    (context
-                     "/bulk" []
-                     :tags ["Bulk"]
-                     bulk-routes)
-                    (context
-                     "/incident" []
-                     :tags ["Incident"]
-                     incident-casebook-link-route)
-                    bundle-routes
-                    observable-routes
-                    metrics-routes
-                    properties-routes
-                    graphql-routes
-                    version-routes))
+                    ;; The order is important here for version-routes
+                    ;; must be before the middleware fn
+                    version-routes
+                    (middleware [wrap-authenticated]
+                                (entity-routes entities)
+                                (context
+                                 "/bulk" []
+                                 :tags ["Bulk"]
+                                 bulk-routes)
+                                (context
+                                 "/incident" []
+                                 :tags ["Incident"]
+                                 incident-casebook-link-route)
+                                bundle-routes
+                                observable-routes
+                                metrics-routes
+                                properties-routes
+                                graphql-routes)))
        (undocumented
         (rt/not-found (ok (unk/err-html))))))

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -32,6 +32,14 @@
 (defn wrap-authentication [handler]
   (testable-wrap-authentication handler @auth-service))
 
+(defn wrap-authenticated [handler]
+  (fn [request]
+    (let [auth-identity (:identity request)]
+      (if (and (not (nil? auth-identity))
+               (auth/authenticated? auth-identity))
+        (handler request)
+        (http-response/forbidden! {:message "Only authenticated users allowed"})))))
+
 (defn require-capability! [required-capability id]
   (if required-capability
     (cond

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -226,6 +226,9 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
+     (helpers/set-capabilities! "baruser" ["bargroup"] "user" #{})
+     (whoami-helpers/set-whoami-response "2222222222222" "baruser" "bargroup" "user")
+
      (let [datamap (initialize-graphql-data)
            indicator-1-id (get-in datamap [:indicator-1 :id])
            indicator-2-id (get-in datamap [:indicator-2 :id])
@@ -256,7 +259,14 @@
              (is (= 400 status))
              (is (= errors
                     ["ValidationError{validationErrorType=FieldUndefined, message=Validation error of type FieldUndefined: Field 'nonexistent' in type 'Root' is undefined, locations=[SourceLocation{line=1, column=19}], description='Field 'nonexistent' in type 'Root' is undefined'}"]))))
-
+         (testing "unauthorized access without capabilities"
+           (let [{:keys [status]}
+                 (helpers/post "ctia/graphql"
+                               :body {:query ""
+                                      :variables {}
+                                      :operationName ""}
+                               :headers {"Authorization" "2222222222222"})]
+             (is (= 401 status))))
          (testing "observable query"
            (let [{:keys [data errors status]}
                  (gh/query graphql-queries
@@ -650,3 +660,4 @@
              (is (empty? errors) "No errors")
              (is (= "indicator" (get-in data [:sighting :relationships :nodes 0
                                               :target_entity :type]))))))))))
+


### PR DESCRIPTION
Related to threatgrid/iroh#2006

A `wrap-authenticated` middleware has been added to check that the current user is authenticated
even if no capabilities are specified for a protected route.