### PR TITLE
bundle/export enabled to specify relationship filters

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -337,9 +337,8 @@
 
 (defn fetch-entity-relationships
   "given an entity id, fetch all related relationship"
-  [id identity-map]
-  (let [filters [{:source_ref id}
-                 {:target_ref id}]
+  [id identity-map related-to]
+  (let [filters (map #(hash-map % id)  related-to)
         rel-lists
         (map
          #(some->
@@ -368,10 +367,11 @@
   [id
    identity-map
    ident
-   {:keys [include_related_entities]
-    :or {include_related_entities true}}]
+   {:keys [include_related_entities related_to]
+    :or {include_related_entities true
+         related_to [:source_ref :target_ref]}}]
   (if-let [record (fetch-record id identity-map)]
-    (let [relationships (fetch-entity-relationships id identity-map)]
+    (let [relationships (fetch-entity-relationships id identity-map related_to)]
       (cond-> {}
         record
         (assoc (-> (:type record)

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -338,7 +338,7 @@
 (defn fetch-entity-relationships
   "given an entity id, fetch all related relationship"
   [id identity-map related-to]
-  (let [filters (map #(hash-map % id)  related-to)
+  (let [filters (map #(hash-map % id) (set related-to))
         rel-lists
         (map
          #(some->
@@ -369,7 +369,7 @@
    ident
    {:keys [include_related_entities related_to]
     :or {include_related_entities true
-         related_to [:source_ref :target_ref]}}]
+         related_to #{:source_ref :target_ref}}}]
   (if-let [record (fetch-record id identity-map)]
     (let [relationships (fetch-entity-relationships id identity-map related_to)]
       (cond-> {}

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -14,6 +14,7 @@
 
 (s/defschema BundleExportQuery
   {:ids [s/Str]
+   (s/optional-key :related_to) [(s/enum :source_ref :target_ref)]
    (s/optional-key :include_related_entities) s/Bool})
 
 (defroutes bundle-routes
@@ -64,7 +65,7 @@
                      (:ids q)
                      identity-map
                      identity
-                     (select-keys q [:include_related_entities]))))
+                     (select-keys q [:include_related_entities :related_to]))))
 
            (POST "/import" []
                  :return BundleImportResult

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -521,6 +521,27 @@
              "default related_to value should be [:source_ref :target_ref]"))))))
 
 
+(def bundle-related-fixture
+  (let [indicator-1 (mk-indicator 1)
+        indicator-2 (mk-indicator 2)
+        indicator-3 (mk-indicator 3)
+        sighting-1 (mk-sighting 1)
+        sighting-2 (mk-sighting 2)
+        relationship-1 (mk-relationship 1 sighting-1 indicator-1 "member-of")
+        relationship-2 (mk-relationship 2 sighting-1 indicator-2 "member-of")
+        relationship-3 (mk-relationship 3 sighting-2 indicator-1 "member-of")
+        relationship-4 (mk-relationship 4 sighting-2 indicator-3 "member-of")]
+    {:type "bundle"
+     :source "source"
+     :indicators #{indicator-1
+                   indicator-2
+                   indicator-3}
+     :sightings #{sighting-1 sighting-2}
+     :relationships #{relationship-1
+                      relationship-2
+                      relationship-3
+                      relationship-4}}))
+
 (deftest bundle-export-related-to-test
   (test-for-each-store
    (fn []
@@ -531,28 +552,9 @@
                                          "user")
 
      (testing "testing related_to filter: relationships should be joined only on attributes specified by related_to values (source_ref and/or target_ref)"
-       (let [indicator-1 (mk-indicator 1)
-             indicator-2 (mk-indicator 2)
-             indicator-3 (mk-indicator 3)
-             sighting-1 (mk-sighting 1)
-             sighting-2 (mk-sighting 2)
-             relationship-1 (mk-relationship 1 sighting-1 indicator-1 "member-of")
-             relationship-2 (mk-relationship 2 sighting-1 indicator-2 "member-of")
-             relationship-3 (mk-relationship 3 sighting-2 indicator-1 "member-of")
-             relationship-4 (mk-relationship 4 sighting-2 indicator-3 "member-of")
-             bundle-fixture {:type "bundle"
-                             :source "source"
-                             :indicators #{indicator-1
-                                           indicator-2
-                                           indicator-3}
-                             :sightings #{sighting-1 sighting-2}
-                             :relationships #{relationship-1
-                                              relationship-2
-                                              relationship-3
-                                              relationship-4}}
-             bundle-res
+       (let [bundle-res
              (:parsed-body (post "ctia/bundle/import"
-                                 :body bundle-fixture
+                                 :body bundle-related-fixture
                                  :headers {"Authorization" "45c1f5e3f05d0"}))
 
              by-type (->> bundle-res :results (group-by :type))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -446,113 +446,171 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
-     (let [bundle-res-1
-           (:parsed-body (post "ctia/bundle/import"
-                               :body bundle-fixture-1
-                               :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-res-2
-           (:parsed-body (post "ctia/bundle/import"
-                               :body bundle-fixture-2
-                               :headers {"Authorization" "45c1f5e3f05d0"}))
-           sighting-id-1
-           (some->> bundle-res-1
-                    :results
-                    (group-by :type)
-                    :sighting
-                    first
-                    :id)
-           sighting-id-2
-           (some->> bundle-res-2
-                    :results
-                    (group-by :type)
-                    :sighting
-                    first
-                    :id)
-           bundle-get-res-1
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids sighting-id-1}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-get-res-2
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids sighting-id-2}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-get-res-3
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-1
-                                      sighting-id-2]}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-get-res-4
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-1
-                                      sighting-id-2]
-                                :include_related_entities false}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-get-res-5
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-1
-                                      sighting-id-2]
-                                :related_to ["target_ref" "source_ref"]}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
+     (testing "filtering on entities ids"
+       (let [bundle-res-1
+             (:parsed-body (post "ctia/bundle/import"
+                                 :body bundle-fixture-1
+                                 :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-res-2
+             (:parsed-body (post "ctia/bundle/import"
+                                 :body bundle-fixture-2
+                                 :headers {"Authorization" "45c1f5e3f05d0"}))
+             sighting-id-1
+             (some->> bundle-res-1
+                      :results
+                      (group-by :type)
+                      :sighting
+                      first
+                      :id)
+             sighting-id-2
+             (some->> bundle-res-2
+                      :results
+                      (group-by :type)
+                      :sighting
+                      first
+                      :id)
+             bundle-get-res-1
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids sighting-id-1}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-get-res-2
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids sighting-id-2}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-get-res-3
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-1
+                                        sighting-id-2]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-get-res-4
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-1
+                                        sighting-id-2]
+                                  :include_related_entities false}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-get-res-5
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-1
+                                        sighting-id-2]
+                                  :related_to ["target_ref" "source_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))]
 
-           indicator-ids
-           (some->> bundle-res-2
-                    :results
-                    (group-by :type)
-                    :indicator
-                    (take 3)
-                    (map :id))
-           bundle-from-source
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids indicator-ids
-                                :related_to ["source_ref"]}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))
-           bundle-from-target
-           (:parsed-body
-            (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-2]
-                                :related_to ["target_ref"]}
-                 :headers {"Authorization" "45c1f5e3f05d0"}))]
+         (is (= 1 (count (:sightings bundle-get-res-1))))
+         (is (= 2 (count (:relationships bundle-get-res-1))))
+         (is (= 2 (count (:indicators bundle-get-res-1))))
 
-       (is (= 1 (count (:sightings bundle-get-res-1))))
-       (is (= 2 (count (:relationships bundle-get-res-1))))
-       (is (= 2 (count (:indicators bundle-get-res-1))))
+         (is (= 1 (count (:sightings bundle-get-res-2))))
+         (is (= 400 (count (:relationships bundle-get-res-2))))
+         (is (= 400 (count (:indicators bundle-get-res-2))))
 
-       (is (= 1 (count (:sightings bundle-get-res-2))))
-       (is (= 400 (count (:relationships bundle-get-res-2))))
-       (is (= 400 (count (:indicators bundle-get-res-2))))
+         (is (= 2 (count (:sightings bundle-get-res-3))))
+         (is (= 402 (count (:relationships bundle-get-res-3))))
+         (is (= 402 (count (:indicators bundle-get-res-3))))
 
-       (is (= 2 (count (:sightings bundle-get-res-3))))
-       (is (= 402 (count (:relationships bundle-get-res-3))))
-       (is (= 402 (count (:indicators bundle-get-res-3))))
-
-       (is (= 2 (count (:sightings bundle-get-res-4))))
-       (is (nil? (:indicators bundle-get-res-4)))
-       (is (= 402 (count (:relationships bundle-get-res-4))))
-
-       (testing "relationships should be joined only on attributes specified by related_to values"
+         (is (= 2 (count (:sightings bundle-get-res-4))))
+         (is (nil? (:indicators bundle-get-res-4)))
+         (is (= 402 (count (:relationships bundle-get-res-4))))
 
          (is (= bundle-get-res-3 bundle-get-res-5)
-             "default related_to value should be [:source_ref :target_ref]")
+             "default related_to value should be [:source_ref :target_ref]"))))))
 
