### PR TITLE
Add the timestamp field to all entities

### DIFF
--- a/src/ctia/entity/feedback/schemas.clj
+++ b/src/ctia/entity/feedback/schemas.clj
@@ -2,7 +2,7 @@
   (:require [clj-momo.lib.time :as time]
             [ctia.domain
              [access-control :refer [properties-default-tlp]]
-             [entities :refer [schema-version]]]
+             [entities :refer [default-realize-fn]]]
             [ctia.schemas
              [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema TempIDs]]
@@ -32,20 +32,8 @@
 (s/defschema PartialStoredFeedback
   (csu/optional-keys-schema StoredFeedback))
 
-(s/defn realize-feedback :- StoredFeedback
-  [new-feedback :- NewFeedback
-   id :- s/Str
-   tempids :- (s/maybe TempIDs)
-   owner :- s/Str
-   groups :- [s/Str]]
-  (assoc new-feedback
-         :id id
-         :type "feedback"
-         :created (time/now)
-         :owner owner
-         :groups groups
-         :tlp (:tlp new-feedback (properties-default-tlp))
-         :schema_version schema-version))
+(def realize-feedback
+  (default-realize-fn "feedback" NewFeedback StoredFeedback))
 
 (def feedback-fields
   (concat sorting/base-entity-sort-fields

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -44,12 +44,17 @@
 (s/defn realize-judgement :- (with-error StoredJudgement)
   ([new-judgement id tempids owner groups]
    (realize-judgement new-judgement id tempids owner groups nil))
-  ([new-judgement id tempids owner groups prev-judgement]
+  ([new-judgement :- NewJudgement
+    id :- s/Str
+    tempids :- (s/maybe TempIDs)
+    owner :- s/Str
+    groups :- [s/Str]
+    prev-judgement :- (s/maybe StoredJudgement)]
    (let [{:keys [error] :as disposition}
          (try
            (determine-disposition-id new-judgement)
            (catch clojure.lang.ExceptionInfo e
-             {:error "Mismatching :dispostion and dispositon_name for judgement"
+             {:error "Mismatching disposition and dispositon_name for judgement"
               :id id
               :type :realize-entity-error
               :judgement new-judgement}))]

--- a/src/ctia/entity/relationship/schemas.clj
+++ b/src/ctia/entity/relationship/schemas.clj
@@ -61,5 +61,6 @@
        :error (str "A relationship cannot be created if a source "
                    "or a target ref is still a transient ID "
                    "(The source or target entity is probably not "
-                   "provided in the bundle)")}
+                   "provided in the bundle)")
+       :type :realize-entity-error}
       e)))

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -2,7 +2,7 @@
   (:require [clj-momo.lib.time :as time]
             [ctia.domain
              [access-control :refer [properties-default-tlp]]
-             [entities :refer [schema-version]]]
+             [entities :refer [default-realize-fn]]]
             [ctia.schemas
              [utils :as csu]
              [core :refer [def-acl-schema def-stored-schema TempIDs]]
@@ -32,34 +32,21 @@
 (s/defschema PartialStoredSighting
   (csu/optional-keys-schema StoredSighting))
 
+(def sighting-default-realize
+  (default-realize-fn "sighting" NewSighting StoredSighting))
+
 (s/defn realize-sighting :- StoredSighting
-  ([new-sighting :- NewSighting
-    id :- s/Str
-    tempids :- (s/maybe TempIDs)
-    owner :- s/Str
-    groups :- [s/Str]]
+  ([new-sighting id tempids owner groups]
    (realize-sighting new-sighting id tempids owner groups nil))
-  ([new-sighting :- NewSighting
-    id :- s/Str
-    tempids :- (s/maybe TempIDs)
-    owner :- s/Str
-    groups :- [s/Str]
-    prev-sighting :- (s/maybe StoredSighting)]
+  ([new-sighting id tempids owner groups prev-sighting]
    (let [now (time/now)]
-     (assoc new-sighting
-            :id id
-            :type "sighting"
-            :owner (or (:owner prev-sighting) owner)
-            :groups (or (:groups prev-sighting) groups)
-            :count (:count new-sighting
-                           (:count prev-sighting 1))
-            :confidence (:confidence new-sighting
-                                     (:confidence prev-sighting "Unknown"))
-            :tlp (:tlp new-sighting
-                       (:tlp prev-sighting (properties-default-tlp)))
-            :schema_version schema-version
-            :created (or (:created prev-sighting) now)
-            :modified now))))
+     (sighting-default-realize
+      (assoc new-sighting
+             :count (:count new-sighting
+                            (:count prev-sighting 1))
+             :confidence (:confidence new-sighting
+                                      (:confidence prev-sighting "Unknown")))
+      id tempids owner groups prev-sighting))))
 
 (def sighting-fields
   (concat sorting/default-entity-sort-fields

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -38,15 +38,19 @@
 (s/defn realize-sighting :- StoredSighting
   ([new-sighting id tempids owner groups]
    (realize-sighting new-sighting id tempids owner groups nil))
-  ([new-sighting id tempids owner groups prev-sighting]
-   (let [now (time/now)]
-     (sighting-default-realize
-      (assoc new-sighting
-             :count (:count new-sighting
-                            (:count prev-sighting 1))
-             :confidence (:confidence new-sighting
-                                      (:confidence prev-sighting "Unknown")))
-      id tempids owner groups prev-sighting))))
+  ([new-sighting :- NewSighting
+    id :- s/Str
+    tempids :- (s/maybe TempIDs)
+    owner :- s/Str
+    groups :- [s/Str]
+    prev-sighting :- (s/maybe StoredSighting)]
+   (sighting-default-realize
+    (assoc new-sighting
+           :count (:count new-sighting
+                          (:count prev-sighting 1))
+           :confidence (:confidence new-sighting
+                                    (:confidence prev-sighting "Unknown")))
+    id tempids owner groups prev-sighting)))
 
 (def sighting-fields
   (concat sorting/default-entity-sort-fields

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -180,8 +180,12 @@
   (let [errors (filter :error entities)]
     (if (and (seq errors)
              (not enveloped-result?))
-      (throw (ex-info (:msg (first errors))
-                      (first errors)))
+      (let [{:keys [msg error] :as full-error} (first errors)]
+        (throw
+         (ex-info (or msg error)
+                  ;; short-id is only used for the enveloped-result
+                  ;; it should not be exposed
+                  (dissoc full-error :id))))
       fm)))
 
 (s/defn ^:private apply-before-hooks :- FlowMap

--- a/src/ctia/flows/schemas.clj
+++ b/src/ctia/flows/schemas.clj
@@ -1,14 +1,15 @@
 (ns ctia.flows.schemas
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s]
+            [schema-tools.core :as st]))
 
 (defn error?
   [v]
   (contains? v :error))
 
 (s/defschema EntityError
-  {:error s/Any
-   :id s/Str
-   s/Keyword s/Any})
+  (st/open-schema
+   {:error s/Any
+    :id s/Str}))
 
 (defn with-error
   [s]

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -94,6 +94,14 @@
       :entity entity
       :class (.getName (class e))})))
 
