### PR TITLE
issue-2599: fix wrong error status code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -74,7 +74,7 @@
                   ;;   - As of 2016-08-25, the latest version is 1.10 (using 1.6)
                   :exclusions [commons-codec]]
                  [yogsototh/clj-jwt "0.2.1"]
-                 [threatgrid/ring-jwt-middleware "0.0.7" :exclusions [metosin/ring-http-response riemann-clojure-client joda-time clj-time com.google.code.findbugs/jsr305 com.andrewmcveigh/cljs-time]]
+                 [threatgrid/ring-jwt-middleware "0.0.10" :exclusions [metosin/compojure-api]]
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -84,7 +84,7 @@
       (get tempids (:id entity))
       (when-let [entity-id (find-checked-id entity)]
         (when-not (auth/capable? identity-obj :specify-id)
-          (http-response/unauthorized!
+          (http-response/forbidden!
            {:error "Missing capability to specify entity ID"
             :entity entity}))
         (if (id/valid-short-id? entity-id)

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -7,7 +7,7 @@
             [compojure.api.impl.logging :as logging]
             [ring.util.http-response :refer [internal-server-error
                                              bad-request
-                                             unauthorized]]
+                                             forbidden]]
             [clojure.data.json :as json]))
 
 (defn ex-message [^Exception e]
@@ -65,7 +65,7 @@
   "Handle access control error"
   [^Exception e data request]
   (logging/log! :info e (ex-message e))
-  (unauthorized
+  (forbidden
    {:error "Access Control validation Client Error"
     :type "Access Control Error"
     :message (.getMessage e)

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -38,19 +38,24 @@
       (if (and (not (nil? auth-identity))
                (auth/authenticated? auth-identity))
         (handler request)
-        (http-response/forbidden! {:message "Only authenticated users allowed"})))))
+        (http-response/unauthorized!
+         {:error :not_authenticated
+          :message "Only authenticated users allowed"})))))
 
 (defn require-capability! [required-capability id]
   (if required-capability
     (cond
       (or (nil? id)
           (not (auth/authenticated? id)))
-      (http-response/forbidden! {:message "Only authenticated users allowed"})
+      (http-response/unauthorized!
+       {:error :not_authenticated
+        :message "Only authenticated users allowed"})
 
       (not (auth/capable? id required-capability))
-      (http-response/unauthorized! {:message "Missing capability"
-                                    :capabilities required-capability
-                                    :owner (auth/login id)}))))
+      (http-response/forbidden! {:message "Missing capability"
+                                 :error :missing_capability
+                                 :capabilities required-capability
+                                 :owner (auth/login id)}))))
 
 ;; Create a compojure-api meta-data handler for capability-based
 ;; security. The :identity field must by on the request object

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -107,24 +107,29 @@
     (testing "no Authorization"
       (let [{body :parsed-body status :status}
             (get (str "ctia/judgement/" (:short-id judgement-id)))]
-        (is (= 403 status))
-        (is (= {:message "Only authenticated users allowed"} body))))
+        (is (= 401 status))
+        (is (= {:message "Only authenticated users allowed"
+                :error :not_authenticated}
+               body))))
 
     (testing "unknown Authorization"
       (let [{body :parsed-body status :status}
             (get (str "ctia/judgement/" (:short-id judgement-id))
                  :headers {"Authorization" "1111111111111"})]
-        (is (= 403 status))
-        (is (= {:message "Only authenticated users allowed"} body))))
+        (is (= 401 status))
+        (is (= {:message "Only authenticated users allowed"
+                :error :not_authenticated}
+               body))))
 
     (testing "doesn't have read capability"
       (let [{body :parsed-body status :status}
             (get (str "ctia/judgement/" (:short-id judgement-id))
                  :headers {"Authorization" "2222222222222"})]
-        (is (= 401 status))
+        (is (= 403 status))
         (is (= {:message "Missing capability",
                 :capabilities :read-judgement,
-                :owner "baruser"}
+                :owner "baruser"
+                :error :missing_capability}
                body))))))
 
 (deftest test-judgement-routes
@@ -239,8 +244,7 @@
                                 :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                          :headers {"Authorization" (str "Bearer " jwt-token)
                                    "origin" "http://external.cisco.com"})]
-               (is (or (= 401 (:status response))
-                       (= 403 (:status response)))
+               (is (= 403 (:status response))
                    "Normal users shouldn't be allowed to set the ids during creation.")))))))))
 
 (deftest cors-test

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -47,7 +47,7 @@
                            :confidence "Low"
                            :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
                                         :end_time "2016-03-11T00:00:00.000-00:00"}})]
-          (is (= 403 status)))
+          (is (= 401 status)))
 
         (let [{status :status}
               (post "ctia/judgement"
@@ -61,7 +61,7 @@
                            :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
                                         :end_time "2016-03-11T00:00:00.000-00:00"}}
                     :headers {"Authorization" "bloodbending"})]
-          (is (= 403 status))))
+          (is (= 401 status))))
 
       (testing "GET /ctia/judgement"
         (let [{status :status
@@ -89,9 +89,9 @@
           (let [{status :status}
                 (get (str "ctia/judgement/" (:short-id judgement-id))
                      :headers {"Authorization" "bloodbending"})]
-            (is (= 403 status)))
+            (is (= 401 status)))
 
           (let [{status :status}
                 (get (str "ctia/judgement/" (:short-id judgement-id)))]
-            (is (= 403 status))))))))
+            (is (= 401 status))))))))
 

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -268,7 +268,7 @@
                                       :variables {}
                                       :operationName ""}
                                :headers {"Authorization" "2222222222222"})]
-             (is (= 401 status))))
+             (is (= 403 status))))
          (testing "observable query"
            (let [{:keys [data errors status]}
                  (gh/query graphql-queries

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -17,7 +17,7 @@
   (assoc entity :tlp "red"))
 
 (def allowed-statuses #{200 204})
-(def forbidden-statuses #{401})
+(def forbidden-statuses #{403})
 
 (defn same-ownership? [entity-1 entity-2]
   (and (= (:owner entity-1)


### PR DESCRIPTION
Related to https://github.com/threatgrid/iroh/issues/2599

Reverse 401 / 403. 401 should be used when authentication is required and has failed or has not yet been provided and 403 when user might not have the necessary permissions.

QA
==

Check that authentication errors (Expired JWT, invalid JWT) return a 401 and that permission errors (missing capability, access control) return 403.

Release Notes
=============

```
intern: Fix usage of 401 and 403 statuses
```
