### PR TITLE
Handle the bundle export when an external entity is referenced

### DIFF
--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -1,0 +1,14 @@
+(ns ctia.bundle.core-test
+  (:require [ctia.bundle.core :as sut]
+            [clojure.test :as t :refer [deftest testing use-fixtures are is]]
+            [ctia.test-helpers.core :as h]))
+
+(use-fixtures :once h/fixture-properties:clean)
+
+(deftest local-entity?-test
+  (are [x y] (= x (sut/local-entity? y))
+    false nil
+    false "http://unknown.site/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"
+    true "indicator-56067199-47c0-4294-8957-13d6b265bdc4"
+    true "http://localhost:57254/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"))
+


### PR DESCRIPTION
Closes threatgrid/iroh#2444
Closes #788 

This PR adds a test to check if an entity that is part of an exported bundle is stored in the local CTIA instance. Otherwise, it is ignored and will not be part of the exported bundle.

QA: Export a bundle containing a Relationship that references an external entity.