### PR TITLE
Fix the redis properties schema used by the rate limit

### DIFF
--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -82,7 +82,7 @@
                       "ctia.http.rate-limit.redis.port" s/Int
                       "ctia.http.rate-limit.redis.ssl" s/Bool
                       "ctia.http.rate-limit.redis.password" s/Str
-                      "ctia.http.rate-limit.redis.db" s/Str
+                      "ctia.http.rate-limit.redis.db" s/Int
                       "ctia.http.rate-limit.redis.timeout-ms" s/Int})
 
    (st/optional-keys {"ctia.http.send-server-version" s/Bool})


### PR DESCRIPTION
Fix properties schema used by rate limit

> / Connected to threatgrid/iroh#2807

<a name="qa">[§](#qa)</a> QA
============================

 Tested by https://github.com/threatgrid/ctia/pull/831

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Fix the properties schema used by the rate limit
```