### PR TITLE
Validate Bulk/Bundle imports with specs

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -60,7 +60,8 @@
              :enveloped-result? true
              :identity auth-identity
              :entities new-entities
-             :tempids tempids)
+             :tempids tempids
+             :spec (-> entities entity-type :new-spec))
             :data (partial map (fn [{:keys [error id] :as result}]
                                  (if error result id))))))
 

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -131,6 +131,7 @@
    :tags ["Actor"]
    :entity :actor
    :plural :actors
+   :new-spec :new-actor/map
    :schema Actor
    :partial-schema PartialActor
    :partial-list-schema PartialActorList

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -149,6 +149,7 @@
    :tags ["Attack Pattern"]
    :entity :attack-pattern
    :plural :attack-patterns
+   :new-spec :new-attack-pattern/map
    :schema AttackPattern
    :partial-schema PartialAttackPattern
    :partial-list-schema PartialAttackPatternList

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -126,6 +126,7 @@
    :tags ["Campaign"]
    :entity :campaign
    :plural :campaigns
+   :new-spec :new-campaign/map
    :schema Campaign
    :partial-schema PartialCampaign
    :partial-list-schema PartialCampaignList

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -309,6 +309,7 @@
    :tags ["Casebook"]
    :entity :casebook
    :plural :casebooks
+   :new-spec :new-casebook/map
    :schema Casebook
    :partial-schema PartialCasebook
    :partial-list-schema PartialCasebookList

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -133,6 +133,7 @@
    :tags ["COA"]
    :entity :coa
    :plural :coas
