### PR TITLE
Bundle import: Fix source_ref and target_ref resolution in relationships

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -138,7 +138,8 @@
                        tempids
                        login
                        {:refresh refresh})
-         entities-tempids (merge-tempids new-entities)
+         entities-tempids (into tempids
+                                (merge-tempids new-entities))
          new-relationships (gen-bulk-from-fn
                             create-entities
                             (select-keys bulk [:relationships])

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -263,6 +263,16 @@
   {:refresh
    (get-in @properties [:ctia :store :bundle-refresh] "false")})
 
+(defn log-errors
+  [response]
+  (let [errors (->> response
+                    :results
+                    (map :error)
+                    seq)]
+    (doseq [error errors]
+      (log/warn error)))
+  response)
+
 (s/defn import-bundle :- BundleImportResult
   [bundle :- NewBundle
    external-key-prefixes :- (s/maybe s/Str)
@@ -279,7 +289,8 @@
     (debug "Import bundle response"
            (->> (bulk/create-bulk bulk tempids auth-identity (bulk-params))
                 (with-bulk-result bundle-import-data)
-                build-response))))
+                build-response
+                log-errors))))
 
 (def bundle-max-size bulk/get-bulk-max-size)
 

--- a/src/ctia/entity/relationship/schemas.clj
+++ b/src/ctia/entity/relationship/schemas.clj
@@ -8,7 +8,8 @@
    [ctia.schemas
     [core :refer [def-acl-schema
                   def-stored-schema]]
-    [sorting :as sorting]]))
+    [sorting :as sorting]]
+   [clojure.string :as string]))
 
 (def-acl-schema Relationship
   rels/Relationship
@@ -52,7 +53,12 @@
    id
    tempids
    & rest-args]
-  (assoc (apply relationship-default-realize new-entity id tempids rest-args)
-         :source_ref (get tempids source_ref source_ref)
-         :target_ref (get tempids target_ref target_ref)))
-
+  (let [e (assoc (apply relationship-default-realize new-entity id tempids rest-args)
+                 :source_ref (get tempids source_ref source_ref)
+                 :target_ref (get tempids target_ref target_ref))]
+    (when (or
+         (string/starts-with? (:source_ref e) "transient:")
+         (string/starts-with? (:target_ref e) "transient:"))
+      (throw (Exception. (str "A relationship cannot be created if a source "
+                              "or a target ref is still a transient ID"))))
+    e))

--- a/src/ctia/flows/schemas.clj
+++ b/src/ctia/flows/schemas.clj
@@ -1,0 +1,15 @@
+(ns ctia.flows.schemas
+  (:require [schema.core :as s]))
+
+(defn error?
+  [v]
+  (contains? v :error))
+
+(s/defschema EntityError
+  {:error s/Any
+   :id s/Str
+   s/Keyword s/Any})
+
+(defn with-error
+  [s]
+  (s/if error? EntityError s))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -73,9 +73,10 @@
   [exception-data models coerce-fn]
   (let [{{:keys [errors items]}
          :es-http-res-body} exception-data]
-    {:data (map (fn [{:keys [error] :as item} model]
+    {:data (map (fn [{:keys [error _id] :as item} model]
                   (if error
-                    {:error error}
+                    {:error error
+                     :id _id}
                     (build-create-result model coerce-fn)))
                 (remove-es-actions items) models)}))
 

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -277,6 +277,23 @@
              (validate-entity-record
               (find-result-by-original-id bundle-result (:id entity))
               entity))))
