### PR TITLE
Add OAuth2 URLs to the connect-src CSP

### DIFF
--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -128,7 +128,7 @@
 
 (defn build-csp
   "Build the Content Security Policy header from the http configuration"
-  [{:keys [swagger] :as http-config}]" connect-src 'self';"
+  [{:keys [swagger] :as http-config}]
   (str "default-src 'self';"
        " style-src 'self' 'unsafe-inline';"
        " img-src 'self' data:;"

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -89,7 +89,7 @@
             (is (= "nosniff"
                    (get-in swagger-ui-resp [:headers "X-Content-Type-Options"]))
                 "Swagger-UI request should contain the X-Content-Type-Options header set to nosniff")
-            (is (= "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; connect-src 'self';"
+            (is (= "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:9001/iroh/oauth2/token http://localhost:9001/iroh/oauth2/refresh;"
                    (get-in swagger-ui-resp [:headers "Content-Security-Policy"]))
                 "The request should contain the Content-Security-Policy header set to nosniff")
             (is (= "DENY"

--- a/test/ctia/http/server_test.clj
+++ b/test/ctia/http/server_test.clj
@@ -64,3 +64,25 @@
          (let [{:keys [headers]}
                (get "ctia/version")]
            (is (clojure.core/get headers "Server"))))))))
+
+(deftest build-csp-test
+  (is (= (str "default-src 'self'; style-src 'self' 'unsafe-inline'; "
+              "img-src 'self' data:; script-src 'self' 'unsafe-inline'; "
+              "connect-src 'self';")
+         (sut/build-csp {})))
+  (is (= (str "default-src 'self'; style-src 'self' 'unsafe-inline'; "
+              "img-src 'self' data:; script-src 'self' 'unsafe-inline'; "
+              "connect-src 'self' https://visibility.int.iroh.site/iroh/oauth2/token;")
+         (sut/build-csp
+          {:swagger
+           {:oauth2
+            {:token-url "https://visibility.int.iroh.site/iroh/oauth2/token"}}})))
+  (is (= (str "default-src 'self'; style-src 'self' 'unsafe-inline'; "
+              "img-src 'self' data:; script-src 'self' 'unsafe-inline'; "
+              "connect-src 'self' https://visibility.int.iroh.site/iroh/oauth2/token "
+              "https://visibility.int.iroh.site/iroh/oauth2/refresh;")
+         (sut/build-csp
+          {:swagger
+           {:oauth2
+            {:token-url "https://visibility.int.iroh.site/iroh/oauth2/token"
+             :refresh-url "https://visibility.int.iroh.site/iroh/oauth2/refresh"}}}))))


### PR DESCRIPTION
Fix OAuth2 code grant in swagger UI

> Close threatgrid/iroh#2981

This PR fixes the OAuth2 code flow in swagger UI by adding the `token-url` and the `refresh-url` to the Content Security Policy header.

<a name="qa">[§](#qa)</a> QA
============================

1. Log into private/public CTIA with the OAuth2 authentication method
2. Execute the query `/ctia/status`
3. The result status should be 200

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Fix OAuth2 authentication in Swagger UI
```
