### PR TITLE
Display DELETE routes by default in Swagger UI

### DIFF
--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -43,7 +43,7 @@
            can-patch?
            can-search?
            can-get-by-external-id?]
-    :or {hide-delete? true
+    :or {hide-delete? false
          can-post? true
          can-update? true
          can-patch? false


### PR DESCRIPTION
This PR changes the default behaviour for our Swagger routes so DELETE calls are included in the spec.

QA Instructions:

- A DELETE route should be listed in Swagger for each entity API subset