### PR TITLE
CODEOWNERS STRIKE BACK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global codeowners
+* @gbuisson @yogsototh @msprunck @ereteog

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,12 @@
 one_line_short_description
 
 > **Epic** #
-> / Close #
-> / Related #
+> Close #
+> Related #
 
 Describe your PR for reviewers.
 Don't forget to set correct labels (User Facing / Beta / Feature Flag)
 If there is UI change please add a screen capture.
-
 
 <a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
 =====================================================================================


### PR DESCRIPTION
With the introduction of [Draft Pull Requests](https://help.github.com/en/articles/about-pull-requests#draft-pull-requests) we can put again the [CODEOWNERS](https://help.github.com/en/articles/about-code-owners) to ease the PR creation process by always adding all the team to the reviewers when the PR is marked a no more being a draft.

## QA

NO QA NEEDED