-         (is (= (set indicator-ids) (->> bundle-from-source
-                                   :indicators
-                                   (map :id)
-                                   set)))
-         (is (= #{sighting-id-2} (->> bundle-from-source
+
+(deftest bundle-export-related-to-test
+  (test-for-each-store
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+
+     (testing "testing related_to filter: relationships should be joined only on attributes specified by related_to values (source_ref and/or target_ref)"
+       (let [indicator-1 (mk-indicator 1)
+             indicator-2 (mk-indicator 2)
+             indicator-3 (mk-indicator 3)
+             sighting-1 (mk-sighting 1)
+             sighting-2 (mk-sighting 2)
+             relationship-1 (mk-relationship 1 sighting-1 indicator-1 "member-of")
+             relationship-2 (mk-relationship 2 sighting-1 indicator-2 "member-of")
+             relationship-3 (mk-relationship 3 sighting-2 indicator-1 "member-of")
+             relationship-4 (mk-relationship 4 sighting-2 indicator-3 "member-of")
+             bundle-fixture {:type "bundle"
+                             :source "source"
+                             :indicators #{indicator-1
+                                           indicator-2
+                                           indicator-3}
+                             :sightings #{sighting-1 sighting-2}
+                             :relationships #{relationship-1
+                                              relationship-2
+                                              relationship-3
+                                              relationship-4}}
+             bundle-res
+             (:parsed-body (post "ctia/bundle/import"
+                                 :body bundle-fixture
+                                 :headers {"Authorization" "45c1f5e3f05d0"}))
+
+             by-type (->> bundle-res :results (group-by :type))
+
+             [sighting-id-1
+              sighting-id-2] (->> (:sighting by-type)
+                                  (sort-by :external_id)
+                                  (map :id))
+             [indicator-id-1
+              indicator-id-2
+              indicator-id-3] (->> (:indicator by-type)
+                                   (sort-by :external_id)
+                                   (map :id))
+             bundle-from-source
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-1]
+                                  :related_to ["source_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-from-target-1
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [indicator-id-1]
+                                  :related_to ["target_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-from-target-2
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [indicator-id-2]
+                                  :related_to ["target_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))]
+
+         (is (= #{indicator-id-1
+                  indicator-id-2} (->> bundle-from-source
+                                       :indicators
+                                       (map :id)
+                                       set)))
+         (is (= #{sighting-id-1} (->> bundle-from-source
                                       :sightings
                                       (map :id)
                                       set)))
-         (is (= 3 (count (:relationships bundle-from-source))))
 
-         (is (= 400 (count (:relationships bundle-from-target))))
-         (is (every? #(= sighting-id-2 (:target_ref %))
-                     (:relationships bundle-from-target))))))))
+         (is (= #{indicator-id-1} (->> bundle-from-target-1
+                                       :indicators
+                                       (map :id)
+                                       set)))
+         (is (= #{sighting-id-1
+                  sighting-id-2} (->> bundle-from-target-1
+                                      :sightings
+                                      (map :id)
+                                      set)))
+         (is (= #{indicator-id-2} (->> bundle-from-target-2
+                                       :indicators
+                                       (map :id)
+                                       set)))
+         (is (= #{sighting-id-1} (->> bundle-from-target-2
+                                      :sightings
+                                      (map :id)
+                                      set))))))))
 
 (defn with-tlp-property-setting [tlp f]
   (with-redefs [ctia.properties/properties

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -17,8 +17,7 @@
              [fake-whoami-service :as whoami-helpers]
              [store :refer [test-for-each-store]]]
             [ctim.domain.id :as id]
-            [ctim.examples.bundles :refer [bundle-maximal]]
-            [clojure.pprint :refer [pprint]]))
+            [ctim.examples.bundles :refer [bundle-maximal]]))
 
 (defn fixture-properties:small-max-bulk-size [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000]
@@ -550,7 +549,6 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
-
      (testing "testing related_to filter: relationships should be joined only on attributes specified by related_to values (source_ref and/or target_ref)"
        (let [bundle-res
              (:parsed-body (post "ctia/bundle/import"

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -499,18 +499,23 @@
                                 :related_to ["target_ref" "source_ref"]}
                  :headers {"Authorization" "45c1f5e3f05d0"}))
 
+           indicator-id
+           (some->> bundle-res-2
+                    :results
+                    (group-by :type)
+                    :indicator
+                    first
+                    :id)
            bundle-from-source
            (:parsed-body
             (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-1
-                                      sighting-id-2]
+                 :query-params {:ids [indicator-id]
                                 :related_to ["source_ref"]}
                  :headers {"Authorization" "45c1f5e3f05d0"}))
            bundle-from-target
            (:parsed-body
             (get "ctia/bundle/export"
-                 :query-params {:ids [sighting-id-1
-                                      sighting-id-2]
+                 :query-params {:ids [sighting-id-2]
                                 :related_to ["target_ref"]}
                  :headers {"Authorization" "45c1f5e3f05d0"}))]
 
@@ -530,17 +535,18 @@
        (is (nil? (:indicators bundle-get-res-4)))
        (is (= 402 (count (:relationships bundle-get-res-4))))
 
-       (is (= (count (:sightings bundle-get-res-3))
-              (count (:sightings bundle-get-res-5))))
-       (is (= (count (:relationships bundle-get-res-3))
-              (count (:relationships bundle-get-res-5))))
-       (is (= (count (:indicators bundle-get-res-3))
-              (count (:indicators bundle-get-res-5))))
+       (is (= bundle-get-res-3 bundle-get-res-5))
 
-       (is (empty? (:relationships bundle-from-source)))
-
-       (is (every? #(contains? #{sighting-id-1 sighting-id-2}
-                               (:target_ref %))
+       (is (= indicator-id (-> bundle-from-source
+                               :indicators
+                               first
+                               :id)))
+       (is (= sighting-id-2 (-> bundle-from-source
+                               :sightings
+                               first
+                               :id)))
+       (is (= 400 (count (:relationships bundle-from-target))))
+       (is (every? #(= sighting-id-2 (:target_ref %))
                    (:relationships bundle-from-target)))))))
 
 (defn with-tlp-property-setting [tlp f]

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -490,7 +490,30 @@
                  :query-params {:ids [sighting-id-1
                                       sighting-id-2]
                                 :include_related_entities false}
+                 :headers {"Authorization" "45c1f5e3f05d0"}))
+           bundle-get-res-5
+           (:parsed-body
+            (get "ctia/bundle/export"
+                 :query-params {:ids [sighting-id-1
+                                      sighting-id-2]
+                                :related_to ["target_ref" "source_ref"]}
+                 :headers {"Authorization" "45c1f5e3f05d0"}))
+
+           bundle-from-source
+           (:parsed-body
+            (get "ctia/bundle/export"
+                 :query-params {:ids [sighting-id-1
+                                      sighting-id-2]
+                                :related_to ["source_ref"]}
+                 :headers {"Authorization" "45c1f5e3f05d0"}))
+           bundle-from-target
+           (:parsed-body
+            (get "ctia/bundle/export"
+                 :query-params {:ids [sighting-id-1
+                                      sighting-id-2]
+                                :related_to ["target_ref"]}
                  :headers {"Authorization" "45c1f5e3f05d0"}))]