+   :new-spec :new-coa/map
    :schema COA
    :partial-schema PartialCOA
    :partial-list-schema PartialCOAList

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -91,6 +91,7 @@
 (def data-table-routes
   (entity-crud-routes
    {:entity :data-table
+    :new-spec :new-data-table/map
     :new-schema NewDataTable
     :entity-schema DataTable
     :get-schema PartialDataTable
@@ -111,6 +112,7 @@
    :tags ["DataTable"]
    :entity :data-table
    :plural :data-tables
+   :new-spec :new-data-table/map
    :schema DataTable
    :partial-schema PartialDataTable
    :partial-list-schema PartialDataTableList

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -80,7 +80,8 @@
     :search-capabilities :search-event}))
 
 (def event-entity
-  {:route-context "/event"
+  {:new-spec map?
+   :route-context "/event"
    :tags ["Event"]
    :schema Event
    :stored-schema Event

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -94,6 +94,7 @@
      :put-capabilities :create-feedback
      :delete-capabilities :delete-feedback
      :external-id-capabilities #{:read-feedback :external-id}
+     :spec :new-feedback/map
      :can-update? false})))
 
 (def feedback-entity
@@ -101,6 +102,7 @@
    :tags ["Feedback"]
    :entity :feedback
    :plural :feedbacks
+   :new-spec :new-feedback/map
    :schema fs/Feedback
    :partial-schema fs/PartialFeedback
    :partial-list-schema fs/PartialFeedbackList

--- a/src/ctia/entity/identity.clj
+++ b/src/ctia/entity/identity.clj
@@ -86,7 +86,8 @@
     (handle-delete state org-id)))
 
 (def identity-entity
-  {:schema Identity
+  {:new-spec map?
+   :schema Identity
    :stored-schema Identity
    :partial-schema PartialIdentity
    :partial-stored-schema PartialIdentity

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -210,6 +210,7 @@
    :tags ["Incident"]
    :entity :incident
    :plural :incidents
+   :new-spec :new-incident/map
    :schema Incident
    :partial-schema PartialIncident
    :partial-list-schema PartialIncidentList

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -185,6 +185,7 @@
    :tags ["Indicator"]
    :entity :indicator
    :plural :indicators
+   :new-spec :new-indicator/map
    :schema Indicator
    :partial-schema PartialIndicator
    :partial-list-schema PartialIndicatorList

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -159,6 +159,7 @@
    :tags ["Investigation"]
    :entity :investigation
    :plural :investigations
+   :new-spec :new-investigation/map
    :schema Investigation
    :partial-schema PartialInvestigation
    :partial-list-schema PartialInvestigationList

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -118,6 +118,7 @@
    :tags ["Judgement"]
    :entity :judgement
    :plural :judgements
+   :new-spec :new-judgement/map
    :schema js/Judgement
    :partial-schema js/PartialJudgement
    :partial-list-schema js/PartialJudgementList

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -150,6 +150,7 @@
    :tags ["Malware"]
    :entity :malware
    :plural :malwares
+   :new-spec :new-malware/map
    :schema Malware
    :partial-schema PartialMalware
    :partial-list-schema PartialMalwareList

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -170,6 +170,7 @@
    :tags ["Relationship"]
    :entity :relationship
    :plural :relationships
+   :new-spec :new-relationship/map
    :schema rs/Relationship
    :partial-schema rs/PartialRelationship
    :partial-list-schema rs/PartialRelationshipList

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -76,6 +76,7 @@
    :tags ["Sighting"]
    :entity :sighting
    :plural :sightings
+   :new-spec :new-sighting/map
    :schema ss/Sighting
    :partial-schema ss/PartialSighting
    :partial-list-schema ss/PartialSightingList

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -89,6 +89,7 @@
    :tags ["Tool"]
    :entity :tool
    :plural :tools
+   :new-spec :new-tool/map
    :schema ts/Tool
    :partial-schema ts/PartialTool
    :partial-list-schema ts/PartialToolList

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -142,5 +142,6 @@
    :realize-fn realize-vulnerability
    :es-store ->VulnerabilityStore
    :es-mapping vulnerability-mapping
+   :new-spec :new-vulnerability/map
    :routes vulnerability-routes
    :capabilities capabilities})

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -148,6 +148,7 @@
    :tags ["Weakness"]
    :entity :weakness
    :plural :weaknesses
+   :new-spec :new-weakness/map
    :schema Weakness
    :partial-schema PartialWeakness
    :partial-list-schema PartialWeaknessList

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -99,14 +99,16 @@
     (when spec
       (when-not (cs/valid? spec entity)
         (throw (ex-info (cs/explain-str spec entity)
-                        {:type :spec-validation-error
+                        {:error "Entity validation Error"
+                         :type :spec-validation-error
                          :entity entity}))))
     (when-let [entity-tlp (:tlp entity)]
       (when-not (allowed-tlp? entity-tlp)
         (throw (ex-info (format "Invalid document TLP %s, allowed TLPs are: %s"
                                 entity-tlp
                                 (clojure.string/join "," (allowed-tlps)))
-                        {:type :invalid-tlp-error
+                        {:error "Entity Access Control validation Error"
+                         :type :invalid-tlp-error
                          :entity entity})))))
   fm)
 
@@ -371,8 +373,8 @@
        :tempids tempids
        :identity identity
        :long-id-fn long-id-fn
-       :realize-fn realize-fn
        :spec spec
+       :realize-fn realize-fn
        :store-fn store-fn
        :create-event-fn to-create-event
        :enveloped-result? enveloped-result?}

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -58,7 +58,8 @@
   [^Exception e data request]
   (logging/log! :info e (ex-message e))
   (unauthorized
-   {:type "Access Control Error"
+   {:error "Access Control validation Client Error"
+    :type "Access Control Error"
     :message (.getMessage e)
     :class (.getName (class e))}))
 
