### PR TITLE
ES Update retry_on_conflict support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.28-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.28"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.27"]
+                 [threatgrid/clj-momo "0.2.28-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version


### PR DESCRIPTION
Uses the latest clj-momo verison that defaults ES update `retry_on_conflict` to 5

closes https://github.com/threatgrid/iroh/issues/2161