+
        (is (= 1 (count (:sightings bundle-get-res-1))))
        (is (= 2 (count (:relationships bundle-get-res-1))))
        (is (= 2 (count (:indicators bundle-get-res-1))))
@@ -505,7 +528,20 @@
 
        (is (= 2 (count (:sightings bundle-get-res-4))))
        (is (nil? (:indicators bundle-get-res-4)))
-       (is (= 402 (count (:relationships bundle-get-res-4))))))))
+       (is (= 402 (count (:relationships bundle-get-res-4))))
+
+       (is (= (count (:sightings bundle-get-res-3))
+              (count (:sightings bundle-get-res-5))))
+       (is (= (count (:relationships bundle-get-res-3))
+              (count (:relationships bundle-get-res-5))))
+       (is (= (count (:indicators bundle-get-res-3))
+              (count (:indicators bundle-get-res-5))))
+
+       (is (empty? (:relationships bundle-from-source)))
+
+       (is (every? #(contains? #{sighting-id-1 sighting-id-2}
+                               (:target_ref %))
+                   (:relationships bundle-from-target)))))))
 
 (defn with-tlp-property-setting [tlp f]
   (with-redefs [ctia.properties/properties

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -17,7 +17,8 @@
              [fake-whoami-service :as whoami-helpers]
              [store :refer [test-for-each-store]]]
             [ctim.domain.id :as id]
-            [ctim.examples.bundles :refer [bundle-maximal]]))
+            [ctim.examples.bundles :refer [bundle-maximal]]
+            [clojure.pprint :refer [pprint]]))
 
 (defn fixture-properties:small-max-bulk-size [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000]
@@ -565,6 +566,12 @@
               indicator-id-3] (->> (:indicator by-type)
                                    (sort-by :external_id)
                                    (map :id))