@@ -68,7 +69,8 @@
   (logging/log! :info e (ex-message e))
   (bad-request
    (let [entity (:entity (ex-data e))]
-     {:type "Invalid Entity Error"
+     {:error "Spec Validation Client Error"
+      :type "Invalid Entity Error"
       :message (.getMessage e)
       :entity entity
       :class (.getName (class e))})))

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -22,6 +22,7 @@
   (st/merge
    {:entity s/Keyword
     :plural s/Keyword
+    :new-spec (s/either s/Keyword s/Any)
     :schema (s/protocol s/Schema)
     :partial-schema (s/protocol s/Schema)
     :partial-list-schema (s/protocol s/Schema)

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -35,7 +35,8 @@
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
 (defn mk-new-actor [n]
-  {:title (str "actor-" n)
+  {:id (str "transient:actor-" n)
+   :title (str "actor-" n)
    :description (str "description: actor-" n)
    :actor_type "Hacker"
    :source "a source"
@@ -44,11 +45,13 @@
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
 
 (defn mk-new-attack-pattern [n]
-  {:name (str "attack-pattern-" n)
+  {:id (str "transient:attack-pattern-" n)
+   :name (str "attack-pattern-" n)
    :description (str "description: attack-pattern-" n)})
 
 (defn mk-new-campaign [n]
-  {:title (str "campaign" n)
+  {:id (str "transient:campaign-" n)
+   :title (str "campaign" n)
    :description "description"
    :campaign_type "anything goes here"
    :intended_effect ["Theft"]
@@ -56,13 +59,15 @@
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
 
 (defn mk-new-coa [n]
-  {:title (str "coa-" n)
+  {:id (str "transient:coa-" n)
+   :title (str "coa-" n)
    :description (str "description: coa-" n)
    :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
 
 (defn mk-new-data-table [n]
-  {:description (str "description: datatable-" n)
+  {:id (str "transient:data-table-" n)
+   :description (str "description: datatable-" n)
    :row_count 1
    :columns [{:name "Column1"
               :type "string"}
@@ -73,18 +78,21 @@
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
 
 (defn mk-new-feedback [n]
-  {:entity_id (str "judgement-" n)
+  {:id (str "transient:feedback-" n)
+   :entity_id (str "transient:foo-" n)
    :feedback -1
    :reason "false positive"})
 
 (defn mk-new-incident [n]
   (-> new-incident-maximal
       (dissoc :id :schema_version :tlp :type)
-      (into {:title (str "incident-" n)
+      (into {:id (str "transient:incident-" n)
+             :title (str "incident-" n)
              :description (str "description: incident-" n)})))
 
 (defn mk-new-indicator [n]
-  {:title (str "indicator-" n)
+  {:id (str "transient:indicator-" n)
+   :title (str "indicator-" n)
    :description (str "description: indicator-" n)
    :producer "producer"
    :indicator_type ["C2" "IP Watchlist"]
@@ -92,7 +100,8 @@
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}})
 
 (defn mk-new-judgement [n]
-  {:valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
+  {:id (str "transient:judgement-" n)
+   :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                 :end_time #inst "2016-07-11T00:40:48.212-00:00"}
    :observable {:value (str "10.0.0." n)
                 :type "ip"}
@@ -103,11 +112,13 @@
    :confidence "Low"})
 
 (defn mk-new-malware [n]
-  {:name (str "malware-" n)
+  {:id (str "transient:malware-" n)
+   :name (str "malware-" n)
    :labels [(str "malware-label-" n)]})
 
-(defn mk-new-relationship [n]
-  {:title (str "title" n)
+(defn mk-new-relationship [n source_ref target_ref]
+  {:id (str "transient:relationship-" n)
+   :title (str "title" n)
    :description (str "description-" n)
    :short_description "short desc"
    :revision 1
@@ -115,13 +126,14 @@
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
    :language "language"
    :source "source"
-   :source_uri "http://example.com"
+   :source_uri "transient:0"
    :relationship_type "targets"
-   :source_ref "http://example.com"
-   :target_ref "http://example.com"})
+   :source_ref source_ref
+   :target_ref target_ref})
 
 (defn mk-new-sighting [n]
-  {:description (str "description: sighting-" n)
+  {:id (str "transient:sighting-" n)
+   :description (str "description: sighting-" n)
    :timestamp #inst "2016-02-11T00:40:48.212-00:00"
    :observed_time {:start_time #inst "2016-02-01T00:00:00.000-00:00"}
    :count 1
@@ -130,8 +142,13 @@
    :confidence "High"})
 
 (defn mk-new-tool [n]
-  {:name (str "tool-" n)
+  {:id (str "transient:tool-" n)
+   :name (str "tool-" n)
    :labels [(str "tool-label-" n)]})
+
+(defn mk-new-vulnerability [n]
+  {:id (str "transient:vulnerability" n)
+   :description "Improper Neutralization of Directives"})
 
 (deftest testing-gen-bulk-from-fn
   (let [new-bulk {:actors (map mk-new-actor (range 6))
@@ -159,7 +176,8 @@
              (fn [type]
                (str/join "&"
                          (map (fn [id]
-                                (let [short-id (:short-id (id/long-id->id id))]
+                                (let [id (if (vector? id) (last id) id)
+                                      short-id (:short-id (id/long-id->id id))]
                                   (str (encode (name type)) "=" (encode short-id))))
                               (core/get bulk-ids type))))
              (keys bulk-ids))))
@@ -174,17 +192,17 @@
                                          "user")
      (testing "POST /ctia/bulk"
        (let [nb 7
+             indicators (map mk-new-indicator (range nb))
+             judgements (map mk-new-judgement (range nb))
              new-bulk {:actors (map mk-new-actor (range nb))
-                       :attack_patterns (map mk-new-attack-pattern (range nb))
-                       :campaigns (map mk-new-campaign (range nb))
-                       :coas (map mk-new-coa (range nb))
-                       :data_tables (map mk-new-data-table (range nb))
                        :feedbacks (map mk-new-feedback (range nb))
-                       :incidents (map mk-new-incident (range nb))
-                       :indicators (map mk-new-indicator (range nb))
-                       :judgements (map mk-new-judgement (range nb))
+                       :indicators indicators
+                       :judgements judgements
                        :malwares (map mk-new-malware (range nb))
-                       :relationships (map mk-new-relationship (range nb))
+                       :relationships (map #(mk-new-relationship %
+                                                                 (-> indicators (nth %) :id)
+                                                                 (-> judgements (nth %) :id))
+                                           (range nb))
                        :sightings (map mk-new-sighting (range nb))
                        :tools (map mk-new-tool (range nb))}
              response (post "ctia/bulk"
@@ -192,7 +210,6 @@
                             :headers {"Authorization" "45c1f5e3f05d0"})
              bulk-ids (:parsed-body response)
              show-props (get-http-show)]
-
          (is (= 201 (:status response)))
 
          (doseq [type (keys new-bulk)]
@@ -210,8 +227,8 @@
 
              (doseq [k (keys new-bulk)]
                (testing (str "retrieved " (name k))
-                 (is (= (core/get new-bulk k)
-                        (map #(dissoc % :id :type :tlp :schema_version :disposition_name)
+                 (is (= (map #(dissoc % :id :source_ref :target_ref) (core/get new-bulk k))
+                        (map #(dissoc % :id :type :tlp :schema_version :disposition_name :source_ref :target_ref)
                              (core/get response k))))
 
                  (let [id (id/long-id->id (:id (first (core/get response k))))]
@@ -222,6 +239,8 @@
 
 (deftest get-bulk-max-size-test
   (let [nb 10
+        indicators (map mk-new-indicator (range nb))
+        judgements (map mk-new-judgement (range nb))
         new-bulk {:actors (map mk-new-actor (range nb))
                   :attack_patterns (map mk-new-attack-pattern (range nb))
                   :campaigns (map mk-new-campaign (range nb))
@@ -229,10 +248,13 @@
                   :data_tables (map mk-new-data-table (range nb))
                   :feedbacks (map mk-new-feedback (range nb))
                   :incidents (map mk-new-incident (range nb))
-                  :indicators (map mk-new-indicator (range nb))
-                  :judgements (map mk-new-judgement (range nb))
+                  :indicators indicators
+                  :judgements judgements
                   :malwares (map mk-new-malware (range nb))
-                  :relationships (map mk-new-relationship (range nb))
+                  :relationships (map #(mk-new-relationship %
+                                                            (-> indicators (nth %) :id)
+                                                            (-> judgements (nth %) :id))
+                                      (range nb))
                   :sightings (map mk-new-sighting (range nb))
                   :tools (map mk-new-tool (range nb))}]
     (is (= (bulk-size new-bulk)
@@ -250,6 +272,8 @@
      ;; Check changing the properties change the computed bulk max size
      (is (= 100 (get-bulk-max-size)))
      (let [nb 7
+           indicators (map mk-new-indicator (range nb))
+           judgements (map mk-new-judgement (range nb))
            new-ok-bulk {:actors (map mk-new-actor (range nb))
                         :attack_patterns (map mk-new-attack-pattern (range nb))
                         :campaigns (map mk-new-campaign (range nb))
@@ -257,24 +281,34 @@
                         :data_tables (map mk-new-data-table (range nb))
                         :feedbacks (map mk-new-feedback (range nb))
                         :incidents (map mk-new-incident (range nb))
-                        :indicators (map mk-new-indicator (range nb))
-                        :judgements (map mk-new-judgement (range nb))
+                        :indicators indicators
+                        :judgements judgements
                         :malwares (map mk-new-malware (range nb))
-                        :relationships (map mk-new-relationship (range nb))
+                        :relationships (map #(mk-new-relationship
+                                              %
+                                              (-> indicators (nth %) :id)
+                                              (-> judgements (nth %) :id))
+                                            (range nb))
                         :sightings (map mk-new-sighting (range nb))
                         :tools (map mk-new-tool (range nb))}
+           incidents (map mk-new-incident (range nb))
+           sightings (map mk-new-sighting (range nb))
            new-too-big-bulk {:actors (map mk-new-actor (range (+ nb 5 7)))
                              :attack_patterns (map mk-new-attack-pattern (range nb))
                              :campaigns (map mk-new-campaign (range nb))
                              :coas (map mk-new-coa (range nb))
                              :data_tables (map mk-new-data-table (range nb))
                              :feedbacks (map mk-new-feedback (range nb))
-                             :incidents (map mk-new-incident (range nb))
+                             :incidents incidents
                              :indicators (map mk-new-indicator (range nb))
                              :judgements (map mk-new-judgement (range nb))
                              :malwares (map mk-new-malware (range nb))
-                             :relationships (map mk-new-relationship (range nb))
-                             :sightings (map mk-new-sighting (range nb))
+                             :relationships (map #(mk-new-relationship
+                                                   %
+                                                   (-> incidents (nth %) :id)
+                                                   (-> sightings (nth %) :id))
+                                                 (range nb))
+                             :sightings sightings
                              :tools (map mk-new-tool (range nb))}
            {status-ok :status
             response :body
@@ -310,9 +344,7 @@
 
      (let [[tool1 tool2 :as tools] (->> (map mk-new-tool (range 2))
                                         (map #(assoc % :id (id/make-transient-id nil))))
-           relationship (assoc (mk-new-relationship 1)
-                               :target_ref (:id tool1)
-                               :source_ref (:id tool2)
+           relationship (assoc (mk-new-relationship 1 (:id tool2) (:id tool1))
                                :id (id/make-transient-id nil))
            ;; Submit all entities to create
            {status-create :status
@@ -342,6 +374,27 @@
            (str "The :tempid field should contain the mapping between all "
                 "transient and real IDs"))))))
 
+(deftest bulk-spec-test
+  (test-for-each-store
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+
+     (let [vulnerability (assoc-in (mk-new-vulnerability 1)
+                                   [:impact :cvss_v2]
+                                   {:base_severity "Low"
+                                    :base_score 1
+                                    :vector_string "CLEARLY INVALID STRING"})
+           {status-create :status
+            bulk-ids :parsed-body}
+           (post "ctia/bulk"
+                 :body {:vulnerabilities [vulnerability]}
+                 :headers {"Authorization" "45c1f5e3f05d0"})]
+       (is (= 400 status-create) "The bulk create should be unsuccessfull")))))
+
 (deftest bulk-error-test
   (test-for-each-store
    (fn []
@@ -364,6 +417,11 @@
            sighting (assoc (mk-new-sighting 1)
                            :id
                            (id/make-transient-id nil))
+           vulnerability (assoc-in (mk-new-vulnerability 1)
+                                   [:impact :cvss_v2]
+                                   {:base_severity "Low"
+                                    :base_score 1
+                                    :vector_string "CLEARLY INVALID STRING"})
            ;; Submit all entities to create
            {status-create :status
             bulk-ids :parsed-body}
@@ -372,15 +430,17 @@
                         :sightings [sighting]}
                  :headers {"Authorization" "45c1f5e3f05d0"})
            ;; Retrieve all entities that have been created
+           query-string (make-get-query-str-from-bulkrefs
+                         (dissoc bulk-ids :tempids :tools :vulnerabilities))
            {status-get :status
             {:keys [sightings] :as body} :parsed-body}
            (get (str "ctia/bulk?"
-                     (make-get-query-str-from-bulkrefs
-                      (dissoc bulk-ids :tempids :tools)))
+                     query-string)
                 :headers {"Authorization" "45c1f5e3f05d0"})]
        (is (= 201 status-create) "The bulk create should be successfull")
        (is (= 200 status-get) "All valid entities should be retrieved")
        (is (not (empty? (:tools bulk-ids))))
        (is (every? #(contains? % :error) (:tools bulk-ids)))
+       (is (every? #(contains? % :error) (:vulnerabilities bulk-ids)))
        (is (= (:description sighting)
               (:description (first sightings))))))))

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -393,7 +393,22 @@
            (post "ctia/bulk"
                  :body {:vulnerabilities [vulnerability]}
                  :headers {"Authorization" "45c1f5e3f05d0"})]
-       (is (= 400 status-create) "The bulk create should be unsuccessfull")))))
+
+       (is (= 201 status-create) "The bulk create status should be 201")
+       (is (= {:vulnerabilities
+               '({:msg
+                  "In: [:impact :cvss_v2 :vector_string] val: \"CLEARLY INVALID STRING\" fails spec: :new-vulnerability.impact.cvss_v2/vector_string at: [:impact :cvss_v2 :vector_string] predicate: :clojure.spec.alpha/unknown\n",
+                  :error "Entity validation Error",
+                  :type :spec-validation-error,
+                  :entity
+                  {:description "Improper Neutralization of Directives",
+                   :id "transient:vulnerability1",
+                   :impact
+                   {:cvss_v2
+                    {:base_severity "Low",
+                     :base_score 1,
+                     :vector_string "CLEARLY INVALID STRING"}}}})} bulk-ids)
+           "The bulk create status should report errors")))))
 
 (deftest bulk-error-test
   (test-for-each-store

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -659,6 +659,8 @@
               :sightings #{sighting}}]
 
          (with-tlp-property-setting "amber"
-           #(is (= 400 (:status (post "ctia/bundle/import"
-                                      :body new-bundle
-                                      :headers {"Authorization" "45c1f5e3f05d0"}))))))))))
+           #(let [res (post "ctia/bundle/import"
+                            :body new-bundle
+                            :headers {"Authorization" "45c1f5e3f05d0"})]
+              (is (= "Entity Access Control validation Error" (-> (:parsed-body res) :results first :error)))
+              (is (= 200 (:status res))))))))))


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2441

⚠️ This change may break existing imports as it makes Bundle/Bulk request checks stricter ⚠️ 

## Description 

This PR adds support for validating bulk/bundle entities using CTIM specs.
as a Bonus I also fixed the exception behaviour so it is uniform for all error cases, 
we now don't throw an error if one of the entities fail spec or top validation but simply return data about the failed entities.

## QA checks:

- Push a Bundle with Invalid fields such as relationship source_ref or target_ref, any entity valid_time
- Push a Bundle with Invalid TLP settings (white in Private CTIA)
- The Response should be either 201 or 200 for bulk/bundles with the incorrect entities marked as error
- Individual entity POST/PUT spec errors should still be 400 http status codes

 

