### PR TITLE
CTIM Stored* schemas removal changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.8-SNAPSHOT"
+                 [threatgrid/ctim "1.0.8"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.7"
+                 [threatgrid/ctim "1.0.8-SNAPSHOT"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -9,6 +9,7 @@
                     SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
+    [utils :as csu]
     [core :refer [def-acl-schema def-stored-schema]]
     [sorting :refer [default-entity-sort-fields]]]
    [ctia.stores.es.store :refer [def-es-store]]
@@ -33,13 +34,10 @@
   as/NewActor
   "new-actor")
 
-(def-stored-schema StoredActor
-  as/StoredActor
-  "stored-actor")
+(def-stored-schema StoredActor Actor)
 
-(def-stored-schema PartialStoredActor
-  (fu/optionalize-all as/StoredActor)
-  "partial-stored-actor")
+(s/defschema PartialStoredActor
+  (csu/optional-keys-schema StoredActor))
 
 (def realize-actor
   (default-realize-fn "actor" NewActor StoredActor))

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -8,6 +8,7 @@
              [crud :refer [entity-crud-routes]]]
             [ctia.store :refer :all]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting :as sorting]]
             [ctia.schemas.graphql
@@ -38,13 +39,10 @@
   attack/NewAttackPattern
   "new-attack-pattern")
 
-(def-stored-schema StoredAttackPattern
-  attack/StoredAttackPattern
-  "stored-attack-pattern")
+(def-stored-schema StoredAttackPattern AttackPattern)
 
-(def-stored-schema PartialStoredAttackPattern
-  (fu/optionalize-all attack/StoredAttackPattern)
-  "partial-stored-attack-pattern")
+(s/defschema PartialStoredAttackPattern
+  (csu/optional-keys-schema StoredAttackPattern))
 
 (def realize-attack-pattern
   (default-realize-fn "attack-pattern" NewAttackPattern StoredAttackPattern))

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -5,6 +5,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting :as sorting :refer [default-entity-sort-fields]]]
             [ctia.stores.es
@@ -30,13 +31,10 @@
   cs/NewCampaign
   "new-campaign")
 
-(def-stored-schema StoredCampaign
-  cs/StoredCampaign
-  "stored-campaign")
+(def-stored-schema StoredCampaign Campaign)
 
-(def-stored-schema PartialStoredCampaign
-  (fu/optionalize-all cs/StoredCampaign)
-  "partial-stored-campaign")
+(s/defschema PartialStoredCampaign
+  (csu/optional-keys-schema StoredCampaign))
 
 (def campaign-fields
   (concat default-entity-sort-fields

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -6,6 +6,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [Bundle def-acl-schema def-stored-schema]]
              [sorting :as sorting]]
             [ctia.schemas.graphql
@@ -47,15 +48,10 @@
    (fu/optionalize-all cs/NewCasebook))
   "new-casebook")
 
-(def-stored-schema StoredCasebook
-  (fu/replace-either-with-any
-   cs/StoredCasebook)
-  "stored-casebook")
+(def-stored-schema StoredCasebook Casebook)
 
-(def-stored-schema PartialStoredCasebook
-  (fu/replace-either-with-any
-   (fu/optionalize-all cs/StoredCasebook))
-  "partial-stored-casebook")
+(s/defschema PartialStoredCasebook
+  (csu/optional-keys-schema StoredCasebook))
 
 (def realize-casebook
   (default-realize-fn "casebook" NewCasebook StoredCasebook))

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -4,6 +4,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting :refer [default-entity-sort-fields]]]
             [ctia.store :refer :all]
@@ -30,13 +31,10 @@
   coas/NewCOA
   "new-coa")
 
-(def-stored-schema StoredCOA
-  coas/StoredCOA
-  "stored-coa")
+(def-stored-schema StoredCOA COA)
 
-(def-stored-schema PartialStoredCOA
-  (fu/optionalize-all coas/StoredCOA)
-  "partial-stored-coa")
+(s/defschema PartialStoredCOA
+  (csu/optional-keys-schema StoredCOA))
 
 (def realize-coa
   (default-realize-fn "coa" NewCOA StoredCOA))

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -4,6 +4,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting :refer [default-entity-sort-fields]]]
             [ctia.store :refer :all]
@@ -34,16 +35,10 @@
    ds/NewDataTable)
   "new-data-table")
 
-(def-stored-schema StoredDataTable
-  (fu/replace-either-with-any
-   ds/StoredDataTable)
-  "stored-data-table")
+(def-stored-schema StoredDataTable DataTable)
 
-(def-stored-schema PartialStoredDataTable
-  (fu/optionalize-all
-   (fu/replace-either-with-any
-    ds/StoredDataTable))
-  "partial-stored-data-table")
+(s/defschema PartialStoredDataTable
+  (csu/optional-keys-schema StoredDataTable))
 
 (def realize-data-table
   (default-realize-fn "data-table" NewDataTable StoredDataTable))

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -16,7 +16,6 @@
    [ctia.stores.es
     [crud :as crud]
     [mapping :as em]]
-   [ctim.events.schemas :as event-schemas]
    [schema-tools.core :as st]
    [schema.core :as s]))
 

