### PR TITLE
ES migration Tweak Index Settings pre/post migration

### DIFF
--- a/benchmarks/ctia/bulk/routes_bench.clj
+++ b/benchmarks/ctia/bulk/routes_bench.clj
@@ -1,4 +1,4 @@
-(ns ctia.http.routes.bulk-bench
+(ns ctia.bulk.routes-bench
   "Benchmark could be launched by `lein bench bulk`"
   (:require [ctia.test-helpers
              [benchmark :refer [cleanup-ctia!

--- a/benchmarks/ctia/entity/actor_bench.clj
+++ b/benchmarks/ctia/entity/actor_bench.clj
@@ -1,0 +1,31 @@
+(ns ctia.entity.actor-bench
+  (:require [ctia.test-helpers
+             [benchmark :refer [cleanup-ctia!
+                                setup-ctia-es-store!]]
+             [core :as helpers :refer [delete post]]]
+            [ctim.examples.actors
+             :refer [new-actor-minimal
+                     new-actor-maximal]]
+            [perforate.core :refer :all]))
+
+(def small-actor new-actor-minimal)
+(def big-actor (dissoc new-actor-maximal :id))
+
+(defgoal create-actor "Create Actor"
+  :setup (fn [] [(setup-ctia-es-store!)])
+  :cleanup (fn [_] cleanup-ctia!))
+
+(defn play [fixture]
+  (let [{:keys [status parsed_body]}
+        (post "ctia/actor"
+              :body fixture
+              :headers {"Authorization" "45c1f5e3f05d0"})]
+    (if (= 201 status)
+      (delete (str "ctia/actor" (:id parsed_body)))
+      (prn "play-big: " status))))
+
+(defcase create-actor :big-actor-es-store
+  [_] (play big-actor))
+
+(defcase create-actor :small-actor-es-store
+  [_] (play small-actor))

--- a/benchmarks/ctia/entity/actor_bench.clj
+++ b/benchmarks/ctia/entity/actor_bench.clj
@@ -21,7 +21,6 @@
               :body fixture
               :headers {"Authorization" "45c1f5e3f05d0"})]
     (if (= 201 status)
-      (delete (str "ctia/actor" (:id parsed_body)))
       (prn "play-big: " status))))
 
 (defcase create-actor :big-actor-es-store

--- a/benchmarks/ctia/entity/actor_bench.clj
+++ b/benchmarks/ctia/entity/actor_bench.clj
@@ -16,12 +16,9 @@
   :cleanup (fn [_] cleanup-ctia!))
 
 (defn play [fixture]
-  (let [{:keys [status parsed_body]}
-        (post "ctia/actor"
-              :body fixture
-              :headers {"Authorization" "45c1f5e3f05d0"})]
-    (if (= 201 status)
-      (prn "play-big: " status))))
+  (post "ctia/actor"
+        :body fixture
+        :headers {"Authorization" "45c1f5e3f05d0"}))
 
 (defcase create-actor :big-actor-es-store
   [_] (play big-actor))

--- a/benchmarks/ctia/entity/campaign_bench.clj
+++ b/benchmarks/ctia/entity/campaign_bench.clj
@@ -19,12 +19,9 @@
   :cleanup (fn [_] cleanup-ctia!))
 
 (defn play [fixture]
-  (let [{:keys [status parsed_body]}
-        (post "ctia/campaign"
-              :body fixture
-              :headers {"Authorization" "45c1f5e3f05d0"})]
-    (if (= 201 status)
-      (prn "play-big: " status))))
+  (post "ctia/campaign"
+        :body fixture
+        :headers {"Authorization" "45c1f5e3f05d0"}))
 
 (defcase create-campaign :big-campaign-es-store
   [_] (play big-campaign))

