### PR TITLE
Use the latest version of CTIM (1.0.6)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.4"
+                 [threatgrid/ctim "1.0.6"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]


### PR DESCRIPTION
To be aligned with IROH that uses the latest version of CTIM with all new observable used by the SMA module.