### PR TITLE
Add rate limiting to CTIA

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ use `limit` and `offset` along with `search_after` filled with the value from th
 
 #### Rate limit
 
-Request can be rate limited by enabling the middleware with the `ctia.http.rate-limit.enabled` property.
+Requests may be rate limited by enabling the middleware using the `ctia.http.rate-limit.enabled` property.
 
 It rate limits how many HTTP requests a CTIA group can make in an hour. The group is identified with the property :identity of the current Ring request.
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Requests may be rate limited by enabling the middleware using the `ctia.http.rat
 
 It rate limits how many HTTP requests a CTIA group can make in an hour. The group is identified with the property :identity of the current Ring request.
 
-When the rate limit is not reached, the header `X-Ratelimit-Group-Limit` is returned in the response:
+Before the rate limit is reached, the header `X-Ratelimit-Group-Limit` is returned in the response:
 
 ```
 HTTP/1.1 200 OK

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ X-Ratelimit-Group-Limit: 8000
 
 If the rate limit is exceeded:
 
-- The client receives a response with the 429 HTTP status, a `retry-after` header and the JSON message `{"error": "Too Many Requests"}`. The retry-after header indicates the number of second to wait before making a new request.
+- The client receives a response with the 429 HTTP status, a `retry-after` header and the JSON message `{"error": "Too Many Requests"}`. The retry-after header indicates the number of seconds to wait before making a new request.
 
  ```
 HTTP/1.1 429 Too Many Requests

--- a/README.md
+++ b/README.md
@@ -318,6 +318,45 @@ use a combination of `offset` and `limit` parameters to paginate results.
 To be used when the result window is superior to `10 000`, allows to easily loop across all pages of a query response.
 use `limit` and `offset` along with `search_after` filled with the value from the `X-Sort` response header to get the next page.
 
+#### Rate limit
+
+Request can be rate limited by enabling the middleware with the `ctia.http.rate-limit.enabled` property.
+
+It rate limits how many HTTP requests a CTIA group can make in an hour. The group is identified with the property :identity of the current Ring request.
+
+When the rate limit is not reached, the header `X-Ratelimit-Group-Limit` is returned in the response:
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=utf-8
+Date: Wed, 31 Oct 2018 14:05:30 GMT
+Server: Jetty(9.4.z-SNAPSHOT)
+Strict-Transport-Security: max-age=31536000; includeSubdomains
+Vary: Accept-Encoding, User-Agent
+X-Ctim-Version: 1.0.6
+X-Ctia-Config: b9b3477528d9616ed85221f2827bf1da443e8f00
+X-Ctia-Version: 70323eb3b72da558e7f056e418533402f65d335a
+X-Ratelimit-Group-Limit: 8000
+```
+
+If the rate limit is exceeded:
+
+- The client receives a response with the 429 HTTP status, a `retry-after` header and the JSON message `{"error": "Too Many Requests"}`. The retry-after header indicates the number of second to wait before making a new request.
+
+ ```
+HTTP/1.1 429 Too Many Requests
+Content-Length: 30
+Content-Type: application/json
+Date: Wed, 31 Oct 2018 14:05:30 GMT
+Retry-After: 3557
+Server: Jetty(9.4.z-SNAPSHOT)
+Strict-Transport-Security: max-age=31536000; includeSubdomains
+X-Ctim-Version: 1.0.6
+X-Ctia-Config: b9b3477528d9616ed85221f2827bf1da443e8f00
+X-Ctia-Version: 70323eb3b72da558e7f056e418533402f65d335a
+ ```
+
+- A message is logged with the :info level
 
 ## License
 

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -88,6 +88,25 @@
 | ctia.http.jwt.local-storage-key | set JWT local storage key             | string (a full path) |
 
 
+*** Rate limit
+
+Rate limit related configuration
+
+| Property                                 | Descripiton                                                                                    | Possible values |
+|------------------------------------------+------------------------------------------------------------------------------------------------+-----------------|
+| ctia.http.rate-limit.enabled             | Enable rate limit                                                                              | =true= =false=  |
+| ctia.http.rate-limit.key-prefix          | The key prefix if the same redis DB is used for several applications                           | string          |
+| ctia.http.rate-limit.unlimited-clientids | List of clientids which are not rate limited as a csv                                          | string          |
+| ctia.http.rate-limit.default-group-limit | The default number of allowed requests per hour per group                                      | number          |
+| ctia.http.rate-limit.custom-group-limits | Define custom limits for groups as csv, the number of requests per hour is delimited by a pipe | string          |
+| ctia.http.rate-limit.redis.host          | Set the redis instance host                                                                    | string          |
+| ctia.http.rate-limit.redis.port          | Set the redis instance port                                                                    | number          |
+| ctia.http.rate-limit.redis.ssl           | Enable SSL connection to the Redis server                                                      | =true= =false=  |
+| ctia.http.rate-limit.redis.password      | Password used for Redis authentication                                                         | string          |
+| ctia.http.rate-limit.redis.db            | Set te redis instance db                                                                       | number          |
+| ctia.http.rate-limit.redis.timeout-ms    | Set redis timeout in milliseconds                                                              | number          |
+
+
 *** Show   
 
    Configure how CTIA is hosted,

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -92,19 +92,19 @@
 
 Rate limit related configuration
 