--- a/benchmarks/ctia/entity/campaign_bench.clj
+++ b/benchmarks/ctia/entity/campaign_bench.clj
@@ -24,7 +24,6 @@
               :body fixture
               :headers {"Authorization" "45c1f5e3f05d0"})]
     (if (= 201 status)
-      (delete (str "ctia/campaign" (:id parsed_body)))
       (prn "play-big: " status))))
 
 (defcase create-campaign :big-campaign-es-store

--- a/benchmarks/ctia/entity/campaign_bench.clj
+++ b/benchmarks/ctia/entity/campaign_bench.clj
@@ -1,0 +1,34 @@
+(ns ctia.entity.campaign-bench
+  (:require
+   [ctim.examples.campaigns :refer [new-campaign-minimal
+                                    new-campaign-maximal]]
+   [ctia.test-helpers
+    [benchmark :refer [cleanup-ctia!
+                       setup-ctia-es-store!]]
+    [core :as helpers :refer [delete post]]]
+   [perforate.core :refer :all]))
+
+(def small-campaign
+  new-campaign-minimal)
+
+(def big-campaign
+  (dissoc new-campaign-maximal :id))
+
+(defgoal create-campaign "Create Campaign"
+  :setup (fn [] [(setup-ctia-es-store!)])
+  :cleanup (fn [_] cleanup-ctia!))
+
+(defn play [fixture]
+  (let [{:keys [status parsed_body]}
+        (post "ctia/campaign"
+              :body fixture
+              :headers {"Authorization" "45c1f5e3f05d0"})]
+    (if (= 201 status)
+      (delete (str "ctia/campaign" (:id parsed_body)))
+      (prn "play-big: " status))))
+
+(defcase create-campaign :big-campaign-es-store
+  [_] (play big-campaign))
+
+(defcase create-campaign :small-campaign-es-store
+  [_] (play small-campaign))

--- a/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
+++ b/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
@@ -78,7 +78,9 @@
 (defcase migrate-store-indexes :base
   [_] (run-migrate-es-stores))
 
-(defcase migrate-store-indexes :optimizations_enabled
-  [_] (with-properties ["ctia.migration.optimizations" true]
+(defcase migrate-store-indexes :optimizations_disabled
+  [_] (with-properties ["ctia.migration.optimizations" false]
         (run-migrate-es-stores)))
+
+
 

--- a/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
+++ b/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
@@ -1,0 +1,84 @@
+(ns ctia.tasks.migrate-es-stores-bench
+  (:require [ctia.task.migrate-es-stores :as sut]
+            [ctia.test-helpers
+             [core :refer [with-properties]]
+             [benchmark :refer [cleanup-ctia!
+                                setup-ctia-es-store!
+                                delete-store-indexes]]
+             [core :as helpers :refer [post-bulk]]]
+            [ctim.domain.id :refer [make-transient-id]]
+            [ctim.examples
+             [actors :refer [actor-maximal]]
+             [attack-patterns :refer [attack-pattern-maximal]]
+             [campaigns :refer [campaign-maximal]]
+             [casebooks :refer [casebook-maximal]]
+             [coas :refer [coa-maximal]]
+             [exploit-targets :refer [exploit-target-maximal]]
+             [incidents :refer [incident-maximal]]
+             [indicators :refer [indicator-maximal]]
+             [investigations :refer [investigation-maximal]]
+             [judgements :refer [judgement-maximal]]
+             [malwares :refer [malware-maximal]]
+             [relationships :refer [relationship-maximal]]
+             [sightings :refer [sighting-maximal]]
+             [tools :refer [tool-maximal]]]
+            [perforate.core :refer [defcase defgoal]]))
+
+(defn randomize [doc]
+  (assoc doc
+         :id (make-transient-id "_")))
+
+(defn n-doc [fixture nb]
+  (map randomize (repeat nb fixture)))
+
+(defn make-examples [fixtures-nb]
+  {:actors (n-doc actor-maximal fixtures-nb)
+   :attack_patterns (n-doc attack-pattern-maximal fixtures-nb)
+   :campaigns (n-doc campaign-maximal fixtures-nb)
+   :coas (n-doc coa-maximal fixtures-nb)
+   :exploit_targets (n-doc exploit-target-maximal fixtures-nb)
+   :incidents (n-doc incident-maximal fixtures-nb)
+   :indicators (n-doc indicator-maximal fixtures-nb)
+   :investigations (n-doc investigation-maximal fixtures-nb)
+   :judgements (n-doc judgement-maximal fixtures-nb)
+   :malwares (n-doc malware-maximal fixtures-nb)
+   :relationships (n-doc relationship-maximal fixtures-nb)
+   :casebooks (n-doc casebook-maximal fixtures-nb)
+   :sightings (n-doc sighting-maximal fixtures-nb)
+   :tools (n-doc tool-maximal fixtures-nb)})
+
+(defn post-fixtures []
+  (dotimes [n 10]
+    (println "posting bulk...")
+    (post-bulk (make-examples 1000))))
+
+(defgoal migrate-store-indexes "Run a migration"
+  :setup (fn [& args]
+           (println "launching CTIA...")
+           (setup-ctia-es-store!)
+
+           (println "clear ES stores")
+           (delete-store-indexes)
+
+           (println "posting fixtures...")
+           (post-fixtures)
+           (prn "fixtures loaded!")
+           [true])
+  :cleanup (fn [& args]
+             (println "cleanup and exit CTIA...")
+             (cleanup-ctia!)))
+
+(defn run-migrate-es-stores []
+  (with-redefs [sut/exit (fn [_] nil)]
+    (sut/run-migration "0.0.0"
+                       [:__test]
+                       1000
+                       true)))
+
+(defcase migrate-store-indexes :base
+  [_] (run-migrate-es-stores))
+
+(defcase migrate-store-indexes :optimizations_enabled
+  [_] (with-properties ["ctia.migration.optimizations" true]
+        (run-migrate-es-stores)))
+

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -257,3 +257,12 @@ one can set defaults for all ES stores using =default= as entity
 | ctia.store.es.[entity].refresh   | control when changes made by this request are made visible to search | string          |
 | ctia.store.es.[entity].replicas  | how many replicas to setup at index creation                         | number          |
 | ctia.store.es.[entity].shards    | how many shards to setup at index creation                           | number          |
+
+** Migration
+
+ES Migration related settings
+
+| Property                     | Description                                                                                                | Possible values |
+|------------------------------+------------------------------------------------------------------------------------------------------------+-----------------|
+| ctia.migration.optimizations | Speed up the migration process disabling indexing and replicas while migrating,                            |boolean          |
+|                              | settings are reverted to their actual values when the process is complete, this should be considered safe. |                 |

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.23"]
+                 [threatgrid/clj-momo "0.2.24-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version
@@ -168,11 +168,14 @@
              :prepush {:plugins [[yogsototh/lein-kibit "0.1.6-SNAPSHOT"]
                                  [lein-bikeshed "0.3.0"]]}}
   :perforate {:environments [{:name :actor
-                              :namespaces [ctia.http.routes.actor-bench]}
+                              :namespaces [ctia.entity.actor-bench]}
                              {:name :campaign
-                              :namespaces [ctia.http.routes.campaign-bench]}
+                              :namespaces [ctia.entity.campaign-bench]}
                              {:name :bulk
-                              :namespaces [ctia.http.routes.bulk-bench]}]}
+                              :namespaces [ctia.bulk.routes-bench]}
+                             {:name :migration
+                              :namespaces [ctia.tasks.migrate-es-stores-bench]}
+                             ]}
   :plugins [[lein-shell "0.5.0"]
             [perforate "0.3.4"]]
   :aliases {"dev-test" ["with-profile" "test,dev-test" "test"]

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.24-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.25"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -40,6 +40,7 @@ ctia.store.es.default.host=127.0.0.1
 ctia.store.es.default.port=9200
 ctia.store.es.default.indexname=ctia
 ctia.store.es.default.replicas=1
+ctia.store.es.default.refresh_interval=1s
 ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
 
@@ -105,3 +106,5 @@ ctia.metrics.riemann.interval=1 # every second
 ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
+
+ctia.migration.optimizations = false

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -107,4 +107,4 @@ ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
-ctia.migration.optimizations = false
+ctia.migration.optimizations = true

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -30,6 +30,7 @@
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
    (str "ctia.store.es." store ".refresh") Refresh
+   (str "ctia.store.es." store ".refresh_interval")  s/Str
    (str "ctia.store.es." store ".replicas") s/Num
    (str "ctia.store.es." store ".shards") s/Num
    (str "ctia.store.es." store ".timeout") s/Num})
