### PR TITLE
Remove read-casebook and list-casebooks from graphql route

### DIFF
--- a/src/ctia/graphql/routes.clj
+++ b/src/ctia/graphql/routes.clj
@@ -49,7 +49,6 @@
           :list-indicators
           :read-feedback
           :list-verdicts
-          :list-casebooks
           :list-feedbacks
           :list-malwares
           :list-data-tables
@@ -62,7 +61,6 @@
           :read-incident
           :list-coas
           :read-tool
-          :read-casebook
           :list-investigations
           :read-data-table}
         :identity-map identity-map


### PR DESCRIPTION
When the casebook entity is not used by setting the configuration `ctia.auth.casebook.scope` with an unused scope, the GraphQL endpoint is no longer usable because it requires the `xxx-casebook` capabilities.

This PR removes the casebooks capabilities from the GraphQL route. The access control is still enabled.