-| Property                                 | Descripiton                                                                                    | Possible values |
-|------------------------------------------+------------------------------------------------------------------------------------------------+-----------------|
-| ctia.http.rate-limit.enabled             | Enable rate limit                                                                              | =true= =false=  |
-| ctia.http.rate-limit.key-prefix          | The key prefix if the same redis DB is used for several applications                           | string          |
-| ctia.http.rate-limit.unlimited-clientids | List of clientids which are not rate limited as a csv                                          | string          |
-| ctia.http.rate-limit.default-group-limit | The default number of allowed requests per hour per group                                      | number          |
-| ctia.http.rate-limit.custom-group-limits | Define custom limits for groups as csv, the number of requests per hour is delimited by a pipe | string          |
-| ctia.http.rate-limit.redis.host          | Set the redis instance host                                                                    | string          |
-| ctia.http.rate-limit.redis.port          | Set the redis instance port                                                                    | number          |
-| ctia.http.rate-limit.redis.ssl           | Enable SSL connection to the Redis server                                                      | =true= =false=  |
-| ctia.http.rate-limit.redis.password      | Password used for Redis authentication                                                         | string          |
-| ctia.http.rate-limit.redis.db            | Set te redis instance db                                                                       | number          |
-| ctia.http.rate-limit.redis.timeout-ms    | Set redis timeout in milliseconds                                                              | number          |
+| Property                                  | Descripiton                                                                                    | Possible values |
+|-------------------------------------------+------------------------------------------------------------------------------------------------+-----------------|
+| ctia.http.rate-limit.enabled              | Enable rate limit                                                                              | =true= =false=  |
+| ctia.http.rate-limit.key-prefix           | The key prefix if the same redis DB is used for several applications                           | string          |
+| ctia.http.rate-limit.unlimited.client-ids | List of clientids which are not rate limited as a csv                                          | string          |
+| ctia.http.rate-limit.limits.group.default | The default number of allowed requests per hour per group                                      | number          |
+| ctia.http.rate-limit.limits.group.customs | Define custom limits for groups as csv, the number of requests per hour is delimited by a pipe | string          |
+| ctia.http.rate-limit.redis.host           | Set the redis instance host                                                                    | string          |
+| ctia.http.rate-limit.redis.port           | Set the redis instance port                                                                    | number          |
+| ctia.http.rate-limit.redis.ssl            | Enable SSL connection to the Redis server                                                      | =true= =false=  |
+| ctia.http.rate-limit.redis.password       | Password used for Redis authentication                                                         | string          |
+| ctia.http.rate-limit.redis.db             | Set te redis instance db                                                                       | number          |
+| ctia.http.rate-limit.redis.timeout-ms     | Set redis timeout in milliseconds                                                              | number          |
 
 
 *** Show   

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (def cheshire-version "5.8.1")
 (def compojure-api-version "1.1.11")
 (def schema-tools-version "0.9.1")
-(def schema-version "1.1.7")
+(def schema-version "1.1.11")
 (def jetty-server-version "9.4.15.v20190215")
 ;; On avoiding dependency overrides:
 ;; - :pedantic? should be set to :abort; Use "lein deps :tree" to resolve
@@ -76,6 +76,8 @@
                   :exclusions [commons-codec]]
                  [yogsototh/clj-jwt "0.2.1"]
                  [threatgrid/ring-jwt-middleware "0.0.10" :exclusions [metosin/compojure-api]]
+                 [threatgrid/ring-turnstile-middleware "0.1.0"
+                  :exclusions [metosin/schema-tools]]
 
                  ;; clients
                  [clj-http "3.7.0" :exclusions [commons-codec]]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -26,6 +26,14 @@ ctia.http.jwt.local-storage-key=:iroh-auth-token
 ctia.http.jwt.claim-prefix=https://schemas.cisco.com/iroh/identity/claims
 ctia.http.min-threads=10
 ctia.http.max-threads=100
+
+ctia.http.rate-limit.enabled=false
+ctia.http.rate-limit.key-prefix=ctia
+ctia.http.rate-limit.default-group-limit=18000
+ctia.http.rate-limit.redis.host=localhost
+ctia.http.rate-limit.redis.port=6379
+ctia.http.rate-limit.redis.timeout-ms=1000
+
 ctia.http.show.hostname=localhost
 ctia.http.show.port=3000
 ctia.http.show.protocol=http

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -29,7 +29,7 @@ ctia.http.max-threads=100
 
 ctia.http.rate-limit.enabled=false
 ctia.http.rate-limit.key-prefix=ctia