@@ -81,6 +82,8 @@
                       "ctia.http.show.path-prefix" s/Str
                       "ctia.http.show.port" s/Int
                       "ctia.http.bulk.max-size" s/Int})
+
+   (st/optional-keys {"ctia.migration.optimizations" s/Bool})
 
    (st/required-keys {"ctia.events.enabled" s/Bool
                       "ctia.nrepl.enabled" s/Bool

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -26,7 +26,6 @@
    connection manager and dedicated store index properties"
   [{:keys [entity indexname shards replicas]
     :as props} :- StoreProperties]
-
   (let [settings {:number_of_shards shards
                   :number_of_replicas replicas}]
     {:index indexname
@@ -40,7 +39,8 @@
   "initiate an ES Store connection,
    put the index template, return an ESConnState"
   [properties :- StoreProperties]
-  (let [{:keys [conn index config] :as conn-state} (init-store-conn properties)]
+  (let [{:keys [conn index config] :as conn-state}
+        (init-store-conn properties)]
     (es-index/create-template! conn index config)
     conn-state))
 

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -8,7 +8,7 @@
             [ctia.task.migrate-es-stores :as sut]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [post with-atom-logger]]
+             [core :as helpers :refer [post post-bulk with-atom-logger]]
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
             [ctim.domain.id :refer [make-transient-id]]
@@ -40,14 +40,6 @@
   whoami-helpers/fixture-reset-state)
 
 (def fixtures-nb 100)
-
-(defn post-bulk [examples]
-  (let [{status :status
-         bulk-res :parsed-body}
-        (post "ctia/bulk"
-              :body examples
-              :headers {"Authorization" "45c1f5e3f05d0"})]
-    (is (= 201 status))))
 
 (defn randomize [doc]
   (assoc doc

--- a/test/ctia/test_helpers/benchmark.clj
+++ b/test/ctia/test_helpers/benchmark.clj
@@ -1,27 +1,30 @@
 (ns ctia.test-helpers.benchmark
   (:require [clj-momo.lib.net :as net]
-            [ctia.init :refer [start-ctia!]]
-            [ctia.flows.hooks :as hooks]
-            [ctia.http.server :as http-server]
-            [ctia.shutdown :as shutdown]
+            [ctia
+             [init :refer [start-ctia!]]
+             [shutdown :as shutdown]]
             [ctia.test-helpers
              [core :as helpers]
              [es :as esh]]))
 
 (defn setup-ctia! [fixture]
   (let [http-port (net/available-port)]
-    (println "Default: Launch CTIA on port" http-port)
-    (fixture (fn [] (helpers/fixture-properties:clean
-                    #(helpers/with-properties ["ctia.store.es.default.refresh" "false"
-                                               "ctia.http.enabled" true
-                                               "ctia.http.port" http-port
-                                               "ctia.http.show.port" http-port]
-                       (start-ctia! :join? false)))))
+    (fixture (fn []
+               (helpers/fixture-properties:clean
+                #(helpers/with-properties ["ctia.store.es.default.refresh" "false"
+                                           "ctia.http.enabled" true
+                                           "ctia.http.port" http-port
+                                           "ctia.http.bulk.max-size" 100000
+                                           "ctia.http.show.port" http-port]
+                   (start-ctia! :join? false)))))
     http-port))
 
 
 (defn setup-ctia-es-store! []
   (setup-ctia! esh/fixture-properties:es-store))
 