+(defn realize-entity-error-handler
+  "Handle error at the realize step"
+  [^Exception e data request]
+  (logging/log! :info e (ex-message e))
+  (bad-request
+   (let [data (ex-data e)]
+     (dissoc data :type))))
+
 (defn default-error-handler
   "Handle default error"
   [^Exception e data request]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -85,6 +85,7 @@
    :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
    :access-control-error ex/access-control-error-handler
    :invalid-tlp-error ex/invalid-tlp-error-handler
+   :realize-entity-error ex/realize-entity-error-handler
    :spec-validation-error ex/spec-validation-error-handler
    :compojure.api.exception/default ex/default-error-handler})
 

--- a/test/ctia/entity/entities_test.clj
+++ b/test/ctia/entity/entities_test.clj
@@ -1,0 +1,32 @@
+(ns ctia.entity.entities-test
+  (:require [ctia.entity.entities :as sut]
+            [clojure.test :as t :refer [deftest is use-fixtures]]
+            [clojure.spec.alpha :refer [gen]]
+            [clojure.spec.gen.alpha :refer [generate]]
+            [schema.test :refer [validate-schemas]]))
+
+(defn gen-sample-entity
+  [{:keys [new-spec]}]
+  (if new-spec
+    (generate (gen new-spec))
+    {}))
+
+(deftest entity-realize-fn-test
+  (let [properties [:id :type :owner :groups :schema_version
+                    :created :modified :timestamp :tlp]
+        ;; properties to dissoc to get a valid entity when
+        ;; using the spec generator
+        to-dissoc [:disposition]]
+    (doseq [[_ {:keys [realize-fn] :as entity}] sut/entities]
+      (when realize-fn
+        (let [realized-entity
+              (-> (apply dissoc
+                         (gen-sample-entity entity)
+                         (concat properties to-dissoc))
+                  (realize-fn "http://host/id" {} "owner" []))]
+          (doseq [property properties]
+            (is (contains? realized-entity property)
+                (format "The realized entity %s should contain the property %s"
+                        (:entity entity)
+                        property))))))))
+

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -19,6 +19,7 @@
                   "http://ex.tld/ctia/feedback/feedback-456"]
    :type "feedback"
    :reason "false positive"
