### PR TITLE
Remove config for missing Riemann from demo

### DIFF
--- a/containers/demo/ctia/config/ctia.properties
+++ b/containers/demo/ctia/config/ctia.properties
@@ -1,4 +1,4 @@
 ctia.store.es.default.host=elasticsearch
 ctia.hook.redismq.host=redis
 ctia.hook.redis.host=redis
-ctia.metrics.riemann.host=riemann
+# ctia.metrics.riemann.host=riemann


### PR DESCRIPTION
The ctia.properties in the demo docker container is configured to look for
Riemann, but no Riemann container is supplied.  This apparently causes CTIA
init to fail when trying to start the demo container.  Commenting out the
Riemann config in the `ctia/config/ctia.properties` file we supply to docker
seems to resolve the issue, allowing CTIA to start normally.

Resolves https://github.com/threatgrid/iroh/issues/2407