### PR TITLE
Remove external-id capability

### DIFF
--- a/src/ctia/auth/capabilities.clj
+++ b/src/ctia/auth/capabilities.clj
@@ -47,7 +47,6 @@
     ;; Other
     :developer
     :specify-id
-    :external-id
     :import-bundle})
 
 (def all-capabilities
@@ -55,12 +54,10 @@
    misc-capabilities
    all-entity-capabilities))
 
-
 (def all-capabilities-no-casebook
   (set/union
    misc-capabilities
    all-entity-no-casebook-capabilities))
-
 
 (comment
 
@@ -110,7 +107,6 @@
      :read-verdict
      :read-weakness
      :list-weaknesses
-     :import-bundle
-     :external-id}
+     :import-bundle}
    :admin
    all-capabilities})

--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -21,9 +21,6 @@
   (get-in @prop/properties [:ctia :auth :casebook :scope]
           "casebook"))
 
-(def ^:private read-only-ctia-capabilities
-  (:user default-capabilities))
-
 (def claim-prefix
   (get-in @prop/properties [:ctia :http :jwt :claim-prefix]
           "https://schemas.cisco.com/iroh/identity/claims"))

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -118,7 +118,7 @@
     :put-capabilities :create-actor
     :delete-capabilities :delete-actor
     :search-capabilities :search-actor
-    :external-id-capabilities #{:read-actor :external-id}}))
+    :external-id-capabilities :read-actor}))
 
 (def capabilities
   #{:create-actor

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -112,7 +112,7 @@
     :put-capabilities :create-attack-pattern
     :delete-capabilities :delete-attack-pattern
     :search-capabilities :search-attack-pattern
-    :external-id-capabilities #{:read-attack-pattern :external-id}}))
+    :external-id-capabilities :read-attack-pattern}))
 
 (def AttackPatternType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -113,7 +113,7 @@
     :put-capabilities :create-campaign
     :delete-capabilities :delete-campaign
     :search-capabilities :search-campaign
-    :external-id-capabilities #{:read-campaign :external-id}}))
+    :external-id-capabilities :read-campaign}))
 
 (def capabilities
   #{:create-campaign

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -302,7 +302,7 @@
      :put-capabilities :create-casebook
      :delete-capabilities :delete-casebook
      :search-capabilities :search-casebook
-     :external-id-capabilities #{:read-casebook :external-id}
+     :external-id-capabilities :read-casebook
      :hide-delete? false})))
 
 (def casebook-entity

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -120,7 +120,7 @@
     :put-capabilities :create-coa
     :delete-capabilities :delete-coa
     :search-capabilities :search-coa
-    :external-id-capabilities #{:read-coa :external-id}}))
+    :external-id-capabilities :read-coa}))
 
 (def capabilities
   #{:create-coa

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -103,7 +103,7 @@
     :get-capabilities :read-data-table
     :post-capabilities :create-data-table
     :delete-capabilities :delete-data-table
-    :external-id-capabilities #{:read-data-table :external-id}
+    :external-id-capabilities :read-data-table
     :can-update? false
     :can-search? false}))
 

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -93,7 +93,7 @@
      :post-capabilities :create-feedback
      :put-capabilities :create-feedback
      :delete-capabilities :delete-feedback
-     :external-id-capabilities #{:read-feedback :external-id}
+     :external-id-capabilities :read-feedback
      :spec :new-feedback/map
      :can-update? false})))
 

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -208,7 +208,7 @@
      :patch-capabilities :create-incident
      :delete-capabilities :delete-incident
      :search-capabilities :search-incident
