### PR TITLE
fixed prepare-docs bug on modified documents

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -63,7 +63,7 @@ ctia.store.es.default.default_operator=AND
 ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
 ctia.store.es.default.rollover.max_docs=10000000
-ctia.store.es.default.aliased=false
+ctia.store.es.default.aliased=true
 
 ctia.store.actor=es
 ctia.store.attack-pattern=es

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -196,17 +196,16 @@
                (:type target-store)
                target-store-size)
 
-    (loop [offset 0
-           sort-keys nil
+    (loop [sort-keys nil
            checked-count 0
            invalids []]
       (let [{:keys [data paging]
              :as batch}
             (mst/fetch-batch target-store
-                         batch-size
-                         offset
-                         nil
-                         sort-keys)
+                             batch-size
+                             0
+                             "asc"
+                             sort-keys)
             next (:next paging)
             offset (:offset next 0)
             search_after (:sort paging)
@@ -214,7 +213,7 @@
             checked-count (+ checked-count
                              (count data))]
         (if next
-          (recur offset search_after checked-count (concat invalids errors))
+          (recur search_after checked-count (concat invalids errors))
           (do
             (log/infof "%s - finished checking %s documents"
                        (:type target-store)

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -200,9 +200,12 @@
 (defn prepare-docs
   "Generates the _index, _id and _type meta data for bulk ops.
   By default we set :_index as write-index for all documents.
-  Then, this function detects documents that were modified during the migration,
-  retrieves the actual target index they were previously inserted,
-  and use it to set :_index meta for these documents"
+  In the case of aliased target, write-index is set to the write alias.
+  This write alias points to last index and a document that was inserted in a previous index,
+  must be updated in that same index in order to avoid its duplication.
+  Thus, this function detects documents that were modified during a migration toward an aliased index,
+  retrieves the actual target indices they were previously inserted in,
+  and uses them to set :_index meta for these documents"
   [{:keys [conn mapping]
     {:keys [aliased write-index]} :props
     :as store-map}

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -203,20 +203,20 @@
     {:keys [aliased write-index]} :props
     :as store-map}
    docs]
-  (let [{modified true not-modified false} (group-by #(search-real-index? aliased %)
-                                                     docs)
-        prepared-not-modified (map #(assoc %
-                                           :_id (:id %)
-                                           :_index write-index
-                                           :_type mapping)
-                                   not-modified)
+  (let [with-metas (map #(assoc %
+                                :_id (:id %)
+                                :_index write-index
+                                :_type mapping)
+                        docs)
+        {modified true not-modified false} (group-by #(search-real-index? aliased %)
+                                                     with-metas)
         modified-by-ids (fmap first (group-by :id modified))
         bulk-metas-res (->> (map :id modified)
                             (bulk-metas store-map))
         prepared-modified (->> bulk-metas-res
                                (merge-with into modified-by-ids)
                                vals)]
-    (concat prepared-modified prepared-not-modified)))
+    (concat prepared-modified not-modified)))
 
 (defn store-batch
   "store a batch of documents using a bulk operation"

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -198,7 +198,11 @@
                 (not= created modified))))
 
 (defn prepare-docs
-  "Generates the _index, _id and _type meta data for bulk ops. In particular it determines in which indices modified documents need to be written."
+  "Generates the _index, _id and _type meta data for bulk ops.
+  By default we set :_index as write-index for all documents.
+  Then, this function detects documents that were modified during the migration,
+  retrieves the actual target index they were previously inserted,
+  and use it to set :_index meta for these documents"
   [{:keys [conn mapping]
     {:keys [aliased write-index]} :props
     :as store-map}

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -127,8 +127,7 @@
           (let [migrated-store (get-in migration-state [:stores store-type])
                 {:keys [source target]} migrated-store]
             (is (= fixtures-nb (:total source)))
-            (is (= fixtures-nb (:migrated target))))
-          )))))
+            (is (= fixtures-nb (:migrated target)))))))))
 
 
 (deftest migration-with-malformed-docs

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -91,6 +91,7 @@
        :headers {"Authorization" "45c1f5e3f05d0"})))
 
 (defn random-updates
+  "select nb random entities of the bulk and update them"
   [bulk-result nb]
   (let [random-ids (->> (select-keys bulk-result
                                      [:malwares
@@ -106,7 +107,7 @@
       (update-entity entity))))
 
 (defn rollover-post-bulk
-  "post data in 2 parts and rollover"
+  "post data in 2 parts with rollover, randomly update son entities"
   []
   (let [bulk-res-1 (post-bulk (fixt/bundle (/ fixtures-nb 2) false))
         _ (rollover-stores @stores)


### PR DESCRIPTION
This PR fixes a migration bug on prepare-docs which does not properly set bulk metas:
2019-09-23 17:53:30,063 ERROR (main) [ctia.task.migration.migrate-es-stores] - Unexpected error during migration. This is the origin of following log error:
```
clojure.lang.ExceptionInfo: ES query parsing error {:type :clj-momo.lib.es.conn/es-query-parsing-error, :es-http-res {:cached nil, :request-time 5, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :http-client #object[org.apache.http.impl.client.InternalHttpClient 0x13d1ca89 "org.apache.http.impl.client.InternalHttpClient@13d1ca89"], :chunked? false, :reason-phrase "Bad Request", :headers {"content-type" "application/json; charset=UTF-8"}, :orig-content-encoding nil, :status 400, :length -1, :body "{\"error\":{\"root_cause\":[{\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: index is missing;2: type is missing;3: index is missing;4: type is missing;\"}],\"type\":\"action_request_validation_exception\",\"reason\":\"Validation Failed: 1: index is missing;2: type is missing;3: index is missing;4: type is missing;\"},\"status\":400}", :trace-redirects []}}
```
This PR also fixes the check store function, which now use `search_after` instead of offset that cannot paginate large windows.

<a name="qa">[§](#qa)</a> QA
============================

No QA needed