### PR TITLE
Use ctim 1.0.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.6"
+                 [threatgrid/ctim "1.0.7"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/src/ctia/entity/vulnerability/mapping.clj
+++ b/src/ctia/entity/vulnerability/mapping.clj
@@ -10,9 +10,7 @@
 
 (def impact
   {:properties
-   {:exploitability_score {:type "float"}
-    :impact_score {:type "float"}
-    :cvss_v2
+   {:cvss_v2
     {:properties
      {:vector_string em/token
       :base_score {:type "float"}
@@ -36,7 +34,9 @@
       :obtain_all_privilege {:type "boolean"}
       :obtain_user_privilege {:type "boolean"}
       :obtain_other_privilege {:type "boolean"}
-      :user_interaction_required {:type "boolean"}}}
+      :user_interaction_required {:type "boolean"}
+      :exploitability_score {:type "float"}
+      :impact_score {:type "float"}}}
 
     :cvss_v3
     {:properties
@@ -68,7 +68,9 @@
       :environmental_score {:type "float"}
       :remediation_level em/token
       :temporal_severity {:type "float"}
-      :integrity_requirement em/token}}}})
+      :integrity_requirement em/token
+      :exploitability_score {:type "float"}
+      :impact_score {:type "float"}}}}})
 
 (def vulnerability-mapping
   {"weakness"

--- a/test/data/vulnerability_fragments.graphql
+++ b/test/data/vulnerability_fragments.graphql
@@ -60,6 +60,8 @@ fragment cvssV2Fields on CVSSv2 {
   obtain_user_privilege
   obtain_other_privilege
   user_interaction_required
+  exploitability_score
+  impact_score
 }
 
 fragment cvssV3Fields on CVSSv3 {
@@ -92,6 +94,8 @@ fragment cvssV3Fields on CVSSv3 {
   remediation_level
   temporal_severity
   integrity_requirement
+  exploitability_score
+  impact_score
 }
 
 fragment impactFields on VulnerabilityImpact {
@@ -101,6 +105,4 @@ fragment impactFields on VulnerabilityImpact {
   cvss_v3 {
     ...cvssV3Fields
   }
-  impact_score
-  exploitability_score 
 }


### PR DESCRIPTION
Connected to https://github.com/threatgrid/ctim/pull/223

> distinct :impact_score and :exploitability_score
data for version 2 and version 3 of the CVSS impact metrics.