### PR TITLE
Change ElasticSearch default sort field

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.25"]
+                 [threatgrid/clj-momo "0.2.26-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.26-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.27"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -21,7 +21,9 @@
    [schema.core :as s]))
 
 (s/defschema RefsByObservableQueryParams
-  (st/dissoc PagingParams :sort_by :sort_order))
+  (st/assoc PagingParams
+            (s/optional-key :sort_by)
+            (describe (s/enum :id) "Sort result on a field")))
 
 (defroutes observable-routes
   (GET "/:observable_type/:observable_value/verdict" []

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -178,6 +178,14 @@
         (throw (ex-info "You are not allowed to delete this document"
                         {:type :access-control-error}))))))
 
+(def default-sort-field :_doc)
+
+(defn with-default-sort-field
+  [params]
+  (if (contains? params :sort_by)
+    params
+    (assoc params :sort_by default-sort-field)))
+
 (defn handle-find
   "Generate an ES find/list handler using some mapping and schema"
   [mapping Model]
@@ -194,7 +202,9 @@
                              (name mapping)
                              (find-restriction-query-part ident)
                              filter-map
-                             (make-es-read-params params)))
+                             (-> params
+                                 with-default-sort-field
+                                 make-es-read-params)))
        :data access-control-filter-list ident))))
 
 (defn handle-query-string-search
@@ -215,5 +225,7 @@
                              {:bool {:must [(find-restriction-query-part ident)
                                             {:query_string {:query query}}]}}
                              filter-map
-                             (make-es-read-params params)))
+                             (-> params
+                                 with-default-sort-field
+                                 make-es-read-params)))
        :data access-control-filter-list ident))))

--- a/test/ctia/test_helpers/pagination.clj
+++ b/test/ctia/test_helpers/pagination.clj
@@ -78,7 +78,8 @@
            full-headers :headers}
           (get route
                :headers headers
-               :query-params {:limit 10000})
+               :query-params {:limit 10000
+                              :sort_by "id"})
 
           total (count full-res)
           limit (total->limit total offset)
@@ -98,7 +99,8 @@
            limited-headers :headers} (get route
                                           :headers headers
                                           :query-params {:limit limit
-                                                         :offset offset})
+                                                         :offset offset
+                                                         :sort_by "id"})
           prev-offset (- offset limit)]
 
       (is (= 200 full-status limited-status))


### PR DESCRIPTION
Connected to threatgrid/iroh#1955
Closes threatgrid/iroh#2128

The field data circuit breaker thrown an error in the TEST env because the memory used by the `:id` field in the field data cache exceeds the limit.

This PR replaces the default sort field `:id` by `:_doc` in Elasticsearch searches. The `:id` field is a text field that uses a large amount of memory in the field data cache due to its high cardinality. The `:_doc` is the most efficient sort and it doesn't use the field data cache.