-ctia.http.rate-limit.default-group-limit=18000
+ctia.http.rate-limit.limits.group.default=18000
 ctia.http.rate-limit.redis.host=localhost
 ctia.http.rate-limit.redis.port=6379
 ctia.http.rate-limit.redis.timeout-ms=1000

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -6,7 +6,8 @@
   (login [this])
   (groups [this])
   (allowed-capabilities [this])
-  (capable? [this capabilities]))
+  (capable? [this capabilities])
+  (rate-limited? [this]))
 
 (defprotocol IAuth
   (identity-for-token [this token]))
@@ -30,6 +31,8 @@
   (allowed-capabilities [_]
     #{})
   (capable? [_ _]
+    false)
+  (rate-limited? [_]
     false))
 
 (def denied-identity-singleton (->DeniedIdentity))

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -7,7 +7,7 @@
   (groups [this])
   (allowed-capabilities [this])
   (capable? [this capabilities])
-  (rate-limited? [this]))
+  (rate-limit-fn [this limit-fn]))
 
 (defprotocol IAuth
   (identity-for-token [this token]))
@@ -32,8 +32,7 @@
     #{})
   (capable? [_ _]
     false)
-  (rate-limited? [_]
-    false))
+  (rate-limit-fn [_ _]))
 
 (def denied-identity-singleton (->DeniedIdentity))
 

--- a/src/ctia/auth/allow_all.clj
+++ b/src/ctia/auth/allow_all.clj
@@ -16,7 +16,9 @@
   (allowed-capabilities [_]
     all-capabilities)
   (capable? [_ _]
-    true))
+    true)
+  (rate-limited? [_]
+    false))
 
 (def identity-singleton
   (->Identity))

--- a/src/ctia/auth/allow_all.clj
+++ b/src/ctia/auth/allow_all.clj
@@ -17,8 +17,7 @@
     all-capabilities)
   (capable? [_ _]
     true)
-  (rate-limited? [_]
-    false))
+  (rate-limit-fn [_ _]))
 
 (def identity-singleton
   (->Identity))

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -33,8 +33,7 @@
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
                  write-capabilities))
-  (rate-limited? [_]
-    false))
+  (rate-limit-fn [_ _]))
 
 (defrecord ReadOnlyIdentity []
   IIdentity
@@ -49,8 +48,7 @@
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
                  read-only-capabilities))
-  (rate-limited? [_]
-    false))
+  (rate-limit-fn [_ _]))
 
 (defrecord AuthService [auth-config]
   IAuth

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -32,7 +32,9 @@
     write-capabilities)
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
-                 write-capabilities)))
+                 write-capabilities))
+  (rate-limited? [_]
+    false))
 
 (defrecord ReadOnlyIdentity []
   IIdentity
@@ -46,7 +48,9 @@
     read-only-capabilities)
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
-                 read-only-capabilities)))
+                 read-only-capabilities))
+  (rate-limited? [_]
+    false))
 
 (defrecord AuthService [auth-config]
   IAuth

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -36,8 +36,7 @@
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
                  (auth/allowed-capabilities this)))
-  (rate-limited? [_]
-    false))
+  (rate-limit-fn [_ _]))
 
 (defn make-whoami-fn [whoami-url]
   (fn [token]

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -35,7 +35,9 @@
     capabilities)
   (capable? [this required-capabilities]
     (set/subset? (as-set required-capabilities)
-                 (auth/allowed-capabilities this))))
+                 (auth/allowed-capabilities this)))
+  (rate-limited? [_]
+    false))
 
 (defn make-whoami-fn [whoami-url]
   (fn [token]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -17,6 +17,7 @@
                                          graphql-routes]]
             [ctia.http.exceptions :as ex]
             [ctia.http.middleware
+             [ratelimit :refer [wrap-rate-limit]]
              [auth :refer :all]
              [cache-control :refer [wrap-cache-control]]
              [unknown :as unk]
@@ -175,7 +176,8 @@
             (apply-oauth2-swagger-conf
              oauth2))}
 
-         (middleware [wrap-not-modified
+         (middleware [wrap-rate-limit
+                      wrap-not-modified
                       wrap-cache-control
                       wrap-version
                       ;; always last

--- a/src/ctia/http/middleware/ratelimit.clj
+++ b/src/ctia/http/middleware/ratelimit.clj
@@ -63,7 +63,7 @@
     (fn [request]
       (when-let [[group limit]
                  (some-> (:identity request)
-                         (auth/groups)
+                         auth/groups
                          (with-limit default-group-limit group-limits)
                          sort-group-limits
                          first)]
@@ -104,4 +104,4 @@
                   (throw e)))))))
       (do
         (log/warn "Rate limit is disabled")
-        (fn [request] (handler request))))))
+        handler))))