+             [relationship-id-1
+              relationship-id-2
+              relationship-id-3
+              relationship-id-4] (->> (:relationship by-type)
+                                      (sort-by :external_id)
+                                      (map :id))
              bundle-from-source
              (:parsed-body
               (get "ctia/bundle/export"
@@ -584,6 +591,11 @@
                                   :related_to ["target_ref"]}
                    :headers {"Authorization" "45c1f5e3f05d0"}))]
 
+         (is (= #{relationship-id-1
+                  relationship-id-2} (->> bundle-from-source
+                                          :relationships
+                                          (map :id)
+                                          set)))
          (is (= #{indicator-id-1
                   indicator-id-2} (->> bundle-from-source
                                        :indicators
@@ -598,11 +610,21 @@
                                        :indicators
                                        (map :id)
                                        set)))
+         (is (= #{relationship-id-1
+                  relationship-id-3} (->> bundle-from-target-1
+                                          :relationships
+                                          (map :id)
+                                          set)))
          (is (= #{sighting-id-1
                   sighting-id-2} (->> bundle-from-target-1
                                       :sightings
                                       (map :id)
                                       set)))
+
+         (is (= #{relationship-id-2} (->> bundle-from-target-2
+                                          :relationships
+                                          (map :id)
+                                          set)))
          (is (= #{indicator-id-2} (->> bundle-from-target-2
                                        :indicators
                                        (map :id)


### PR DESCRIPTION
connected to threatgrid/iroh/issues/2095

bundle/export: introduced an optional `related_to` parameter which enables to search relationships only by `target_ref` or `source_ref`

**QA**
WIthout precising `related_to` parameter or selecting both `target_ref` and `source_ref` the behavior should be the same as before.
If you set related_to to `source_ref` (respectively `target_ref`), the requested ids must be only in `source_ref` (respectively `target_ref`) of retrieved relationships. 