### PR TITLE
Entity and lookup sort Improvements

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -347,7 +347,9 @@
                                list-fn
                                {:one-of filters}
                                identity-map
-                               {:limit max-relationships}))
+                               {:limit max-relationships
+                                :sort_by "timestamp"
+                                :sort_order "desc"}))
             ent/un-store-all)))
 
 (defn fetch-record

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -5,7 +5,9 @@
              [schemas :as js]]
             [ctia.entity.relationship.graphql-schemas :as relationship]
             [ctia.http.routes
-             [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
+             [common :refer [BaseEntityFilterParams
+                             PagingParams
+                             SourcableEntityFilterParams]]
              [crud :refer [entity-crud-routes]]]
             [ctia.schemas.graphql
              [flanders :as f]
@@ -18,21 +20,29 @@
             [schema-tools.core :as st]
             [schema.core :as s]))
 
-(def judgements-by-observable-sort-fields
-  (apply s/enum (map name (conj js/judgement-fields
-                                "disposition:asc,valid_time.start_time:desc"))))
+(def judgement-fields
+  (apply s/enum
+         (map name js/judgement-fields)))
 
 (def judgement-sort-fields
-  (apply s/enum js/judgement-fields))
+  (apply s/enum
+         (map name js/judgement-sort-fields)))
+
+(def judgements-by-observable-sort-fields
+  (apply s/enum
+         (map name
+              (concat js/judgements-by-observable-sort-fields
+                      js/judgement-sort-fields))))
 
 (s/defschema JudgementFieldsParam
-  {(s/optional-key :fields) [judgement-sort-fields]})
+  {(s/optional-key :fields) [judgement-fields]})
 
 (s/defschema JudgementsByObservableQueryParams
   (st/merge
    PagingParams
    JudgementFieldsParam
-   {(s/optional-key :sort_by) judgements-by-observable-sort-fields}))
+   {(s/optional-key :sort_by)
+    judgements-by-observable-sort-fields}))
 
 (s/defschema JudgementSearchParams
   (st/merge
@@ -46,7 +56,7 @@
     (s/optional-key :priority) s/Int
     (s/optional-key :severity) s/Str
     (s/optional-key :confidence) s/Str
-    (s/optional-key :sort_by)  judgement-sort-fields}))
+    (s/optional-key :sort_by) judgement-sort-fields}))
 
 (def JudgementGetParams JudgementFieldsParam)
 

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -80,4 +80,11 @@
            :observable.type
            :observable.value]))
 
+(def judgement-sort-fields
+  (concat judgement-fields
+          ["valid_time.start_time,timestamp"]))
 
+(def judgements-by-observable-sort-fields
+  (map name (conj judgement-fields
+                  "disposition:asc,valid_time.start_time:desc"
+                  "disposition:asc,valid_time.start_time:desc,timestamp:desc")))

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -9,10 +9,13 @@
             [schema.core :as s]))
 
 (def sighting-sort-fields
-  (apply s/enum ss/sighting-fields))
+  (apply s/enum (map name ss/sighting-sort-fields)))
+
+(def sighting-fields
+  (apply s/enum (map name ss/sighting-fields)))
 
 (s/defschema SightingFieldsParam
-  {(s/optional-key :fields) [sighting-sort-fields]})
+  {(s/optional-key :fields) [sighting-fields]})
 
 (s/defschema SightingSearchParams
   (st/merge
@@ -24,18 +27,13 @@
     (s/optional-key :sensor) s/Str
     (s/optional-key :observables.value) s/Str
     (s/optional-key :observables.type) s/Str
-    (s/optional-key :sort_by)  sighting-sort-fields}))
+    (s/optional-key :sort_by) sighting-sort-fields}))
 
 (s/defschema SightingsByObservableQueryParams
   (st/merge
    PagingParams
    SightingFieldsParam
-   {(s/optional-key :sort_by)
-    (s/enum
-     :id
-     :timestamp
-     :confidence
-     :observed_time.start_time)}))
+   {(s/optional-key :sort_by) sighting-sort-fields}))
 
 (def SightingGetParams SightingFieldsParam)
 

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -59,3 +59,7 @@
            :confidence
            :count
            :sensor]))
+
+(def sighting-sort-fields
+  (conj sighting-fields
+        "observed_time.start_time,timestamp"))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -5,7 +5,8 @@
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
             ctia.properties
-            [ctia.entity.judgement.schemas :refer [judgement-fields]]
+            [ctia.entity.judgement.schemas
+             :refer [judgement-fields judgement-sort-fields]]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
@@ -552,7 +553,7 @@
        (pagination-test
         "ctia/ip/1.2.3.4/judgements"
         {"Authorization" "45c1f5e3f05d0"}
-        [:id :disposition :priority :severity :confidence])
+        judgement-sort-fields)
 
        (field-selection-tests
         ["ctia/ip/1.2.3.4/judgements"

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -1,11 +1,13 @@
 (ns ctia.entity.sighting-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.sighting.schemas :refer [sighting-fields]]
+            [ctia.entity.sighting.schemas :refer [sighting-sort-fields
+                                                  sighting-fields]]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [post-entity-bulk]]
+             [core :as helpers :refer [post-entity-bulk
+                                       post-bulk]]
              [crud :refer [entity-crud-test]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
@@ -56,12 +58,27 @@
                 new-sighting-maximal
                 :sightings
                 30
-                {"Authorization" "45c1f5e3f05d0"})]
+                {"Authorization" "45c1f5e3f05d0"})
 
+           sample (dissoc new-sighting-maximal :id)
+           first-sighting (-> sample
+                              (assoc-in [:observed_time :start_time]
+                                        #inst "2016-01-01T01:01:01.000Z"))
+           second-sighting (-> sample
+                               (assoc-in [:observed_time :start_time]
+                                         #inst "2016-01-02T01:01:01.000Z"))
+           third-sighting (-> sample
+                              (assoc :timestamp
+                                     #inst "2016-01-03T01:01:01.000Z")
+                              (assoc-in [:observed_time :start_time]
+                                        #inst "2016-01-02T01:01:01.000Z"))
+           custom-samples (post-bulk {:sightings [first-sighting
+                                                  second-sighting
+                                                  third-sighting]})]
        (pagination-test
         "ctia/sighting/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        sighting-fields)
+        sighting-sort-fields)
 
        (field-selection-tests
         ["ctia/sighting/search?query=*"

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -170,7 +170,8 @@
         (post "ctia/bulk"
               :body examples
               :socket-timeout (* 5 60000)
-              :headers {"Authorization" "45c1f5e3f05d0"})]))
+              :headers {"Authorization" "45c1f5e3f05d0"})]
+    bulk-res))
 
 (defn post-entity-bulk [example plural x headers]
   (let [new-records


### PR DESCRIPTION
This PR Adds 
- new sort options for Sighting and Judgements, allowing to easily fetch latest objects
- Changes Bundle export so it includes objects ordered from latest Relationships first


> **Epic** https://github.com/threatgrid/iroh/issues/2696

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. POST multiple `Judgements` and `Sightings` with different`valid_time`, `observed_time` and `timestamps`
2. query using the new sort choices
3. your responses should be correctly ordered based on the sort choice

4. POST an entity and link it to another one multiple times, exceeding the Bundle export limit
5. Retrieved entities should be the most recently linked

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
public: New sort choices to get the latest Sightings and Judgements
```

