### PR TITLE
Client dev container

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                  [threatgrid/ring-jwt-middleware "0.0.7" :exclusions [metosin/ring-http-response riemann-clojure-client joda-time clj-time com.google.code.findbugs/jsr305 com.andrewmcveigh/cljs-time]]
 
                  ;; nREPL server
-                 [nrepl "0.3.1"]
+                 [nrepl "0.3.1" :exclusions [com.andrewmcveigh/cljs-time org.clojure/tools.logging]]
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]

--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                  [threatgrid/ring-jwt-middleware "0.0.7" :exclusions [metosin/ring-http-response riemann-clojure-client joda-time clj-time com.google.code.findbugs/jsr305 com.andrewmcveigh/cljs-time]]
 
                  ;; nREPL server
-                 [org.clojure/tools.nrepl "0.2.13"]
+                 [nrepl "0.3.1"]
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]


### PR DESCRIPTION
According to [https://github.com/nrepl/nrepl](https://github.com/nrepl/nrepl):
> `[nrepl "0.3.1"]` is a drop-in replacement for `[org.clojure/tools.nrepl "0.2.13"]`

This is needed to address resolve https://github.com/nrepl/nrepl/issues/20 in our build.

However, it looks as though our tests don't run with this in place.  Details to follow.