--- a/src/ctia/entity/feedback/schemas.clj
+++ b/src/ctia/entity/feedback/schemas.clj
@@ -4,10 +4,12 @@
              [access-control :refer [properties-default-tlp]]
              [entities :refer [schema-version]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema TempIDs]]
              [sorting :as sorting]]
             [ctim.schemas.feedback :as feedbacks]
             [flanders.utils :as fu]
+            [schema-tools.core :as st]
             [schema.core :as s]))
 
 (def-acl-schema Feedback
@@ -25,13 +27,10 @@
   feedbacks/NewFeedback
   "new-feedback")
 
-(def-stored-schema StoredFeedback
-  feedbacks/StoredFeedback
-  "stored-feedback")
+(def-stored-schema StoredFeedback Feedback)
 
-(def-stored-schema PartialStoredFeedback
-  (fu/optionalize-all feedbacks/StoredFeedback)
-  "partial-stored-feedback")
+(s/defschema PartialStoredFeedback
+  (csu/optional-keys-schema StoredFeedback))
 
 (s/defn realize-feedback :- StoredFeedback
   [new-feedback :- NewFeedback

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -8,6 +8,7 @@
     [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
+    [utils :as csu]
     [core :refer [def-acl-schema def-stored-schema Reference]]
     [sorting :refer [default-entity-sort-fields describable-entity-sort-fields sourcable-entity-sort-fields]]]
    [ctia.store :refer :all]
@@ -42,16 +43,13 @@
   "new-incident")
 
 (def-stored-schema StoredIncident
-  is/StoredIncident
-  "stored-incident")
+  Incident)
 
-(def-stored-schema PartialNewIncident
-  (fu/optionalize-all is/NewIncident)
-  "partial-new-incident")
+(s/defschema PartialNewIncident
+  (csu/optional-keys-schema NewIncident))
 
