### PR TITLE
Hidding creds when printing properties at startup

### DIFF
--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -6,6 +6,7 @@
              [riemann :as riemann]
              [jmx :as jmx]
              [console :as console]]
+            [ctia.lib.utils :as utils]
             [ctia
              [auth :as auth]
              [events :as e]
@@ -55,13 +56,13 @@
 (defn log-properties []
   (log/debug (with-out-str
                (do (newline)
-                   (clojure.pprint/pprint
+                   (utils/safe-pprint
                     (mp/debug-properties-by-source p/PropertiesSchema
                                                    p/files)))))
 
   (log/info (with-out-str
               (do (newline)
-                  (clojure.pprint/pprint @p/properties)))))
+                  (utils/safe-pprint @p/properties)))))
 (defn start-ctia!
   "Does the heavy lifting for ctia.main (ie entry point that isn't a class)"
   [& {:keys [join?]}]

--- a/src/ctia/lib/utils.clj
+++ b/src/ctia/lib/utils.clj
@@ -1,0 +1,21 @@
+(ns ctia.lib.utils
+  (:require [clojure.walk :as walk]))
+
+(defn filter-out-creds [m]
+  (reduce-kv (fn [acc k v]
+               (if (re-matches #"(?i).*(key|pass|token|secret).*" (str k))
+                 (assoc acc k "********")
+                 (assoc acc k v)))
+             m
+             m))
+
+(defn deep-filter-out-creds [m]
+  (walk/prewalk #(if (map? %)
+                   (filter-out-creds %)
+                   %)
+                m))
+
+(defn safe-pprint [& xs]
+  (->> xs
+       (map deep-filter-out-creds)
+       (apply clojure.pprint/pprint)))

--- a/test/ctia/lib/utils_test.clj
+++ b/test/ctia/lib/utils_test.clj
@@ -1,0 +1,36 @@
+(ns ctia.lib.utils-test
+  (:require [ctia.lib.utils :as sut]
+            [clojure.test :as t :refer [deftest is testing]]))
+
+(def map-with-creds
+  {:ctia
+   {"password" "abcd"
+    :auth
+    {:static
+     {:secret "1234"}}}})
+
+(def map-with-hidden-creds
+  {:ctia
+   {"password" "********"
+    :auth
+    {:static
+     {:secret "********"}}}})
+
+(deftest filter-out-creds-test
+  (is (= {}
+         (sut/filter-out-creds {})))
+  (is (= (get-in map-with-hidden-creds [:ctia :auth :static])
+         (sut/filter-out-creds (get-in map-with-creds [:ctia :auth :static])))
+      "filter-out-creds should hide values that could potentially have creds"))
+
+(deftest deep-filter-out-creds-test
+  (is (= map-with-hidden-creds
+         (sut/deep-filter-out-creds map-with-creds))))
+
+(deftest safe-pprint-test
+  (is (= (with-out-str (clojure.pprint/pprint map-with-hidden-creds))
+         (with-out-str
+           (sut/safe-pprint map-with-creds)))))
+
+
+


### PR DESCRIPTION
Closes threatgrid/iroh#2035

A `safe-pprint` fn has been added to mimic the `pprint` fn in a more secure way by hiding credentials with stars.