### PR TITLE
Fix the NPE which occurs when a relationship contains an invalid ref

### DIFF
--- a/src/ctia/entity/relationship/graphql_schemas.clj
+++ b/src/ctia/entity/relationship/graphql_schemas.clj
@@ -39,7 +39,7 @@
     (g/new-object name description [] (into fields
                                             related-judgement-fields))))
 
-(s/defn ref->entity-type :- s/Keyword
+(s/defn ref->entity-type :- (s/maybe s/Keyword)
   "Extracts the entity type from the Reference"
   [ref :- s/Str]
   (some-> ref
@@ -69,25 +69,26 @@
 
 (def relation-fields
   (merge
-   (g/non-nulls
-    {:source_entity {:type Entity
-                     :resolve (fn [context args field-selection src]
-                                (log/debug "Source resolver" args src)
-                                (let [ref (:source_ref src)
-                                      entity-type (ref->entity-type ref)]
-                                  (entity-by-id entity-type
-                                                ref
-                                                (:ident context)
-                                                field-selection)))}
-     :target_entity {:type Entity
-                     :resolve (fn [context args field-selection src]
-                                (log/debug "Target resolver" args src)
-                                (let [ref (:target_ref src)
-                                      entity-type (ref->entity-type ref)]
-                                  (entity-by-id entity-type
-                                                ref
-                                                (:ident context)
-                                                field-selection)))}})))
+   {:source_entity {:type Entity
+                    :resolve (fn [context args field-selection src]
+                               (log/debug "Source resolver" args src)
+                               (let [ref (:source_ref src)
+                                     entity-type (ref->entity-type ref)]
+                                 (when entity-type
+                                   (entity-by-id entity-type
+                                                 ref
+                                                 (:ident context)
+                                                 field-selection))))}
+    :target_entity {:type Entity
+                    :resolve (fn [context args field-selection src]
+                               (log/debug "Target resolver" args src)
+                               (let [ref (:target_ref src)
+                                     entity-type (ref->entity-type ref)]
+                                 (when entity-type
+                                   (entity-by-id entity-type
+                                                 ref
+                                                 (:ident context)
+                                                 field-selection))))}}))
 
 (def RelationshipType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/relationship/graphql_schemas.clj
+++ b/src/ctia/entity/relationship/graphql_schemas.clj
@@ -68,27 +68,26 @@
     refs/ToolRef]))
 
 (def relation-fields
-  (merge
-   {:source_entity {:type Entity
-                    :resolve (fn [context args field-selection src]
-                               (log/debug "Source resolver" args src)
-                               (let [ref (:source_ref src)
-                                     entity-type (ref->entity-type ref)]
-                                 (when entity-type
-                                   (entity-by-id entity-type
-                                                 ref
-                                                 (:ident context)
-                                                 field-selection))))}
-    :target_entity {:type Entity
-                    :resolve (fn [context args field-selection src]
-                               (log/debug "Target resolver" args src)
-                               (let [ref (:target_ref src)
-                                     entity-type (ref->entity-type ref)]
-                                 (when entity-type
-                                   (entity-by-id entity-type
-                                                 ref
-                                                 (:ident context)
-                                                 field-selection))))}}))
+  {:source_entity {:type Entity
+                   :resolve (fn [context args field-selection src]
+                              (log/debug "Source resolver" args src)
+                              (let [ref (:source_ref src)
+                                    entity-type (ref->entity-type ref)]
+                                (when entity-type
+                                  (entity-by-id entity-type
+                                                ref
+                                                (:ident context)
+                                                field-selection))))}
+   :target_entity {:type Entity
+                   :resolve (fn [context args field-selection src]
+                              (log/debug "Target resolver" args src)
+                              (let [ref (:target_ref src)
+                                    entity-type (ref->entity-type ref)]
+                                (when entity-type
+                                  (entity-by-id entity-type
+                                                ref
+                                                (:ident context)
+                                                field-selection))))}})
 
 (def RelationshipType
   (let [{:keys [fields name description]}

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -42,6 +42,10 @@
                       {:relationship_type "variant-of"
                        :target_ref (:id ap3)
                        :source_ref (:id ap1)})
+    (gh/create-object "relationship"
+                      {:relationship_type "variant-of"
+                       :target_ref "transient:123"
+                       :source_ref (:id ap1)})
     {:attack-pattern-1 ap1
      :attack-pattern-2 ap2
      :attack-pattern-3 ap3}))
@@ -89,7 +93,12 @@
                                    :target_ref attack-pattern-3-id
                                    :source_ref attack-pattern-1-id
                                    :source_entity (:attack-pattern-1 datamap)
-                                   :target_entity (:attack-pattern-3 datamap)}])
+                                   :target_entity (:attack-pattern-3 datamap)}
+                                  {:relationship_type "variant-of"
+                                   :target_ref "transient:123"
+                                   :source_ref attack-pattern-1-id
+                                   :source_entity (:attack-pattern-1 datamap)
+                                   :target_entity nil}])
 
              (testing "sorting"
                (gh/connection-sort-test


### PR DESCRIPTION
Closes threatgrid/iroh#1829

This PR fixes the NPE which occurs when a relationship contains an invalid ID, ex:
`transient:1345`. 

The NPE was thrown by the code that resolves the entity identified by the invalid ID when a `target_entity` or `source_entity` field was requested in a GraphQL query.

Ex: 

```graphql
query TTPs {
  observable(type:"sha1", value:"8305cb9f39638dad87bbc1bfb84f8de1630e2b32") {
    type
    value
    judgements {
      nodes {
         relationships {
          nodes {
            target_entity {
              ...indicatorFields
            }
          }
        }
      }
    }
  }
}

fragment indicatorFields on Indicator {
  type
  relationships {
    nodes {
      target_entity {
        ...attackPatternFields
        ...malwareFields
        ...toolFields
      }
    }
  }
}

fragment attackPatternFields on AttackPattern {
  id
  type
  name
}

fragment malwareFields on Malware {
  id
  type
  name
}

fragment toolFields on Tool {
  id
  type
  name
}
```

QA:

1. Add a relationship with a `target_ref` set with `transient:1234` to CTIA
2. Send a GraphQL query that requests the `target_source` field