-(def-stored-schema PartialStoredIncident
-  (fu/optionalize-all is/StoredIncident)
-  "partial-stored-incident")
+(s/defschema PartialStoredIncident
+  (csu/optional-keys-schema StoredIncident))
 
 (def realize-incident
   (default-realize-fn "incident" NewIncident StoredIncident))

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -7,7 +7,9 @@
     [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
-    [core :refer [CTIAEntity
+    [utils :as csu]
+    [core :refer [def-stored-schema
+                  CTIAEntity
                   CTIAStoredEntity]]
     [sorting :as sorting]]
    [ctia.schemas.graphql
@@ -55,20 +57,10 @@
 
 (f-spec/->spec ins/NewIndicator "new-indicator")
 
-(s/defschema StoredIndicator
-  (st/merge (f-schema/->schema
-             (fu/replace-either-with-any
-              ins/StoredIndicator))
-            CTIAStoredEntity))
-
-(f-spec/->spec ins/StoredIndicator "stored-indicator")
+(def-stored-schema StoredIndicator Indicator)
 
 (s/defschema PartialStoredIndicator
-  (st/merge (f-schema/->schema
-             (fu/optionalize-all
-              (fu/replace-either-with-any
-               ins/StoredIndicator)))
-            CTIAStoredEntity))
+  (csu/optional-keys-schema StoredIndicator))
 
 (def realize-indicator
   (default-realize-fn "indicator" NewIndicator StoredIndicator))

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -5,7 +5,10 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
-             [core :refer [CTIAEntity CTIAStoredEntity]]
+             [utils :as csu]
+             [core :refer [def-stored-schema
+                           CTIAEntity
+                           CTIAStoredEntity]]
              [sorting :as sorting]]
             [ctia.schemas.graphql
              [sorting :as graphql-sorting]
@@ -45,132 +48,125 @@
 
 (f-spec/->spec inv/NewInvestigation "new-investigation")
 
-(s/defschema StoredInvestigation
-  (st/merge (f-schema/->schema inv/StoredInvestigation)
-            CTIAStoredEntity
-            {s/Keyword s/Any}))
-
-(f-spec/->spec inv/StoredInvestigation "stored-investigation")
+(def-stored-schema StoredInvestigation Investigation)
 
 (s/defschema PartialStoredInvestigation
-  (st/merge (f-schema/->schema (fu/optionalize-all inv/StoredInvestigation))
-            CTIAStoredEntity
-            {s/Keyword s/Any}))
+  (csu/optional-keys-schema StoredInvestigation))
 
 (def realize-investigation
-  (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
+(default-realize-fn "investigation" NewInvestigation StoredInvestigation))
 
 (def investigation-mapping
-  {"investigation"
-   {:dynamic false
-    :properties
-    (merge
-     em/base-entity-mapping
-     em/describable-entity-mapping
-     em/sourcable-entity-mapping
-     em/stored-entity-mapping)}})
+{"investigation"
+ {:dynamic false
+  :properties
+  (merge
+   em/base-entity-mapping
+   em/describable-entity-mapping
+   em/sourcable-entity-mapping
+   em/stored-entity-mapping)}})
 
 (def-es-store InvestigationStore :investigation
-  StoredInvestigation
-  PartialStoredInvestigation)
+StoredInvestigation
+PartialStoredInvestigation)
 
 (def investigation-fields
-  (concat sorting/default-entity-sort-fields
-          sorting/describable-entity-sort-fields
-          sorting/sourcable-entity-sort-fields))
+(concat sorting/default-entity-sort-fields
+        sorting/describable-entity-sort-fields
+        sorting/sourcable-entity-sort-fields))
 
 (def investigation-sort-fields
-  (apply s/enum investigation-fields))
+(apply s/enum investigation-fields))
 
 (def investigation-select-fields
-  (apply s/enum (concat investigation-fields
-                        [:description
-                         :type
-                         :search-txt
-                         :short_description
-                         :created_at])))
+(apply s/enum (concat investigation-fields
+                      [:description
+                       :type
+                       :search-txt
+                       :short_description
+                       :created_at])))
 
 (s/defschema InvestigationFieldsParam
-  {(s/optional-key :fields) [investigation-select-fields]})
+{(s/optional-key :fields) [investigation-select-fields]})
 
 (s/defschema InvestigationSearchParams
-  (st/merge
-   PagingParams
-   BaseEntityFilterParams
-   SourcableEntityFilterParams
-   InvestigationFieldsParam
-   {:query s/Str}
-   {s/Keyword s/Any}))
+(st/merge
+ PagingParams
+ BaseEntityFilterParams
+ SourcableEntityFilterParams
+ InvestigationFieldsParam
+ {:query s/Str}
+ {s/Keyword s/Any}))
 
 (def InvestigationGetParams InvestigationFieldsParam)
 
 (s/defschema InvestigationsByExternalIdQueryParams
-  (st/merge
-   InvestigationFieldsParam
-   PagingParams))
+(st/merge
+ InvestigationFieldsParam
+ PagingParams))
 
 (def InvestigationType
-  (let [{:keys [fields name description]}
-        (flanders/->graphql
-         (fu/optionalize-all inv/Investigation)
-         {})]
-    (g/new-object
-     name
-     description
-     []
-     fields)))
+(let [{:keys [fields name description]}
+      (flanders/->graphql
+       (fu/optionalize-all inv/Investigation)
+       {})]
+  (g/new-object
+   name
+   description
+   []
+   fields)))
 
 (def investigation-order-arg
-  (graphql-sorting/order-by-arg
-   "InvestigationOrder"
-   "investigations"
-   (into {}
-         (map (juxt graphql-sorting/sorting-kw->enum-name name)
-              investigation-fields))))
+(graphql-sorting/order-by-arg
+ "InvestigationOrder"
+ "investigations"
+ (into {}
+       (map (juxt graphql-sorting/sorting-kw->enum-name name)
+            investigation-fields))))
 
 (def InvestigationConnectionType
-  (pagination/new-connection InvestigationType))
+(pagination/new-connection InvestigationType))
 
 (def investigation-routes
-  (entity-crud-routes
-   {:entity :investigation
-    :new-schema NewInvestigation
-    :entity-schema Investigation
-    :get-schema PartialInvestigation
-    :get-params InvestigationGetParams
-    :list-schema PartialInvestigationList
-    :search-schema PartialInvestigationList
-    :external-id-q-params InvestigationsByExternalIdQueryParams
-    :search-q-params InvestigationSearchParams
-    :new-spec :new-investigation/map
-    :realize-fn realize-investigation
-    :get-capabilities :read-investigation
-    :post-capabilities :create-investigation
-    :put-capabilities :create-investigation
-    :delete-capabilities :delete-investigation
-    :search-capabilities :search-investigation
-    :external-id-capabilities #{:read-investigation :external-id}}))
+(entity-crud-routes
+ {:entity :investigation
+  :new-schema NewInvestigation
+  :entity-schema Investigation
+  :get-schema PartialInvestigation
+  :get-params InvestigationGetParams
+  :list-schema PartialInvestigationList
+  :search-schema PartialInvestigationList
+  :external-id-q-params InvestigationsByExternalIdQueryParams
+  :search-q-params InvestigationSearchParams
+  :new-spec :new-investigation/map
+  :realize-fn realize-investigation
+  :get-capabilities :read-investigation
+  :post-capabilities :create-investigation
+  :put-capabilities :create-investigation
+  :delete-capabilities :delete-investigation
+  :search-capabilities :search-investigation
+  :external-id-capabilities #{:read-investigation :external-id}}))
 
 (def capabilities
-  #{:read-investigation
-    :list-investigations
-    :create-investigation
-    :search-investigation
-    :delete-investigation})
+#{:read-investigation
+  :list-investigations
+  :create-investigation
+  :search-investigation
+  :delete-investigation})
 
 (def investigation-entity
-  {:route-context "/investigation"
-   :tags ["Investigation"]
-   :entity :investigation
-   :plural :investigations
-   :schema Investigation
-   :partial-schema PartialInvestigation
-   :partial-list-schema PartialInvestigationList
-   :new-schema NewInvestigation
-   :stored-schema StoredInvestigation
-   :partial-stored-schema PartialStoredInvestigation
-   :realize-fn realize-investigation
-   :es-store ->InvestigationStore
-   :es-mapping investigation-mapping
-   :routes investigation-routes
-   :capabilities capabilities})
+{:route-context "/investigation"
+ :tags ["Investigation"]
+ :entity :investigation
+ :plural :investigations
+ :schema Investigation
+ :partial-schema PartialInvestigation
+ :partial-list-schema PartialInvestigationList
+ :new-schema NewInvestigation
+ :stored-schema StoredInvestigation
+ :partial-stored-schema PartialStoredInvestigation
+ :realize-fn realize-investigation
+ :es-store ->InvestigationStore
+ :es-mapping investigation-mapping
+ :routes investigation-routes
+ :capabilities capabilities})

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -54,7 +54,7 @@
   (csu/optional-keys-schema StoredInvestigation))
 
 (def realize-investigation
-(default-realize-fn "investigation" NewInvestigation StoredInvestigation))
+  (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
 
 (def investigation-mapping
 {"investigation"
@@ -67,8 +67,8 @@
    em/stored-entity-mapping)}})
 
 (def-es-store InvestigationStore :investigation
-StoredInvestigation
-PartialStoredInvestigation)
+  StoredInvestigation
+  PartialStoredInvestigation)
 
 (def investigation-fields
 (concat sorting/default-entity-sort-fields
@@ -76,15 +76,15 @@ PartialStoredInvestigation)
         sorting/sourcable-entity-sort-fields))
 
 (def investigation-sort-fields
-(apply s/enum investigation-fields))
+  (apply s/enum investigation-fields))
 
 (def investigation-select-fields
-(apply s/enum (concat investigation-fields
-                      [:description
-                       :type
-                       :search-txt
-                       :short_description
-                       :created_at])))
+  (apply s/enum (concat investigation-fields
+                        [:description
+                         :type
+                         :search-txt
+                         :short_description
+                         :created_at])))
 
 (s/defschema InvestigationFieldsParam
 {(s/optional-key :fields) [investigation-select-fields]})

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -57,23 +57,23 @@
   (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
 
 (def investigation-mapping
-{"investigation"
- {:dynamic false
-  :properties
-  (merge
-   em/base-entity-mapping
-   em/describable-entity-mapping
-   em/sourcable-entity-mapping
-   em/stored-entity-mapping)}})
+  {"investigation"
+   {:dynamic false
+    :properties
+    (merge
+     em/base-entity-mapping
+     em/describable-entity-mapping
+     em/sourcable-entity-mapping
+     em/stored-entity-mapping)}})
 
 (def-es-store InvestigationStore :investigation
   StoredInvestigation
   PartialStoredInvestigation)
 
 (def investigation-fields
-(concat sorting/default-entity-sort-fields
-        sorting/describable-entity-sort-fields
-        sorting/sourcable-entity-sort-fields))
+  (concat sorting/default-entity-sort-fields
+          sorting/describable-entity-sort-fields
+          sorting/sourcable-entity-sort-fields))
 
 (def investigation-sort-fields
   (apply s/enum investigation-fields))
