### PR TITLE
Add properties to secure connection with Redis servers

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -152,24 +152,29 @@
 
    setup pushing events to redisMQ
 
-| Property                     | Description                          | Possible values |
-|------------------------------+--------------------------------------+-----------------|
-| ctia.hook.redismq.queue-name | set the queue name                   | string          |
-| ctia.hook.redismq.port       | set the port of the redisMQ instance | number          |
-| ctia.hook.redismq.timeout-ms | event pushing timeout                | number          |
-| ctia.hook.redismq.max-depth  |                                      | number          |
+| Property                     | Description                               | Possible values |
+|------------------------------+-------------------------------------------+-----------------|
+| ctia.hook.redismq.queue-name | set the queue name                        | string          |
+| ctia.hook.redismq.port       | set the host of the redisMQ instance      | number          |
+| ctia.hook.redismq.port       | set the port of the redisMQ instance      | number          |
+| ctia.hook.redismq.ssl        | Enable SSL connection to the Redis server | boolean         |
+| ctia.hook.redismq.password   | Password used for Redis authentication    | string          |
+| ctia.hook.redismq.timeout-ms | event pushing timeout                     | number          |
+| ctia.hook.redismq.max-depth  |                                           | number          |
 
 
 *** Redis
 
    setup pushing events to a channel on a redis instance
 
-| Property                     | Description                           | Possible values |
-|------------------------------+---------------------------------------+-----------------|
-| ctia.hook.redis.host         | set the redis instance host           | string          |
-| ctia.hook.redis.port         | set the redis instace port            | number          |
-| ctia.hook.redis.timeout-ms   | event pushing timeout                 | number          |
-| ctia.hook.redis.channel-name | the chan where events shall be pushed | string          |
+| Property                     | Description                               | Possible values |
+|------------------------------+-------------------------------------------+-----------------|
+| ctia.hook.redis.host         | set the redis instance host               | string          |
+| ctia.hook.redis.port         | set the redis instace port                | number          |
+| ctia.hook.redis.ssl          | Enable SSL connection to the Redis server | boolean         |
+| ctia.hook.redis.password     | Password used for Redis authentication    | string          |
+| ctia.hook.redis.timeout-ms   | event pushing timeout                     | number          |
+| ctia.hook.redis.channel-name | the chan where events shall be pushed     | string          |
 
 
 *** Generic

