### PR TITLE
bundle/export: limit number of retrieved relationships

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -128,14 +128,22 @@
 |----------------------------+-------------------------------------------------------------------------------+-----------------|
 | ctia.http.bulk.max-size    | Set the maximum number of entities one can post using a single bulk operation | number          |
 
+*** Bundle
+
+   Set limits for entity bulk operations
+
+| Property                                  | Description                              | Possible values |
+|-------------------------------------------+------------------------------------------+-----------------|
+| ctia.http.bundle.export.max-relationships | maximum number of exported relationships | number          |
 
 ** Events
 
   Event related configuration
 
-| Property        | Description           | Possible values |
-|-----------------+-----------------------+-----------------|
-| ctia.events.log | enable CTIA Event log | =true= =false= |
+| Property                         | Description                                         | Possible values |
+|----------------------------------+-----------------------------------------------------+-----------------|
+| ctia.events.log                  | enable CTIA Event log                               | =true= =false=  |
+| ctia.events.timeline.max-seconds | max seconds between 2 consecutive events in buckets | number          |
 
 
 ** Hooks

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.8"
+                 [threatgrid/ctim "1.0.9"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -18,7 +18,7 @@ ctia.http.access-control-allow-origin=http://(localhost|127.0.0.1)(:\\d+)?
 ctia.http.access-control-allow-methods=get,post,put,patch,delete
 
 ctia.http.events.timeline.max-seconds=5
-ctia.http.bundle.max-relationships=1000
+ctia.http.bundle.export.max-relationships=1000
 
 ctia.http.jwt.enabled=true
 ctia.http.jwt.public-key-path=resources/cert/ctia-jwt.pub

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -17,6 +17,9 @@ ctia.http.port=3000
 ctia.http.access-control-allow-origin=http://(localhost|127.0.0.1)(:\\d+)?
 ctia.http.access-control-allow-methods=get,post,put,patch,delete
 
+ctia.http.events.timeline.max-seconds=5
+ctia.http.bundle.max-relationships=1000
+
 ctia.http.jwt.enabled=true
 ctia.http.jwt.public-key-path=resources/cert/ctia-jwt.pub
 ctia.http.jwt.local-storage-key=:iroh-auth-token
@@ -38,9 +41,6 @@ ctia.http.swagger.oauth2.flow=accessCode
 ctia.http.swagger.oauth2.client-id=swagger
 ctia.http.swagger.oauth2.app-name=swagger
 ctia.http.swagger.oauth2.realm=blank
-
-
-ctia.http.events.timeline.max-seconds=5
 
 ctia.events.enabled=true
 ctia.events.log=false

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -333,7 +333,7 @@
   [id identity-map related-to]
   (let [filters (->> (map #(hash-map % id) (set related-to))
                      (apply merge))
-        max-relationships (get-in @properties [:ctia :http :bundle :max-relationships] 1000)]
+        max-relationships (get-in @properties [:ctia :http :bundle :export :max-relationships] 1000)]
     (some-> (:data (read-store :relationship
                                list-fn
                                {:one-of filters}

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -21,7 +21,6 @@
    [schema.core :as s]))
 
 (def find-by-external-ids-limit 1000)
-(def list-limit find-by-external-ids-limit)
 
 (def bundle-entity-keys
   (set (vals bulk/bulk-entity-mapping)))
@@ -333,12 +332,13 @@
   "given an entity id, fetch all related relationship"
   [id identity-map related-to]
   (let [filters (->> (map #(hash-map % id) (set related-to))
-                     (apply merge))]
-    (some-> (list-all-pages :relationship
-                            list-fn
-                            {:one-of filters}
-                            identity-map
-                            {:limit list-limit})
+                     (apply merge))
+        max-relationships (get-in @properties [:ctia :http :bundle :max-relationships] 1000)]
+    (some-> (:data (read-store :relationship
+                               list-fn
+                               {:one-of filters}
+                               identity-map
+                               {:limit max-relationships}))
             ent/un-store-all)))
 
 (defn fetch-record

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -12,10 +12,16 @@
    [ring.util.http-response :refer :all]
    [schema.core :as s]))
 
-(s/defschema BundleExportQuery
-  {:ids [s/Str]
-   (s/optional-key :related_to) [(s/enum :source_ref :target_ref)]
+(s/defschema BundleExportOptions
+  {(s/optional-key :related_to) [(s/enum :source_ref :target_ref)]
    (s/optional-key :include_related_entities) s/Bool})
+
+(s/defschema BundleExportIds
+  {:ids [s/Str]})
+
+(s/defschema BundleExportQuery
+  (merge BundleExportIds
+         BundleExportOptions))
 
 (def export-capabilities
   #{:list-campaigns
@@ -72,13 +78,14 @@
            (POST "/export" []
                 :return NewBundle
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
-                :body [q BundleExportQuery]
+                :query [q BundleExportOptions]
+                :body [b BundleExportIds]
                 :summary "Export a record with its local relationships"
                 :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map
                 (ok (export-bundle
-                     (:ids q)
+                     (:ids b)
                      identity-map
                      identity
                      (select-keys q [:include_related_entities :related_to]))))

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -17,6 +17,41 @@
    (s/optional-key :related_to) [(s/enum :source_ref :target_ref)]
    (s/optional-key :include_related_entities) s/Bool})
 
+(def export-capabilities
+  #{:list-campaigns
+    :read-actor
+    :read-malware
+    :read-attack-pattern
+    :read-judgement
+    :read-sighting
+    :list-sightings
+    :list-relationships
+    :read-coa
+    :read-indicator
+    :list-judgements
+    :list-tools
+    :list-indicators
+    :read-feedback
+    :list-verdicts
+    :list-feedbacks
+    :list-malwares
+    :list-data-tables
+    :list-incidents
+    :read-campaign
+    :list-attack-patterns
+    :read-relationship
+    :list-actors
+    :read-investigation
+    :read-incident
+    :list-coas
+    :read-tool
+    :list-investigations
+    :read-data-table
+    :read-weakness
+    :list-weaknesses
+    :read-vulnerability
+    :list-vulnerabilities})
+
 (defroutes bundle-routes
   (context "/bundle" []
            :tags ["Bundle"]
@@ -25,40 +60,21 @@
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportQuery]
                 :summary "Export a record with its local relationships"
-                :capabilities
-                #{:list-campaigns
-                  :read-actor
-                  :read-malware
-                  :read-attack-pattern
-                  :read-judgement
-                  :read-sighting
-                  :list-sightings
-                  :list-relationships
-                  :read-coa
-                  :read-indicator
-                  :list-judgements
-                  :list-tools
-                  :list-indicators
-                  :read-feedback
-                  :list-verdicts
-                  :list-feedbacks
-                  :list-malwares
-                  :list-data-tables
-                  :list-incidents
-                  :read-campaign
-                  :list-attack-patterns
-                  :read-relationship
-                  :list-actors
-                  :read-investigation
-                  :read-incident
-                  :list-coas
-                  :read-tool
-                  :list-investigations
-                  :read-data-table
-                  :read-weakness
-                  :list-weaknesses
-                  :read-vulnerability
-                  :list-vulnerabilities}
+                :capabilities export-capabilities
+                :auth-identity identity
+                :identity-map identity-map
+                (ok (export-bundle
+                     (:ids q)
+                     identity-map
+                     identity
+                     (select-keys q [:include_related_entities :related_to]))))
+
+           (POST "/export" []
+                :return NewBundle
+                :header-params [{Authorization :- (s/maybe s/Str) nil}]
+                :body [q BundleExportQuery]
+                :summary "Export a record with its local relationships"
+                :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map
                 (ok (export-bundle

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -95,7 +95,8 @@
                       "ctia.http.show.hostname" s/Str
                       "ctia.http.show.path-prefix" s/Str
                       "ctia.http.show.port" s/Int
-                      "ctia.http.bulk.max-size" s/Int})
+                      "ctia.http.bulk.max-size" s/Int
+                      "ctia.http.bundle.max-relationships" s/Int})
 
    (st/optional-keys {"ctia.migration.optimizations" s/Bool})
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -96,7 +96,7 @@
                       "ctia.http.show.path-prefix" s/Str
                       "ctia.http.show.port" s/Int
                       "ctia.http.bulk.max-size" s/Int