@@ -87,86 +87,86 @@
                          :created_at])))
 
 (s/defschema InvestigationFieldsParam
-{(s/optional-key :fields) [investigation-select-fields]})
+  {(s/optional-key :fields) [investigation-select-fields]})
 
 (s/defschema InvestigationSearchParams
-(st/merge
- PagingParams
- BaseEntityFilterParams
- SourcableEntityFilterParams
- InvestigationFieldsParam
- {:query s/Str}
- {s/Keyword s/Any}))
+  (st/merge
+   PagingParams
+   BaseEntityFilterParams
+   SourcableEntityFilterParams
+   InvestigationFieldsParam
+   {:query s/Str}
+   {s/Keyword s/Any}))
 
 (def InvestigationGetParams InvestigationFieldsParam)
 
 (s/defschema InvestigationsByExternalIdQueryParams
-(st/merge
- InvestigationFieldsParam
- PagingParams))
+  (st/merge
+   InvestigationFieldsParam
+   PagingParams))
 
 (def InvestigationType
-(let [{:keys [fields name description]}
-      (flanders/->graphql
-       (fu/optionalize-all inv/Investigation)
-       {})]
-  (g/new-object
-   name
-   description
-   []
-   fields)))
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all inv/Investigation)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     fields)))
 
 (def investigation-order-arg
-(graphql-sorting/order-by-arg
- "InvestigationOrder"
- "investigations"
- (into {}
-       (map (juxt graphql-sorting/sorting-kw->enum-name name)
-            investigation-fields))))
+  (graphql-sorting/order-by-arg
+   "InvestigationOrder"
+   "investigations"
+   (into {}
+         (map (juxt graphql-sorting/sorting-kw->enum-name name)
+              investigation-fields))))
 
 (def InvestigationConnectionType
-(pagination/new-connection InvestigationType))
+  (pagination/new-connection InvestigationType))
 
 (def investigation-routes
-(entity-crud-routes
- {:entity :investigation
-  :new-schema NewInvestigation
-  :entity-schema Investigation
-  :get-schema PartialInvestigation
-  :get-params InvestigationGetParams
-  :list-schema PartialInvestigationList
-  :search-schema PartialInvestigationList
-  :external-id-q-params InvestigationsByExternalIdQueryParams
-  :search-q-params InvestigationSearchParams
-  :new-spec :new-investigation/map
-  :realize-fn realize-investigation
-  :get-capabilities :read-investigation
-  :post-capabilities :create-investigation
-  :put-capabilities :create-investigation
-  :delete-capabilities :delete-investigation
-  :search-capabilities :search-investigation
-  :external-id-capabilities #{:read-investigation :external-id}}))
+  (entity-crud-routes
+   {:entity :investigation
+    :new-schema NewInvestigation
+    :entity-schema Investigation
+    :get-schema PartialInvestigation
+    :get-params InvestigationGetParams
+    :list-schema PartialInvestigationList
+    :search-schema PartialInvestigationList
+    :external-id-q-params InvestigationsByExternalIdQueryParams
+    :search-q-params InvestigationSearchParams
+    :new-spec :new-investigation/map
+    :realize-fn realize-investigation
+    :get-capabilities :read-investigation
+    :post-capabilities :create-investigation
+    :put-capabilities :create-investigation
+    :delete-capabilities :delete-investigation
+    :search-capabilities :search-investigation
+    :external-id-capabilities #{:read-investigation :external-id}}))
 
 (def capabilities
-#{:read-investigation
-  :list-investigations
-  :create-investigation
-  :search-investigation
-  :delete-investigation})
+  #{:read-investigation
+    :list-investigations
+    :create-investigation
+    :search-investigation
+    :delete-investigation})
 
 (def investigation-entity
-{:route-context "/investigation"
- :tags ["Investigation"]
- :entity :investigation
- :plural :investigations
- :schema Investigation
- :partial-schema PartialInvestigation
- :partial-list-schema PartialInvestigationList
- :new-schema NewInvestigation
- :stored-schema StoredInvestigation
- :partial-stored-schema PartialStoredInvestigation
- :realize-fn realize-investigation
- :es-store ->InvestigationStore
- :es-mapping investigation-mapping
- :routes investigation-routes
- :capabilities capabilities})
+  {:route-context "/investigation"
+   :tags ["Investigation"]
+   :entity :investigation
+   :plural :investigations
+   :schema Investigation
+   :partial-schema PartialInvestigation
+   :partial-list-schema PartialInvestigationList
+   :new-schema NewInvestigation
+   :stored-schema StoredInvestigation
+   :partial-stored-schema PartialStoredInvestigation
+   :realize-fn realize-investigation
+   :es-store ->InvestigationStore
+   :es-mapping investigation-mapping
+   :routes investigation-routes
+   :capabilities capabilities})

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -4,6 +4,7 @@
              [access-control :refer [properties-default-tlp]]
              [entities :refer [schema-version make-valid-time]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema TempIDs]]
              [sorting :as sorting]]
             [ctim.schemas
@@ -11,7 +12,9 @@
              [judgement :as js]]
             [flanders.utils :as fu]
             [ring.util.http-response :as http-response]
