### PR TITLE
Add quotes to the etag header as specified by RFC7232

### DIFF
--- a/src/ctia/http/middleware/cache_control.clj
+++ b/src/ctia/http/middleware/cache_control.clj
@@ -9,10 +9,12 @@
   (= (:status response) 200))
 
 (defn calculate-etag [accept body]
-  (case (class body)
-    String (sha1 (str accept ":" body))
-    File (str (.lastModified body) "-" (.length body))
-    (sha1 (.getBytes (str accept ":" (pr-str body)) "UTF-8"))))
+  (let [etagc
+        (case (class body)
+          String (sha1 (str accept ":" body))
+          File (str (.lastModified body) "-" (.length body))
+          (sha1 (.getBytes (str accept ":" (pr-str body)) "UTF-8")))]
+    (str \" etagc \")))
 
 (defn update-headers
   [headers etag body]

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -49,8 +49,10 @@
       (let [first-res (get-actor actor-id nil)
             etag (get-in first-res [:headers "ETag"])
             second-res (get-actor actor-id {"If-none-match" etag})]
-
         (is (= 200 (:status first-res)))
         (is (not (nil? etag)))
         (is (= 304 (:status second-res)))
-        (is (nil? (:parsed-body second-res)))))))
+        (is (nil? (:parsed-body second-res)))
+        (is (and (= (first etag) \")
+                 (= (last etag) \"))
+            "Etag is quoted")))))


### PR DESCRIPTION
Add quotes around the etag header

> / Closes threatgrid/iroh#2791

The `etag` header wasn't quoted like specified in RFC7232. This PR fixes it.

<a name="qa">[§](#qa)</a> QA
============================

1. Request the CTIA API
2. The value of the `etag` header in the response should be quoted

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Add quotes to the value of the etag in the API response header
```
