### PR TITLE
improve target initialisation during migration

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -2,26 +2,31 @@
  This task will run through all configured stores, transform and copy data to new elasticsearch indices. 
  A migration state will be stored in a configured state to enable restart.
 
-# migration steps
- - as the migration task copies indexes, make sure you have enough disk space before launching it.
- - keep current ctia ES properties: host, port, transport and current store indices.
- - modify alias and rollover conditions according to the need of future indices. Note that only `max_docs` rollover condition will be considered during migration.
- - if possible, stop any processes that push data into CTIA.
- - launch migration task while your CTIA instance keep running. You can launch parallel migrations for different stores.
- - stop CTIA.
- - complete migration using `--restart` parameter to complete migration and handle writes that occured during migration.
- - after the migration task completes, you will need to edit your properties, changing each store index to the new one.
- - launch new version of CTIA. 
- - this task doesn't alter the existing indices, you should delete them after a successful migration.
+# :warning: Prepare Migration :warning:
+ - As the migration task copies indexes, make sure you have enough disk space before launching it.
+ - Make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted.
+ - Prepare the migration properties (ex: `ctia_migration.properties`):
+   - Modify `aliased` and `rollover` options according to the need of future indices. Note that only `max_docs` rollover condition will be considered during migration.
+   - Keep current ctia ES properties: host, port, transport and current store indices.
+ - Prepare the future migration properties (ex: `ctia_vX.X.X.properties`) that will be used to restart CTIA on migration indices. In particular you will have to set `aliased`, `rollover`, and `indexname` options according to targeted indices state.
+ - If possible, stop any processes that push data into CTIA.
+
+
+# Migration Steps
+ - Launch migration task while your CTIA instance keep running. You can launch parallel migrations for different stores.
+ - Stop CTIA.
+ - Complete migration using `--restart` parameter to complete migration and handle writes that occured during migration.
+ - After the migration task completes, replace CTIA properties with the one you prepared to launch the server with migrated indices (ex: `ctia_vX.X.X.properties`).
+ - Launch new version of CTIA. 
+ - The migration task doesn't alter the existing indices, you should delete them after a successful migration.
  
  
  In case of failure, you have 2 solutions depending on the situation:
    - you can relaunch the task at will, it should fully recreate the new indices.
    - you can restart this migration with `--restart` parameter, it will reuse the migration
  
- Make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted (unless the migration is restarted)
  
-# launch the task with:
+# Launch the task with:
  
 `java -cp ctia.jar:resources:. clojure.main -m ctia.task.migration.migrate-es-stores <options>`
 
@@ -51,7 +56,7 @@ or from source
 - the migration failed, you corrected the issue that made it fail, you can restart it with `--restart` (or `-r`) parameter (same command as above). 
 
 
-# available migrations
+# Available migrations
 
 | migration task | target ctia versions          | sample command                                                                                          |
 |----------------|-------------------------------|---------------------------------------------------------------------------------------------------------|

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -13,13 +13,14 @@
 
 
 # Migration Steps
+ - replace `ctia.properties` by the migration property file that you prepared (`ctia_migration.properties`).
  - Launch migration task while your CTIA instance keep running. You can launch parallel migrations for different stores.
- - Stop CTIA.
- - Complete migration using `--restart` parameter to complete migration and handle writes that occured during migration.
- - After the migration task completes, replace CTIA properties with the one you prepared to launch the server with migrated indices (ex: `ctia_vX.X.X.properties`).
+ - Stop CTIA server instance.
+ - Complete migration using `--restart` parameter to handle writes that occurred during the migration. Keep the same migration properties.
+ - After the migration task completes, replace CTIA properties of the server instance with the one you prepared to launch the server with migrated indices (ex: `ctia_vX.X.X.properties`).
  - Launch new version of CTIA. 
- - The migration task doesn't alter the existing indices, you should delete them after a successful migration.
- 
+ - The migration task doesn't alter the existing indices, you can delete them after a successful migration.
+
  
  In case of failure, you have 2 solutions depending on the situation:
    - you can relaunch the task at will, it should fully recreate the new indices.

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -8,6 +8,7 @@
  - Prepare the migration properties (ex: `ctia_migration.properties`):
    - Modify `aliased` and `rollover` options according to the need of future indices. Note that only `max_docs` rollover condition will be considered during migration.
    - Keep current ctia ES properties: host, port, transport and current store indices.
+   - Configure desired number of shards.
  - Prepare the future migration properties (ex: `ctia_vX.X.X.properties`) that will be used to restart CTIA on migration indices. In particular you will have to set `aliased`, `rollover`, and `indexname` options according to targeted indices state.
  - If possible, stop any processes that push data into CTIA.
 

