### PR TITLE
Bundle export documentation

### DIFF
--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -68,7 +68,7 @@
                 :return NewBundleExport
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportQuery]
-                :summary "Export a record with its local relationships"
+                :summary "Export records with their local relationships. Ids must be URIs (with port if precised)."
                 :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map
@@ -83,7 +83,7 @@
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportOptions]
                 :body [b BundleExportIds]
-                :summary "Export a record with its local relationships"
+                :summary "Export records with their local relationships. Ids must be URIs (with port if precised)."
                 :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -68,7 +68,7 @@
                 :return NewBundleExport
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportQuery]
-                :summary "Export records with their local relationships. Ids must be URIs (with port if precised)."
+                :summary "Export records with their local relationships. Ids are URIs (with port if precised)."
                 :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map
@@ -83,7 +83,7 @@
                 :header-params [{Authorization :- (s/maybe s/Str) nil}]
                 :query [q BundleExportOptions]
                 :body [b BundleExportIds]
-                :summary "Export records with their local relationships. Ids must be URIs (with port if precised)."
+                :summary "Export records with their local relationships. Ids are URIs (with port if precised)."
                 :capabilities export-capabilities
                 :auth-identity identity
                 :identity-map identity-map

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -15,7 +15,10 @@
              [pagination :as pagination]
              [sorting :as graphql-sorting]
              [refs :as refs]]
-            [ctia.store :refer :all]
+            [ctia.store :refer [read-record
+                                update-record
+                                read-store
+                                write-store]]
             [ctia.stores.es
              [mapping :as em]
              [store :refer [def-es-store]]]


### PR DESCRIPTION
closes https://github.com/threatgrid/ctia/issues/807

The problem was that the port was forgotten in the id of bundle/export route that works as expected.