### PR TITLE
Fix a NPE while attempting to convert an ID on Bulk Export

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -69,11 +69,14 @@
   "Retrieve many entities of the same type provided their ids and common type"
   [ids entity-type auth-identity]
   (let [read-entity (read-fn entity-type auth-identity {})]
-    (map (fn [id] (try (with-long-id
-                         (read-entity id))
-                       (catch Exception e
-                         (do (log/error (pr-str e))
-                             nil)))) ids)))
+    (map (fn [id]
+           (try
+             (if-let [entity (read-entity id)]
+               (with-long-id entity)
+               nil)
+             (catch Exception e
+               (do (log/error (pr-str e))
+                   nil)))) ids)))
 
 (defn gen-bulk-from-fn
   "Kind of fmap but adapted for bulk

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -1,0 +1,10 @@
+(ns ctia.bulk.core-test
+  (:require [ctia.bulk.core :as sut :refer [read-fn]]
+            [clojure.test :refer [deftest testing is]]))
+
+(deftest read-entities-test
+  (testing "Attempting to read an unreachable entity should not throw"
+    (let [res (with-redefs [ctia.bulk.core/read-fn (fn [_ _ _] (fn [id] nil))]
+                (sut/read-entities ["judgement-123"]
+                                   :judgement {}))]
+      (is (= [nil] res)))))

--- a/test/ctia/flows/hooks/kafka_event_hook_test.clj
+++ b/test/ctia/flows/hooks/kafka_event_hook_test.clj
@@ -37,7 +37,7 @@
                (.countDown finish-signal)))
            30000)
           ;; await rebalance
-          _ (Thread/sleep 5000)]
+          _ (Thread/sleep 10000)]
       (let [{{judgement-1-long-id :id} :parsed-body
              judgement-1-status :status
              :as judgement-1}
@@ -93,7 +93,7 @@
         (is (= 201 judgement-2-status))
         (is (= 201 judgement-3-status))
 
-        (is (.await finish-signal 5 TimeUnit/SECONDS)
+        (is (.await finish-signal 30 TimeUnit/SECONDS)
             "Unexpected timeout waiting for events")
 
         (lk/stop-consumer consumer-map)


### PR DESCRIPTION
This PR fixes an NPE occurring on bulk export

> / Close https://github.com/threatgrid/iroh/issues/2810

The Bulk export process read entities and attempt to convert retrieved entity IDs to URLs, previous behaviour didn't check that the entity was existing before attempting to convert the ID, thus leading to a NPE, this PR fixes that and add a test to check the behaviour.

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. Attempt to call Bundle/Export with an unexisting entity ID
2. You shouldn't get a 500


<a name="ops">[§](#ops)</a> Ops
===============================

Nothing

<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

Nothing

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Fix a Bug in CTIA Bulk export 
```