--- a/src/ctia/http/middleware/ratelimit.clj
+++ b/src/ctia/http/middleware/ratelimit.clj
@@ -1,0 +1,107 @@
+(ns ctia.http.middleware.ratelimit
+  (:require [clojure.string :as string]
+            [clojure.tools.logging :as log]
+            [ctia
+             [auth :as auth]
+             [properties :refer [properties]]]
+            [ctia.lib
+             [collection :refer [fmap]]
+             [redis :refer [server-connection]]]
+            [ring.middleware.turnstile :as turnstile
+             :refer
+             [default-rate-limit-handler LimitFunction]]
+            [schema.core :as s])
+  (:import clojure.lang.ExceptionInfo))
+
+(def rate-limited-request-handler
+  "Handler called when a request is rate limited"
+  (fn [request
+       next-slot-in-sec
+       {:keys [nb-request-per-hour name-in-headers
+               rate-limit-key] :as limit}]
+    (let [ctx {:next-slot-in-sec next-slot-in-sec
+               :nb-request-per-hour nb-request-per-hour
+               :name-in-headers name-in-headers
+               :rate-limit-key rate-limit-key}]
+      (if (log/enabled? :debug)
+        (log/debugf "Rate limited request (request: %s, rate limit:%s)"
+                    (pr-str request)
+                    ctx)
+        (log/infof "Rate limited request, path: %s, identity: %s"
+                   (:uri request)
+                   (:identity request))))
+    (default-rate-limit-handler request next-slot-in-sec limit)))
+
+(defn with-limit
+  [groups default-group-limit custom-group-limits]
+  (map (fn [group-id]
+         [group-id
+          (get custom-group-limits
+               group-id
+               default-group-limit)])
+       groups))
+
+(defn parse-group-limits
+  "Parses group limits defined in the properties
+
+   Ex: group1|25000,group2|80000"
+  [limits]
+  (some->> (when limits (string/split limits #","))
+           (map #(string/split % #"\|"))
+           (fmap #(Integer/parseInt %))))
+
+(defn sort-group-limits
+  "Sorts group limits by nb of requests by hour and by group name
+   in descending order."
+  [group-limits]
+  (sort-by (juxt second first) #(compare %2 %1) group-limits))
+
+(s/defn ^:always-validate group-limit-fn :- LimitFunction
+  "Builds the group limit function"
+  [{:keys [default-group-limit custom-group-limits]}]
+  (let [group-limits (parse-group-limits custom-group-limits)]
+    (fn [request]
+      (when-let [[group limit]
+                 (some-> (:identity request)
+                         (auth/groups)
+                         (with-limit default-group-limit group-limits)
+                         sort-group-limits
+                         first)]
+        {:nb-request-per-hour limit
+         :rate-limit-key group
+         :name-in-headers "GROUP"}))))
+
+(s/defn with-rate-limited :- LimitFunction
+  [limit-fn]
+  (fn [request]
+    (let [auth-identity (:identity request)]
+      (when (auth/rate-limited? auth-identity)
+        (limit-fn request)))))
+
+(defn wrap-rate-limit
+  [handler]
+  (let [{:keys [redis enabled key-prefix] :as conf}
+        (get-in @properties [:ctia :http :rate-limit])]
+    (if enabled
+      (let [turnstile-mw
+            (turnstile/wrap-rate-limit
+             handler
+             (do
+               {:redis-conn (server-connection redis)
+                 :limit-fns [(with-rate-limited
+                               (group-limit-fn conf))]
+                 :rate-limit-handler rate-limited-request-handler
+                 :key-prefix key-prefix}))]
+        (fn [request]
+          (try
+            (turnstile-mw request)
+            (catch ExceptionInfo e
+              (let [origin (-> (ex-data e) :origin)]
+                (if (= origin :ring-turnstile-middleware)
+                  (do
+                    (log/error e "Unexpected error in the rate limit middleware")
+                    (handler request))
+                  (throw e)))))))
+      (do
+        (log/warn "Rate limit is disabled")
+        (fn [request] (handler request))))))

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -5,7 +5,9 @@
              [shutdown :as shutdown]]
             [ctia.auth.jwt :as auth-jwt]
             [ctia.http.handler :as handler]
-            [ctia.http.middleware.auth :as auth]
+            [ctia.http.middleware
+             [auth :as auth]
+             [ratelimit :refer [wrap-rate-limit]]]
             [ring-jwt-middleware.core :as rjwt]
             [ring.adapter.jetty :as jetty]
             [ring.middleware
@@ -60,7 +62,7 @@
                     (allow-origin-regexps access-control-allow-origin)
                     :access-control-allow-methods
                     (str->set-of-keywords access-control-allow-methods)
-                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version")
+                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,X-RateLimit-GROUP-Remaining,X-RateLimit-GROUP-Limit")
 
          true wrap-params
 

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -62,7 +62,7 @@
                     (allow-origin-regexps access-control-allow-origin)
                     :access-control-allow-methods
                     (str->set-of-keywords access-control-allow-methods)
-                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,X-RateLimit-GROUP-Remaining,X-RateLimit-GROUP-Limit")
+                    :access-control-expose-headers "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,X-RateLimit-GROUP-Limit")
 
          true wrap-params
 

--- a/src/ctia/lib/redis.clj
+++ b/src/ctia/lib/redis.clj
@@ -4,11 +4,12 @@
 ;; Connections
 
 (defn redis-conf->conn-spec
-  [{:keys [host port timeout-ms password ssl]}]
+  [{:keys [host port db timeout-ms password ssl]}]
   (cond-> {:host host
-           :port port
-           :timeout-ms timeout-ms}
+           :port port}
+    timeout-ms (assoc :timeout-ms timeout-ms)
     password (assoc :password password)
+    db (assoc :db db)
     ssl (assoc :ssl-fn :default)))
 
 (defn server-connection

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -57,8 +57,6 @@
    StorePropertiesSchema
    (st/required-keys {"ctia.auth.type" s/Keyword})
 
-
-
    (st/optional-keys {"ctia.auth.threatgrid.cache" s/Bool
                       "ctia.auth.entities.scope" s/Str
                       "ctia.auth.casebook.scope" s/Str
@@ -74,6 +72,18 @@
                       "ctia.http.access-control-allow-methods" s/Str
                       "ctia.http.min-threads" s/Int
                       "ctia.http.max-threads" s/Int})
+
+   (st/optional-keys {"ctia.http.rate-limit.enabled" s/Bool
+                      "ctia.http.rate-limit.key-prefix" s/Str
+                      "ctia.http.rate-limit.unlimited-clientids" s/Str
+                      "ctia.http.rate-limit.default-group-limit" s/Int
+                      "ctia.http.rate-limit.custom-group-limits" s/Str
+                      "ctia.http.rate-limit.redis.host" s/Str
+                      "ctia.http.rate-limit.redis.port" s/Int
+                      "ctia.http.rate-limit.redis.ssl" s/Bool
+                      "ctia.http.rate-limit.redis.password" s/Str
+                      "ctia.http.rate-limit.redis.db" s/Str
+                      "ctia.http.rate-limit.redis.timeout-ms" s/Int})
 
    (st/optional-keys {"ctia.http.send-server-version" s/Bool})
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -75,9 +75,9 @@
 
    (st/optional-keys {"ctia.http.rate-limit.enabled" s/Bool
                       "ctia.http.rate-limit.key-prefix" s/Str
-                      "ctia.http.rate-limit.unlimited-clientids" s/Str
-                      "ctia.http.rate-limit.default-group-limit" s/Int
-                      "ctia.http.rate-limit.custom-group-limits" s/Str
+                      "ctia.http.rate-limit.unlimited.client-ids" s/Str
+                      "ctia.http.rate-limit.limits.group.default" s/Int
+                      "ctia.http.rate-limit.limits.group.customs" s/Str
                       "ctia.http.rate-limit.redis.host" s/Str
                       "ctia.http.rate-limit.redis.port" s/Int
                       "ctia.http.rate-limit.redis.ssl" s/Bool

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -2,7 +2,8 @@
   (:require [ctia.auth.jwt :as sut]
             [ctia.auth.capabilities :as caps]
             [clojure.test :as t :refer [deftest is]]
-            [clojure.set :as set]))
+            [clojure.set :as set])
+  (:import [ctia.auth.jwt JWTIdentity]))
 
 (deftest wrap-jwt-to-ctia-auth-test
   (let [handler (fn [r]
@@ -20,17 +21,17 @@
                    :url "http://localhost:8080/foo"}
             :status 200}
            response-no-jwt))
-    (is (= {:body {:body "foo"
-                   :url "http://localhost:8080/foo"
-                   :jwt {:sub "subject name"
-                         (sut/iroh-claim "org/id") "organization-id"}
-                   :identity #ctia.auth.jwt.JWTIdentity {:jwt {:sub "subject name"
-                                                            "https://schemas.cisco.com/iroh/identity/claims/org/id" "organization-id"}}
-                   :groups ["organization-id"]
-                   :login  "subject name"}
+    (is (= {:body
+            {:body "foo"
+             :url "http://localhost:8080/foo"
+             :jwt {:sub "subject name"
+                   (sut/iroh-claim "org/id") "organization-id"}
+             :groups ["organization-id"]
+             :login  "subject name"}
             :status 200}
-           response-jwt))))
-
+           (update response-jwt :body dissoc :identity)))
+    (is (instance? ctia.auth.jwt.JWTIdentity
+                   (get-in response-jwt [:body :identity])))))
 
 (deftest scopes-to-capapbilities-test
   (is (= "private-intel" (sut/entity-root-scope))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -254,7 +254,7 @@
   {"Access-Control-Expose-Headers"
    (str "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,"
         "X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,"
-        "X-RateLimit-GROUP-Remaining,X-RateLimit-GROUP-Limit"),
+        "X-RateLimit-GROUP-Limit"),
    "Access-Control-Allow-Origin" "http://external.cisco.com",
    "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"})
 

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -250,6 +250,14 @@
                (is (= 403 (:status response))
                    "Normal users shouldn't be allowed to set the ids during creation.")))))))))
 
