### PR TITLE
open schema for POST bundle/export route

### DIFF
--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -79,7 +79,7 @@
                      (select-keys q [:include_related_entities :related_to]))))
 
            (POST "/export" []
-                :return NewBundle
+                :return NewBundleExport
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportOptions]
                 :body [b BundleExportIds]

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -822,7 +822,12 @@
              bundle-get-res (get "ctia/bundle/export"
                                  :query-params {:ids [sighting-id
                                                       judgement-id]}
-                                 :headers {"Authorization" "45c1f5e3f05d0"})]
+                                 :headers {"Authorization" "45c1f5e3f05d0"})
+             bundle-post-res (post "ctia/bundle/export"
+                                   :body {:ids [sighting-id
+                                                judgement-id]}
+                                   :headers {"Authorization" "45c1f5e3f05d0"})]
+         (is (= 200 (:status bundle-post-res)))
          (is (= 200 (:status bundle-get-res))))))))
 
 (deftest bundle-export-casebook-test


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2498

Adds an open schema for POST bundle/export route that is now used by CTIA Investigate.

**QA**
- POST a judgement, for any observable, with `authorized_users` and `authorized_groups`
- send a POST bundle/export request with the id of that judgement, the export should not return any schema error
- the observe route in IROH on the corresponding observable should now work for ctia investigate module
- In addition, you can add the same test for the GET bundle/export route