### PR TITLE
Sighting sensor coordinates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,7 @@
                   :exclusions [prismatic/plumbing
                                potemkin
                                com.andrewmcveigh/cljs-time]]
-                 [threatgrid/ctim "1.0.9"
+                 [threatgrid/ctim "1.0.11"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
                                com.google.guava/guava]]

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -25,7 +25,6 @@
      {:observed_time em/valid-time
       :count {:type "long"}
       :sensor em/token
-      :sensor_coordinates em/sighting-sensor
       :targets em/sighting-target
       :reference em/token
       :confidence em/token

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -31,6 +31,7 @@
       :confidence em/token
       :severity em/token
       :resolution em/token
+      :data em/embedded-data-table
       :internal {:type "boolean"}
       :observables em/observable
       :observables_hash em/token

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -25,6 +25,7 @@
      {:observed_time em/valid-time
       :count {:type "long"}
       :sensor em/token
+      :sensor_coordinates em/sighting-sensor
       :targets em/sighting-target
       :reference em/token
       :confidence em/token

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -309,8 +309,14 @@
    {:type token
     :observed_time valid-time
     :os token
-    :observables observable
-    :properties_data_tables token}})
+    :observables observable}})
+
+(def sighting-sensor
+  {:dynamic false
+   :properties
+   {:type token
+    :os token
+    :observables observable}})
 
 (def texts
   {:properties {:type token

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -309,14 +309,8 @@
    {:type token
     :observed_time valid-time
     :os token
-    :observables observable}})
-
-(def sighting-sensor
-  {:dynamic false
-   :properties
-   {:type token
-    :os token
-    :observables observable}})
+    :observables observable
+    :properties_data_tables token}})
 
 (def texts
   {:properties {:type token

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -318,6 +318,13 @@
     :os token
     :observables observable}})
 
+(def embedded-data-table
+  {:dynamic false
+   :properties
+   {:row_count {:type "long"}
+    :columns {:enabled false}
+    :rows {:enabled false}}})
+
 (def texts
   {:properties {:type token
                 :text text}})

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -39,7 +39,7 @@
            new-sightings (->> (csg/sample (cs/gen :new-sighting/map) 5)
                               (map #(-> (assoc %
                                                :observables [observable])
-                                        (dissoc % :relations)))
+                                        (dissoc % :relations :data)))
                               (map #(assoc % :id (url-id :sighting))))
            route-pref (str "ctia/" (:type observable) "/" (:value observable))]
 


### PR DESCRIPTION
Connected to threatgrid/ctim#237 and threatgrid/ctim#238

Changes to es stores mapping for adding Sensor Coordinates in Sighting. This change is to support the data model change in CTIM

Upgrade to CTIM 1.0.11 (sensor coordinates and data table in Sighting)

QA:
1. Post a new Sighting with sensor coordinates and a data table
2. Retrieve the same entity and check that the data is the same
3. Retrieve an old entity without error