-            [schema.core :as s]))
+            [schema-tools.core :as st]
+            [schema.core :as s]
+            [ctim.schemas.incident :as is]))
 
 (def-acl-schema Judgement
   js/Judgement
@@ -29,12 +32,10 @@
   "new-judgement")
 
 (def-stored-schema StoredJudgement
-  js/StoredJudgement
-  "stored-judgement")
+  Judgement)
 
-(def-stored-schema PartialStoredJudgement
-  (fu/optionalize-all js/StoredJudgement)
-  "partial-stored-judgement")
+(s/defschema PartialStoredJudgement
+  (csu/optional-keys-schema StoredJudgement))
 
 (s/defn realize-judgement :- StoredJudgement
   ([new-judgement :- NewJudgement

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -6,6 +6,7 @@
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting :as sorting]]
             [ctia.schemas.graphql
@@ -37,16 +38,13 @@
   malware/NewMalware
   "new-malware")
 
-(def-stored-schema StoredMalware
-  malware/StoredMalware
-  "stored-malware")
+(def-stored-schema StoredMalware Malware)
 
-(def-stored-schema PartialStoredMalware
-  (fu/optionalize-all malware/StoredMalware)
-  "partial-stored-malware")
+(s/defschema PartialStoredMalware
+  (csu/optional-keys-schema StoredMalware))
 
-(def realize-malware
-  (default-realize-fn "malware" NewMalware StoredMalware))
+  (def realize-malware
+    (default-realize-fn "malware" NewMalware StoredMalware))
 
 (def malware-mapping
   {"malware"

--- a/src/ctia/entity/relationship/schemas.clj
+++ b/src/ctia/entity/relationship/schemas.clj
@@ -6,6 +6,7 @@
    [ctim.schemas.relationship :as rels]
    [schema.core :as s]
    [ctia.schemas
+    [utils :as csu]
     [core :refer [def-acl-schema
                   def-stored-schema]]
     [sorting :as sorting]]
@@ -27,13 +28,10 @@
   rels/NewRelationship
   "new-relationship")
 
-(def-stored-schema StoredRelationship
-  rels/StoredRelationship
-  "stored-relationship")
+(def-stored-schema StoredRelationship Relationship)
 
-(def-stored-schema PartialStoredRelationship
-  (fu/optionalize-all rels/StoredRelationship)
-  "partial-stored-relationship")
+(s/defschema PartialStoredRelationship
+  (csu/optional-keys-schema StoredRelationship))
 
 (def relationship-default-realize
   (default-realize-fn "relationship" NewRelationship StoredRelationship))

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -4,10 +4,12 @@
              [access-control :refer [properties-default-tlp]]
              [entities :refer [schema-version]]]
             [ctia.schemas
+             [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema TempIDs]]
              [sorting :as sorting]]
             [ctim.schemas.sighting :as ss]
             [flanders.utils :as fu]
