### PR TITLE
aliased true conf on existing unaliased indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ tools to know what to look for.
 
 In addition to the RESTful HTTP API, it also has an Event Bus.
 
-The data model is defined in the [CTIM](/threatgrid/ctim) project,
+The data model is defined in the [CTIM](https://github.com/threatgrid/ctim) project,
 although it's quite easy to see the API and the models it handles
 using the built-in [Swagger UI](http://localhost:3000/index.html) once
 you have it running.

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -117,7 +117,7 @@
   [mapping Model]
   (let [coerce! (coerce-to-fn (s/maybe Model))]
     (s/fn :- (s/maybe [Model])
-      [{:keys [index props] :as state} :- ESConnState
+      [{:keys [props] :as state} :- ESConnState
        models :- [Model]
        ident
        {:keys [refresh] :as params}]

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -1,40 +1,117 @@
 (ns ctia.stores.es.init-test
   (:require [ctia.stores.es.init :as sut]
+            [clj-http.client :as http]
+            [clj-momo.lib.es
+             [index :as index]
+             [document :as doc]
+             [conn :as conn]]
             [clojure.test :refer [deftest testing is]]))
 
-(deftest init-store-conn
-  (let [props-not-aliased {:entity :sighting
-                           :indexname "ctia_sighting"
-                           :shards 2
-                           :replicas 1
-                           :mappings {:a 1 :b 2}
-                           :host "localhost"
-                           :port 9200}
-        {:keys [index props config conn]}
-        (sut/init-store-conn props-not-aliased)]
-    (is (= index "ctia_sighting"))
-    (is (= (:write-index props) "ctia_sighting"))
-    (is (= "http://localhost:9200" (:uri conn)))
-    (is (nil? (:aliases config)))
-    (is (= 1 (get-in config [:settings :number_of_replicas])))
-    (is (= 2 (get-in config [:settings :number_of_shards])))
-    (is (= {} (select-keys (:mappings config) [:a :b]))))
+(def es-conn (conn/connect {:host "localhost"
+                            :port "9200"}))
+(def indexname "ctia_init_test_sighting")
+(def write-alias (str indexname "-write"))
+(def props-aliased {:entity :sighting
+                    :indexname indexname
+                    :shards 2
+                    :replicas 1
+                    :mappings {:a 1 :b 2}
+                    :host "localhost"
+                    :port 9200
+                    :aliased true})
 
-  (let [props-aliased {:entity :sighting
-                       :indexname "ctia_sighting"
-                       :shards 2
-                       :replicas 1
-                       :mappings {:a 1 :b 2}
-                       :host "localhost"
-                       :port 9200
-                       :aliased true}
-        {:keys [index props config conn]}
-        (sut/init-store-conn props-aliased)]
-    (is (= index "ctia_sighting"))
-    (is (= (:write-index props) "ctia_sighting-write"))
-    (is (= "http://localhost:9200" (:uri conn)))
-    (is (= "ctia_sighting"
-           (-> config :aliases keys first)))
-    (is (= 1 (get-in config [:settings :number_of_replicas])))
-    (is (= 2 (get-in config [:settings :number_of_shards])))
-    (is (= {} (select-keys (:mappings config) [:a :b])))))
+(def props-not-aliased {:entity :sighting
+                        :indexname indexname
+                        :shards 2
+                        :replicas 1
+                        :mappings {:a 1 :b 2}
+                        :host "localhost"
+                        :port 9200
+                        :aliased false})
+
+(deftest init-store-conn-test
+  (testing "init store conn should return a proper conn state with unaliased conf"
+    (let [{:keys [index props config conn]}
+          (sut/init-store-conn props-not-aliased)]
+      (is (= index indexname))
+      (is (= (:write-index props) indexname))
+      (is (= "http://localhost:9200" (:uri conn)))
+      (is (nil? (:aliases config)))
+      (is (= 1 (get-in config [:settings :number_of_replicas])))
+      (is (= 2 (get-in config [:settings :number_of_shards])))
+      (is (= {} (select-keys (:mappings config) [:a :b])))))
+
+  (testing "init store conn should return a proper conn state with unaliased conf"
+    (let [{:keys [index props config conn]}
+          (sut/init-store-conn props-aliased)]
+      (is (= index indexname))
+      (is (= (:write-index props) write-alias))
+      (is (= "http://localhost:9200" (:uri conn)))
+      (is (= indexname
+             (-> config :aliases keys first)))
+      (is (= 1 (get-in config [:settings :number_of_replicas])))
+      (is (= 2 (get-in config [:settings :number_of_shards])))
+      (is (= {} (select-keys (:mappings config) [:a :b]))))))
+
+(deftest init-es-conn!-test
+  (index/delete! es-conn (str indexname "*"))
+  (testing "init-es-conn! should return a proper conn state with unaliased conf, but not create any index"
+    (let [{:keys [index props config conn]}
+          (sut/init-es-conn! props-not-aliased)
+          existing-index (index/get es-conn (str indexname "*"))]
+      (is (empty? existing-index))
+      (is (= index indexname))
+      (is (= (:write-index props) indexname))
+      (is (= "http://localhost:9200" (:uri conn)))
+      (is (nil? (:aliases config)))
+      (is (= 1 (get-in config [:settings :number_of_replicas])))
+      (is (= 2 (get-in config [:settings :number_of_shards])))
+      (is (= {} (select-keys (:mappings config) [:a :b])))))
+
+  (testing "init-es-conn! should return a proper conn state with aliased conf, and create an initial aliased index"
+    (index/delete! es-conn (str indexname "*"))
+    (let [{:keys [index props config conn]}
+          (sut/init-es-conn! props-aliased)
+          existing-index (index/get es-conn (str indexname "*"))
+          created-aliases (->> existing-index
+                               vals
+                               first
+                               :aliases
+                               keys
+                               set)]
+      (is (= #{(keyword indexname) (keyword write-alias)}
+             created-aliases))
+      (is (= index indexname))
+      (is (= (:write-index props) write-alias))
+      (is (= "http://localhost:9200" (:uri conn)))
+      (is (= indexname
+             (-> config :aliases keys first)))
+      (is (= 1 (get-in config [:settings :number_of_replicas])))
+      (is (= 2 (get-in config [:settings :number_of_shards])))
+      (is (= {} (select-keys (:mappings config) [:a :b])))))
+
+  (testing "init-es-conn! should return a conn state that ignore aliased conf setting when an unaliased index already exists"
+    (index/delete! es-conn (str indexname "*"))
+    (http/delete (str "http://localhost:9200/_template/" indexname "*"))
+    (index/create! es-conn indexname {})
+    (let [{:keys [index props config conn]}
+          (sut/init-es-conn! props-aliased)
+          existing-index (index/get es-conn (str indexname "*"))
+          created-aliases (->> existing-index
+                               vals
+                               first
+                               :aliases
+                               keys
+                               set)]
+      (is (= #{} created-aliases))
+      (is (= index indexname))
+      (is (= (:write-index props) indexname))
+      (is (= "http://localhost:9200" (:uri conn)))
+      (is (= indexname
+             (-> config :aliases keys first)))
+      (is (= 1 (get-in config [:settings :number_of_replicas])))
+      (is (= 2 (get-in config [:settings :number_of_shards])))
+      (is (= {} (select-keys (:mappings config) [:a :b])))))
+
+  (http/delete (str "http://localhost:9200/_template/" indexname "*"))
+  (index/delete! es-conn (str indexname "*")))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -3,7 +3,6 @@
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
             [clj-momo.lib.es.index :as es-index]
-            [clojure.pprint :refer [pprint]]
             [ctia
              [properties :refer [properties]]
              [store :as store]]


### PR DESCRIPTION
This PR enables a CTIA instance to not fail on inconsistent `aliased=true` conf and existing unaliased store. 

> Close threatgrid/iroh#2954


<a name="qa">[§](#qa)</a> QA
============================

No QA needed