--- a/doc/migration.md
+++ b/doc/migration.md
@@ -6,8 +6,8 @@
  - As the migration task copies indexes, make sure you have enough disk space before launching it.
  - Make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted.
  - Prepare the migration properties (ex: `ctia_migration.properties`):
-   - Modify `aliased` and `rollover` options according to the need of future indices. Note that only `max_docs` rollover condition will be considered during migration.
-   - Keep current ctia ES properties: host, port, transport and current store indices.
+   - Keep current CTIA ES properties: host, port, transport and current store indices. These properties will be used to read source indices.
+   - Modify `aliased`, `rollover`, and `shards` options according to the need of future indices. The migrated indices will be built with these options. Note that only `max_docs` rollover condition will be considered during migration.
    - Configure desired number of shards.
  - Prepare the future migration properties (ex: `ctia_vX.X.X.properties`) that will be used to restart CTIA on migration indices. In particular you will have to set `aliased`, `rollover`, and `indexname` options according to targeted indices state.
  - If possible, stop any processes that push data into CTIA.

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -1,5 +1,6 @@
 (ns ctia.stores.es.init
   (:require
+   [clojure.tools.logging :as log]
    [ctia.properties :refer [properties]]
    [ctia.stores.es.mapping :refer [store-settings]]
    [clj-momo.lib.es
@@ -58,7 +59,9 @@
                         (update config :aliases assoc (:write-index props) {})))
     (cond-> conn-state
       (contains? existing-index (keyword index))
-      (assoc-in [:props :write-index] index))))
+      (do (log/error "an existing unaliased was configured as aliased. Switching from unaliased to aliased indices requires a migration."
+                     properties)
+          (assoc-in [:props :write-index] index)))))
 
 
 (s/defn get-store-properties :- StoreProperties

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -57,11 +57,11 @@
       (es-index/create! conn
                         (format "<%s-{now/d}-000001>" index)
                         (update config :aliases assoc (:write-index props) {})))
-    (cond-> conn-state
-      (contains? existing-index (keyword index))
+    (if (contains? existing-index (keyword index))
       (do (log/error "an existing unaliased was configured as aliased. Switching from unaliased to aliased indices requires a migration."
                      properties)
-          (assoc-in [:props :write-index] index)))))
+          (assoc-in conn-state [:props :write-index] index))
+      conn-state)))
 
 
 (s/defn get-store-properties :- StoreProperties

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -43,18 +43,26 @@
    :config s/Any
    :props {s/Any s/Any}})
 
+
+(s/defn store-state->map :- StoreMap
+  "transform a store state
+   into a properties map for easier manipulation,
+   override the cm to use the custom timeout "
+  [{:keys [index props conn config] :as state}
+   conn-overrides]
+  (let [entity-type (-> props :entity name)]
+    {:conn (merge conn conn-overrides)
+     :indexname index
+     :props props
+     :mapping entity-type
+     :type entity-type
+     :settings (:settings props)
+     :config config}))
+
 (s/defn store->map :- StoreMap
   "transform a store record
    into a properties map for easier manipulation,
    override the cm to use the custom timeout "
   [store conn-overrides]
-  (let [store-state (-> store first :state)
-        entity-type (-> store-state :props :entity name)]
-    {:conn (merge (:conn store-state)
-                  conn-overrides)
-     :indexname (:index store-state)
-     :props (:props store-state)
-     :mapping entity-type
-     :type entity-type
-     :settings (-> store-state :props :settings)
-     :config (:config store-state)}))
+  (-> store first :state
+      (store-state->map conn-overrides)))

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -228,9 +228,7 @@
   "check all new es store indexes"
   [store-keys batch-size prefix]
   (let [current-stores (mst/stores->maps (select-keys @stores store-keys))
-        target-stores
-        (mst/source-store-maps->target-store-maps current-stores
-                                              prefix)
+        target-stores (mst/get-target-stores prefix store-keys)
         batch-size (or batch-size default-batch-size)]
 
     (log/infof "checking stores: %s" (keys current-stores))

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -15,10 +15,12 @@
             [ctia.lib.collection :refer [fmap]]
             [ctia.stores.es
              [crud :as crud]
-             [init :refer [init-store-conn init-es-conn! get-store-properties]]
+             [init :refer [init-store-conn
+                           init-es-conn!
+                           get-store-properties
+                           StoreProperties]]
              [mapping :as em]
              [store :refer [StoreMap] :as es-store]]
-            [ctia.lib.collection :refer [fmap]]
             [ctia.task.rollover :refer [rollover-store]]
             [ctia
              [init :refer [init-store-service! log-properties]]
@@ -144,10 +146,11 @@
   (let [version-trimmed (string/replace index #"^v[^_]*_" "")]
     (format "v%s_%s" prefix version-trimmed)))
 
+(def conn-overrides {:cm (conn/make-connection-manager {:timeout timeout})})
+
 (defn store->map
   [store-record]
-  (es-store/store->map store-record
-              {:cm (conn/make-connection-manager {:timeout timeout})}))
+  (es-store/store->map store-record conn-overrides))
 
 (defn stores->maps
   "transform store records to maps"
@@ -168,15 +171,6 @@
     (-> (assoc-in store [:config :aliases] aliases)
         (update-in [:props :write-index] prefixer)
         (update :indexname prefixer))))
-
-
-(defn source-store-maps->target-store-maps
-  "transform target store records to maps"
-  [source-stores prefix]
-  (into {}
-        (map (fn [[sk sr]]
-               {sk (source-store-map->target-store-map sr prefix)})
-             source-stores)))
 
 (def bulk-max-size (* 5 1024 1024)) ;; 5Mo
 
@@ -373,6 +367,28 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
     (retry es-max-retry es-index/create-template! conn indexname index-config)
     (retry es-max-retry es-index/create! conn (format "<%s-{now/d}-000001>" indexname) index-config)))
 