+            [schema-tools.core :as st]
             [schema.core :as s]))
 
 (def-acl-schema NewSighting
@@ -25,13 +27,10 @@
 (s/defschema PartialSightingList
   [PartialSighting])
 
-(def-stored-schema StoredSighting
-  ss/StoredSighting
-  "stored-sighting")
+(def-stored-schema StoredSighting Sighting)
 
-(def-stored-schema PartialStoredSighting
-  (fu/optionalize-all ss/StoredSighting)
-  "partial-stored-sighting")
+(s/defschema PartialStoredSighting
+  (csu/optional-keys-schema StoredSighting))
 
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting :- NewSighting

--- a/src/ctia/entity/tool/schemas.clj
+++ b/src/ctia/entity/tool/schemas.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.tool.schemas
   (:require [ctia.domain.entities :refer [default-realize-fn]]
             [ctia.schemas.core :refer [def-acl-schema def-stored-schema]]
+            [ctia.schemas.utils :as csu]
             [ctim.schemas.tool :as tool]
             [ctia.schemas.sorting :as sorting]
             [flanders.utils :as fu]
@@ -20,13 +21,10 @@
   tool/NewTool
   "new-tool")
 
-(def-stored-schema StoredTool
-  tool/StoredTool
-  "stored-tool")
+(def-stored-schema StoredTool Tool)
 
-(def-stored-schema PartialStoredTool
-  (fu/optionalize-all tool/StoredTool)
-  "partial-stored-tool")
+(s/defschema PartialStoredTool
+  (csu/optional-keys-schema StoredTool))
 
 (def realize-tool
   (default-realize-fn "tool" NewTool StoredTool))

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -17,6 +17,7 @@
                     SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
+    [utils :as csu]
     [core :refer [def-acl-schema def-stored-schema]]
     [sorting :refer [default-entity-sort-fields]]]
    [ctia.stores.es.store :refer [def-es-store]]
@@ -40,13 +41,10 @@
   ws/NewVulnerability
   "new-vulnerability")
 
-(def-stored-schema StoredVulnerability
-  ws/StoredVulnerability
-  "stored-vulnerability")
+(def-stored-schema StoredVulnerability Vulnerability)
 
-(def-stored-schema PartialStoredVulnerability
-  (fu/optionalize-all ws/StoredVulnerability)
-  "partial-stored-vulnerability")
+(s/defschema PartialStoredVulnerability
+  (csu/optional-keys-schema StoredVulnerability))
 
 (def realize-vulnerability
   (default-realize-fn "vulnerability" NewVulnerability StoredVulnerability))

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -17,6 +17,7 @@
                     SourcableEntityFilterParams]]
     [crud :refer [entity-crud-routes]]]
    [ctia.schemas
+    [utils :as csu]
     [core :refer [def-acl-schema def-stored-schema]]
     [sorting :refer [default-entity-sort-fields]]]
    [ctia.stores.es.store :refer [def-es-store]]
@@ -40,13 +41,10 @@
   ws/NewWeakness
   "new-weakness")
 
-(def-stored-schema StoredWeakness
-  ws/StoredWeakness
-  "stored-weakness")
+(def-stored-schema StoredWeakness Weakness)
 
-(def-stored-schema PartialStoredWeakness
-  (fu/optionalize-all ws/StoredWeakness)
-  "partial-stored-weakness")
+(s/defschema PartialStoredWeakness
+  (csu/optional-keys-schema StoredWeakness))
 
 (def realize-weakness
   (default-realize-fn "weakness" NewWeakness StoredWeakness))

--- a/src/ctia/events.clj
+++ b/src/ctia/events.clj
@@ -2,7 +2,7 @@
   (:require [clj-momo.lib.time :as time]
             [ctia.lib.async :as la]
             [ctia.shutdown :as shutdown]
-            [ctim.events.schemas :as es]
+            [ctia.entity.event.schemas :as es]
             [ctim.schemas.common :as c]
             [clojure.core.async :as a :refer [go-loop alt! chan tap]]
             [schema.core :as s :refer [=>]]
@@ -13,9 +13,6 @@
 (def shutdown-max-wait-ms (* 1000 60 60))
 
 (defonce central-channel (atom nil))
-
-(def ModelEvent (st/merge es/ModelEventBase
-                          {s/Any s/Any}))
 
 (s/defn shutdown! :- s/Num
   "Close the central-channel, waiting up to max-wait-ms for the buffer

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -1,14 +1,14 @@
 (ns ctia.flows.hooks.event-hooks
   (:require [clojure.tools.logging :as log])
   (:require
-    [ctia.events :as events]
-    [ctia.flows.hook-protocol :refer [Hook]]
-    [ctia.lib.redis :as lr]
-    [ctia.properties :refer [properties]]
-    [ctim.events.schemas :refer [CreateEventType
-                                 DeleteEventType]]
-    [redismq.core :as rmq]
-    [schema.core :as s]))
+   [ctia.events :as events]
+   [ctia.flows.hook-protocol :refer [Hook]]
+   [ctia.lib.redis :as lr]
+   [ctia.properties :refer [properties]]
+   [ctia.entity.event.schemas :refer [CreateEventType
+                                      DeleteEventType]]
+   [redismq.core :as rmq]
+   [schema.core :as s]))
 
 (defrecord RedisEventPublisher [conn publish-channel-name]
   Hook

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -11,6 +11,13 @@
             [schema-tools.core :as st]
             [schema.core :as s :refer [Bool Str]]))
 
