### PR TITLE
Exposes the version of the configuration via headers and /version

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -360,3 +360,9 @@ ES Migration related settings
 |------------------------------+------------------------------------------------------------------------------------------------------------+-----------------|
 | ctia.migration.optimizations | Speed up the migration process disabling indexing and replicas while migrating,                            |boolean          |
 |                              | settings are reverted to their actual values when the process is complete, this should be considered safe. |                 |
+
+** Versions
+
+| Property             | Description                                                   | Possible values |
+|----------------------+---------------------------------------------------------------+-----------------|
+| ctia.versions.config | Version of the configuration if managed in another repository | string          |

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -146,3 +146,4 @@ ctia.hook.kafka.topic.name=ctia-events
 ctia.hook.kafka.topic.num-partitions=1
 ctia.hook.kafka.topic.replication-factor=1
 
+ctia.versions.config=local

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -179,7 +179,8 @@
 
                       "ctia.store.es.migration.indexname" s/Str
                       "ctia.store.es.event.slicing.granularity"
-                      (s/enum :minute :hour :day :week :month :year)})))
+                      (s/enum :minute :hour :day :week :month :year)})
+   (st/optional-keys {"ctia.versions.config" s/Str})))
 
 (def configurable-properties
   (mls/keys PropertiesSchema))

--- a/src/ctia/version.clj
+++ b/src/ctia/version.clj
@@ -15,23 +15,19 @@
               (str (:out (shell/sh "git" "log" "-n" "1" "--pretty=format:%H "))
                    (:out (shell/sh "git" "symbolic-ref" "--short" "HEAD"))))))
 
-(def current-config-hash
-  (memoize #(-> @properties
-                set
-                str
-                .getBytes
-                sha1)))
+(defn current-config-version []
+  (get-in @properties [:ctia :versions :config] ""))
 
 (defn version-data []
   {:base "/ctia"
    :ctim-version schema-version
    :beta true
    :ctia-build (st/replace (current-version) #"\s\n" "")
-   :ctia-config (current-config-hash)
+   :ctia-config (current-config-version)
    :ctia-supported_features []})
 
 
 (defn version-headers []
   {"X-Ctia-Version" (st/replace (current-version) #"\n" "")
-   "X-Ctia-Config" (current-config-hash)
+   "X-Ctia-Config" (current-config-version)
    "X-Ctim-Version" schema-version})

--- a/test/ctia/http/routes/version_test.clj
+++ b/test/ctia/http/routes/version_test.clj
@@ -27,7 +27,8 @@
      (testing "GET /ctia/version"
        (let [response (get "ctia/version")]
          (is (= 200 (:status response)))
-         (is (= schema-version (get-in response [:parsed-body :ctim-version]))))))))
+         (is (= schema-version (get-in response [:parsed-body :ctim-version])))
+         (is (= "test" (get-in response [:parsed-body :ctia-config]))))))))
 
 (deftest test-version-headers
   (test-for-each-store
@@ -39,4 +40,5 @@
          (is (every? (set (keys headers))
                      ["X-Ctia-Version"
                       "X-Ctia-Config"
-                      "X-Ctim-Version"])))))))
+                      "X-Ctim-Version"]))
+         (is (= "test" (clojure.core/get headers "X-Ctia-Config"))))))))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -62,7 +62,8 @@
                     "ctia.hook.redis.channel-name"    "events-test"
                     "ctia.metrics.riemann.enabled"    false
                     "ctia.metrics.console.enabled"    false
-                    "ctia.metrics.jmx.enabled"        false]
+                    "ctia.metrics.jmx.enabled"        false
+                    "ctia.versions.config"            "test"]
     ;; run tests
     (f)))
 


### PR DESCRIPTION
The config version/commit is now available in the `x-ctia-config` header and in the new `/ctia/version` API endpoint.

> Connected to threatgrid/iroh#2645

This PR exposes the config version defined in the properties with `ctia.versions.config`.

This version is visible in the `x-ctia-config` header:

```
content-length: 177 
 content-type: application/json;charset=utf-8 
 date: Mon, 16 Sep 2019 16:18:14 GMT 
 etag: "1975e222683d66675edbfc9a0ba19480a6b1712b" 
 x-content-type-options: nosniff 
 x-ctia-config: local 
 x-ctia-version: f1a839a71dd37576b76cfbefa0432e7a911c1f81 iroh-issue-2645 
 x-ctim-version: 1.0.11
```

and in the response to GET `/ctia/config`:

```json
{
  "base": "/ctia",
  "ctim-version": "1.0.11",
  "ctia-build": "f1a839a71dd37576b76cfbefa0432e7a911c1f81 iroh-issue-2645\n",
  "beta": true,
  "ctia-config": "local",
  "ctia-supported_features": []
}
```

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. Make a request to `https://intel.test.iroh.site/ctia/version`
2. The commit number configured in `ctia.versions.config` should be displayed in the response and in the header

<a name="ops">[§](#ops)</a> Ops
===============================

- Config change needed: threatgrid/tenzin#

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Exposes the commit number of config in a response header and in the response of `/ctia/version` 
```