### PR TITLE
Bump to clj-momo 0.2.29

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.28"]
+                 [threatgrid/clj-momo "0.2.29"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version


### PR DESCRIPTION
This fixes `search_after` inconsistencies related to our environment, switching the default ES sort field to `_uid`.