+   :timestamp #inst "2042-01-01T00:00:00.000Z"
    :tlp "green"})
 
 (defn feedback-by-entity-id-test

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -491,7 +491,7 @@
                    :headers {"Authorization" "45c1f5e3f05d0"})]
          (is (= 400 status))
          (is (=
-              {:error "Mismatching :dispostion and dispositon_name for judgement",
+              {:error "Mismatching disposition and dispositon_name for judgement",
                :judgement {:observable {:value "1.2.3.4"
                                         :type "ip"}
                            :disposition 1
@@ -519,7 +519,7 @@
                    :headers {"Authorization" "45c1f5e3f05d0"})]
          (is (= 400 status))
          (is (deep=
-              {:error "Mismatching :dispostion and dispositon_name for judgement",
+              {:error "Mismatching disposition and dispositon_name for judgement",
                :judgement {:observable {:value "1.2.3.4"
                                         :type "ip"}
                            :disposition 1

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -176,6 +176,7 @@
                           :disposition 2
                           :source "test"
                           :priority 100
+                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                           :severity "High"
                           :confidence "Low"
                           :reason "This is a bad IP address that talked to some evil servers"
@@ -213,6 +214,7 @@
                        :disposition 2
                        :disposition_name "Malicious"
                        :priority 100
+                       :timestamp #inst "2042-01-01T00:00:00.000Z"
                        :severity "High"
                        :confidence "Low"
                        :source "test"
@@ -266,6 +268,7 @@
                           :disposition 2
                           :source "test"
                           :priority 100
+                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                           :severity "High"
                           :confidence "Low"
                           :reason "This is a bad IP address that talked to some evil servers"
@@ -280,6 +283,7 @@
                                           :disposition 2
                                           :source "test"
                                           :priority 100
+                                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                                           :severity "High"
                                           :confidence "Low"
                                           :reason "This is a bad IP address that talked to some evil servers"
@@ -344,6 +348,7 @@
                        :disposition 2
                        :disposition_name "Malicious"
                        :priority 100
+                       :timestamp #inst "2042-01-01T00:00:00.000Z"
                        :severity "High"
                        :confidence "Low"
                        :source "test"
@@ -381,6 +386,7 @@
                           :disposition 2
                           :source "test"
                           :priority 100
+                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                           :severity "High"
                           :confidence "Low"
                           :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
@@ -394,6 +400,7 @@
                :disposition_name "Malicious"
                :source "test"
                :priority 100
+               :timestamp #inst "2042-01-01T00:00:00.000Z"
                :severity "High"
                :confidence "Low"
                :tlp "green"
@@ -412,6 +419,7 @@
                           :disposition_name "Malicious"
                           :source "test"
                           :priority 100
+                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                           :severity "High"
                           :confidence "Low"
                           :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
@@ -425,6 +433,7 @@
                :disposition_name "Malicious"
                :source "test"
                :priority 100
+               :timestamp #inst "2042-01-01T00:00:00.000Z"
                :severity "High"
                :confidence "Low"
                :tlp "green"
@@ -442,6 +451,7 @@
                                        :type "ip"}
                           :source "test"
                           :priority 100
+                          :timestamp #inst "2042-01-01T00:00:00.000Z"
                           :severity "High"
                           :confidence "Low"
                           :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
@@ -455,6 +465,7 @@
                :disposition_name "Unknown"
                :source "test"
                :priority 100
+               :timestamp #inst "2042-01-01T00:00:00.000Z"
                :severity "High"
                :confidence "Low"
                :tlp "green"

--- a/test/ctia/flows/events_test.clj
+++ b/test/ctia/flows/events_test.clj
@@ -162,5 +162,5 @@
                           :groups ["Administrators"]}
                  :event_type :record-created}]
                (->> events
-                    (map #(dissoc % :http-params :id :timestamp :created))
-                    (map #(update % :entity dissoc :created)))))))))
+                    (map #(dissoc % :http-params :id :timestamp :created :modified))
+                    (map #(update % :entity dissoc :created :modified :timestamp)))))))))

--- a/test/ctia/flows/hooks/redis_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redis_event_hook_test.clj
@@ -152,8 +152,8 @@
                           :groups ["Administrators"]}
                  :event_type :record-created}]
                (->> @results
-                    (map #(dissoc % :timestamp :http-params :id))
-                    (map #(update % :entity dissoc :created)))))
+                    (map #(dissoc % :timestamp :http-params :id :modified))
+                    (map #(update % :entity dissoc :created :modified :timestamp)))))
 
         (testing "variable event fields have correct type"
           (doseq [event @results]

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -25,6 +25,7 @@
                        :disposition 2
                        :source "test"
                        :priority 100
+                       :timestamp #inst "2042-01-01T00:00:00.000Z"
                        :severity "High"
                        :confidence "Low"
                        :valid_time {:start_time "2016-02-11T00:00:00.000-00:00"
@@ -43,6 +44,7 @@
             :tlp "green"
             :schema_version schema-version
             :priority 100
+            :timestamp #inst "2042-01-01T00:00:00.000Z"
             :severity "High"
             :confidence "Low"
             :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
@@ -65,6 +67,7 @@
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100
+                :timestamp #inst "2042-01-01T00:00:00.000Z"
                 :severity "High"
                 :confidence "Low"
                 :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -24,6 +24,7 @@
                 :body {:observable {:value "1.2.3.4"
                                     :type "ip"}
                        :disposition 2
+                       :timestamp #inst "2042-01-01T00:00:00.000Z"
                        :source "test"
                        :priority 100
                        :severity "High"
@@ -77,6 +78,7 @@
                 :disposition 2
                 :disposition_name "Malicious"
                 :source "test"
+                :timestamp #inst "2042-01-01T00:00:00.000Z"
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100


### PR DESCRIPTION
> Closes threatgrid/iroh#2607

This PR uses the `default-realise-fn` for all entities. It ensures that all common fields are added when the entity is realized. Only the addition of specific fields are defined in the `realize-judgement` and `realize-sighting` fns.

<a name="qa">[§](#qa)</a> QA
============================

1. Post a Judgement and a Sighting without the `timestamp` field
2. Retrieve the stored entities and check that the `timestamp` has been added automatically