-                      "ctia.http.bundle.max-relationships" s/Int})
+                      "ctia.http.bundle.export.max-relationships" s/Int})
 
    (st/optional-keys {"ctia.migration.optimizations" s/Bool})
 

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -502,10 +502,10 @@
                    :headers {"Authorization" "45c1f5e3f05d0"}))
              bundle-post-res
              (:parsed-body
-              (get "ctia/bundle/export"
-                   :query-params {:ids [sighting-id-1
-                                        sighting-id-2]
-                                  :related_to ["target_ref" "source_ref"]}
+              (post "ctia/bundle/export"
+                   :body {:ids [sighting-id-1
+                                sighting-id-2]
+                          :related_to ["target_ref" "source_ref"]}
                    :headers {"Authorization" "45c1f5e3f05d0"}))]
 
          (is (= 1 (count (:sightings bundle-get-res-1))))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -21,7 +21,7 @@
 
 (defn fixture-properties [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000
-                            "ctia.http.bundle.max-relationships" 500]
+                            "ctia.http.bundle.export.max-relationships" 500]
     (t)))
 
 (defn fixture-find-by-external-ids-limit [t]
@@ -504,8 +504,8 @@
              (:parsed-body
               (post "ctia/bundle/export"
                    :body {:ids [sighting-id-1
-                                sighting-id-2]
-                          :related_to ["target_ref" "source_ref"]}
+                                sighting-id-2]}
+                   :query-params {:related_to ["target_ref" "source_ref"]}
                    :headers {"Authorization" "45c1f5e3f05d0"}))]
 
          (is (= 1 (count (:sightings bundle-get-res-1))))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -19,7 +19,7 @@
             [ctim.domain.id :as id]
             [ctim.examples.bundles :refer [bundle-maximal]]))
 
