### PR TITLE
Fix client-dev and demo container setup, remove nrepl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,6 @@ Running from a cloned repository:
 
 `lein run`
 
-If you like, you can cider-connect to the NREPL listener that it
-starts by default.  Be sure NOT to run the service this way in
-production, unless you ensure access to the NREPL port is restricted.
-
 ### Packaging and running as standalone jar
 
 This is the proper way to run this in production.

--- a/containers/client-dev/ctia/config/ctia.properties
+++ b/containers/client-dev/ctia/config/ctia.properties
@@ -1,3 +1,4 @@
 ctia.store.es.default.host=elasticsearch-client-dev
 ctia.hook.redismq.host=redis-client-dev
 ctia.hook.redis.host=redis-client-dev
+ctia.http.jwt.enabled=false

--- a/containers/demo/ctia/config/ctia.properties
+++ b/containers/demo/ctia/config/ctia.properties
@@ -1,4 +1,4 @@
 ctia.store.es.default.host=elasticsearch
 ctia.hook.redismq.host=redis
 ctia.hook.redis.host=redis
-# ctia.metrics.riemann.host=riemann
+ctia.http.jwt.enabled=false

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -119,16 +119,6 @@
 | ctia.events.log | enable CTIA Event log | =true= =false= |
 
 
-** nRepl
-
-  setup clojure nrepl support, for development
-
-| Property           | Description                      | Possible values |
-|--------------------+----------------------------------+-----------------|
-| ctia.nrepl.enabled | enable CTIA nrepl                | =true= =false=  |
-| ctia.nrepl.port    | set the port to access the nrepl | number          |
-
-
 ** Hooks
 
 *** RedisMQ

--- a/project.clj
+++ b/project.clj
@@ -67,9 +67,6 @@
                  [yogsototh/clj-jwt "0.2.1"]
                  [threatgrid/ring-jwt-middleware "0.0.7" :exclusions [metosin/ring-http-response riemann-clojure-client joda-time clj-time com.google.code.findbugs/jsr305 com.andrewmcveigh/cljs-time]]
 
-                 ;; nREPL server
-                 [org.clojure/tools.nrepl "0.2.13"]
-
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]
                  [com.taoensso/carmine "2.17.0"]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -29,9 +29,6 @@ ctia.http.show.protocol=http
 
 ctia.http.bulk.max-size=2000
 