+(defn target-store-properties
+  [prefix store-key]
+  (-> (get-store-properties store-key)
+      (update :indexname
+              #(prefixed-index % prefix))))
+
+(s/defn init-storemap :- StoreMap
+  [props :- StoreProperties]
+  (-> (init-store-conn props)
+      (es-store/store-state->map conn-overrides)))
+
+(defn get-target-store
+  [prefix store-key]
+  (init-storemap (target-store-properties prefix store-key)))
+
+(defn get-target-stores
+  [prefix store-keys]
+  (->> (map (fn [k]
+              {k (get-target-store prefix k)})
+            store-keys)
+       (into {})))
+
 (s/defn init-migration :- MigrationSchema
   "init the migration state, for each store it provides necessary data on source and target stores (indexname, type, source size, search_after).
 when confirm? is true, it stores this state and creates the target indices."
@@ -380,10 +396,8 @@ when confirm? is true, it stores this state and creates the target indices."
    prefix :- s/Str
    store-keys :- [s/Keyword]
    confirm? :- s/Bool]
-
   (let [source-stores (stores->maps (select-keys @stores store-keys))
-        target-stores
-        (source-store-maps->target-store-maps source-stores prefix)
+        target-stores (get-target-stores prefix store-keys)
         migration-properties (migration-store-properties)
         now (time/now)
         migration-stores (->> source-stores
@@ -407,7 +421,7 @@ when confirm? is true, it stores this state and creates the target indices."
    {source :source
     target :target :as raw-store} :- MigratedStore]
   (let [source-store (store->map (get @stores entity-type))
-        target-store (source-store-map->target-store-map source-store prefix)]
+        target-store (get-target-store prefix entity-type)]
     (-> (assoc-in raw-store [:source :store] source-store)
         (assoc-in [:target :store] target-store))))
 

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -91,15 +91,12 @@
 
 (deftest get-target-stores-test
   (let [{:keys [tool malware plop]}
-        (sut/get-target-stores "0.0.0" [:tool :malware :plop])]
+        (sut/get-target-stores "0.0.0" [:tool :malware])]
     (is (= "v0.0.0_ctia_malware" (:indexname malware)))
     (is (= "v0.0.0_ctia_tool" (:indexname tool)))
-    (is (= "v0.0.0_test_ctia" (:indexname plop))
-        "target-stores should use default configuration when index is not configured")
     (is (= "v0.0.0_ctia_malware-write" (get-in malware [:props :write-index])))
-    (is (= "v0.0.0_ctia_tool-write" (get-in tool [:props :write-index])))
-    (is (= "v0.0.0_test_ctia-write" (get-in plop [:props :write-index]))
-        "target-stores should use default configuration when index is not configured")))
+    (is (= "v0.0.0_ctia_tool-write" (get-in tool [:props :write-index])))))
+
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -89,43 +89,17 @@
                                       :modified "04-29-2019"}))))
 
 