-(defn cleanup-ctia! [_]
-  (shutdown/shutdown-ctia!))
+(def delete-store-indexes esh/delete-store-indexes)
+
+(defn cleanup-ctia! []
+  (esh/delete-store-indexes)
+  #(shutdown/shutdown-ctia!))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -59,7 +59,8 @@
                     "ctia.hook.redis.channel-name"    "events-test"
                     "ctia.metrics.riemann.enabled"    false
                     "ctia.metrics.console.enabled"    false
-                    "ctia.metrics.jmx.enabled"        false]
+                    "ctia.metrics.jmx.enabled"        false
+                    "ctia.migration.optimizations"    false]
     ;; run tests
     (f)))
 
@@ -154,6 +155,14 @@
 
 (def post
   (mthh/with-port-fn get-http-port mthh/post))
+
+(defn post-bulk [examples]
+  (let [{status :status
+         bulk-res :parsed-body}
+        (post "ctia/bulk"
+              :body examples
+              :socket-timeout (* 5 60000)
+              :headers {"Authorization" "45c1f5e3f05d0"})]))
 
 (defn post-entity-bulk [example plural x headers]
   (let [new-records

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -17,12 +17,15 @@
         (es-init/get-store-properties entity)]
     (http/post (format "http://%s:%s/_refresh" host port))))
 
+(defn delete-store-indexes []
+  (doseq [store-impls (vals @store/stores)
+          {:keys [state]} store-impls]
+    (es-store/delete-state-indexes state)))
+
 (defn fixture-delete-store-indexes
   "walk through all the es stores delete each store indexes"
   [t]
-  (doseq [store-impls (vals @store/stores)
-          {:keys [state]} store-impls]
-    (es-store/delete-state-indexes state))
+  (delete-store-indexes)
   (t))
 
 (defn purge-event-indexes []
@@ -43,6 +46,7 @@
   (h/with-properties ["ctia.store.es.default.shards" 1
                       "ctia.store.es.default.replicas" 1
                       "ctia.store.es.default.refresh" "true"
+                      "ctia.store.es.default.refresh_interval" "1s"
                       "ctia.store.es.default.port" "9200"
                       "ctia.store.es.default.indexname" "test_ctia"
                       "ctia.store.es.actor.indexname" "ctia_actor"


### PR DESCRIPTION
Change the migraton behavior so that:
- new indices are first created using 0 replicas and indexing disabled
- then when the migration is done, the correct values are set and manual indexing is triggered.

- this new behavior can be turned on/off using properties, (off by default)
- also exposed the ES refresh_interval configuration on properties https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
- moved previous benchmarks to their correct ns

On my machine, the perforate bench shows on averagea 2s improvement over a migration of 100k records.

```
Goal:  Run a migration
-----
Case:  :optimizations_enabled
Evaluation count : 12 in 12 samples of 1 calls.
             Execution time mean : 1.274855 min
    Execution time std-deviation : 939.727463 ms
   Execution time lower quantile : 1.253696 min ( 2.5%)
   Execution time upper quantile : 1.293570 min (97.5%)

Case:  :base
Evaluation count : 12 in 12 samples of 1 calls.
             Execution time mean : 1.297877 min
    Execution time std-deviation : 1.253525 sec
   Execution time lower quantile : 1.271381 min ( 2.5%)
   Execution time upper quantile : 1.327619 min (97.5%)
```