### PR TITLE
Fix build error after deprecating .deb packages

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -14,9 +14,9 @@ function build-and-publish-package {
   lein uberjar
   BUILD_NAME="${CTIA_MAJOR_VERSION}-${PKG_TYPE}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:8}"
   echo $BUILD_NAME
-  echo "Build: $BUILD_NAME" > ./target/pkg/deb/srv/ctia/BUILD
-  echo "Commit: ${TRAVIS_COMMIT}" >> ./target/pkg/deb/srv/ctia/BUILD
-  echo "Version: $BUILD_NAME" >> ./target/pkg/deb/DEBIAN/control
+  echo "Build: $BUILD_NAME"
+  echo "Commit: ${TRAVIS_COMMIT}"
+  echo "Version: $BUILD_NAME"
 
   # Upload the jar directly to the artifacts S3 bucket
   if [ "${PKG_TYPE}" == "int" ]; then


### PR DESCRIPTION
This fix the `./build/build.sh: line 17: ./target/pkg/deb/srv/ctia/BUILD: No such file or directory` error after we deprecated .deb package builds.