-(defn fixture-properties:small-max-bulk-size [t]
+(defn fixture-properties [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000
                             "ctia.http.bundle.max-relationships" 500]
     (t)))
@@ -32,7 +32,7 @@
   (join-fixtures
    [mth/fixture-schema-validation
     helpers/fixture-properties:clean
-    fixture-properties:small-max-bulk-size
+    fixture-properties
     fixture-find-by-external-ids-limit
     whoami-helpers/fixture-server]))
 
@@ -586,17 +586,16 @@
 
 (def fixture-many-relationships
   (let [indicators (map mk-indicator (range 300))
-        sightings (map #(mk-sighting %) (range 1))
-        relationships (mapcat
+        sighting (mk-sighting 0)
+        relationships (map
                        (fn [idx indicator]
-                         (keep-indexed #(mk-relationship (* %1 idx) indicator %2 "indicates")
-                                       sightings))
+                         (mk-relationship idx indicator sighting "indicates"))
                        (range)
                        (concat indicators indicators))]
     {:type "bundle"
      :source "source"
      :indicators (set indicators)
-     :sightings (set sightings)
+     :sightings #{sighting}
      :relationships (set relationships)}))
 
 (deftest bundle-max-relationships-test

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -499,6 +499,13 @@
                    :query-params {:ids [sighting-id-1
                                         sighting-id-2]
                                   :related_to ["target_ref" "source_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-post-res
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-1
+                                        sighting-id-2]
+                                  :related_to ["target_ref" "source_ref"]}
                    :headers {"Authorization" "45c1f5e3f05d0"}))]
 
          (is (= 1 (count (:sightings bundle-get-res-1))))
@@ -518,7 +525,9 @@
          (is (= 402 (count (:relationships bundle-get-res-4))))
 
          (is (= bundle-get-res-3 bundle-get-res-5)
-             "default related_to value should be [:source_ref :target_ref]"))))))
+             "default related_to value should be [:source_ref :target_ref]")
+         (is (= bundle-get-res-5 bundle-post-res)
+             "POST and GET bundle/export routes must return the same results"))))))
 
 (deftest bundle-export-with-unreachable-external-entity
   (test-for-each-store


### PR DESCRIPTION
related to https://github.com/threatgrid/iroh/issues/2479
This PR introduced in bundle export, a limit to the number of relationships that can be retrieved per entity.
It also adds a POST bundle/export route for enabling large numbers of ids as parameters.

**QA**
- Bundle/export shall not return more than configured ctia.http.bundle.max-relationships property per retrieved entity.
- New POST bundle/export route must behave like GET bundle/export route.