-ctia.nrepl.port=3001
-ctia.nrepl.enabled=true
-
 ctia.events.enabled=true
 ctia.events.log=false
 

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -2,7 +2,6 @@
   (:require
    [ctia.entity.entities :refer [validate-entities]]
    [clj-momo.properties :as mp]
-   [clojure.tools.nrepl.server :as nrepl-server]
    [clojure.tools.logging :as log]
    [ctia.lib.metrics
     [riemann :as riemann]
@@ -99,12 +98,6 @@
   ;; hooks init
   (h/init!)
 
-  ;; Start nREPL server
-  (let [{nrepl-port :port
-         nrepl-enabled? :enabled} (get-in @p/properties [:ctia :nrepl])]
-    (when (and nrepl-enabled? nrepl-port)
-      (log/info (str "Starting nREPL server on port " nrepl-port))
-      (nrepl-server/start-server :port nrepl-port)))
   ;; Start HTTP server
   (let [{http-port :port
          enabled? :enabled} (get-in @p/properties [:ctia :http])]

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -86,7 +86,6 @@
    (st/optional-keys {"ctia.migration.optimizations" s/Bool})
 
    (st/required-keys {"ctia.events.enabled" s/Bool
-                      "ctia.nrepl.enabled" s/Bool
                       "ctia.hook.redis.enabled" s/Bool
                       "ctia.hook.redismq.enabled" s/Bool})
 
@@ -94,7 +93,6 @@
                       "ctia.access-control.default-tlp" TLP})
 
    (st/optional-keys {"ctia.events.log" s/Bool
-                      "ctia.nrepl.port" s/Int
                       "ctia.hook.redis.host" s/Str
                       "ctia.hook.redis.port" s/Int
                       "ctia.hook.redis.channel-name" s/Str

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -56,7 +56,6 @@
                     "ctia.http.jwt.enabled"           true
                     "ctia.http.jwt.public-key-path"   "resources/cert/ctia-jwt.pub"
                     "ctia.http.bulk.max-size"         30000
-                    "ctia.nrepl.enabled"              false
                     "ctia.hook.redis.enabled"         false
                     "ctia.hook.redis.channel-name"    "events-test"
                     "ctia.metrics.riemann.enabled"    false


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2407

Since the beginning of this project, we never used nrepl support, this dependency is not really meant to be included in the project source:

- it produces dependency conflicts with the dev tools
- it produces dependency conflicts with other libs
- it is a potential security hole in production

This PR removes nrepl  support and dependencies, 
changes the demo and client-dev setup disabling JWT.

in the end CTIA runs in the container and I'm able to push data:

```bash
elasticsearch-client-dev_1_e60e59d0ece2 | [2019-01-21T09:42:50,862][INFO ][o.e.c.r.a.AllocationService] [kllgKvy] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[ctia_actor][1]] ...]).
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:03,307 INFO (main) [org.eclipse.jetty.util.log] - Logging initialized @26627ms
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:03,588 INFO (main) [ctia.init] - starting CTIA version:  3ba416535fd70638a9e73042a35b6300289d7e90 master
ctia_1_274a5c2bb6a1         |
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:03,933 INFO (main) [ctia.init] -
ctia_1_274a5c2bb6a1         | {:ctia
ctia_1_274a5c2bb6a1         |  {:http
ctia_1_274a5c2bb6a1         |   {:bulk {:max-size 2000},
ctia_1_274a5c2bb6a1         |    :port 3000,
ctia_1_274a5c2bb6a1         |    :jwt
ctia_1_274a5c2bb6a1         |    {:enabled false,
ctia_1_274a5c2bb6a1         |     :local-storage-key "********",
ctia_1_274a5c2bb6a1         |     :public-key-path "********",
ctia_1_274a5c2bb6a1         |     :claim-prefix "https://schemas.cisco.com/iroh/identity/claims"},
ctia_1_274a5c2bb6a1         |    :min-threads 10,
ctia_1_274a5c2bb6a1         |    :access-control-allow-methods "get,post,put,patch,delete",
ctia_1_274a5c2bb6a1         |    :max-threads 100,
ctia_1_274a5c2bb6a1         |    :access-control-allow-origin "http://(localhost|127.0.0.1)(:\\d+)?",
ctia_1_274a5c2bb6a1         |    :enabled true,
ctia_1_274a5c2bb6a1         |    :show {:hostname "localhost", :protocol "http", :port 3000}},
ctia_1_274a5c2bb6a1         |   :hook
ctia_1_274a5c2bb6a1         |   {:redismq
ctia_1_274a5c2bb6a1         |    {:max-depth 0,
ctia_1_274a5c2bb6a1         |     :timeout-ms 1000,
ctia_1_274a5c2bb6a1         |     :port 6379,
ctia_1_274a5c2bb6a1         |     :enabled false,
ctia_1_274a5c2bb6a1         |     :host "redis-client-dev",
ctia_1_274a5c2bb6a1         |     :queue-name "ctim-event-queue"},
ctia_1_274a5c2bb6a1         |    :redis
ctia_1_274a5c2bb6a1         |    {:port 6379,
ctia_1_274a5c2bb6a1         |     :host "redis-client-dev",
ctia_1_274a5c2bb6a1         |     :timeout-ms 1000,
ctia_1_274a5c2bb6a1         |     :enabled true,
ctia_1_274a5c2bb6a1         |     :channel-name "ctim-event-pubsub"}},
ctia_1_274a5c2bb6a1         |   :metrics
ctia_1_274a5c2bb6a1         |   {:riemann
ctia_1_274a5c2bb6a1         |    {:interval 1, :host "127.0.0.1", :enabled false, :port 5555},
ctia_1_274a5c2bb6a1         |    :jmx {:enabled false},
ctia_1_274a5c2bb6a1         |    :console {:enabled false, :interval 60}},
ctia_1_274a5c2bb6a1         |   :store
ctia_1_274a5c2bb6a1         |   {:identity "es",
ctia_1_274a5c2bb6a1         |    :es
ctia_1_274a5c2bb6a1         |    {:identity {:indexname "ctia_identity"},
ctia_1_274a5c2bb6a1         |     :feedback {:indexname "ctia_feedback"},
ctia_1_274a5c2bb6a1         |     :investigation {:indexname "ctia_investigation"},
ctia_1_274a5c2bb6a1         |     :default
ctia_1_274a5c2bb6a1         |     {:port 9200,
ctia_1_274a5c2bb6a1         |      :indexname "ctia",
ctia_1_274a5c2bb6a1         |      :refresh "false",
ctia_1_274a5c2bb6a1         |      :replicas 1,
ctia_1_274a5c2bb6a1         |      :host "elasticsearch-client-dev",
ctia_1_274a5c2bb6a1         |      :refresh_interval "1s",
ctia_1_274a5c2bb6a1         |      :shards 5},
ctia_1_274a5c2bb6a1         |     :data-table {:indexname "ctia_data-table"},
ctia_1_274a5c2bb6a1         |     :tool {:indexname "ctia_tool"},
ctia_1_274a5c2bb6a1         |     :relationship {:indexname "ctia_relationship"},
ctia_1_274a5c2bb6a1         |     :vulnerability {:indexname "ctia_vulnerability"},
ctia_1_274a5c2bb6a1         |     :judgement {:indexname "ctia_judgement"},
ctia_1_274a5c2bb6a1         |     :weakness {:indexname "ctia_weakness"},
ctia_1_274a5c2bb6a1         |     :coa {:indexname "ctia_coa"},
ctia_1_274a5c2bb6a1         |     :attack-pattern {:indexname "ctia_attack_pattern"},
ctia_1_274a5c2bb6a1         |     :incident {:indexname "ctia_incident"},
ctia_1_274a5c2bb6a1         |     :event {:indexname "ctia_event"},
ctia_1_274a5c2bb6a1         |     :indicator {:indexname "ctia_indicator"},
ctia_1_274a5c2bb6a1         |     :campaign {:indexname "ctia_campaign"},
ctia_1_274a5c2bb6a1         |     :sighting {:indexname "ctia_sighting"},
ctia_1_274a5c2bb6a1         |     :casebook {:indexname "ctia_casebook"},
ctia_1_274a5c2bb6a1         |     :malware {:indexname "ctia_malware"},
ctia_1_274a5c2bb6a1         |     :actor {:indexname "ctia_actor"}},
ctia_1_274a5c2bb6a1         |    :feedback "es",
ctia_1_274a5c2bb6a1         |    :investigation "es",
ctia_1_274a5c2bb6a1         |    :data-table "es",
ctia_1_274a5c2bb6a1         |    :tool "es",
ctia_1_274a5c2bb6a1         |    :relationship "es",
ctia_1_274a5c2bb6a1         |    :bundle-refresh "wait_for",
ctia_1_274a5c2bb6a1         |    :vulnerability "es",
ctia_1_274a5c2bb6a1         |    :judgement "es",
ctia_1_274a5c2bb6a1         |    :bulk-refresh "false",
ctia_1_274a5c2bb6a1         |    :weakness "es",
ctia_1_274a5c2bb6a1         |    :coa "es",
ctia_1_274a5c2bb6a1         |    :attack-pattern "es",
ctia_1_274a5c2bb6a1         |    :incident "es",
ctia_1_274a5c2bb6a1         |    :event "es",
ctia_1_274a5c2bb6a1         |    :indicator "es",
ctia_1_274a5c2bb6a1         |    :campaign "es",
ctia_1_274a5c2bb6a1         |    :external-key-prefixes "********",
ctia_1_274a5c2bb6a1         |    :sighting "es",
ctia_1_274a5c2bb6a1         |    :casebook "es",
ctia_1_274a5c2bb6a1         |    :malware "es",
ctia_1_274a5c2bb6a1         |    :actor "es"},
ctia_1_274a5c2bb6a1         |   :access-control {:min-tlp "green", :default-tlp "green"},
ctia_1_274a5c2bb6a1         |   :auth
ctia_1_274a5c2bb6a1         |   {:threatgrid {:cache true},
ctia_1_274a5c2bb6a1         |    :casebook {:scope "casebook"},
ctia_1_274a5c2bb6a1         |    :entities {:scope "private-intel"},
ctia_1_274a5c2bb6a1         |    :type :allow-all},
ctia_1_274a5c2bb6a1         |   :events {:log false, :enabled true},
ctia_1_274a5c2bb6a1         |   :migration {:optimizations true}}}
ctia_1_274a5c2bb6a1         |
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:05,234 INFO (main) [ctia.flows.hooks] - Hooks Initialized:  {:before-create [], :after-create [], :before-update [], :after-update [], :before-delete [], :after-delete [], :event [#ctia.flows.hooks.event_hooks.RedisEventPublisher{:conn {:pool {}, :spec {:host "redis-client-dev", :port 6379, :timeout-ms 1000}}, :publish-channel-name "ctim-event-pubsub"}]}
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:05,234 INFO (main) [ctia.init] - Starting HTTP server on port 3000
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:05,597 INFO (main) [org.eclipse.jetty.server.Server] - jetty-9.2.z-SNAPSHOT
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:05,701 INFO (main) [org.eclipse.jetty.server.ServerConnector] - Started ServerConnector@13d2a198{HTTP/1.1}{0.0.0.0:3000}
ctia_1_274a5c2bb6a1         | 2019-01-21 09:43:05,704 INFO (main) [org.eclipse.jetty.server.Server] - Started @29024ms

```