### PR TITLE
Added more security headers

### DIFF
--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -112,6 +112,7 @@
            max-threads
            min-threads
            port
+           trusted-urls
            access-control-allow-origin
            access-control-allow-methods
            jwt
@@ -156,9 +157,15 @@
                     (allow-origin-regexps access-control-allow-origin)
                     :access-control-allow-methods
                     (str->set-of-keywords access-control-allow-methods)
-                    :access-control-expose-headers "X-Total-Hits,X-Content-Type-Options,X-Next,X-Previous,X-Sort,Etag,X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,X-RateLimit-GROUP-Limit")
+                    :access-control-expose-headers "*")
 
-         true (wrap-specific-headers {"X-Content-Type-Options" "nosniff"})
+         true (wrap-specific-headers {"X-Content-Type-Options" "nosniff"
+                                      "Content-Security-Policy" (str "default-src 'self';"
+                                                                     " style-src 'self' 'unsafe-inline';"
+                                                                     " img-src 'self' data:;"
+                                                                     " script-src 'self' 'unsafe-inline';"
+                                                                     " connect-src 'self';")
+                                      "X-Frame-Options" "DENY"})
 
          true wrap-params
 

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -41,11 +41,8 @@
    :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}})
 
 (def expected-headers
-  {"Access-Control-Expose-Headers"
-   (str "X-Total-Hits,X-Content-Type-Options,X-Next,X-Previous,X-Sort,Etag,"
-        "X-Ctia-Version,X-Ctia-Config,X-Ctim-Version,"
-        "X-RateLimit-GROUP-Limit"),
-   "Access-Control-Allow-Origin" "http://external.cisco.com",
+  {"Access-Control-Expose-Headers" "*"
+   "Access-Control-Allow-Origin" "http://external.cisco.com"
    "Access-Control-Allow-Methods" "DELETE, GET, PATCH, POST, PUT"})
 
 (deftest headers-test
@@ -84,11 +81,18 @@
             (is (= "nosniff"
                    (get-in resp [:headers "X-Content-Type-Options"]))
                 "The request should contain the X-Content-Type-Options header set to nosniff")
-
             (is (= 200 (:status swagger-ui-resp)))
             (is (= "nosniff"
                    (get-in swagger-ui-resp [:headers "X-Content-Type-Options"]))
                 "Swagger-UI request should contain the X-Content-Type-Options header set to nosniff")
+            (is (= "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; connect-src 'self';"
+                   (get-in swagger-ui-resp [:headers "Content-Security-Policy"]))
+                "The request should contain the Content-Security-Policy header set to nosniff")
+            (is (= "DENY"
+                   (get-in swagger-ui-resp [:headers "X-Frame-Options"]))
+                "The request should contain the Content-Security-Policy header set to nosniff")
+
+
             (is (= 201 (:status bad-origin-resp)))
             (is (= {}
                    (select-keys (:headers bad-origin-resp)


### PR DESCRIPTION
> Close https://github.com/threatgrid/iroh/issues/2942


- took the liberty to replace the full list of CORS headers by just '*'.
  C.f. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
- took the liberty to be more restrictive than we are for headers for the UI

<a name="qa">[§](#qa)</a> QA
============================

Check that calls for the index.html page for swagger UI contains the following headers:

`Content-Type-Security`, `X-Frame-Options`, and `X-Content-Type-Options` and that everything work as expected (you can use swagger-ui to make requests mostly.


<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: More security headers
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================
