### PR TITLE
Es migration 2556

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ or from source
 | -i, --id ID                 | id of the migration state to create or restart    | migration-1   | 
 | -p, --prefix PREFIX         | prefix of the newly created indices               | 1.1.0         |
 | -m, --migrations MIGRATIONS | a comma separated list of migration ids to apply  | 0.4.28,1.0.0  |
-| -b, --batch-size SIZE       | number of migrated documents per batch                            | 1000          |
+| -b, --batch-size SIZE       | number of migrated documents per batch            | 1000          |
+|   , --buffer-size SIZE      | max batches in buffer between source and target   | 10            |
 | -s, --stores STORES         | comma separated list of stores to migrate         | tool,malware  |
 | -c, --confirm               | really do the migration?                          |               |
 | -r, --restart               | restart ongoing migration?                        |               |

--- a/README.md
+++ b/README.md
@@ -263,60 +263,8 @@ Response of the bundle API endpoint:
 |`:error`       |Error message|
 
 ### Store Migrations
- 
- There is a dedicated task to migrate data from prior versions of CTIA.
- this task will run through all configured stores, transform and copy data to new Elasticsearch indices.
- 
- - This task doesn't alter the existing indices, you should delete them after a successful migration.
 
- - As the migration task copies indexes, make sure you have enough disk space before launching it.
- 
- - After the migration task completes, you will need to edit your properties, changing each store index to the new one and restart CTIA.
- 
- - In case of failure, you have 2 solutions:
-   - you can relaunch the task at will, it should fully recreate the new indices.
-   - you can restart this migration with `--restart` parameter 
- 
- - make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted (unless the migration is restarted)
- 
- Launch the task with:
- 
-`java -cp ctia.jar:resources:. clojure.main -m ctia.task.migration.migrate-es-stores <options>`
-
-or from source
-
-`lein run -m ctia.task.migration.migrate-es-stores <options>`
-
-#### Task arguments
-|argument                     | description                                       | example 
-|-----------------------------|---------------------------------------------------|---------------|
-| -i, --id ID                 | id of the migration state to create or restart    | migration-1   | 
-| -p, --prefix PREFIX         | prefix of the newly created indices               | 1.1.0         |
-| -m, --migrations MIGRATIONS | a comma separated list of migration ids to apply  | 0.4.28,1.0.0  |
-| -b, --batch-size SIZE       | number of migrated documents per batch            | 1000          |
-|   , --buffer-size SIZE      | max batches in buffer between source and target   | 10            |
-| -s, --stores STORES         | comma separated list of stores to migrate         | tool,malware  |
-| -c, --confirm               | really do the migration?                          |               |
-| -r, --restart               | restart ongoing migration?                        |               |
-| -h, --help                  | prints usage                                      |               |
-
-#### Examples
-
-- apply migration 0.4.28 and 1.0.0, use prefix 1.1.0 for newly created indices, only for stores tool and malware, with batches of size 1000, and assign migration-1 as id for the migration state:
-    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c`
-- The previous command completed, you restart your CTIA instance on new indices, but you want to handle writes between the end of your migration and your restart of CTIA. Restart previous migration with`--restart` or '-r':
-    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c --restart`
-- the migration failed, you corrected the issue that made it fail, you can restart it with `--restart` (or '-c') parameter (same command as above). 
-
-
-#### Available migrations
-
-| migration task | target CTIA versions          | sample command                                                                                     |
-|----------------|-------------------------------|----------------------------------------------------------------------------------------------------|
-|         0.4.16 | All versions before 1.0.0-rc1 | `java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores 0.4.16 0.4.16 200 true` |
-|         0.4.28 | All versions before 1.1.0     | `java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores 0.4.28 0.4.28 200 true` |
-|          1.0.0 | 1.1.0                         | `java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores 1.0.0 1.0.0 200 true`   |
-
+see [Migration procedure](migration.md)
 
 ### Store Checks
  

--- a/README.md
+++ b/README.md
@@ -273,26 +273,39 @@ Response of the bundle API endpoint:
  
  - After the migration task completes, you will need to edit your properties, changing each store index to the new one and restart CTIA.
  
- - In case of failure, you can relaunch the task at will, it should fully recreate the new indices.
+ - In case of failure, you have 2 solutions:
+   - you can relaunch the task at will, it should fully recreate the new indices.
+   - you can restart this migration with `--restart` parameter 
  
- - make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted.
+ - make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted (unless the migration is restarted)
  
  Launch the task with:
  
-`java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores <prefix> <migrations> <batch-size> <confirm?>`
+`java -cp ctia.jar:resources:. clojure.main -m ctia.task.migration.migrate-es-stores <options>`
 
-or from source with leiningen:
+or from source
 
-`lein run -m ctia.task.migrate-es-stores <prefix> <migrations> <batch-size> <confirm?>`
+`lein run -m ctia.task.migration.migrate-es-stores <options>`
 
 #### Task arguments
+|argument                     | description                                       | example 
+|-----------------------------|---------------------------------------------------|---------------|
+| -i, --id ID                 | id of the migration state to create or restart    | migration-1   | 
+| -p, --prefix PREFIX         | prefix of the newly created indices               | 1.1.0         |
+| -m, --migrations MIGRATIONS | a comma separated list of migration ids to apply  | 0.4.28,1.0.0  |
+| -b, --batch-size SIZE       | migration batch size                              | 1000          |
+| -s, --stores STORES         | comma separated list of stores to migrate         | tool,malware  |
+| -c, --confirm               | really do the migration?                          |               |
+| -r, --restart               | restart ongoing migration?                        |               |
+| -h, --help                  | prints usage                                      |               |
 
-| argument   | description                                                                                     | example       |
-|------------|-------------------------------------------------------------------------------------------------|---------------|
-| prefix     | a prefix string for the newly create indexes, it will be wrapped with `v<prefix>_`              | 0.4.16        |
-| migrations | a migrations task list to run                                                                   | 0.4.16,0.4.17 |
-| batch-size | how many documents to fetch and and convert at once                                             | 1000          |
-| confirm?   | setting this to false will not write anything to the ES data store and simulate transforms only | true          |
+#### Examples
+
+- apply migration 0.4.28 and 1.0.0, use prefix 1.1.0 for newly created indices, only for stores tool and malware, with batches of size 1000, and assign migration-1 as id for the migration state:
+    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c`
+- The previous command completed, you restart your CTIA instance on new indices, but you want to handle writes between the end of your migration and your restart of CTIA. Restart previous migration with`--restart` or '-r':
+    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c --restart`
+- the migration failed, you corrected the issue that made it fail, you can restart it with `--restart` (or '-c') parameter (same command as above). 
 
 
 #### Available migrations

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ or from source
 | -i, --id ID                 | id of the migration state to create or restart    | migration-1   | 
 | -p, --prefix PREFIX         | prefix of the newly created indices               | 1.1.0         |
 | -m, --migrations MIGRATIONS | a comma separated list of migration ids to apply  | 0.4.28,1.0.0  |