+       (testing "Bundle with missing entities"
+         (let [relationship (mk-relationship 2001
+                                             (mk-indicator 2001)
+                                             (first sightings)
+                                             "indicates")
+               bundle {:type "bundle"
+                       :source "source"
+                       :relationships [relationship]}
+               response-create (post "ctia/bundle/import"
+                                     :query-params {"external-key-prefixes" "custom-"}
+                                     :body bundle
+                                     :headers {"Authorization" "45c1f5e3f05d0"})
+               bundle-result-create (:parsed-body response-create)]
+           (is (= 500 (:status response-create))
+               (str "A relationship cannot be created if the source and the "
+                    "target entities referenced by a transient ID are not "
+                    "included in the bundle."))))
        (testing "Custom external prefix keys"
          (let [bundle {:type "bundle"
                        :source "source"

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -251,6 +251,32 @@
              (validate-entity-record
               (find-result-by-original-id bundle-result (:id entity))
               entity))))
+       (testing "Update and create"
+         (let [indicator (mk-indicator 2000)
+               sighting (first sightings)
+               relationship (mk-relationship 2000
+                                             indicator
+                                             sighting
+                                             "indicates")
+               bundle
+               {:type "bundle"
+                :source "source"
+                :indicators [indicator]
+                :sightings [sighting]
+                :relationships [relationship]}
+               response (post "ctia/bundle/import"
+                              :body bundle
+                              :headers {"Authorization" "45c1f5e3f05d0"})
+               bundle-result (:parsed-body response)]
+           (is (= 200 (:status response)))
+
+           (is (pos? (count (:results bundle-result))))
+
+           (doseq [entity [indicator sighting
+                           (resolve-ids bundle-result relationship)]]
+             (validate-entity-record
+              (find-result-by-original-id bundle-result (:id entity))
+              entity))))
        (testing "Custom external prefix keys"
          (let [bundle {:type "bundle"
                        :source "source"

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -290,7 +290,16 @@
                                      :body bundle
                                      :headers {"Authorization" "45c1f5e3f05d0"})
                bundle-result-create (:parsed-body response-create)]
-           (is (= 500 (:status response-create))
+           (is (= 200 (:status response-create)))
+           (is (= [{:original_id (:id relationship),
+                    :result "error",
+                    :type :relationship,
+                    :error (str "A relationship cannot be created if a "
+                                "source or a target ref is still a transient "
+                                "ID (The source or target entity is probably "
+                                "not provided in the bundle)")}]
+                  (filter (fn [r] (= (:result r) "error"))
+                          (:results bundle-result-create)))
                (str "A relationship cannot be created if the source and the "
                     "target entities referenced by a transient ID are not "
                     "included in the bundle."))))

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -16,6 +16,8 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
+  (def external-ref "http://external.com/ctia/attack-pattern/attack-pattern-ab053333-2ad2-41d0-a445-31e9b9c38caf")
+
 (defn init-graph-data []
   (let [ap1 (gh/create-object
              "attack-pattern"
@@ -44,7 +46,7 @@
                        :source_ref (:id ap1)})
     (gh/create-object "relationship"
                       {:relationship_type "variant-of"
-                       :target_ref "transient:123"
+                       :target_ref external-ref
                        :source_ref (:id ap1)})
     {:attack-pattern-1 ap1
      :attack-pattern-2 ap2
@@ -95,7 +97,7 @@
                                    :source_entity (:attack-pattern-1 datamap)
                                    :target_entity (:attack-pattern-3 datamap)}
                                   {:relationship_type "variant-of"
-                                   :target_ref "transient:123"
+                                   :target_ref external-ref
                                    :source_ref attack-pattern-1-id
                                    :source_entity (:attack-pattern-1 datamap)
                                    :target_entity nil}])

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -3,7 +3,8 @@
             [clojure.test :as t :refer [is testing deftest]]))
 
 (deftest partial-results-test
-  (is (= {:data [{:error "Exception"}
+  (is (= {:data [{:error "Exception"
+                  :id "123"}
                  {:id "124"}]}
          (sut/partial-results
           {:es-http-res-body


### PR DESCRIPTION
Closes threatgrid/iroh#2207

- transient IDs  resolution in Relationhips has been fixed
- a Relationship entity cannot be created if the source or the target ref contains a transient ID
- all errors related to a bundle import are logged with the WARN level

QA:

1- Import a bundle with a Relationship containing transient IDs for the source and the target ref
2- Import the same bundle a second time
3- All entities should be imported once