+(def expected-headers
+  {"Access-Control-Expose-Headers"
+   (str "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,"
+        "X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,"
+        "X-RateLimit-GROUP-Remaining,X-RateLimit-GROUP-Limit"),
+   "Access-Control-Allow-Origin" "http://external.cisco.com",
+   "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"})
+
 (deftest cors-test
   (test-for-each-store
    (fn []
@@ -295,10 +303,7 @@
              judgement-external-ids (:external_ids judgement)]
 
          (is (= 201 status))
-         (is (= {"Access-Control-Expose-Headers"
-                 "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version",
-                 "Access-Control-Allow-Origin" "http://external.cisco.com",
-                 "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"}
+         (is (= expected-headers
                 (select-keys (:headers resp)
                              ["Access-Control-Expose-Headers"
                               "Access-Control-Allow-Origin"
@@ -320,10 +325,7 @@
                       :headers {"Authorization" "Bearer 45c1f5e3f05d0"
                                 "Origin" "http://external.cisco.com"})]
              (is (= 401 (:status response)))
-             (is (= {"Access-Control-Expose-Headers"
-                     "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version",
-                     "Access-Control-Allow-Origin" "http://external.cisco.com",
-                     "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"}
+             (is (= expected-headers
                     (select-keys (:headers response)
                                  ["Access-Control-Expose-Headers"
                                   "Access-Control-Allow-Origin"
@@ -359,10 +361,7 @@
                        :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                     :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
                       judgement))
-               (is (= {"Access-Control-Expose-Headers"
-                       "X-Total-Hits,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version",
-                       "Access-Control-Allow-Origin" "http://external.cisco.com",
-                       "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"}
+               (is (= expected-headers
                       (select-keys (:headers response)
                                    ["Access-Control-Expose-Headers"
                                     "Access-Control-Allow-Origin"

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -1,0 +1,155 @@
+(ns ctia.http.middleware.ratelimit-test
+  (:require [ctia.http.middleware.ratelimit :as sut]
+            [clojure.test :as t
+             :refer [deftest is are join-fixtures use-fixtures testing]]
+            [schema.test :refer [validate-schemas]]
+            [ctia.auth :as auth :refer [IIdentity]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.es :as es-helpers]
+            [taoensso.carmine :as car]
+            [clj-momo.lib.clj-time.core :as time]))
+
+(use-fixtures :once validate-schemas)
+
+(defrecord FakeIdentity [groups limited?]
+  IIdentity
+  (authenticated? [_] true)
+  (login [_] "user")
+  (groups [_] groups)
+  (allowed-capabilities [_] #{})
+  (capable? [_ _] true)
+  (rate-limited? [_] limited?))
+
+(deftest with-limit-test
+  (is (= [["tg:3" 10]
+          ["tg:2" 30]
+          ["tg:1" 20]]
+         (sut/with-limit
+           ["tg:3" "tg:2" "tg:1"]
+           10
+           {"tg:1" 20 "tg:2" 30}))))
+
+(some-> ["tg:3" "tg:2" "tg:1"]
+        (sut/with-limit
+          10
+          {"tg:1" 20 "tg:2" 30})
+        sut/sort-group-limits
+        first)
+
+(deftest parse-group-limits
+  (is (= {"tg:1" 20
+          "tg:2" 30}
+         (sut/parse-group-limits "tg:1|20,tg:2|30"))))
+
+(deftest sort-group-limits
+  (is (= [["g3" 20] ["g2" 20] ["g1" 10]]
+         (sut/sort-group-limits
+          [["g1" 10] ["g2" 20] ["g3" 20]]))))
+
+(deftest group-limit-fn-test
+  (let [limit-fn (sut/group-limit-fn
+                  {:default-group-limit 10
+                   :custom-group-limits "tg:1|20,tg:2|30"})]
+    (is (nil? (limit-fn {}))
+        "The request shouldn't be limited if there is no identity in the request")
+    (is (= {:nb-request-per-hour 10
+            :rate-limit-key "tg:3"
+            :name-in-headers "GROUP"}
+           (limit-fn {:identity (->FakeIdentity ["tg:3"] true)})))
+    (is (= {:nb-request-per-hour 30
+            :rate-limit-key "tg:2"
+            :name-in-headers "GROUP"}
+           (limit-fn {:identity
+                      (->FakeIdentity ["tg:3" "tg:2" "tg:1"] true)})))))
+
+(deftest with-rate-limited-test
+  (let [limit-fn (sut/with-rate-limited
+                   (sut/group-limit-fn
+                    {:default-group-limit 10
+                     :custom-group-limits "tg:1|20,tg:2|30"}))]
+    (is (= {:nb-request-per-hour 30
+            :rate-limit-key "tg:2"
+            :name-in-headers "GROUP"}
+           (limit-fn
+            {:identity (->FakeIdentity ["tg:3" "tg:2" "tg:1"] true)})))
+    (is (nil?  (limit-fn
+                {:identity (->FakeIdentity ["tg:3" "tg:2" "tg:1"]
+                                           false)})))))
+
+(def jwt-token "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL3VzZXIvZW1haWwiOiJnYnVpc3NvbitxYV9zZGNfaXJvaEBjaXNjby5jb20iLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL3VzZXIvaWRwL2lkIjoiYW1wIiwiaHR0cHM6Ly9zY2hlbWFzLmNpc2NvLmNvbS9pcm9oL2lkZW50aXR5L2NsYWltcy91c2VyL25pY2siOiJnYnVpc3NvbitxYV9zZGNfaXJvaEBjaXNjby5jb20iLCJlbWFpbCI6ImdidWlzc29uK3FhX3NkY19pcm9oQGNpc2NvLmNvbSIsInN1YiI6IjU2YmI1ZjhjLWNjNGUtNGVkMy1hOTFhLWM2NjA0Mjg3ZmUzMiIsImlzcyI6IklST0ggQXV0aCIsImh0dHBzOi8vc2NoZW1hcy5jaXNjby5jb20vaXJvaC9pZGVudGl0eS9jbGFpbXMvc2NvcGVzIjpbImNhc2Vib29rIiwiZ2xvYmFsLWludGVsIiwicHJpdmF0ZS1pbnRlbCIsImNvbGxlY3QiLCJlbnJpY2giLCJpbnNwZWN0IiwiaW50ZWdyYXRpb24iLCJpcm9oLWF1dGgiLCJyZXNwb25zZSIsInVpLXNldHRpbmdzIl0sImV4cCI6MTc4Nzc3Mjg1MCwiaHR0cHM6Ly9zY2hlbWFzLmNpc2NvLmNvbS9pcm9oL2lkZW50aXR5L2NsYWltcy9vYXV0aC9jbGllbnQvbmFtZSI6Imlyb2gtdWkiLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL29yZy9pZCI6IjYzNDg5Y2Y5LTU2MWMtNDk1OC1hMTNkLTZkODRiN2VmMDlkNCIsImh0dHBzOi8vc2NoZW1hcy5jaXNjby5jb20vaXJvaC9pZGVudGl0eS9jbGFpbXMvb3JnL25hbWUiOiJJUk9IIFRlc3RpbmciLCJqdGkiOiJhMjY4YWU3YTMtMDljOS00MTQ5LWI0OTUtYjk4YzhjNWRlNjY2IiwibmJmIjoxNDg3MTY3NzUwLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL3VzZXIvaWQiOiI1NmJiNWY4Yy1jYzRlLTRlZDMtYTkxYS1jNjYwNDI4N2ZlMzIiLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL29hdXRoL2NsaWVudC9pZCI6Imlyb2gtdWkiLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL3ZlcnNpb24iOiIxIiwiaWF0IjoxNDg3MTY4MDUwLCJodHRwczovL3NjaGVtYXMuY2lzY28uY29tL2lyb2gvaWRlbnRpdHkvY2xhaW1zL29hdXRoL2tpbmQiOiJzZXNzaW9uLXRva2VuIn0.Y1XTBTOeBIeV0nCGMKG08-AfNzAAwWQPV4hxXQnZClnb5AVvExRME2gAWIoLzHr7MN67UD7LeAifSSBStdRhCcLOX15Fn8n1TEhr3al6UCXfw3Rbx_8L7zEa6yNpXNbrlR_L4qIy1VUSFMV-uFvjQjitKtafBG8nWcl3zjUBAX7PRmG9kw_Lsyih84BgvqRSwglNkLU9gLsy03ghb8H64pjgfWe1VLzfi3mx5uwDMyW9vwR83auizlADqlijUqh1jKPRCo9INkMEEiRGBntqH5j6NJg9pdh9qa7jywEG8Tge0cu74kpNCyU_6AY5456x8JEpAaNtS63n5kfYVxCRSg")
+
+(def reset-redis
+  (fn [t]
+    (car/wcar {} {} (car/flushdb))
+    (t)))
+
+(defn apply-fixtures
+  [properties fn]
+  (let [fixture-fn
+        (join-fixtures [reset-redis
+                        helpers/fixture-properties:clean
+                        (helpers/fixture-properties:static-auth "user" "pwd")
+                        #(helpers/with-properties properties (%))
+                        es-helpers/fixture-properties:es-store
+                        helpers/fixture-ctia
+                        es-helpers/fixture-delete-store-indexes])]
+    (fixture-fn fn)))
+
+(deftest rate-limit-test
+  (with-redefs [time/now (constantly (time/date-time 2017 02 16 0 0 0))]
+    (let [call #(helpers/get "ctia/status"
+                             :headers {"Authorization" (str "Bearer " jwt-token)
+                                       "Origin" "http://external.cisco.com"})]
+      (testing "Group limit"
+        (apply-fixtures
+         ["ctia.http.rate-limit.default-group-limit" 5
+          "ctia.http.rate-limit.enabled" true]
+         (fn []
+           (let [response (call)]
+             (testing "Rate limit headers"
+               (is (= 200 (:status response)))
+               (is (= "5" (get-in response [:headers "X-RateLimit-GROUP-Limit"]))))
+             (testing "Rate limit status and response"
+               (dotimes [_ 4] (call))
+               (let [response (call)]
+                 (is (= 429 (:status response)))
+                 (is (= "3600" (get-in response [:headers "Retry-After"])))
+                 (is (= "{\"error\": \"Too Many Requests\"}"
+                        (:body response)))))))))
+      (testing "Custom group limits"
+        (apply-fixtures
+         ["ctia.http.rate-limit.default-group-limit" 15
+          "ctia.http.rate-limit.custom-group-limits" "63489cf9-561c-4958-a13d-6d84b7ef09d4|4,tg:1|1"
+          "ctia.http.rate-limit.enabled" true]
+         (fn []
+           (let [response (call)]
+             (is (= "4" (get-in response [:headers "X-RateLimit-GROUP-Limit"])))))))
+      (testing "Unlimited client"
+        (apply-fixtures
+         ["ctia.http.rate-limit.default-group-limit" 15
+          "ctia.http.rate-limit.custom-group-limits" "63489cf9-561c-4958-a13d-6d84b7ef09d4|4,tg:1|1"
+          "ctia.http.rate-limit.unlimited-clientids" "iroh-ui"
+          "ctia.http.rate-limit.enabled" true]
+         (fn []
+           (let [response (call)]
+             (is (= 200 (:status response)))))))
+      (testing "rate limit disabled"
+        (apply-fixtures
+         ["ctia.http.rate-limit.default-group-limit" 15
+          "ctia.http.rate-limit.custom-group-limits" "63489cf9-561c-4958-a13d-6d84b7ef09d4|4,tg:1|1"
+          "ctia.http.rate-limit.enabled" false]
+         (fn []
+           (let [response (call)]
+             (is (= 200 (:status response)))))))
+      (testing "Error handling (wrong redis port)"
+        (apply-fixtures
+         ["ctia.http.rate-limit.default-group-limit" 15
+          "ctia.http.rate-limit.enabled" true
+          "ctia.http.rate-limit.redis.port" 7887]
+         (fn []
+           (let [response (call)]
+             (is (= 200 (:status response)))
+             (is (nil? (get-in response [:headers "X-RateLimit-GROUP-Limit"]))))))))))
+


### PR DESCRIPTION
Add a rate limiter

> **Epic** threatgrid/iroh#2807

This PR adds a rate limiter by group on all routes. See the modified Readme.md for more details.

When the rate limit is not reached, the following headers are returned in the response:
```
"x-ratelimit-group-limit": "18000",
```

If the rate limit is exceeded:
- The client receives a response with the 429 HTTP status, a `retry-after` header and the JSON message `{"error": "Too Many Requests"}`
- A message is logged with the `:info` level

<a name="qa">[§](#qa)</a> QA
============================

1. Check that Cisco Threat Response client is not rate limited (by checking the response headers)
2. Create an Oauth2 client with CTR and use it with CTIA APIs
3. The response headers `x-ratelimit-group-limit` should be set in the response
4. Make the number of requests to exceed the rate limit and check that future calls are blocked

<a name="ops">[§](#ops)</a> Ops
===============================

- Config change needed: https://github.com/threatgrid/tenzin-config/pull/36

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
public: AMP Global Intel and Private AMP Global Intel APIs are now rate limited
```