### PR TITLE
Improve Flow entity validation behavior

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -83,14 +83,17 @@
   ~~~~
   "
   [func bulk & args]
-  (->> bulk
-       (pmap (fn [[bulk-k entities]]
-               (let [entity-type (entity-type-from-bulk-key bulk-k)]
-                 [bulk-k
-                  (apply func
-                         entities
-                         entity-type args)])))
-       (into {})))
+  (try
+    (->> bulk
+         (pmap (fn [[bulk-k entities]]
+                 (let [entity-type (entity-type-from-bulk-key bulk-k)]
+                   [bulk-k
+                    (apply func
+                           entities
+                           entity-type args)])))
+         (into {}))
+    (catch java.util.concurrent.ExecutionException e
+      (throw (.getCause e)))))
 
 (defn merge-tempids
   "Merges tempids from all entities

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -95,19 +95,19 @@
 
 (s/defn ^:private validate-entities :- FlowMap
   [{:keys [spec entities] :as fm} :- FlowMap]
-  (when spec
-    (doseq [entity entities]
+  (doseq [entity entities]
+    (when spec
       (when-not (cs/valid? spec entity)
-        (throw (http-response/bad-request!
-                {:error (cs/explain-str spec entity)
-                 :entity entity})))
-      (when-let [entity-tlp (:tlp entity)]
-        (when-not (allowed-tlp? entity-tlp)
-          (throw (http-response/bad-request!
-                  {:error (format "Invalid document TLP %s, allowed TLPs are: %s"
-                                  entity-tlp
-                                  (clojure.string/join "," (allowed-tlps)))
-                   :entity entity}))))))
+        (throw (ex-info (cs/explain-str spec entity)
+                        {:type :spec-validation-error
+                         :entity entity}))))
+    (when-let [entity-tlp (:tlp entity)]
+      (when-not (allowed-tlp? entity-tlp)
+        (throw (ex-info (format "Invalid document TLP %s, allowed TLPs are: %s"
+                                entity-tlp
+                                (clojure.string/join "," (allowed-tlps)))
+                        {:type :invalid-tlp-error
+                         :entity entity})))))
   fm)
 
 (s/defn ^:private create-ids-from-transient :- FlowMap

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -62,6 +62,28 @@
     :message (.getMessage e)
     :class (.getName (class e))}))
 
+(defn spec-validation-error-handler
+  "Handle spec validation error"
+  [^Exception e data request]
+  (logging/log! :info e (ex-message e))
+  (bad-request
+   (let [entity (:entity (ex-data e))]
+     {:type "Invalid Entity Error"
+      :message (.getMessage e)
+      :entity entity
+      :class (.getName (class e))})))
+
+(defn invalid-tlp-error-handler
+  "Handle access control error"
+  [^Exception e data request]
+  (logging/log! :info e (ex-message e))
+  (bad-request
+   (let [entity (:entity (ex-data e))]
+     {:type "Invalid TLP Error"
+      :message (.getMessage e)
+      :entity entity
+      :class (.getName (class e))})))
+
 (defn default-error-handler
   "Handle default error"
   [^Exception e data request]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -84,6 +84,8 @@
           :compojure.api.exception/response-validation ex/response-validation-handler
           :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
           :access-control-error ex/access-control-error-handler
+          :invalid-tlp-error ex/invalid-tlp-error-handler
+          :spec-validation-error ex/spec-validation-error-handler
           :compojure.api.exception/default ex/default-error-handler}}
         :swagger {:ui "/"
                   :spec "/swagger.json"

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -749,7 +749,7 @@
 
     (is (= 400 status-disallowed-tlp))
     (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
-           (:error body-disallowed-tlp)))))
+           (:message body-disallowed-tlp)))))
 
 (defn access-control-test
   [entity


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2237

This changes the flow validate-entities fn in 2 ways,

- validate TLP settings even if there is no spec for an entity
- don't savagely return http exceptions but properly descend them to the underlying caller

finally I added 2 custom http exception handlers, one for spec client errors and another for tlp client errors