-
-(defn apply-fixtures
-  [properties fn]
-  (let [fixture-fn
-        (join-fixtures [#(helpers/with-properties properties (%))
-                        helpers/fixture-ctia
-                        es-helpers/fixture-delete-store-indexes])]
-    (fixture-fn fn)))
-
 (deftest get-target-stores-test
-  (testing "get-target-stores should properly init store maps from configuration"
-    (apply-fixtures
-     ["ctia.store.es.default.shards" 1
-      "ctia.store.es.default.replicas" 1
-      "ctia.store.es.default.port" "9200"
-      "ctia.store.es.default.indexname" "ctia_default"
-      "ctia.store.es.default.default_operator" "AND"
-      "ctia.store.es.default.aliased" true
-      "ctia.store.es.default.rollover.max_docs" 50
-      "ctia.store.es.malware.indexname" "ctia_malware"
-      "ctia.store.es.tool.indexname" "ctia_tool"
-      "ctia.store.es.tool.aliased" false
-      "ctia.store.malware" "es"
-      "ctia.store.tool" "es"]
-     #(let [{:keys [tool malware plop]}
-            (sut/get-target-stores "0.0.0" [:tool :malware :plop])]
-        (println "plop")
-       (is (= "v0.0.0_ctia_malware" (:indexname malware)))
-       (is (= "v0.0.0_ctia_tool" (:indexname tool)))
-       (is (= "v0.0.0_ctia_default" (:indexname plop))
-           "target-stores should use default configuration when index is not configured")
-       (is (= "v0.0.0_ctia_malware-write" (get-in malware [:props :write-index]))
-           "aliased stores should write on dedicated alias")
-       (is (= "v0.0.0_ctia_tool" (get-in tool [:props :write-index]))
-           "unaliased store should directly write on index")
-       (is (= "v0.0.0_ctia_default-write" (get-in plop [:props :write-index]))
-           "target-stores should use default configuration when index is not configured")))))
+  (let [{:keys [tool malware plop]}
+        (sut/get-target-stores "0.0.0" [:tool :malware :plop])]
+    (is (= "v0.0.0_ctia_malware" (:indexname malware)))
+    (is (= "v0.0.0_ctia_tool" (:indexname tool)))
+    (is (= "v0.0.0_test_ctia" (:indexname plop))
+        "target-stores should use default configuration when index is not configured")
+    (is (= "v0.0.0_ctia_malware-write" (get-in malware [:props :write-index])))
+    (is (= "v0.0.0_ctia_tool-write" (get-in tool [:props :write-index])))
+    (is (= "v0.0.0_test_ctia-write" (get-in plop [:props :write-index]))
+        "target-stores should use default configuration when index is not configured")))
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -99,7 +99,7 @@
     (fixture-fn fn)))
 
 (deftest get-target-stores-test
-  (testing "something"
+  (testing "get-target-stores should properly init store maps from configuration"
     (apply-fixtures
      ["ctia.store.es.default.shards" 1
       "ctia.store.es.default.replicas" 1

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -125,8 +125,7 @@
        (is (= "v0.0.0_ctia_tool" (get-in tool [:props :write-index]))
            "unaliased store should directly write on index")
        (is (= "v0.0.0_ctia_default-write" (get-in plop [:props :write-index]))
-           "target-stores should use default configuration when index is not configured")
-       ))))
+           "target-stores should use default configuration when index is not configured")))))
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -57,33 +57,6 @@
     (is (nil? (get-in wo-stores [:source :store])))
     (is (nil? (get-in wo-stores [:target :store])))))
 
-(deftest source-store-maps->target-store-maps-test
-  (let [malware-source-store {:indexname "ctia-malware"
-                              :mapping :malware
-                              :config {:aliases {"ctia-malware" {}
-                                                 "ctia-malware-write" {}}}
-                              :props {:write-index "ctia-malware-write"}}
-        sighting-source-store {:indexname "ctia-sighting"
-                               :mapping :sighting
-                               :config {:aliases {"ctia-sighting" {}
-                                                  "ctia-sighting-write" {}}}
-                               :props {:write-index "ctia-sighting-write"}}
-        malware-target-store  {:indexname "v0.0.0_ctia-malware"
-                               :mapping :malware
-                               :config {:aliases {"v0.0.0_ctia-malware" {}
-                                                  "v0.0.0_ctia-malware-write" {}}}
-                               :props {:write-index "v0.0.0_ctia-malware-write"}}
-        sighting-target-store  {:indexname "v0.0.0_ctia-sighting"
-                                :mapping :sighting
-                                :config {:aliases {"v0.0.0_ctia-sighting" {}
-                                                   "v0.0.0_ctia-sighting-write" {}}}
-                                :props {:write-index "v0.0.0_ctia-sighting-write"}}]
-    (is (= {:malware malware-target-store
-            :sighting sighting-target-store}
-           (sut/source-store-maps->target-store-maps {:malware malware-source-store
-                                                      :sighting sighting-source-store}
-           "0.0.0")))))
-
 (deftest rollover?-test
   (is (false? (sut/rollover? false 10 10 10))
       "rollover? should returned false when index is not aliased")


### PR DESCRIPTION
This PR fixes the migration that was broken by https://github.com/threatgrid/ctia/pull/849.

> Related #threatgrid/iroh#2954

This PR normalizes the creation of the target store independently of the source store. For creating a target store it only reads the configuration, modifies the indexname with desired prefix and then build the store map.

<a name="qa">[§](#qa)</a> QA
============================

No QA needed
