### PR TITLE
handle casebook not found on operation routes

### DIFF
--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -20,7 +20,7 @@
              [store :refer [def-es-store]]]
             [ctim.schemas.casebook :as cs]
             [flanders.utils :as fu]
-            [ring.util.http-response :refer [ok]]
+            [ring.util.http-response :refer [ok not-found]]
             [schema-tools.core :as st]
             [schema.core :as s]))
 
@@ -136,27 +136,27 @@
           :capabilities :create-casebook
           :auth-identity identity
           :identity-map identity-map
-          (-> (flows/patch-flow
-               :get-fn #(read-store :casebook
-                                    read-record
-                                    %
-                                    identity-map
-                                    {})
-               :realize-fn realize-casebook
-               :update-fn #(write-store :casebook
-                                        update-record
-                                        (:id %)
-                                        %
-                                        identity-map)
-               :long-id-fn with-long-id
-               :entity-type :casebook
-               :entity-id id
-               :identity identity
-               :patch-operation :replace
-               :partial-entity partial-casebook
-               :spec :new-casebook/map)
-              un-store
-              ok))
+          (if-let [res (flows/patch-flow
+                        :get-fn #(read-store :casebook
+                                             read-record
+                                             %
+                                             identity-map
+                                             {})
+                        :realize-fn realize-casebook
+                        :update-fn #(write-store :casebook
+                                                 update-record
+                                                 (:id %)
+                                                 %
+                                                 identity-map)
+                        :long-id-fn with-long-id
+                        :entity-type :casebook
+                        :entity-id id
+                        :identity identity
+                        :patch-operation :replace
+                        :partial-entity partial-casebook
+                        :spec :new-casebook/map)]
+            (ok (un-store res))
+            (not-found {:error "casebook not found"})))
    (context "/:id/observables" []
             (POST "/" []
                   :return Casebook
@@ -168,27 +168,27 @@
                   :capabilities :create-casebook
                   :auth-identity identity
                   :identity-map identity-map
-                  (-> (flows/patch-flow
-                       :get-fn #(read-store :casebook
-                                            read-record
-                                            %
-                                            identity-map
-                                            {})
-                       :realize-fn realize-casebook
-                       :update-fn #(write-store :casebook
-                                                update-record
-                                                (:id %)
-                                                %
-                                                identity-map)
-                       :long-id-fn with-long-id
-                       :entity-type :casebook
-                       :entity-id id
-                       :identity identity
-                       :patch-operation (:operation operation)
-                       :partial-entity {:observables (:observables operation)}
-                       :spec :new-casebook/map)
-                      un-store
-                      ok)))
+                  (if-let [res (flows/patch-flow
+                                :get-fn #(read-store :casebook
+                                                     read-record
+                                                     %
+                                                     identity-map
+                                                     {})
+                                :realize-fn realize-casebook
+                                :update-fn #(write-store :casebook
+                                                         update-record
+                                                         (:id %)
+                                                         %
+                                                         identity-map)
+                                :long-id-fn with-long-id
+                                :entity-type :casebook
+                                :entity-id id
+                                :identity identity
+                                :patch-operation (:operation operation)
+                                :partial-entity {:observables (:observables operation)}
+                                :spec :new-casebook/map)]
+                    (ok (un-store res))
+                    (not-found {:error "casebook not found"}))))
 
    (context "/:id/texts" []
             (POST "/" []
@@ -201,27 +201,27 @@
                   :capabilities :create-casebook
                   :auth-identity identity
                   :identity-map identity-map
-                  (-> (flows/patch-flow
-                       :get-fn #(read-store :casebook
-                                            read-record
-                                            %
-                                            identity-map
-                                            {})
-                       :realize-fn realize-casebook
-                       :update-fn #(write-store :casebook
-                                                update-record
-                                                (:id %)
-                                                %
-                                                identity-map)
-                       :long-id-fn with-long-id
-                       :entity-type :casebook
-                       :entity-id id
-                       :identity identity
-                       :patch-operation (:operation operation)
-                       :partial-entity {:texts (:texts operation)}
-                       :spec :new-casebook/map)
-                      un-store
-                      ok)))
+                  (if-let [res (flows/patch-flow
+                                :get-fn #(read-store :casebook
+                                                     read-record
+                                                     %
+                                                     identity-map
+                                                     {})
+                                :realize-fn realize-casebook
+                                :update-fn #(write-store :casebook
+                                                         update-record
+                                                         (:id %)
+                                                         %
+                                                         identity-map)
+                                :long-id-fn with-long-id
+                                :entity-type :casebook
+                                :entity-id id
+                                :identity identity
+                                :patch-operation (:operation operation)
+                                :partial-entity {:texts (:texts operation)}
+                                :spec :new-casebook/map)]
+                    (ok (un-store res))
+                    (not-found {:error "casebook not found"}))))
 
    (context "/:id/bundle" []
             (POST "/" []
@@ -234,27 +234,27 @@
                   :capabilities :create-casebook
                   :auth-identity identity
                   :identity-map identity-map
-                  (-> (flows/patch-flow
-                       :get-fn #(read-store :casebook
-                                            read-record
-                                            %
-                                            identity-map
-                                            {})
-                       :realize-fn realize-casebook
-                       :update-fn #(write-store :casebook
-                                                update-record
-                                                (:id %)
-                                                %
-                                                identity-map)
-                       :long-id-fn with-long-id
-                       :entity-type :casebook
-                       :entity-id id
-                       :identity identity
-                       :patch-operation (:operation operation)
-                       :partial-entity {:bundle (:bundle operation)}
-                       :spec :new-casebook/map)
-                      un-store
-                      ok)))))
+                  (if-let [res (flows/patch-flow
+                                :get-fn #(read-store :casebook
+                                                     read-record
+                                                     %
+                                                     identity-map
+                                                     {})
+                                :realize-fn realize-casebook
+                                :update-fn #(write-store :casebook
+                                                         update-record
+                                                         (:id %)
+                                                         %
+                                                         identity-map)
+                                :long-id-fn with-long-id
+                                :entity-type :casebook
+                                :entity-id id
+                                :identity identity
+                                :patch-operation (:operation operation)
+                                :partial-entity {:bundle (:bundle operation)}
+                                :spec :new-casebook/map)]
+                    (ok (un-store res))
+                    (not-found {:error "casebook not found"}))))))
 
 (def CasebookType
   (let [{:keys [fields name description]}

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -35,6 +35,16 @@
       (is (= 200 (:status response)))
       (is (deep= expected-entity updated-casebook))))
 
+  (testing "POST /ctia/casebook/:id/observables :add on non existing casebook"
+    (let [new-observables [{:type "ip" :value "42.42.42.42"}]
+          expected-entity (update casebook :observables concat new-observables)
+          response (post (str "ctia/casebook/" (str (:short-id casebook-id) "42") "/observables")
+                         :body {:operation :add
+                                :observables new-observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
+
   (testing "POST /ctia/casebook/:id/observables :remove"
     (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
                                {:value "42.42.42.42" :type "ip"}]
@@ -47,6 +57,17 @@
       (is (= 200 (:status response)))
       (is (deep= expected-entity
                  updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/observables :remove on non existing casebook"
+    (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
+                               {:value "42.42.42.42" :type "ip"}]
+          expected-entity (update casebook :observables #(remove (set deleted-observables) %))
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/observables")
+                         :body {:operation :remove
+                                :observables deleted-observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/observables :replace"
     (let [observables [{:value "42.42.42.42" :type "ip"}]
@@ -72,7 +93,15 @@
       (is (deep= expected-entity
                  updated-casebook))))
 
-
+  (testing "POST /ctia/casebook/:id/observables :replace on non existing casebook"
+    (let [observables (:observables new-casebook-maximal)
+          expected-entity (assoc casebook :observables observables)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/observables")
+                         :body {:operation :replace
+                                :observables observables}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
   ;; texts
   (testing "POST /ctia/casebook/:id/texts :add"
     (let [new-texts [{:type "some" :text "text"}]
@@ -87,6 +116,16 @@
       (is (= 200 (:status response)))
       (is (deep= expected-entity updated-casebook))))
 
+  (testing "POST /ctia/casebook/:id/texts :add on non existing casebook"
+    (let [new-texts [{:type "some" :text "text"}]
+          expected-entity (update casebook :texts concat new-texts)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
+                         :body {:operation :add
+                                :texts new-texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
+
   (testing "POST /ctia/casebook/:id/texts :remove"
     (let [deleted-texts [{:type "some" :text "text"}]
           expected-entity (update casebook :texts #(remove (set deleted-texts) %))
@@ -97,6 +136,16 @@
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
       (is (deep= expected-entity updated-casebook))))
+
+  (testing "POST /ctia/casebook/:id/texts :remove on non existing casebook"
+    (let [deleted-texts [{:type "some" :text "text"}]
+          expected-entity (update casebook :texts #(remove (set deleted-texts) %))
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
+                         :body {:operation :remove
+                                :texts deleted-texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/texts :replace"
     (let [texts [{:type "text" :text "text"}]
@@ -118,6 +167,15 @@
       (is (= 200 (:status response)))
       (is (= texts (:texts updated-casebook)))))
 
+  (testing "POST /ctia/casebook/:id/texts :replace on non existing casebook"
+    (let [texts (:texts new-casebook-maximal)
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
+                         :body {:operation :replace
+                                :texts texts}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
+
   ;; bundle
   (testing "POST /ctia/casebook/:id/bundle :add"
     (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
@@ -137,6 +195,19 @@
       (is (subset? (set (:malwares new-bundle-entities))
                    (set (-> updated-casebook :bundle :malwares))))))
 
+  (testing "POST /ctia/casebook/:id/bundle :add on non existing casebook"
+    (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                            :type "malware"
+                                            :schema_version ctim-schema-version
+                                            :name "TEST"
+                                            :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                         :body {:operation :add
+                                :bundle new-bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
+
   (testing "POST /ctia/casebook/:id/bundle :remove"
     (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
                                                 :type "malware"
@@ -154,6 +225,19 @@
       (is (not (subset? (set (:malwares deleted-bundle-entities))
                         (set (-> updated-casebook :bundle :malwares)))))))
 
+  (testing "POST /ctia/casebook/:id/bundle :remove on non existing casebook"
+    (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                                :type "malware"
+                                                :schema_version ctim-schema-version
+                                                :name "TEST"
+                                                :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                         :body {:operation :remove
+                                :bundle deleted-bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
+
   (testing "POST /ctia/casebook/:id/bundle :replace"
     (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
                                         :type "malware"
@@ -170,6 +254,19 @@
                  (update updated-casebook :bundle dissoc :malwares)))
       (is (= (:malwares bundle-entities)
              (-> updated-casebook :bundle :malwares)))))
+
+  (testing "POST /ctia/casebook/:id/bundle :replace on non existing casebook"
+    (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+                                        :type "malware"
+                                        :schema_version ctim-schema-version
+                                        :name "TEST"
+                                        :labels ["malware"]}}}
+          response (post (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                         :body {:operation :replace
+                                :bundle bundle-entities}
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+          updated-casebook (:parsed-body response)]
+      (is (= 404 (:status response)))))
 
   (testing "schema_version changes with PATCH"
     (testing "Test setup: PATCH /ctia/casebook/:id redefing schema_version"


### PR DESCRIPTION
closes #753 

This is a fix to handle the case where an operation route is called for an invalid casebook ID, properly returning a 404 instead of a 500 response validation error.