-     :external-id-capabilities #{:read-incident :external-id}})))
+     :external-id-capabilities :read-incident})))
 
 (def IncidentType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -149,7 +149,7 @@
     :put-capabilities :create-indicator
     :delete-capabilities :delete-indicator
     :search-capabilities :search-indicator
-    :external-id-capabilities #{:read-indicator :external-id}}))
+    :external-id-capabilities :read-indicator}))
 
 (def capabilities
   #{:read-indicator

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -145,7 +145,7 @@
     :put-capabilities :create-investigation
     :delete-capabilities :delete-investigation
     :search-capabilities :search-investigation
-    :external-id-capabilities #{:read-investigation :external-id}}))
+    :external-id-capabilities :read-investigation}))
 
 (def capabilities
   #{:read-investigation

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -79,7 +79,7 @@
     :put-capabilities #{:create-judgement :developer}
     :delete-capabilities :delete-judgement
     :search-capabilities :search-judgement
-    :external-id-capabilities #{:read-judgement :external-id}
+    :external-id-capabilities :read-judgement
     :can-update? true}))
 
 (def capabilities

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -143,7 +143,7 @@
     :put-capabilities :create-malware
     :delete-capabilities :delete-malware
     :search-capabilities :search-malware
-    :external-id-capabilities #{:read-malware :external-id}}))
+    :external-id-capabilities :read-malware}))
 
 (def malware-entity
   {:route-context "/malware"

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -156,7 +156,7 @@
     :put-capabilities :create-relationship
     :delete-capabilities :delete-relationship
     :search-capabilities :search-relationship
-    :external-id-capabilities #{:read-relationship :external-id}}))
+    :external-id-capabilities :read-relationship}))
 
 (def capabilities
   #{:create-relationship

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -61,8 +61,7 @@
     :post-capabilities :create-sighting
     :put-capabilities :create-sighting
     :delete-capabilities :delete-sighting
-    :search-capabilities :search-sighting
-    :external-id-capabilities #{:read-sighting :external-id}}))
+    :search-capabilities :search-sighting}))
 
 (def capabilities
   #{:create-sighting

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -82,7 +82,7 @@
     :put-capabilities :create-tool
     :delete-capabilities :delete-tool
     :search-capabilities :search-tool
-    :external-id-capabilities #{:read-tool :external-id}}))
+    :external-id-capabilities :read-tool}))
 
 (def tool-entity
   {:route-context "/tool"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -120,7 +120,7 @@
     :put-capabilities :create-vulnerability
     :delete-capabilities :delete-vulnerability
     :search-capabilities :search-vulnerability
-    :external-id-capabilities #{:read-vulnerability :external-id}}))
+    :external-id-capabilities :read-vulnerability}))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -135,7 +135,7 @@
     :put-capabilities :create-weakness
     :delete-capabilities :delete-weakness
     :search-capabilities :search-weakness
-    :external-id-capabilities #{:read-weakness :external-id}}))
+    :external-id-capabilities :read-weakness}))
 
 (def capabilities
   #{:create-weakness

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -41,7 +41,7 @@
            :delete-casebook}
          (sut/scope-to-capabilities (sut/casebook-root-scope)))
       "Check the casebook capabilities from the casebook scope")
-  (is (= #{:developer :specify-id :external-id}
+  (is (= #{:developer :specify-id}
          (set/difference caps/all-capabilities
                          (sut/scopes-to-capabilities #{(sut/entity-root-scope)
                                                        (sut/casebook-root-scope)})))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -125,16 +125,6 @@
         (is (= {:message "Missing capability",
                 :capabilities :read-judgement,
                 :owner "baruser"}
-               body))))
-
-    (testing "doesn't have list by external id capability"
-      (let [{body :parsed-body status :status}
-            (get  "ctia/judgement/external_id/123"
-                  :headers {"Authorization" "2222222222222"})]
-        (is (= 401 status))
-        (is (= {:message "Missing capability",
-                :capabilities #{:read-judgement :external-id},
-                :owner "baruser"}
                body))))))
 
 (deftest test-judgement-routes


### PR DESCRIPTION
Closes #707 

This PR removes the `external-id` capability that was missing.

QA: Use the reproducer in #707 