### PR TITLE
Allow Regular users bundle import capability

### DIFF
--- a/src/ctia/auth/capabilities.clj
+++ b/src/ctia/auth/capabilities.clj
@@ -110,6 +110,7 @@
      :read-verdict
      :read-weakness
      :list-weaknesses
-     :import-bundle}
+     :import-bundle
+     :external-id}
    :admin
    all-capabilities})

--- a/src/ctia/auth/capabilities.clj
+++ b/src/ctia/auth/capabilities.clj
@@ -109,6 +109,7 @@
      :read-tool
      :read-verdict
      :read-weakness
-     :list-weaknesses}
+     :list-weaknesses
+     :import-bundle}
    :admin
    all-capabilities})

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -40,7 +40,6 @@
                   :list-indicators
                   :read-feedback
                   :list-verdicts
-                  :list-casebooks
                   :list-feedbacks
                   :list-malwares
                   :list-data-tables
@@ -53,7 +52,6 @@
                   :read-incident
                   :list-coas
                   :read-tool
-                  :read-casebook
                   :list-investigations
                   :read-data-table
                   :read-weakness

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -86,11 +86,15 @@
   bundle/Bundle
   "bundle")
 
+
+;; Casebooks should be considered fully separate from CTIM
 (s/defschema NewBundle
-  (csutils/recursive-open-schema-version CTIMNewBundle))
+  (st/dissoc
+   (csutils/recursive-open-schema-version CTIMNewBundle) :casebooks))
 
 (s/defschema Bundle
-  (csutils/recursive-open-schema-version CTIMBundle))
+  (st/dissoc
+   (csutils/recursive-open-schema-version CTIMBundle) :casebooks))
 
 ;; common
 


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2279
- Remove Casebook from Bunde, NewBundle
- Add the `bundle-import` capability for all users