### PR TITLE
Docker HUB docker-compose config (demo and client-dev)

### DIFF
--- a/containers/client-dev/README.md
+++ b/containers/client-dev/README.md
@@ -17,6 +17,13 @@ If your docker host OS is Linux,
 Elasticsearch 5x bootstrap checks the maximum map count configuration,
 tune it accordingly with `sudo sysctl -w vm.max_map_count=262144`
 
+
+To run the latest containers from Docker HUB simply invoke docker-compose with this configuration:
+
+``` bash
+~/path-to/ctia/containers/client-dev$ docker-compose up
+```
+
 To build and run the containers with docker-compose, install docker and docker compose. Then, `cd` to your the `ctia` directory (at the top of this repo) and run the following commands to build the CTIA jar, the CTIA docker container, and then to start the services via `docker-compose`:
 
 
@@ -41,7 +48,7 @@ Step 1/6 : FROM clojure:alpine
 ...
 Successfully tagged ctia:latest
 
-~/path-to/ctia/containers/client-dev$ sudo docker-compose up
+~/path-to/ctia/containers/client-dev$ docker-compose up
 ```
 
 ## URI Endpoints

--- a/containers/client-dev/docker-compose.yml
+++ b/containers/client-dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   ctia:
-    image: ctia:latest
+    image: ciscoctr/ctia:latest
     volumes:
       - ./ctia/config/ctia.properties:/usr/src/app/resources/ctia.properties
     build:

--- a/containers/client-dev/docker-compose.yml
+++ b/containers/client-dev/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "2"
 services:
   ctia:
+    #image: ctia:latest
     image: ciscoctr/ctia:latest
     volumes:
       - ./ctia/config/ctia.properties:/usr/src/app/resources/ctia.properties

--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   ctia:
-    image: ctia:latest
+    image: ciscoctr/ctia:latest
     volumes:
       - ./ctia/config/ctia.properties:/usr/src/app/resources/ctia.properties
     build:

--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "2"
 services:
   ctia:
+    #image: ctia:latest
     image: ciscoctr/ctia:latest
     volumes:
       - ./ctia/config/ctia.properties:/usr/src/app/resources/ctia.properties


### PR DESCRIPTION
This PR changes docker-compose setup for both client-dev and demo so they use the image available at docker Hub, this make it possible to launch a demo instance of CTIA locally without setting anything besides docker.