-| -b, --batch-size SIZE       | migration batch size                              | 1000          |
+| -b, --batch-size SIZE       | number of migrated documents per batch                            | 1000          |
 | -s, --stores STORES         | comma separated list of stores to migrate         | tool,malware  |
 | -c, --confirm               | really do the migration?                          |               |
 | -r, --restart               | restart ongoing migration?                        |               |

--- a/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
+++ b/benchmarks/ctia/tasks/migrate_es_stores_bench.clj
@@ -77,7 +77,7 @@
   [_] (run-migrate-es-stores))
 
 (defcase migrate-store-indexes :optimizations_disabled
-  [_] (with-properties ["ctia.migration.optimizations" false]
+  [_] (with-properties ["ctia.migration.es/indexname" "ctia_migration"]
         (run-migrate-es-stores)))
 
 

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,60 @@
+ There is a dedicated task to migrate data from prior versions of CTIA. 
+ This task will run through all configured stores, transform and copy data to new elasticsearch indices. 
+ A migration state will be stored in a configured state to enable restart.
+
+# migration steps
+ - as the migration task copies indexes, make sure you have enough disk space before launching it.
+ - keep current ctia ES properties: host, port, transport and current store indices.
+ - if possible, stop any processes that push data into CTIA.
+ - launch migration task while your CTIA instance keep running. You can launch parallel migrations for different stores.
+ - stop CTIA.
+ - complete migration using `--restart` parameter to complete migration and handle writes that occured during migration.
+ - after the migration task completes, you will need to edit your properties, changing each store index to the new one.
+ - launch new version of CTIA. 
+ - this task doesn't alter the existing indices, you should delete them after a successful migration.
+ 
+ 
+ In case of failure, you have 2 solutions depending on the situation:
+   - you can relaunch the task at will, it should fully recreate the new indices.
+   - you can restart this migration with `--restart` parameter, it will reuse the migration
+ 
+ Make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted (unless the migration is restarted)
+ 
+# launch the task with:
+ 
+`java -cp ctia.jar:resources:. clojure.main -m ctia.task.migration.migrate-es-stores <options>`
+
+or from source
+
+`lein run -m ctia.task.migration.migrate-es-stores <options>`
+
+## task arguments
+| argument                    | description                                      | example      | default value      |
+|-----------------------------|--------------------------------------------------|--------------|--------------------|
+| -i, --id id                 | id of the migration state to create or restart   | migration-1  | generated          |
+| -p, --prefix prefix         | prefix of the newly created indices              | 1.1.0        | none, required     |
+| -m, --migrations migrations | a comma separated list of migration ids to apply | 0.4.28,1.0.0 | none, required     |
+| -b, --batch-size size       | number of migrated documents per batch           | 1000         | 100                |
+| , --buffer-size size        | max batches in buffer between source and target  | 10           | 30                 |
+| -s, --stores stores         | comma separated list of stores to migrate        | tool,malware | all                |
+| -c, --confirm               | really do the migration?                         |              | false (positional) |
+| -r, --restart               | restart ongoing migration?                       |              | false (positional) |
+| -h, --help                  | prints usage                                     |              |                    |
+
+## examples
+
+- apply migration 0.4.28 and 1.0.0, use prefix 1.1.0 for newly created indices, only for stores tool and malware, with batches of size 1000, and assign migration-1 as id for the migration state:
+    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c`
+- the previous command completed, you restart your ctia instance on new indices, but you want to handle writes between the end of your migration and your restart of ctia. restart previous migration with`--restart` or '-r':
+    `lein run -m ctia.task.migration.migrate-es-stores -m 0.4.28,1.0.0 -p 1.1.0 -s tool,malware -b 1000 -i migration-1 -c --restart`
+- the migration failed, you corrected the issue that made it fail, you can restart it with `--restart` (or `-r`) parameter (same command as above). 
+
+
+# available migrations
+
+| migration task | target ctia versions          | sample command                                                                                          |
+|----------------|-------------------------------|---------------------------------------------------------------------------------------------------------|
+|         0.4.16 | all versions before 1.0.0-rc1 | java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores -m 0.4.16 -p 0.4.16 -b 200 -c |
+|         0.4.28 | all versions before 1.1.0     | java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores -m 0.4.28 -p 0.4.28 -b 200 -c |
+|          1.0.0 | 1.1.0                         | java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores -m 1.0.0 -p 1.0.0 -b 200 -c   |
+|       identity | used for mapping migration    | java -cp ctia.jar:resources:. clojure.main -m ctia.task.migrate-es-stores -m identity -p 1.0.1 -b 200 -c|

--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 [threatgrid/clj-momo "0.2.30"]
+                 [threatgrid/clj-momo "0.2.31-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  [org.slf4j/slf4j-log4j12 "1.8.0-beta0"]
                  [org.clojure/core.memoize "0.5.9"]
                  [org.clojure/tools.logging "0.4.0"]
-                 [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.cli "0.4.1"]
                  [pandect "0.6.1"]
 
                  ;; Schemas

--- a/project.clj
+++ b/project.clj
@@ -48,8 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
-                 ;; TODO deploy clj-momo 0.2.31 and update version
-                 [threatgrid/clj-momo "0.2.31-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.2.31"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -48,6 +48,7 @@
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]
+                 ;; TODO deploy clj-momo 0.2.31 and update version
                  [threatgrid/clj-momo "0.2.31-SNAPSHOT"]
 
                  ;; Web server

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -74,6 +74,7 @@ ctia.store.tool=es
 ctia.store.vulnerability=es
 ctia.store.weakness=es
 
+ctia.store.es.migration.indexname=ctia_migration
 ctia.store.es.actor.indexname=ctia_actor
 ctia.store.es.attack-pattern.indexname=ctia_attack_pattern
 ctia.store.es.campaign.indexname=ctia_campaign
@@ -119,4 +120,4 @@ ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
-ctia.migration.es.indexname=ctia_migration
+

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -119,5 +119,4 @@ ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
-ctia.migration.optimizations = true
 ctia.migration.es.indexname=ctia_migration

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -120,3 +120,4 @@ ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
 ctia.migration.optimizations = true
+ctia.migration.es.indexname=ctia_migration

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -100,7 +100,6 @@
                       "ctia.http.bulk.max-size" s/Int
                       "ctia.http.bundle.export.max-relationships" s/Int})
 
-   (st/optional-keys {"ctia.migration.optimizations" s/Bool})
    (st/optional-keys {"ctia.migration.es.indexname" s/Bool})
 
    (st/required-keys {"ctia.events.enabled" s/Bool

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -40,7 +40,7 @@
   (let [configurable-stores (map name (keys @store/stores))
         store-names (conj configurable-stores "default")]
     (st/optional-keys
-     (reduce merge {"ctia.store.es.migration.indexname" s/Str}
+     (reduce merge {}
              (map (fn [s] (merge (default-store-properties s)
                                  (es-store-impl-properties s)))
                   store-names)))))
@@ -139,6 +139,7 @@
                       "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
 
+                      "ctia.store.es.migration.indexname" s/Str
                       "ctia.store.es.event.slicing.strategy"
                       (s/maybe (s/enum :aliased-index))
                       "ctia.store.es.event.slicing.granularity"

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -40,7 +40,7 @@
   (let [configurable-stores (map name (keys @store/stores))
         store-names (conj configurable-stores "default")]
     (st/optional-keys
-     (reduce merge {}
+     (reduce merge {"ctia.store.es.migration.indexname" s/Str}
              (map (fn [s] (merge (default-store-properties s)
                                  (es-store-impl-properties s)))
                   store-names)))))
@@ -99,8 +99,6 @@
                       "ctia.http.show.port" s/Int
                       "ctia.http.bulk.max-size" s/Int
                       "ctia.http.bundle.export.max-relationships" s/Int})
-
-   (st/optional-keys {"ctia.migration.es.indexname" s/Bool})
 
    (st/required-keys {"ctia.events.enabled" s/Bool
                       "ctia.hook.redis.enabled" s/Bool

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -101,6 +101,7 @@
                       "ctia.http.bundle.export.max-relationships" s/Int})
 
    (st/optional-keys {"ctia.migration.optimizations" s/Bool})
+   (st/optional-keys {"ctia.migration.es.indexname" s/Bool})
 
    (st/required-keys {"ctia.events.enabled" s/Bool
                       "ctia.hook.redis.enabled" s/Bool

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -27,6 +27,7 @@
 (defn es-store-impl-properties [store]
   {(str "ctia.store.es." store ".host") s/Str
    (str "ctia.store.es." store ".port") s/Int
+   (str "ctia.store.es." store ".transport") s/Keyword
    (str "ctia.store.es." store ".clustername") s/Str
    (str "ctia.store.es." store ".indexname") s/Str
    (str "ctia.store.es." store ".refresh") Refresh

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -24,14 +24,14 @@
 (s/defn init-store-conn :- ESConnState
   "initiate an ES store connection, returning a map containing a
    connection manager and dedicated store index properties"
-  [{:keys [entity indexname shards replicas]
+  [{:keys [entity indexname shards replicas mappings]
     :as props} :- StoreProperties]
   (let [settings {:number_of_shards shards
                   :number_of_replicas replicas}]
     {:index indexname
      :props props
      :config {:settings (merge store-settings settings)
-              :mappings (get store-mappings entity)}
+              :mappings (get store-mappings entity mappings)}
      :conn (connect props)}))
 
 

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -34,7 +34,6 @@
               :mappings (get store-mappings entity mappings)}
      :conn (connect props)}))
 
-
 (s/defn init-es-conn! :- ESConnState
   "initiate an ES Store connection,
    put the index template, return an ESConnState"

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,6 +1,10 @@
 (ns ctia.stores.es.store
-  (:require [clj-momo.lib.es.index :as es-index]
-            [clj-momo.lib.es.conn :as conn]
+  (:require [schema.core :as s]
+            [schema-tools.core :as st]
+            [clj-momo.lib.es
+             [index :as es-index]
+             [conn :as conn]
+             [schemas :refer [ESConn]]]
             [ctia.store :refer :all]
             [ctia.stores.es.crud :as crud]))
 
@@ -30,7 +34,15 @@
       ((crud/handle-query-string-search ~entity
                                         ~partial-stored-schema) ~(symbol "state") query# filtermap# ident# params#))))
 
-(defn store->map
+(s/defschema StoreMap
+  {:conn ESConn
+   :indexname s/Str
+   :mapping s/Str
+   :type s/Str
+   :settings s/Any
+   :config s/Any})
+
+(s/defn store->map :- StoreMap
   "transform a store record
    into a properties map for easier manipulation,
    override the cm to use the custom timeout "

--- a/src/ctia/task/check_es_stores.clj
+++ b/src/ctia/task/check_es_stores.clj
@@ -15,7 +15,6 @@
    [ctia.entity.entities :refer [entities]]
    [ctia.entity.sighting.schemas :refer [StoredSighting]]
    [ctia.stores.es.crud :refer [coerce-to-fn]]
-   [ctia.task.migrations :refer [available-migrations]]
    [schema-tools.core :as st]
    [schema.core :as s]))
 

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -135,8 +135,7 @@
    confirm? :- s/Bool
    restart? :- s/Bool]
   (let [migration-state (if restart?
-                          (mst/restart-migration migration-id
-                                                 @mst/migration-es-conn)
+                          (mst/get-migration migration-id @mst/migration-es-conn)
                           (mst/init-migration migration-id prefix store-keys confirm?))
         migrations (compose-migrations migrations)
         batch-size (or batch-size default-batch-size)]

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -42,7 +42,7 @@
 (s/defn handle-deletes
   [{:keys [created stores]} :- mst/MigrationSchema
    store-keys :- [s/Keyword]
-   confirm? :- [s/Bool]]
+   confirm? :- s/Bool]
   (let [deletes (mst/fetch-deletes store-keys created)]
     (doseq [[entity-type entities] deletes]
       (log/infof "Handling %s deleted %s during migration"

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -221,10 +221,11 @@
 
 (defn run-migration
   [migration-id prefix migrations store-keys batch-size confirm? restart?]
-  ;; TODO when restart is true, it shall works only from migration-id
-  (assert prefix "Please provide an indexname prefix for target store creation")
-  (assert migrations "Please provide a csv migration list argument")
+  (assert migration-id "Please provide an indexname prefix for target store creation")
+  (when-not restart?
+    (assert prefix "Please provide an indexname prefix for target store creation"))
   (assert batch-size "Please specify a batch size")
+  (assert migrations "Please provide a csv migration list argument")
   (log/info "migrating all ES Stores")
   (try
     (mst/setup!)

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -125,9 +125,15 @@
                                          target-store
                                          @mst/migration-es-conn))))))))
 
-(defn migrate-store-indexes
+(s/defn migrate-store-indexes
   "migrate all es store indexes"
-  [migration-id prefix migrations store-keys batch-size confirm? restart?]
+  [migration-id :- s/Str
+   prefix :- s/Str
+   migrations :- [s/Any]
+   store-keys :- [s/Keyword]
+   batch-size :- s/Int
+   confirm? :- s/Bool
+   restart? :- s/Bool]
   (let [migration-state (if restart?
                           (mst/restart-migration migration-id
                                                  @mst/migration-es-conn)

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -222,6 +222,7 @@
 
 (defn run-migration
   [migration-id prefix migrations store-keys batch-size confirm? restart?]
+  ;; TODO when restart is true, it shall works only from migration-id
   (assert prefix "Please provide an indexname prefix for target store creation")
   (assert migrations "Please provide a csv migration list argument")
   (assert batch-size "Please specify a batch size")

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -150,7 +150,8 @@
            doc))))
 
 (def available-migrations
-  {:__test (map #(assoc % :groups ["migration-test"]))
+  {:identity identity
+   :__test (map #(assoc % :groups ["migration-test"]))
    :0.4.16 (comp (append-version "0.4.16")
                  add-groups
                  fix-end-time)

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -1,4 +1,4 @@
-(ns ctia.task.migrations
+(ns ctia.task.migration.migrations
   (:require [clj-momo.lib.clj-time
              [coerce :as time-coerce]
              [core :as time-core]]

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -1,0 +1,224 @@
+(ns ctia.task.migration.store
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [schema.core :as s]
+            [clj-momo.lib.time :as time]
+            [clj-momo.lib.es
+             [conn :as conn]
+             [document :as es-doc]
+             [index :as es-index]]
+            [ctia.stores.es
+             [mapping :as em]
+             [store :refer [store->map]]]
+            [ctia
+             [init :refer [init-store-service! log-properties]]
+             [properties :refer [properties]]
+             [store :refer [stores]]]))
+
+(def timeout (* 5 60000))
+
+(defn store-mapping
+  [[k store]]
+  {k {:type "object"
+      :properties {:source {:type "object"
+                            :properties
+                            {:index em/token
+                             :total {:type "long"}}}
+                   :target {:type "object"
+                            :properties
+                            {:index em/token
+                             :migrated {:type "long"}}}
+                   :started em/ts
+                   :completed em/ts}}})
+
+(def migration-mapping
+  {"migration"
+   {:dynamic false
+    :properties
+    {:id em/token
+     :timestamp em/ts
+     :stores {:type "object"
+              :properties (->> (map store-mapping @stores)
+                               (apply merge))}}}})
+
+(def migration-store
+  {:entity :migration
+   :indexname (get-in @properties [:ctia :migration :es :indexname])
+   :shards 1
+   :replicas 1})
+
+(s/defschema MigratedStore
+  {:source {:index s/Str
+            :total s/Int}
+   :target {:index s/Str
+            :migrated s/Int}
+   (s/optional-key :started) s/Inst
+   (s/optional-key :completed) s/Inst})
+
+(s/defschema MigrationSchema
+  {:id s/Str
+   :created java.util.Date
+   :stores {s/Keyword MigratedStore}})
+
+(defn store-size
+  [{:keys [conn indexname mapping]}]
+  (es-doc/count-docs conn indexname mapping))
+
+(defn init-migration-store
+  [source target]
+  {:source {:index (:indexname source)
+            :total (or (store-size source) 0)}
+   :target {:index (:indexname target)
+            :migrated 0}})
+
+(s/defn init-migration :- MigrationSchema
+  [id :- s/Str
+   source-stores
+   target-stores]
+  (let [now (time/now)
+        migration-id (or id (str "migration-" (str (java.util.UUID/randomUUID))))
+        migration-stores (map (fn [[k v]]
+                                {k (init-migration-store v (k target-stores))})
+                              source-stores)
+        migration {:id migration-id
+                   :created now
+                   :stores (apply merge migration-stores)}]
+    migration))
+
+(defn prefixed-index [index prefix]
+  (let [version-trimmed (string/replace index #"^v[^_]*_" "")]
+    (format "v%s_%s" prefix version-trimmed)))
+
+(defn stores->maps
+  "transform store records to maps"
+  [stores]
+  (into {}
+        (map (fn [[store-key store-record]]
+               {store-key
+                (store->map store-record
+                            {:cm (conn/make-connection-manager
+                                  {:timeout timeout})})})
+             stores)))
+
+(defn source-store-map->target-store-map
+  "transform a source store map into a target map,
+  essentially updating indexname"
+  [store prefix]
+  (update store :indexname #(prefixed-index % prefix)))
+
+
+(defn source-store-maps->target-store-maps
+  "transform target store records to maps"
+  [current-stores prefix]
+  (into {}
+        (map (fn [[sk sr]]
+               {sk (source-store-map->target-store-map sr prefix)})
+             current-stores)))
+
+(def bulk-max-size (* 5 1024 1024)) ;; 5Mo
+
+(defn store-batch
+  "store a batch of documents using a bulk operation"
+  [{:keys [conn indexname mapping type]} batch]
+  (log/debugf "%s - storing %s records"
+              type
+              (count batch))
+  (let [prepared-docs
+        (map #(assoc %
+                     :_id (:id %)
+                     :_index indexname
+                     :_type mapping)
+             batch)]
+
+    (es-doc/bulk-create-doc
+     conn
+     prepared-docs
+     "false"
+     bulk-max-size)))
+
+(defn fetch-batch
+  "fetch a batch of documents from an es index"
+  [{:keys [conn
+           indexname
+           mapping]}
+   batch-size
+   offset
+   sort-order
+   search_after]
+  (let [sort-by (conj (case mapping
+                        "event" [{"timestamp" sort-order}]
+                        "identity" []
+                        [{"modified" sort-order}])
+                      {"_uid" sort-order})
+        params
+        (merge
+         {:offset (or offset 0)
+          :limit batch-size}
+         (when sort-order
+           {:sort sort-by})
+         (when search_after
+           {:search_after search_after}))]
+    (es-doc/search-docs conn
+                        indexname
+                        mapping
+                        nil
+                        {}
+                        params)))
+
+(defn target-index-settings [settings]
+  {:index (into settings
+                {:number_of_replicas 0
+                 :refresh_interval -1})})
+
+(defn revert-optimizations-settings
+  [settings]
+  {:index (dissoc settings
+                  :number_of_shards
+                  :analysis)})
+
+(defn create-target-store!
+  "create the target store, pushing its template"
+  [target-store confirm? restart?]
+
+  (when (and confirm?
+             ;; do not recreate index on restart
+             (not (and (es-index/index-exists? (:conn target-store)
+                                               (:indexname target-store))
+                       restart?)))
+    (let [wildcard (:indexname target-store)
+          settings (get-in target-store [:config :settings])
+          index-settings (target-index-settings settings)]
+      (log/infof "%s - purging indexes: %s"
+                 (:type target-store)
+                 wildcard)
+      (es-index/delete!
+       (:conn target-store)
+       wildcard)
+      (log/infof "%s - creating index template: %s"
+                 (:type target-store)
+                 (:indexname target-store))
+      (log/infof "%s - creating index: %s"
+                 (:type target-store)
+                 (:indexname target-store))
+
+      (es-index/create-template!
+       (:conn target-store)
+       (:indexname target-store)
+       (:config target-store))
+
+      (es-index/create!
+       (:conn target-store)
+       (:indexname target-store)
+       index-settings))))
+
+(defn finalize-migration!
+  [source-store target-store]
+  (log/infof "%s - update index settings" (:type source-store))
+  (es-index/update-settings! (:conn target-store)
+                             (:indexname target-store)
+                             (revert-optimizations-settings
+                              (get-in target-store [:config :settings])))
+
+  (log/infof "%s - trigger refresh" (:type source-store))
+  (es-index/refresh! (:conn target-store)
+                     (:indexname target-store)))

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -61,26 +61,27 @@
         :refresh true
         :mappings migration-mapping})))
 
+(s/defschema SourceState
+  {:index s/Str
+   :total s/Int
+   (s/optional-key :search_after) s/Any
+   (s/optional-key :store) StoreMap})
+
+(s/defschema TargetState
+  {:index s/Str
+   :migrated s/Int
+   (s/optional-key :store) StoreMap})
+
 (s/defschema MigratedStore
-  {:source {:index s/Str
-            :total s/Int
-            (s/optional-key :search_after) s/Any
-            (s/optional-key :store) StoreMap}
-   :target {:index s/Str
-            :migrated s/Int
-            (s/optional-key :store) StoreMap}
+  {:source SourceState
+   :target TargetState
    (s/optional-key :started) s/Inst
    (s/optional-key :completed) s/Inst})
 
 (s/defschema PartialMigratedStore
   (st/optional-keys
-   {:source (st/optional-keys {:index s/Str
-                               :total s/Int
-                               :search_after s/Any
-                               :store StoreMap})
-    :target (st/optional-keys {:index s/Str
-                               :migrated s/Int
-                               :store StoreMap})
+   {:source (st/optional-keys SourceState)
+    :target (st/optional-keys TargetState)
     (s/optional-key :started) s/Inst
     (s/optional-key :completed) s/Inst}))
 

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -211,7 +211,7 @@
    search_after :- (s/maybe [s/Any])]
   (query-fetch-batch nil store batch-size offset sort-order search_after))
 
-(s/defn fetch-deletes :- [s/Str]
+(s/defn fetch-deletes :- (s/maybe {s/Any s/Any})
   "retrieves delete events for given entity types and since given date"
   [entity-types :- [s/Keyword]
    since :- s/Inst]

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -51,7 +51,7 @@
      :timestamp em/ts
      :stores {:type "object"
               :properties (->> (map store-mapping @stores)
-                               (apply merge))}}}})
+                               (into {}))}}}})
 
 (defn migration-store-properties []
   (-> (get-store-properties :migration)
@@ -285,10 +285,10 @@
         (source-store-maps->target-store-maps source-stores prefix)
         migration-properties (migration-store-properties)
         now (time/now)
-        migration-stores (apply merge
-                                (map (fn [[k v]]
-                                       {k (init-migration-store v (k target-stores))})
-                                     source-stores))
+        migration-stores (into {}
+                               (map (fn [[k v]]
+                                      {k (init-migration-store v (k target-stores))})
+                                    source-stores))
         migration {:id migration-id
                    :created now
                    :stores migration-stores}
@@ -326,7 +326,7 @@
                              with-search-after
                              update-source-size)})
             stores)
-       (apply merge)))
+       (into {})))
 
 (s/defn get-migration :- MigrationSchema
   [migration-id :- s/Str

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -103,12 +103,12 @@
             :migrated 0
             :store target}})
 
-(s/defn wo-storemaps
+(s/defn wo-storemaps :- MigrationSchema
   [{:keys [stores] :as migration} :- MigrationSchema]
   (assoc migration
          :stores
-         (fmap #(-> (update-in % [:source] dissoc :store)
-                    (update-in [:target] dissoc :store))
+         (fmap #(-> (update % :source dissoc :store)
+                    (update :target dissoc :store))
                stores)))
 
 (s/defn store-migration
@@ -170,11 +170,10 @@
                      :_type mapping)
              batch)]
 
-    (es-doc/bulk-create-doc
-     conn
-     prepared-docs
-     "false"
-     bulk-max-size)))
+    (es-doc/bulk-create-doc conn
+                            prepared-docs
+                            "false"
+                            bulk-max-size)))
 
 (s/defn query-fetch-batch :- {s/Any s/Any}
   "fetch a batch of documents from an es index and a query"

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -51,8 +51,7 @@
               :properties (->> (map store-mapping @stores)
                                (apply merge))}}}})
 
-(defn migration-store-properties
-  []
+(defn migration-store-properties []
   (-> (get-store-properties :migration)
       (merge
        {:shards 1

--- a/src/ctia/version.clj
+++ b/src/ctia/version.clj
@@ -26,7 +26,7 @@
   {:base "/ctia"
    :ctim-version schema-version
    :beta true
-   :ctia-build (st/replace (current-version) #"\n" "")
+   :ctia-build (st/replace (current-version) #"\s\n" "")
    :ctia-config (current-config-hash)
    :ctia-supported_features []})
 

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -107,6 +107,7 @@
       (sut/migrate-store-indexes "0.0.0"
                                  [:0.4.16]
                                  10
+                                 false
                                  false))
     (testing "migrate es indexes"
       (let [logger (atom [])]
@@ -114,7 +115,8 @@
           (sut/migrate-store-indexes "0.0.0"
                                      [:__test]
                                      10
-                                     true))
+                                     true
+                                     false))
 
         (testing "shall produce valid logs"
           (let [messages (set @logger)]

--- a/test/ctia/task/migrate_es_stores_test.clj
+++ b/test/ctia/task/migrate_es_stores_test.clj
@@ -11,6 +11,7 @@
              [core :as helpers :refer [post post-bulk with-atom-logger]]
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
+            [ctia.store :refer [stores]]
             [ctim.domain.id :refer [make-transient-id]]
             [ctim.examples
              [actors :refer [actor-minimal]]
@@ -106,6 +107,7 @@
     (testing "simulate migrate es indexes"
       (sut/migrate-store-indexes "0.0.0"
                                  [:0.4.16]
+                                 (keys @stores)
                                  10
                                  false
                                  false))
@@ -114,6 +116,7 @@
         (with-atom-logger logger
           (sut/migrate-store-indexes "0.0.0"
                                      [:__test]
+                                     (keys @stores)
                                      10
                                      true
                                      false))

--- a/test/ctia/task/migration/fixtures.clj
+++ b/test/ctia/task/migration/fixtures.clj
@@ -1,0 +1,49 @@
+(ns ctia.task.migration.fixtures
+  (:require [ctim.domain.id :refer [make-transient-id]]
+            [ctim.examples
+             [actors :refer [actor-minimal]]
+             [attack-patterns :refer [attack-pattern-minimal]]
+             [campaigns :refer [campaign-minimal]]
+             [coas :refer [coa-minimal]]
+             [incidents :refer [incident-minimal]]
+             [indicators :refer [indicator-minimal]]
+             [investigations :refer [investigation-minimal]]
+             [judgements :refer [judgement-minimal]]
+             [malwares :refer [malware-minimal]]
+             [relationships :refer [relationship-minimal]]
+             [casebooks :refer [casebook-minimal]]
+             [sightings :refer [sighting-minimal]]
+             [tools :refer [tool-minimal]]
+             [vulnerabilities :refer [vulnerability-minimal]]
+             [weaknesses :refer [weakness-minimal]]]))
+
+(def fixtures-nb 100)
+
+(defn randomize [doc]
+  (assoc doc
+         :id (make-transient-id "_")))
+
+(defn n-doc [fixture nb]
+  (map randomize (repeat nb fixture)))
+
+(def examples
+  {:actors (n-doc actor-minimal fixtures-nb)
+   :attack_patterns (n-doc attack-pattern-minimal fixtures-nb)
+   :campaigns (n-doc campaign-minimal fixtures-nb)
+   :coas (n-doc coa-minimal fixtures-nb)
+   :incidents (n-doc incident-minimal fixtures-nb)
+   :indicators (n-doc indicator-minimal fixtures-nb)
+   :investigations (n-doc investigation-minimal fixtures-nb)
+   :judgements (n-doc judgement-minimal fixtures-nb)
+   :malwares (n-doc malware-minimal fixtures-nb)
+   :relationships (n-doc relationship-minimal fixtures-nb)
+   :casebooks (n-doc casebook-minimal fixtures-nb)
+   :sightings (n-doc sighting-minimal fixtures-nb)
+   :tools (n-doc tool-minimal fixtures-nb)
+   :vulnerabilities (n-doc vulnerability-minimal fixtures-nb)
+   :weaknesses (n-doc weakness-minimal fixtures-nb)})
+
+(def example-types
+  (->> (vals examples)
+       (map #(-> % first :type keyword))
+       set))

--- a/test/ctia/task/migration/fixtures.clj
+++ b/test/ctia/task/migration/fixtures.clj
@@ -1,23 +1,21 @@
 (ns ctia.task.migration.fixtures
   (:require [ctim.domain.id :refer [make-transient-id]]
             [ctim.examples
-             [actors :refer [actor-minimal]]
-             [attack-patterns :refer [attack-pattern-minimal]]
-             [campaigns :refer [campaign-minimal]]
-             [coas :refer [coa-minimal]]
-             [incidents :refer [incident-minimal]]
-             [indicators :refer [indicator-minimal]]
-             [investigations :refer [investigation-minimal]]
-             [judgements :refer [judgement-minimal]]
-             [malwares :refer [malware-minimal]]
-             [relationships :refer [relationship-minimal]]
-             [casebooks :refer [casebook-minimal]]
-             [sightings :refer [sighting-minimal]]
-             [tools :refer [tool-minimal]]
-             [vulnerabilities :refer [vulnerability-minimal]]
-             [weaknesses :refer [weakness-minimal]]]))
-
-(def fixtures-nb 100)
+             [actors :refer [actor-maximal actor-minimal]]
+             [attack-patterns :refer [attack-pattern-maximal attack-pattern-minimal]]
+             [campaigns :refer [campaign-maximal campaign-minimal]]
+             [coas :refer [coa-maximal coa-minimal]]
+             [incidents :refer [incident-maximal incident-minimal]]
+             [indicators :refer [indicator-maximal indicator-minimal]]
+             [investigations :refer [investigation-maximal investigation-minimal]]
+             [judgements :refer [judgement-maximal judgement-minimal]]
+             [malwares :refer [malware-maximal malware-minimal]]
+             [relationships :refer [relationship-maximal relationship-minimal]]
+             [casebooks :refer [casebook-maximal casebook-minimal]]
+             [sightings :refer [sighting-maximal sighting-minimal]]
+             [tools :refer [tool-maximal tool-minimal]]
+             [vulnerabilities :refer [vulnerability-maximal vulnerability-minimal]]
+             [weaknesses :refer [weakness-maximal weakness-minimal]]]))
 
 (defn randomize [doc]
   (assoc doc
@@ -26,24 +24,39 @@
 (defn n-doc [fixture nb]
   (map randomize (repeat nb fixture)))
 
-(def examples
-  {:actors (n-doc actor-minimal fixtures-nb)
-   :attack_patterns (n-doc attack-pattern-minimal fixtures-nb)
-   :campaigns (n-doc campaign-minimal fixtures-nb)
-   :coas (n-doc coa-minimal fixtures-nb)
-   :incidents (n-doc incident-minimal fixtures-nb)
-   :indicators (n-doc indicator-minimal fixtures-nb)
-   :investigations (n-doc investigation-minimal fixtures-nb)
-   :judgements (n-doc judgement-minimal fixtures-nb)
-   :malwares (n-doc malware-minimal fixtures-nb)
-   :relationships (n-doc relationship-minimal fixtures-nb)
-   :casebooks (n-doc casebook-minimal fixtures-nb)
-   :sightings (n-doc sighting-minimal fixtures-nb)
-   :tools (n-doc tool-minimal fixtures-nb)
-   :vulnerabilities (n-doc vulnerability-minimal fixtures-nb)
-   :weaknesses (n-doc weakness-minimal fixtures-nb)})
+(defn n-examples
+  [entity-type nb maximal?]
+  (case entity-type
+    :actor (n-doc (if maximal? actor-maximal actor-minimal) nb)
+    :attack-pattern (n-doc (if maximal? attack-pattern-maximal attack-pattern-minimal) nb)
+    :campaign (n-doc (if maximal? campaign-maximal campaign-minimal) nb)
+    :coa (n-doc (if maximal? coa-maximal coa-minimal) nb)
+    :incident (n-doc (if maximal? incident-maximal incident-minimal) nb)
+    :indicator (n-doc (if maximal? indicator-maximal indicator-minimal) nb)
+    :investigation (n-doc (if maximal? investigation-maximal investigation-minimal) nb)
+    :judgement (n-doc (if maximal? judgement-maximal judgement-minimal) nb)
+    :malware (n-doc (if maximal? malware-maximal malware-minimal) nb)
+    :relationship (n-doc (if maximal? relationship-maximal relationship-minimal) nb)
+    :casebook (n-doc (if maximal? casebook-maximal casebook-minimal) nb)
+    :sighting (n-doc (if maximal? sighting-maximal sighting-minimal) nb)
+    :tool (n-doc (if maximal? tool-maximal tool-minimal) nb)
+    :vulnerability (n-doc (if maximal? vulnerability-maximal vulnerability-minimal) nb)
+    :weakness (n-doc (if maximal? weakness-maximal weakness-minimal) nb)))
 
-(def example-types
-  (->> (vals examples)
-       (map #(-> % first :type keyword))
-       set))
+(defn bundle
+  [fixtures-nb maximal?]
+  {:actors (n-examples :actor fixtures-nb maximal?)
+   :attack_patterns (n-examples :attack-pattern fixtures-nb maximal?)
+   :campaigns (n-examples :campaign fixtures-nb maximal?)
+   :coas (n-examples :coa fixtures-nb maximal?)
+   :incidents (n-examples :incident fixtures-nb maximal?)
+   :indicators (n-examples :indicator fixtures-nb maximal?)
+   :investigations (n-examples :investigation fixtures-nb maximal?)
+   :judgements (n-examples :judgement fixtures-nb maximal?)
+   :malwares (n-examples :malware fixtures-nb maximal?)
+   :relationships (n-examples :relationship fixtures-nb maximal?)
+   :casebooks (n-examples :casebook fixtures-nb maximal?)
+   :sightings (n-examples :sighting fixtures-nb maximal?)
+   :tools (n-examples :tool fixtures-nb maximal?)
+   :vulnerabilities (n-examples :vulnerability fixtures-nb maximal?)
+   :weaknesses (n-examples :weakness fixtures-nb maximal?)})

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -6,6 +6,7 @@
              [walk :refer [keywordize-keys]]]
             [ctia.properties :as props]
             [ctia.task.migration.migrate-es-stores :as sut]
+            [ctia.task.migration.store :refer [setup!]]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post post-bulk with-atom-logger]]
@@ -96,7 +97,7 @@
                                       "foouser"
                                       "foogroup"
                                       "user")
-
+  (setup!)
   (testing "migrate ES Stores test setup"
     (post-bulk examples)
     (testing "simulate migrate es indexes"
@@ -106,11 +107,13 @@
                                  (keys @stores)
                                  10
                                  false
-                                 nil))
+                                 nil)
+      ;; TODO check does nothing was created
+      )
     (testing "migrate es indexes"
       (let [logger (atom [])]
         (with-atom-logger logger
-          (sut/migrate-store-indexes "test2"
+          (sut/migrate-store-indexes "test-2"
                                      "0.0.0"
                                      [:__test]
                                      (keys @stores)

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -104,6 +104,7 @@
                                    [:__test]
                                    store-types
                                    10
+                                   30
                                    true
                                    false))
       (let [messages (set @logger)
@@ -146,6 +147,7 @@
                                  [:0.4.16]
                                  (keys @stores)
                                  10
+                                 30
                                  false
                                  false)
 
@@ -164,6 +166,7 @@
                                    [:__test]
                                    (keys @stores)
                                    10
+                                   30
                                    true
                                    false))
       (testing "shall generate a proper migration state"
@@ -304,6 +307,7 @@
                                    [:__test]
                                    (keys @stores)
                                    2 ;; small batch to check proper delete paging
+                                   10
                                    true
                                    true)
         (let [migration-state (get-migration "test-2" es-conn)
@@ -349,6 +353,7 @@
                                        [:__test]
                                        (into [] example-types)
                                        batch-size
+                                       30
                                        true
                                        false)
           end (System/currentTimeMillis)

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -219,6 +219,21 @@
                               (map #(get-in % [:_source :groups])))]
                 (is (every? #(= ["migration-test"] %)
                             hits))))))))
-    ;; clean
+    ;;TODO test restart
+    ;;insert/modify/delete documents
+    ;; run migrate with restart true
+    ;; check that modifications are taken into account in targets
+    ;; (sut/migrate-store-indexes "test-2"
+    ;;                            "0.0.0"
+    ;;                            [:__test]
+    ;;                            (keys @stores)
+    ;;                            10
+    ;;                            true
+    ;;                            true))
+
+
+
+    ;; TODO delete inserted examples / events, or remove indexes
     (es-index/delete! es-conn "v0.0.0*")
     (es-doc/delete-doc es-conn migration-index "migration" "test-2" "true")))
+

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -1,11 +1,11 @@
-(ns ctia.task.migrate-es-stores-test
+(ns ctia.task.migration.migrate-es-stores-test
   (:require [clj-http.client :as client]
             [clj-momo.test-helpers.core :as mth]
             [clojure
              [test :refer [deftest is join-fixtures testing use-fixtures]]
              [walk :refer [keywordize-keys]]]
             [ctia.properties :as props]
-            [ctia.task.migrate-es-stores :as sut]
+            [ctia.task.migration.migrate-es-stores :as sut]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post post-bulk with-atom-logger]]
@@ -85,12 +85,6 @@
    :tools (n-doc tool-minimal fixtures-nb)
    :vulnerabilities (n-doc vulnerability-minimal fixtures-nb)
    :weaknesses (n-doc weakness-minimal fixtures-nb)})
-
-(deftest prefixed-index-test
-  (is (= "v0.4.2_ctia_actor"
-         (sut/prefixed-index "ctia_actor" "0.4.2")))
-  (is (= "v0.4.2_ctia_actor"
-         (sut/prefixed-index "v0.4.1_ctia_actor" "0.4.2"))))
 
 (deftest test-migrate-store-indexes
   (helpers/set-capabilities! "foouser"

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -254,8 +254,7 @@
               {last-target-malwares :data} (fetch-batch malware-target-store 3 0 "desc" nil)
               {:keys [conn indexname mapping]} (get-in sighting-migration [:target :store])
               updated-sighting (es-doc/get-doc conn indexname mapping sighting1-id nil)
-              get-deleted-sighting-res (es-doc/get-doc conn indexname mapping sighting2-id nil)
-              ]
+              get-deleted-sighting-res (es-doc/get-doc conn indexname mapping sighting2-id nil)]
           (is (= (repeat 3 "INSERTED") (map :description last-target-malwares))
               "inserted malwares must found in target malware store")
 

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -333,7 +333,7 @@
 
 (defn load-test-fn
   [maximal?]
-  ;; insert 100000 docs per entity-type
+  ;; insert 20000 docs per entity-type
   (doseq [bundle (repeatedly 20 #(fixt/bundle 1000 maximal?))]
     (post-bulk bundle))
   (doseq [batch-size [100 1000 3000 6000 10000]]

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -87,6 +87,7 @@
    :weaknesses (n-doc weakness-minimal fixtures-nb)})
 
 (deftest test-migrate-store-indexes
+  ;; TODO clean data
   (helpers/set-capabilities! "foouser"
                              ["foogroup"]
                              "user"
@@ -99,21 +100,23 @@
   (testing "migrate ES Stores test setup"
     (post-bulk examples)
     (testing "simulate migrate es indexes"
-      (sut/migrate-store-indexes "0.0.0"
+      (sut/migrate-store-indexes "test-1"
+                                 "0.0.0"
                                  [:0.4.16]
                                  (keys @stores)
                                  10
                                  false
-                                 false))
+                                 nil))
     (testing "migrate es indexes"
       (let [logger (atom [])]
         (with-atom-logger logger
-          (sut/migrate-store-indexes "0.0.0"
+          (sut/migrate-store-indexes "test2"
+                                     "0.0.0"
                                      [:__test]
                                      (keys @stores)
                                      10
                                      true
-                                     false))
+                                     nil))
 
         (testing "shall produce valid logs"
           (let [messages (set @logger)]

--- a/test/ctia/task/migration/migrations_test.clj
+++ b/test/ctia/task/migration/migrations_test.clj
@@ -1,7 +1,7 @@
-(ns ctia.task.migrations-test
+(ns ctia.task.migration.migrations-test
   (:require [clojure.test :refer [deftest is]]
             [ctia.entity.incident :refer [StoredIncident]]
-            [ctia.task.migrations :as sut]
+            [ctia.task.migration.migrations :as sut]
             [schema.core :as s]))
 
 (deftest add-groups-test

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -181,7 +181,8 @@
                       :config {}}
           tool-batch (map #(hash-map :id (str "tool-" %)
                                      :timestamp (rand-int 100)
-                                     :modified %)
+                                     :modified %
+                                     :created %)
                           (range 100))
           malware-store {:conn es-conn
                          :indexname indexname
@@ -191,7 +192,8 @@
                          :config {}}
           malware-batch (map #(hash-map :id (str "malware-" %)
                                         :timestamp (rand-int 100)
-                                        :modified %)
+                                        :modified %
+                                        :created %)
                              (range 100))]
       (sut/store-batch tool-store tool-batch)
       (sut/store-batch malware-store malware-batch)

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.task.migration.store-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
 
+            [clj-momo.test-helpers.core :as mth]
             [clj-momo.lib.es
              [conn :refer [connect]]
              [document :as es-doc]
@@ -10,11 +11,25 @@
              [relationships :refer [relationship-minimal]]
              [tools :refer [tool-minimal]]]
 
-            [ctia.test-helpers.core :refer [post-bulk]]
+            [ctia.test-helpers
+             [core :as helpers :refer [post-bulk]]
+             [es :as es-helpers]
+             [fake-whoami-service :as whoami-helpers]]
             [ctia.task.migration
              [fixtures :refer [examples fixtures-nb]]
              [store :as sut]]
             [ctia.properties :as props]))
+
+(use-fixtures :once
+  (join-fixtures [mth/fixture-schema-validation
+                  helpers/fixture-properties:clean
+                  es-helpers/fixture-properties:es-store
+                  helpers/fixture-ctia
+                  whoami-helpers/fixture-server
+                  es-helpers/fixture-delete-store-indexes]))
+
+(use-fixtures :each
+  whoami-helpers/fixture-reset-state)
 
 (deftest prefixed-index-test
   (is (= "v0.4.2_ctia_actor"

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -1,6 +1,20 @@
 (ns ctia.task.migration.store-test
-  (:require [ctia.task.migration.store :as sut]
-            [clojure.test :refer [deftest is testing]]))
+  (:require [clojure.test :refer [deftest is testing]]
+
+            [clj-momo.lib.es
+             [conn :refer [connect]]
+             [document :as es-doc]
+             [index :as es-index]]
+            [ctim.examples
+             [malwares :refer [malware-minimal]]
+             [relationships :refer [relationship-minimal]]
+             [tools :refer [tool-minimal]]]
+
+            [ctia.task.migration
+             [fixtures :refer [examples fixtures-nb]]
+             [store :as sut]]
+            [ctia.properties :as props]
+            ))
 
 (deftest prefixed-index-test
   (is (= "v0.4.2_ctia_actor"
@@ -16,3 +30,41 @@
   (is (= {:index {:number_of_replicas 0
                   :refresh_interval -1}}
          (sut/target-index-settings {}))))
+
+(sut/setup!)
+(def es-props (get-in @props/properties [:ctia :store :es]))
+(def es-conn (connect (:default es-props)))
+(def migration-index (get-in es-props [:migration :indexname]))
+
+(deftest init-migration-test
+  (let [prefix "0.0.0"
+        entity-types [:tool :malware :relationship]
+        migration-id-1 "migration-1"
+        {:keys [id created stores]} (sut/init-migration migration-id-1
+                                                        prefix
+                                                        entity-types
+                                                        false)]
+    (is (= id migration-id-1))
+    (is (= (set (keys stores))
+           (set entity-types)))
+    (doseq [entity-type entity-types]
+      (let [{:keys [source target started completed]} (get stores entity-type)]
+        (is (nil? started))
+        (is (nil? completed))
+        (is (= 0 (:migrated target)))
+        (is (= fixtures-nb (:total source)))
+        (is (nil? (:started source)))
+        (is (nil? (:completed target)))
+        (is (= entity-type
+               (keyword (get-in source [:store :type]))))
+        (is (= entity-type
+               (keyword (get-in target [:store :type]))))
+        (is (= (:index source)
+               (get-in source [:store :indexname])))
+        (is (= (:index target)
+               (get-in target [:store :indexname])))))))
+
+
+;; TODO test others ns functions
+;; note that this ns is already partially tested in migrate-es-stores-test
+;; however it should more deeply test different functions

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -1,0 +1,18 @@
+(ns ctia.task.migration.store-test
+  (:require [ctia.task.migration.store :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest prefixed-index-test
+  (is (= "v0.4.2_ctia_actor"
+         (sut/prefixed-index "ctia_actor" "0.4.2")))
+  (is (= "v0.4.2_ctia_actor"
+         (sut/prefixed-index "v0.4.1_ctia_actor" "0.4.2"))))
+
+(deftest target-index-settings-test
+  (is (= {:index {:number_of_replicas 0
+                  :refresh_interval -1
+                  :mapping {}}}
+         (sut/target-index-settings {:mapping {}})))
+  (is (= {:index {:number_of_replicas 0
+                  :refresh_interval -1}}
+         (sut/target-index-settings {}))))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -60,8 +60,7 @@
                     "ctia.hook.redis.channel-name"    "events-test"
                     "ctia.metrics.riemann.enabled"    false
                     "ctia.metrics.console.enabled"    false
-                    "ctia.metrics.jmx.enabled"        false
-                    "ctia.migration.es.indexname"     "ctia_migration"]
+                    "ctia.metrics.jmx.enabled"        false]
     ;; run tests
     (f)))
 

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -61,7 +61,7 @@
                     "ctia.metrics.riemann.enabled"    false
                     "ctia.metrics.console.enabled"    false
                     "ctia.metrics.jmx.enabled"        false
-                    "ctia.migration.optimizations"    false]
+                    "ctia.migration.es.indexname"     "ctia_migration"]
     ;; run tests
     (f)))
 

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -50,6 +50,7 @@
                       "ctia.store.es.default.port" "9200"
                       "ctia.store.es.default.indexname" "test_ctia"
                       "ctia.store.es.actor.indexname" "ctia_actor"
+                      "ctia.store.es.migration.indexname" "ctia_migration"
                       "ctia.store.actor" "es"
                       "ctia.store.attack-pattern" "es"
                       "ctia.store.campaign" "es"


### PR DESCRIPTION
closes https://github.com/threatgrid/iroh/issues/2556

Enable to restart migration where it stops and handle writings (update and deletes) during migration.
The number of parameter has augmented so it now uses tool.cli for command line parameters.
```
  -i, --id ID                  id of the migration state to create or restart
  -p, --prefix PREFIX          prefix of the newly created indices 
  -m, --migrations MIGRATIONS  a comma separated list of migration ids to apply
  -b, --batch-size SIZE        migration batch size
      , --buffer-size SIZE       max number of batches in buffer between source and target
  -s, --stores STORES          comma separated list of stores to migrate
  -c, --confirm                really do the migration?
  -r, --restart                restart ongoing migration?
  -h, --help  
```

- apply migration `1.0.0` with prefix `1.0.1` to stores `tool` and `malware` with batches of size `1000`, and assign `migration-1`as id:
`lein run -m ctia.task.migration.migrate-es-stores -p 1.0.1 -m 1.0.0 -c -i migration-1 -s tool,malware -b 1000`
- add `-r`to restart that migration, behavior should be slightly modified to enable to restart when only migration-id, batch-size and restart parameters
`lein run -m ctia.task.migration.migrate-es-stores -m 1.0.0 -c -i migration-1 -b 1000 -r`

<a name="qa">[§](#qa)</a> QA
============================

No QA specifically needed on this PR. It is only about the migration process, not the transformations of documents and indices' mappings. However, when the migration will be applied on test, CTIA should be fully retested.

<a name="ops">[§](#ops)</a> Ops
===============================

This PR includes a migration.md document, you should read it and validate its clarity.

<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

- migration.md describes how to migrate CTIA stores.
