### PR TITLE
Update nREPL to version 0.3.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                  [threatgrid/ring-jwt-middleware "0.0.7" :exclusions [metosin/ring-http-response riemann-clojure-client joda-time clj-time com.google.code.findbugs/jsr305 com.andrewmcveigh/cljs-time]]
 
                  ;; nREPL server
-                 [org.clojure/tools.nrepl "0.2.13"]
+                 [nrepl "0.3.1"]
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]


### PR DESCRIPTION
`[nrepl "0.3.1"]` is a drop in replacement for `[org.clojure/tools.nrepl "0.2.13"]`
which, among other things resolves the ipv6 protocol binding exception from the nrepl
library: https://github.com/nrepl/nREPL/issues/20

Resolves https://github.com/threatgrid/iroh/issues/2407