+(def base-stored-entity-entries
+  {:id s/Str
+   :owner s/Str
+   :groups [s/Str]
+   :created java.util.Date
+   (s/optional-key :modified) java.util.Date})
+
 (s/defschema Entity
   (st/merge
    {:entity s/Keyword
@@ -44,7 +51,7 @@
 
 (s/defschema CTIAStoredEntity
   (st/merge CTIAEntity
-            {(s/optional-key :groups) [Str]}))
+            base-stored-entity-entries))
 
 (defmacro defschema [name-sym ddl spec-kw-ns]
   `(do
@@ -52,14 +59,14 @@
        (f-schema/->schema ~ddl))
      (f-spec/->spec ~ddl ~spec-kw-ns)))
 
-(defmacro def-stored-schema [name-sym ddl spec-kw-ns]
+(defmacro def-stored-schema
+  [name-sym sch]
   `(do
      (s/defschema ~name-sym
        (csutils/recursive-open-schema-version
         (st/merge
-         (f-schema/->schema ~ddl)
-         CTIAStoredEntity)))
-     (f-spec/->spec ~ddl ~spec-kw-ns)))
+         ~sch
+         CTIAStoredEntity)))))
 
 (defmacro def-acl-schema [name-sym ddl spec-kw-ns]
   `(do

--- a/src/ctia/schemas/utils.clj
+++ b/src/ctia/schemas/utils.clj
@@ -19,8 +19,9 @@
    s))
 
 
-;; fns below are backported
+;; fns below are backported from schema-tools master
 ;; from https://github.com/metosin/schema-tools/blob/master/src/schema_tools/core.cljc#L266
+;; TODO those can be removed once we use 0.10.6
 
 (defn- explicit-key [k] (if (s/specific-key? k) (s/explicit-schema-key k) k))
 

--- a/src/ctia/schemas/utils.clj
+++ b/src/ctia/schemas/utils.clj
@@ -1,5 +1,7 @@
 (ns ctia.schemas.utils
   (:require [schema-tools.walk :as sw]
+            [schema-tools.util :as stu]
+            [schema-tools.core :as st]
             [schema.core :as s]))
 
 (defn recursive-open-schema-version
@@ -15,3 +17,52 @@
        (recursive-open-schema-version x)))
    identity
    s))
+
+
+;; fns below are backported
+;; from https://github.com/metosin/schema-tools/blob/master/src/schema_tools/core.cljc#L266
+
+(defn- explicit-key [k] (if (s/specific-key? k) (s/explicit-schema-key k) k))
+
+(defn- explicit-key-set [ks]
+  (reduce (fn [s k] (conj s (explicit-key k))) #{} ks))
+
+(defn- maybe-anonymous [original current]
+  (if (= original current)
+    original
+    (vary-meta
+     current
+     (fn [meta]
+       (let [new-meta (clojure.core/dissoc meta :name :ns)]
+         (if (empty? new-meta)
+           nil
+           new-meta))))))
+
+(defn- transform-keys
+  [schema f ks]
+  (assert (or (not ks) (vector? ks)) "input should be nil or a vector of keys.")
+  (maybe-anonymous
+   schema
+   (let [ks? (explicit-key-set ks)]
+     (stu/map-keys
+      (fn [k]
+        (cond
+          (and ks (not (ks? (explicit-key k)))) k
+          (s/specific-key? k) (f (s/explicit-schema-key k))
+          :else k))
+      schema))))
+
+(defn optional-keys
+  "Makes given map keys optional. Defaults to all keys."
+  ([m] (optional-keys m nil))
+  ([m ks] (transform-keys m s/optional-key ks)))
+
+(defn optional-keys-schema
+  "Walks a schema making all keys optional in Map Schemas."
+  [schema]
+  (sw/prewalk
+   (fn [x]
+     (if (and (map? x) (not (record? x)))
+       (optional-keys x)
+       x))
+   schema))

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -47,7 +47,6 @@
                                                        (sut/casebook-root-scope)})))
       "with all scopes you should have most capabilities except some very
        specific ones")
-
   (is (= #{:search-casebook
            :list-casebooks
            :create-casebook

--- a/test/ctia/events_test.clj
+++ b/test/ctia/events_test.clj
@@ -1,12 +1,18 @@
 (ns ctia.events-test
-  (:require [ctia.events :as e]
-            [ctia.lib.async :as la]
-            [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.es :as es-helpers]
-            [ctim.events.obj-to-event :as o2e]
-            [clojure.test :as t :refer :all]
-            [clojure.core.async :refer [poll! chan tap <!!]]
-            [schema.test :as st]))
+  (:require
+   [clojure.test :refer [deftest
+                         is
+                         testing
+                         use-fixtures
+                         join-fixtures]]
+   [clojure.core.async :refer [<!! chan poll! tap]]
+   [ctia.entity.event.obj-to-event :as o2e]
+   [ctia.events :as e]
+   [ctia.lib.async :as la]
+   [ctia.test-helpers
+    [core :as helpers]
+    [es :as es-helpers]]
+   [schema.test :as st]))
 
 (use-fixtures :once st/validate-schemas)
 
@@ -23,18 +29,24 @@
       (e/send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-1"
+                         :tlp "white"
                          :type :test
-                         :data 1}))
+                         :data 1}
+                        "test-1"))
       (e/send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-2"
+                         :tlp "white"
                          :type :test
-                         :data 2}))
+                         :data 2}
+                        "test-2"))
       (e/send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-3"
+                         :tlp "white"
                          :type :test
-                         :data 3}))
+                         :data 3}
+                        "test-3"))
       (is (= 1 (-> (<!! output) :entity :data)))
       (is (= 2 (-> (<!! output) :entity :data)))
       (is (= 3 (-> (<!! output) :entity :data)))
@@ -49,13 +61,17 @@
     (e/send-event (o2e/to-create-event
                    {:owner "tester"
                     :id "test-1"
+                    :tlp "white"
                     :type :test
-                    :data 1}))
+                    :data 1}
+                   "test-1"))
     (e/send-event (o2e/to-create-event
                    {:owner "teseter"
                     :id "test-2"
+                    :tlp "white"
                     :type :test
-                    :data 2}))
+                    :data 2}
+                   "test-2"))
     (is (= 1 (-> (<!! output) :entity :data)))
     (is (= 2 (-> (<!! output) :entity :data)))
     (is (nil? (poll! output)))))

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -44,7 +44,6 @@
       (let [scrubbed (-> (str sb)
                          (str/replace #"#inst \"[^\"]*\"" "#inst \"\"")
                          (str/replace #":id event[^,]*" ":id event"))
-            _ (prn scrubbed)
             expected
             "event: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-1, :type :test, :tlp green, :data 1}, :timestamp #inst \"\", :id test-1, :type event, :tlp green, :event_type :record-created}\nevent: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-2, :type :test, :tlp green, :data 2}, :timestamp #inst \"\", :id test-2, :type event, :tlp green, :event_type :record-created}\n"]
         (is (= expected scrubbed))))))

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -3,7 +3,7 @@
             [ctia.test-helpers
              [core :as test-helpers]
              [es :as es-helpers]]
-            [ctim.events.obj-to-event :as o2e]
+            [ctia.entity.event.obj-to-event :as o2e]
             [clojure.test :as t :refer :all]
             [schema.test :as st]
             [clojure.tools.logging :as log]
@@ -18,9 +18,9 @@
 (deftest test-logged
   (let [sb (StringBuilder.)
         patched-log (fn [logger
-                        level
-                        throwable
-                        message]
+                         level
+                         throwable
+                         message]
                       (.append sb message)
                       (.append sb "\n"))]
     (with-redefs [log/log* patched-log]
@@ -29,16 +29,22 @@
                       :groups ["foo"]
                       :id "test-1"
                       :type :test
-                      :data 1}))
+                      :tlp "green"
+                      :data 1}
+                     "test-1"))
       (e/send-event (o2e/to-create-event
                      {:owner "tester"
                       :groups ["foo"]
                       :id "test-2"
                       :type :test
-                      :data 2}))
+                      :tlp "green"
+                      :data 2}
+                     "test-2"))
       (Thread/sleep 100)   ;; wait until the go loop is done
       (let [scrubbed (-> (str sb)
                          (str/replace #"#inst \"[^\"]*\"" "#inst \"\"")
                          (str/replace #":id event[^,]*" ":id event"))
-            expected "event: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-1, :type :test, :data 1}, :timestamp #inst \"\", :id test-1, :type CreatedModel}\nevent: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-2, :type :test, :data 2}, :timestamp #inst \"\", :id test-2, :type CreatedModel}\n"]
+            _ (prn scrubbed)
+            expected
+            "event: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-1, :type :test, :tlp green, :data 1}, :timestamp #inst \"\", :id test-1, :type event, :tlp green, :event_type :record-created}\nevent: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-2, :type :test, :tlp green, :data 2}, :timestamp #inst \"\", :id test-2, :type event, :tlp green, :event_type :record-created}\n"]
         (is (= expected scrubbed))))))


### PR DESCRIPTION
This PR updates CTIA to use the latest version of CTIM 1.0.8

- remove references to CTIM Stored schemas, compute them from the original entity schema
- update all CTIA Event code to use the factories from CTIA and not CTIM