### PR TITLE
Add optional wait_for param in for entity creation

### DIFF
--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -56,7 +56,7 @@
      (when can-post?
        (POST "/" []
              :return entity-schema
-             :query [q {(s/optional-key :refresh) (s/enum "false" "wait_for")}]
+             :query [q {(s/optional-key :wait_for) s/Bool}]
              :body [new-entity new-schema {:description (format "a new %s" capitalized)}]
              :summary (format "Adds a new %s" capitalized)
              :capabilities post-capabilities
@@ -69,7 +69,10 @@
                                           create-record
                                           %
                                           identity-map
-                                          q)
+                                          (case (:wait_for q)
+                                            true {:refresh "wait_for"}
+                                            false {:refresh "false"}
+                                            {}))
                   :long-id-fn with-long-id
                   :entity-type entity
                   :identity identity

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -15,6 +15,7 @@
     [created filter-map-search-options paginated-ok search-options]]
    [ctia.store :refer :all]
    [ring.util.http-response :refer [no-content not-found ok]]
+   [ring.swagger.schema :refer [describe]]
    [schema.core :as s]))
 
 (defn entity-crud-routes
@@ -56,7 +57,7 @@
      (when can-post?
        (POST "/" []
              :return entity-schema
-             :query [q {(s/optional-key :wait_for) s/Bool}]
+             :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
              :body [new-entity new-schema {:description (format "a new %s" capitalized)}]
              :summary (format "Adds a new %s" capitalized)
              :capabilities post-capabilities
@@ -69,7 +70,7 @@
                                           create-record
                                           %
                                           identity-map
-                                          (case (:wait_for q)
+                                          (case wait_for
                                             true {:refresh "wait_for"}
                                             false {:refresh "false"}
                                             {}))

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -56,6 +56,7 @@
      (when can-post?
        (POST "/" []
              :return entity-schema
+             :query [q {(s/optional-key :refresh) (s/enum "false" "wait_for")}]
              :body [new-entity new-schema {:description (format "a new %s" capitalized)}]
              :summary (format "Adds a new %s" capitalized)
              :capabilities post-capabilities
@@ -68,7 +69,7 @@
                                           create-record
                                           %
                                           identity-map
-                                          {})
+                                          q)
                   :long-id-fn with-long-id
                   :entity-type entity
                   :identity identity

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -127,13 +127,13 @@
               "Create queries should wait for index refresh when wait_for is true")
           ;; we trigger next 404 tests twice because the refresh could occur between the first POST / GET sequence.
           (is (some #(= 404 %)
-                    (repeatedly 100 (fn [] (get-status false))))
+                    (repeatedly 100 #(get-status false)))
              "Create queries should not wait for index refresh when wait_for is false")
           (testing "Configured ctia.store.es.default.refresh value is applied when wait_for is not specified"
             (if (= "false" (get-in properties [:ctia :store :es :default :refresh]))
 
               (is (some #(= 404 %)
-                        (repeatedly 100 (fn [] (get-status nil)))))
+                        (repeatedly 100 #(get-status nil))))
               (is (= 200 (get-status nil)))))))
 
       (when invalid-tests?

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -125,11 +125,11 @@
                                  :status)))]
           (is (= 200 (get-status true))
               "Create queries should wait for index refresh when wait_for is true")
-          ;; we trigger newt tests twice because the refresh could occur between the first POST / GET sequence.
+          ;; we trigger next 404 tests twice because the refresh could occur between the first POST / GET sequence.
           (is (or (= 404 (get-status false))
                   (= 404 (get-status false)))
              "Create queries should not wait for index refresh when wait_for is false")
-          (testing "default refresh value is applied when wait_for is not specified"
+          (testing "Configured ctia.store.es.default.refresh value is applied when wait_for is not specified"
             (if (= "false" (get-in properties [:ctia :store :es :default :refresh]))
               (is (or (= 404 (get-status nil))
                       (= 404 (get-status nil))))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -131,8 +131,6 @@
           :throw-exceptions false
           :body (json/generate-string obj)})]
     (when (not= 201 status)
-      (println "Post to ES failed.\nWrong HTTP status code: " status)
-      (pprint response)
       (throw (AssertionError. "POST to ES failed")))))
 
 (defn post-all-to-es [objects]


### PR DESCRIPTION
This PR enables to specify `wait_for` param when creating a resource in order to wait for availability of created resource (refresh index in case of ES store).

> / Close https://github.com/threatgrid/iroh/issues/2672

This PR adds an optional `wait_for` param in the creates routes that are generated in `src/ctia/http/routes/crud.clj`.
In crud tests, The creation is now performed with the `wait_for` param, and the the GET query is directly made after the POST query to ensure that the availability of the created resource is waited for.

<a name="qa">[§](#qa)</a> QA
============================

- Using a script, perform a  loop that repeats the following test 100 times: 
1. Create any entity with `wait_for=true` as query param
2. Retrieve the response ID and generate the short version of that ID (last part of the the url)
3. Retrieve that resource using the short ID
4. Check that the response status is 200

- Using a script, perform a loop that repeats the following test 100 times: 
1. Create any entity with`wait_for=false` as query param
2. Retrieve the response ID and generate the short version of that ID (last part of the the url)
3. Retrieve that resource using the short ID
4. Check the returned status: most of the status of the GET should be 404 (in some lucky cases some can be 200)

- Using a script, perform a loop that repeats the following test 100 times: 
1. Create any entity without the `wait_for` query param
2. Retrieve the response ID and generate the short version of that ID (last part of the the url)
3. Retrieve that resource using the short ID
4. Check the returned status: most of the status of the GET should be 404 (in some lucky cases some can be 200).

```
intern: When creating a resource, the query param `wait_for=true` could be used to deal with inconsistencies.
```

