### PR TITLE
Upgrade Redis lib carmine and linked deps

### DIFF
--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - kibana
       - elasticsearch
   redis:
-    image: redis
+    image: redis:5.0.5
     ports:
       - "6379:6379"
 

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis-dev:
-    image: redis
+    image: redis:5.0.5
     ports:
       - "6379:6379"
   elasticsearch-dev:

--- a/containers/test/docker-compose.yml
+++ b/containers/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis-dev:
-    image: redis
+    image: redis:5.0.5
     ports:
       - "6379:6379"
   elasticsearch-dev:

--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,8 @@
                  [threatgrid/ctim "1.0.11"
                   :exclusions [threatgrid/flanders
                                metosin/ring-swagger
-                               com.google.guava/guava]]
+                               com.google.guava/guava
+                               org.clojure/tools.reader]]
                  [threatgrid/clj-momo "0.2.31"]
 
                  ;; Web server
@@ -78,8 +79,7 @@
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]
-                 [com.taoensso/carmine "2.19.1"
-                  :exclusions [org.clojure/tools.reader]]
+                 [com.taoensso/carmine "2.19.1"]
 
                  ;; Metrics
                  [metrics-clojure "2.10.0"]
@@ -96,8 +96,7 @@
                  [hiccup "2.0.0-alpha1"]
 
                  ;; Hooks
-                 [threatgrid/redismq "0.1.1"
-                  :exclusions [org.clojure/tools.reader]]
+                 [threatgrid/redismq "0.1.1"]
 
                  ;; GraphQL
                  [base64-clj "0.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -79,8 +79,7 @@
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]
                  [com.taoensso/carmine "2.19.1"
-                  :exclusions [com.andrewmcveigh/cljs-time
-                               org.clojure/tools.reader]]
+                  :exclusions [org.clojure/tools.reader]]
 
                  ;; Metrics
                  [metrics-clojure "2.10.0"]
@@ -98,7 +97,7 @@
 
                  ;; Hooks
                  [threatgrid/redismq "0.1.1"
-                  :exclusions [com.taoensso/carmine]]
+                  :exclusions [org.clojure/tools.reader]]
 
                  ;; GraphQL
                  [base64-clj "0.1.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def cheshire-version "5.8.0")
+(def cheshire-version "5.8.1")
 (def compojure-api-version "1.1.11")
 (def schema-tools-version "0.9.1")
 (def schema-version "1.1.7")
@@ -33,7 +33,7 @@
                  [org.clojure/core.async "0.3.465" :exclusions [org.clojure/tools.reader]]
                  [org.slf4j/slf4j-log4j12 "1.8.0-beta0"]
                  [org.clojure/core.memoize "0.5.9"]
-                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.cli "0.4.1"]
                  [pandect "0.6.1"]
 
@@ -78,7 +78,9 @@
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]
-                 [com.taoensso/carmine "2.17.0"]
+                 [com.taoensso/carmine "2.19.1"
+                  :exclusions [com.andrewmcveigh/cljs-time
+                               org.clojure/tools.reader]]
 
                  ;; Metrics
                  [metrics-clojure "2.10.0"]
@@ -95,7 +97,8 @@
                  [hiccup "2.0.0-alpha1"]
 
                  ;; Hooks
-                 [threatgrid/redismq "0.1.0"]
+                 [threatgrid/redismq "0.1.1"
+                  :exclusions [com.taoensso/carmine]]
 
                  ;; GraphQL
                  [base64-clj "0.1.1"]


### PR DESCRIPTION
Upgrade the carmine library in order to ensure support of at-rest encryption

> / Related https://github.com/threatgrid/iroh/issues/2772

<a name="qa">[§](#qa)</a> QA
============================

No QA needed

<a name="ops">[§](#ops)</a> Ops
===============================

This version of CTIA has been unit tested with the latest version of Redis (5.0.5)

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Upgrade to ensure support of Redis at-rest encryption
```