--- a/src/ctia/flows/hooks/event_hooks.clj
+++ b/src/ctia/flows/hooks/event_hooks.clj
@@ -26,9 +26,9 @@
     event))
 
 (defn redis-event-publisher []
-  (let [{:keys [channel-name timeout-ms host port] :as redis-config}
+  (let [{:keys [channel-name] :as redis-config}
         (get-in @properties [:ctia :hook :redis])]
-    (->RedisEventPublisher (lr/server-connection host port timeout-ms)
+    (->RedisEventPublisher (lr/server-connection redis-config)
                            channel-name)))
 
 (defrecord RedisMQPublisher [queue]
@@ -45,16 +45,16 @@
     event))
 
 (defn redismq-publisher []
-  (let [{:keys [queue-name host port timeout-ms max-depth enabled]
+  (let [{:keys [queue-name host port timeout-ms max-depth enabled
+                password ssl]
          :as config
          :or {queue-name "ctim-event-queue"
               host "localhost"
               port 6379}}
-        (get-in @properties [:ctia :hook :redismq])]
+        (get-in @properties [:ctia :hook :redismq])
+        conn-spec (lr/redis-conf->conn-spec config)]
     (->RedisMQPublisher (rmq/make-queue queue-name
-                                        {:host host
-                                         :port port
-                                         :timeout-ms timeout-ms}
+                                        conn-spec
                                         {:max-depth max-depth}))))
 
 (defrecord ChannelEventPublisher []

--- a/src/ctia/lib/redis.clj
+++ b/src/ctia/lib/redis.clj
@@ -3,14 +3,20 @@
 
 ;; Connections
 
+(defn redis-conf->conn-spec
+  [{:keys [host port timeout-ms password ssl]}]
+  (cond-> {:host host
+           :port port
+           :timeout-ms timeout-ms}
+    password (assoc :password password)
+    ssl (assoc :ssl-fn :default)))
+
 (defn server-connection
   "Build the server config"
-  [host port timeout-ms]
+  [{:keys [host port] :as redis-config}]
   (assert (and host port) "Redis has been de-configured")
   {:pool {}
-   :spec {:host host
-          :port port
-          :timeout-ms timeout-ms}})
+   :spec (redis-conf->conn-spec redis-config)})
 
 ;; Pub/Sub
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -113,12 +113,16 @@
                       "ctia.http.events.timeline.max-seconds" s/Int
                       "ctia.hook.redis.host" s/Str
                       "ctia.hook.redis.port" s/Int
+                      "ctia.hook.redis.ssl" s/Bool
+                      "ctia.hook.redis.password" s/Str
                       "ctia.hook.redis.channel-name" s/Str
                       "ctia.hook.redis.timeout-ms" s/Int
 
                       "ctia.hook.redismq.queue-name" s/Str
                       "ctia.hook.redismq.host" s/Str
                       "ctia.hook.redismq.port" s/Int
+                      "ctia.hook.redismq.ssl" s/Bool
+                      "ctia.hook.redismq.password" s/Str
                       "ctia.hook.redismq.timeout-ms" s/Int
                       "ctia.hook.redismq.max-depth" s/Int
 

--- a/test/ctia/flows/hooks/redis_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redis_event_hook_test.clj
@@ -25,8 +25,9 @@
   (testing "Events are published to redis"
     (let [results (atom [])
           finish-signal (CountDownLatch. 3)
-          {:keys [timeout-ms channel-name host port] :as redis-config} (get-in @properties [:ctia :hook :redis])
-          listener (lr/subscribe-to-messages (lr/server-connection host port timeout-ms)
+          {:keys [channel-name] :as redis-config}
+          (get-in @properties [:ctia :hook :redis])
+          listener (lr/subscribe-to-messages (lr/server-connection redis-config)
                                              channel-name
                                              (fn test-events-pubsub-fn [ev]
                                                (swap! results conj ev)

--- a/test/ctia/lib/redis_test.clj
+++ b/test/ctia/lib/redis_test.clj
@@ -14,10 +14,28 @@
                       es-helpers/fixture-properties:es-store
                       test-helpers/fixture-ctia-fast]))
 
+(deftest redis-conf->conn-spec-test
+  (is (= {:port 6379
+          :host "redis.local"
+          :timeout-ms 1000}
+         (lr/redis-conf->conn-spec {:port 6379
+                                    :host "redis.local"
+                                    :timeout-ms 1000})))
+  (is (= {:port 6379
+          :host "redis.local"
+          :timeout-ms 1000
+          :ssl-fn :default
+          :password "secret"}
+         (lr/redis-conf->conn-spec {:port 6379
+                                    :host "redis.local"
+                                    :timeout-ms 1000
+                                    :ssl true
+                                    :password "secret"}))))
+
 (deftest ^:integration test-redis-pubsub-works
   (testing "That we can connect to redis and do pub/sub"
-    (let [{:keys [timeout-ms host port] :as redis-config} (get-in @properties [:ctia :hook :redis])
-          server-connection (lr/server-connection host port timeout-ms)
+    (let [redis-config (get-in @properties [:ctia :hook :redis])
+          server-connection (lr/server-connection redis-config)
           event-channel-name (str (gensym "events"))
           results (atom [])
           finish-signal (CountDownLatch. 4)


### PR DESCRIPTION
Add configuration properties to enable SSL and Authentication in redis clients

> / Related threatgrid/iroh#2517


<a name="qa">[§](#qa)</a> QA
============================

No QA needed

<a name="ops">[§](#ops)</a> Ops
===============================

To enable SSL:
```
ctia.hook.redismq.ssl=true
ctia.hook.redis.ssl=true
```

To enable authentication:
```
ctia.hook.redis.password=secret
ctia.hook.redismq.password=secret
```

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Add the capability to encrypt and authenticate connection to redis servers
```
