### PR TITLE
Fix typo in unlimited properties used for the rate limit

### DIFF
--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -153,8 +153,8 @@
   [keyword-name]
   (str claim-prefix "/" keyword-name))
 
-(defn unlimited-clientids
-  "Retrieves and parses unlimited clientids defined in the properties"
+(defn unlimited-client-ids
+  "Retrieves and parses unlimited client-ids defined in the properties"
   []
   (some-> (get-in @prop/properties
                   [:ctia :http :rate-limit :unlimited :client-ids])
@@ -163,9 +163,9 @@
 
 (defn parse-unlimited-props
   []
-  (let [clientids (unlimited-clientids)]
+  (let [client-ids (unlimited-client-ids)]
     (cond-> {}
-      (seq clientids) (assoc :clienids clientids))))
+      (seq client-ids) (assoc :client-ids client-ids))))
 
 (defrecord JWTIdentity [jwt unlimited-fn]
   IIdentity
@@ -187,9 +187,9 @@
 
 (defn unlimited?
   [unlimited-properties jwt]
-  (let [clientid (get jwt (iroh-claim "oauth/client/id"))
-        unlimited-clientids (get unlimited-properties :clientids)]
-    (contains? unlimited-clientids clientid)))
+  (let [client-id (get jwt (iroh-claim "oauth/client/id"))
+        unlimited-client-ids (get unlimited-properties :client-ids)]
+    (contains? unlimited-client-ids client-id)))
 
 (defn wrap-jwt-to-ctia-auth
   [handler]

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -134,7 +134,8 @@
           "ctia.http.rate-limit.enabled" true]
          (fn []
            (let [response (call)]
-             (is (= 200 (:status response)))))))
+             (is (= 200 (:status response)))
+             (is (nil? (get-in response [:headers "X-RateLimit-GROUP-Limit"])))))))
       (testing "rate limit disabled"
         (apply-fixtures
          ["ctia.http.rate-limit.limits.group.default" 15


### PR DESCRIPTION
Fix a bug where the `ctia.http.rate-limit.unlimited.client-ids` property was not taken into account

> **Epic** threatgrid/iroh#2807

<a name="qa">[§](#qa)</a> QA
============================

See https://github.com/threatgrid/ctia/pull/831#qa

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Fix a bug where iroh-ui was rate limited
```
