### PR TITLE
Add the capability to filter by long ID in the search routes

### DIFF
--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -42,6 +42,12 @@
   (let [[orig docid] (re-matches #".*?([^/]+)\z" id) ]
     docid))
 
+(defn ensure-document-id-in-map
+  "Ensure a document ID in a given filter map"
+  [{:keys [id] :as m}]
+  (cond-> m
+    id (update :id ensure-document-id)))
+
 (defn remove-es-actions
   "Removes the ES action level
 
@@ -206,7 +212,6 @@
     params
     (assoc params :sort_by default-sort-field)))
 
-
 (s/defschema FilterSchema
   (st/optional-keys
    {:all-of {s/Any s/Any}
@@ -309,7 +314,7 @@
                                  (name mapping)
                                  {:bool {:must [(find-restriction-query-part ident)
                                                 {:query_string query_string}]}}
-                                 filter-map
+                                 (ensure-document-id-in-map filter-map)
                                  (-> params
                                      rename-sort-fields
                                      with-default-sort-field

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -9,6 +9,17 @@
              [core :as helpers]
              [es :as es-helpers]]))
 
+(deftest ensure-document-id-in-map-test
+  (is (= {:id "actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7"}
+         (sut/ensure-document-id-in-map
+          {:id "http://localhost:3000/ctia/actor/actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7"})))
+  (is (= {:id "actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7"}
+         (sut/ensure-document-id-in-map
+          {:id "actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7"})))
+  (is (= {:title "title"}
+         (sut/ensure-document-id-in-map
+          {:title "title"}))))
+
 (deftest partial-results-test
   (is (= {:data [{:error "Exception"
                   :id "123"}


### PR DESCRIPTION
Entity searches can be filtered by "long" ID. Only the internal "short" ID was working.

> Close threatgrid/iroh#1417

This PR fixes a bug in all search routes where it was only possible to filter with the "short" ID

Short ID: `sighting-6779d46c-b07d-4f38-a604-c34f28474332`
Long ID: `https://intel.amp.cisco.com:443/ctia/sighting/sighting-6779d46c-b07d-4f38-a604-c34f28474332`

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. Search sightings with the endpoint `https://intel.test.iroh.site/ctia/sighting/search` with the query `*`
2. Take the ID of the first result
3. Filter by ID with its ID
4. One Sighting should be returned
5. Filter by ID with the short form of its ID
6. One Sighting should be returned

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Add the capability to filter by long ID in the search routes
```