### PR TITLE
update setting task

### DIFF
--- a/doc/es_stores.md
+++ b/doc/es_stores.md
@@ -63,6 +63,15 @@ or from source:
 `lein run -m ctia.task.rollover` 
 
 
+## Updating indices dynamic settings
+CTIA proposes a task to update indices dynamic settings like `refresh_interval` and `number_of_replicas`. For that purpose, you must first update the property file with the desired value for these settings and then launch the task with:
+`java -cp ctia.jar:resources:. clojure.main -m ctia.task.settings`
+or from source:
+`lein run -m ctia.task.settings` 
+You can also select some stores with the option `--stores` and a comma separated list of store names:
+`lein run -m ctia.task.settings --stores relaitonship,malware,indicator` 
+
+
 ## From aliased to unaliased and back
 
 Changing the `aliased` mode will only be applied after a migration, it's not possible to do it while running neither by restarting CTIA with modified configuration. In order to do so, you have to modify `aliased` and `rollover` properties and run a migration with current settings. After the migration, properly set the new indexname and restart CTIA.

--- a/doc/es_stores.md
+++ b/doc/es_stores.md
@@ -64,7 +64,7 @@ or from source:
 
 
 ## Updating indices dynamic settings
-CTIA proposes a task to update indices dynamic settings like `refresh_interval` and `number_of_replicas`. For that purpose, you must first update the property file with the desired value for these settings and then launch the task with:
+When CTIA starts, it updates the dynamic settings of store indices, like `refresh_interval` and `number_of_replicas`, according to property file. However CTIA also proposes a task to update indices dynamic settings without restarting CTIA. For that purpose, you must first update the property file with the desired values for these settings and then launch the task with:
 `java -cp ctia.jar:resources:. clojure.main -m ctia.task.settings`
 or from source:
 `lein run -m ctia.task.settings` 

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                                com.google.guava/guava
                                org.clojure/tools.reader
                                org.clojure/clojurescript]]
-                 [threatgrid/clj-momo "0.3.1"]
+                 [threatgrid/clj-momo "0.3.2"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -50,7 +50,8 @@
 
 (defn upsert-template!
   [conn index config]
-  (es-index/create-template! conn index config))
+  (es-index/create-template! conn index config)
+  (log/infof "updated template: %s" index))
 
 (s/defn init-es-conn! :- ESConnState
   "initiate an ES Store connection,

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -47,6 +47,11 @@
                 {:aliases {indexname {}}}))
      :conn (connect props)}))
 
+
+(defn upsert-template!
+  [conn index config]
+  (es-index/create-template! conn index config))
+
 (s/defn init-es-conn! :- ESConnState
   "initiate an ES Store connection,
    put the index template, return an ESConnState"
@@ -54,7 +59,7 @@
   (let [{:keys [conn index props config] :as conn-state}
         (init-store-conn properties)
         existing-index (es-index/get conn (str index "*"))]
-    (es-index/create-template! conn index config)
+    (upsert-template! conn index config)
     (when (and (:aliased props)
                (empty? existing-index))
       ;;https://github.com/elastic/elasticsearch/pull/34499

--- a/src/ctia/task/settings.clj
+++ b/src/ctia/task/settings.clj
@@ -1,12 +1,12 @@
 (ns ctia.task.settings
+  (:import clojure.lang.ExceptionInfo)
   (:require [clojure.tools.cli :refer [parse-opts]]
             [clojure.tools.logging :as log]
-
             [schema.core :as s]
             [clj-momo.lib.es
              [index :as es-index]
              [schemas :refer [ESConnState]]]
-            [ctia.stores.es.init :refer [upsert-template!]]
+            [ctia.stores.es.init :refer [StoreProperties init-es-conn! get-store-properties]]
             [ctia
              [init :refer [init-store-service! log-properties]]
              [properties :refer [properties init!]]
@@ -14,16 +14,14 @@
 
 (s/defn update-store!
   "read store properties of given stores and update indices settings."
-  [{:keys [conn index config]
-    {:keys [settings]} :config
-    :as state} :- ESConnState]
+  [props :- StoreProperties]
   (try
-    (upsert-template! conn index config)
-    (log/info "updated template: " index)
-    (->> {:index (select-keys settings [:refresh_interval :number_of_replicas])}
-         (es-index/update-settings! conn index))
-    (log/info "updated settings: " index)
-    (catch clojure.lang.ExceptionInfo e
+    (let [{:keys [conn index]
+           {:keys [settings]} :config} (init-es-conn! props)]
+      (->> {:index (select-keys settings [:refresh_interval :number_of_replicas])}
+           (es-index/update-settings! conn index))
+      (log/info "updated settings:" index))
+    (catch ExceptionInfo e
       (log/warn "could not update settings on that store"
                 (pr-str (ex-data e))))))
 
@@ -31,8 +29,7 @@
   [store-keys]
   (doseq [kw store-keys]
     (log/infof "updating settings for store: %s" (name kw))
-    (update-store! (-> @stores kw first :state))))
-
+    (update-store! (get-store-properties kw))))
 
 (def cli-options
   [["-h" "--help"]
@@ -53,5 +50,4 @@
     (clojure.pprint/pprint options)
     (init!)
     (log-properties)
-    (init-store-service!)
     (update-stores! (:stores options))))

--- a/src/ctia/task/settings.clj
+++ b/src/ctia/task/settings.clj
@@ -35,7 +35,8 @@
 
 
 (def cli-options
-  [["-s" "--stores STORES" "comma separated list of store names"
+  [["-h" "--help"]
+   ["-s" "--stores STORES" "comma separated list of store names"
     :default (set (keys @stores))
     :parse-fn #(map keyword (clojure.string/split % #","))]])
 

--- a/src/ctia/task/settings.clj
+++ b/src/ctia/task/settings.clj
@@ -6,30 +6,17 @@
             [clj-momo.lib.es
              [index :as es-index]
              [schemas :refer [ESConnState]]]
-            [ctia.stores.es.init :refer [StoreProperties init-es-conn! get-store-properties]]
+            [ctia.stores.es.init :refer [init-es-conn! get-store-properties]]
             [ctia
              [init :refer [init-store-service! log-properties]]
              [properties :refer [properties init!]]
              [store :refer [stores]]]))
 
-(s/defn update-store!
-  "read store properties of given stores and update indices settings."
-  [props :- StoreProperties]
-  (try
-    (let [{:keys [conn index]
-           {:keys [settings]} :config} (init-es-conn! props)]
-      (->> {:index (select-keys settings [:refresh_interval :number_of_replicas])}
-           (es-index/update-settings! conn index))
-      (log/info "updated settings:" index))
-    (catch ExceptionInfo e
-      (log/warn "could not update settings on that store"
-                (pr-str (ex-data e))))))
-
 (defn update-stores!
   [store-keys]
   (doseq [kw store-keys]
     (log/infof "updating settings for store: %s" (name kw))
-    (update-store! (get-store-properties kw))))
+    (init-es-conn! (get-store-properties kw))))
 
 (def cli-options
   [["-h" "--help"]

--- a/src/ctia/task/settings.clj
+++ b/src/ctia/task/settings.clj
@@ -1,0 +1,56 @@
+(ns ctia.task.settings
+  (:require [clojure.tools.cli :refer [parse-opts]]
+            [clojure.tools.logging :as log]
+
+            [schema.core :as s]
+            [clj-momo.lib.es
+             [index :as es-index]
+             [schemas :refer [ESConnState]]]
+            [ctia.stores.es.crud :as es-crud]
+            [ctia
+             [init :refer [init-store-service! log-properties]]
+             [properties :refer [properties init!]]
+             [store :refer [stores]]]))
+
+(s/defn update-store!
+  "read store properties of given stores and update indices settings."
+  [{conn :conn
+    indexname :index
+    {:keys [settings]} :config
+    :as state} :- ESConnState]
+  (try
+    (->> {:index (select-keys settings [:refresh_interval :number_of_replicas])}
+         (es-index/update-settings! conn indexname)
+         pr-str
+         (log/info "updated settings: "))
+    (catch clojure.lang.ExceptionInfo e
+      (log/warn "could not update settings on that store"
+                (pr-str (ex-data e))))))
+
+(defn update-stores!
+  [store-keys]
+  (doseq [kw store-keys]
+    (log/infof "updating settings for store: %s" (name kw))
+    (update-store! (-> @stores kw first :state))))
+
+
+(def cli-options
+  [["-s" "--stores STORES" "comma separated list of store names"
+    :default (set (keys @stores))
+    :parse-fn #(map keyword (clojure.string/split % #","))]])
+
+(defn -main [& args]
+  (let [{:keys [options errors summary]} (parse-opts args cli-options)]
+    (when errors
+      (binding  [*out* *err*]
+        (println (clojure.string/join "\n" errors))
+        (println summary))
+      (System/exit 1))
+    (when (:help options)
+      (println summary)
+      (System/exit 0))
+    (clojure.pprint/pprint options)
+    (init!)
+    (log-properties)
+    (init-store-service!)
+    (update-stores! (:stores options))))

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -30,21 +30,6 @@
                         :port 9200
                         :aliased false})
 
-(deftest dynamic-settings-test
-  (is {:number_of_replicas 1
-       :number_of_shards 2
-       :refresh_interval "1s"}
-      (sut/dynamic-settings props-not-aliased))
-  (is {:number_of_replicas 1
-       :number_of_shards 2
-       :refresh_interval "2s"}
-      (sut/dynamic-settings props-aliased))
-
-  (is {:number_of_replicas 1
-       :number_of_shards 1
-       :refresh_interval "1s"}
-      (sut/dynamic-settings {})))
-
 (deftest init-store-conn-test
   (testing "init store conn should return a proper conn state with unaliased conf"
     (let [{:keys [index props config conn]}

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -1,0 +1,38 @@
+(ns ctia.task.settings-test
+  (:require [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
+            [ctia.task.settings :as sut]
+            [ctia.stores.es.init :as init]
+            [clj-momo.lib.es.index :as es-index]))
+
+
+(deftest update-store!-test
+  (let [initial-props {:entity :malware
+                       :indexname "ctia_malware"
+                       :host "localhost"
+                       :aliased true
+                       :port 9200
+                       :shards 5
+                       :replicas 2
+                       :refresh_interval "1s"}
+        ;; create index
+        {:keys [conn index]} (init/init-es-conn! initial-props)
+        new-props (assoc initial-props
+                         :shards 4
+                         :replicas 1
+                         :refresh_interval "2s")
+        new-conn-state (init/init-store-conn new-props)
+        _ (sut/update-store! new-conn-state)
+        {:keys [refresh_interval
+                number_of_shards
+                number_of_replicas]} (-> (es-index/get conn index)
+                                         first
+                                         val
+                                         :settings
+                                        :index)]
+    (is (= "5" number_of_shards)
+        "the number of shards is a static parameter")
+    (testing "dynamic parameters should be updated"
+      (is (= "1" number_of_replicas))
+      (is (= "2s" refresh_interval)))
+    (es-index/delete! conn (str index "*"))))
+

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -4,7 +4,6 @@
             [ctia.stores.es.init :as init]
             [clj-momo.lib.es.index :as es-index]))
 
-
 (deftest update-store!-test
   (let [initial-props {:entity :malware
                        :indexname "ctia_malware"
@@ -20,8 +19,7 @@
                          :shards 4
                          :replicas 1
                          :refresh_interval "2s")
-        new-conn-state (init/init-store-conn new-props)
-        _ (sut/update-store! new-conn-state)
+        _ (sut/update-store! new-props)
         {:keys [refresh_interval
                 number_of_shards
                 number_of_replicas]} (-> (es-index/get conn index)

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -1,36 +1,64 @@
 (ns ctia.task.settings-test
   (:require [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
+            [ctia.properties :as props]
             [ctia.task.settings :as sut]
             [ctia.stores.es.init :as init]
-            [clj-momo.lib.es.index :as es-index]))
+            [clj-momo.lib.es
+             [index :as es-index]
+             [conn :as es-conn]]
+            [ctia.test-helpers
+             [core :refer [fixture-ctia fixture-properties:clean]]
+             [es :refer [fixture-properties:es-store fixture-delete-store-indexes]]]))
 
-(deftest update-store!-test
-  (let [initial-props {:entity :malware
-                       :indexname "ctia_malware"
-                       :host "localhost"
-                       :aliased true
-                       :port 9200
-                       :shards 5
-                       :replicas 2
-                       :refresh_interval "1s"}
-        ;; create index
-        {:keys [conn index]} (init/init-es-conn! initial-props)
-        new-props (assoc initial-props
-                         :shards 4
-                         :replicas 1
-                         :refresh_interval "2s")
-        _ (sut/update-store! new-props)
-        {:keys [refresh_interval
-                number_of_shards
-                number_of_replicas]} (-> (es-index/get conn index)
-                                         first
-                                         val
-                                         :settings
-                                        :index)]
-    (is (= "5" number_of_shards)
-        "the number of shards is a static parameter")
-    (testing "dynamic parameters should be updated"
-      (is (= "1" number_of_replicas))
-      (is (= "2s" refresh_interval)))
-    (es-index/delete! conn (str index "*"))))
+(use-fixtures :each (join-fixtures [fixture-properties:es-store
+                                    fixture-ctia
+                                    fixture-delete-store-indexes]))
 
+(defn get-setting
+  "helper for retrieving a setting inside an index/template ES res"
+  [es-res setting]
+  (-> (first es-res)
+      val
+      (get-in [:settings :index setting])))
+
+(deftest update-stores!-test
+  ;;init all stores
+  (props/init!)
+  (let [initial-indicator-props (init/get-store-properties :indicator)
+        _ (swap! props/properties
+                 #(-> (assoc-in %
+                                [:ctia :store :es :relationship :replicas]
+                                12)
+                      (assoc-in [:ctia :store :es :malware :refresh_interval]
+                                "12s")
+                      (assoc-in [:ctia :store :es :indicator :refresh_interval]
+                                "12s")))
+        _ (sut/update-stores! [:relationship :malware])
+        es-props (get-in @props/properties [:ctia :store :es])
+        conn (es-conn/connect (:default es-props))
+        relationship-indexname (get-in es-props [:relationship :indexname])
+        relationship-index (es-index/get conn (str relationship-indexname "*"))
+        relationship-template (es-index/get-template conn relationship-indexname)
+
+        malware-indexname (get-in es-props [:malware :indexname])
+        malware-index (es-index/get conn (str malware-indexname "*"))
+        malware-template (es-index/get-template conn malware-indexname)
+
+        indicator-indexname (get-in es-props [:indicator :indexname])
+        indicator-index (es-index/get conn (str indicator-indexname "*"))
+        indicator-template (es-index/get-template conn indicator-indexname)]
+    (testing "stores that are passed to update-stores! should have their settings updated"
+      (is (= "12"
+             (get-setting relationship-index :number_of_replicas)
+             (get-setting relationship-template :number_of_replicas)))
+      (is (= "12s"
+             (get-setting malware-index :refresh_interval)
+             (get-setting malware-template :refresh_interval))))
+
+    (testing "stores that are not passed to update-stores! should not have their settings updated"
+      (is (= (:refresh_interval initial-indicator-props)
+             (get-setting indicator-index :refresh_interval)
+             (get-setting indicator-template :refresh_interval)))
+      (is (= (str (:replicas initial-indicator-props))
+             (get-setting indicator-index :number_of_replicas)
+             (get-setting indicator-template :number_of_replicas))))))


### PR DESCRIPTION
> Closes https://github.com/threatgrid/iroh/issues/3030

This PR introduces a new task to update indices settings while also updating indices settings at startup. It also fixes a bug at index creation, `refresh_interval` is no more ignored.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="ops">[§](#ops)</a> Ops
===============================
CTIA proposes a new task to update dynamic settings like `refresh_interval` and `number_of_replicas`. For that purpose, you must first update the property file with the desired values for these settings (by default or per store) and then launch the task with:
`java -cp ctia.jar:resources:. clojure.main -m ctia.task.settings`
or from source:
`lein run -m ctia.task.settings` 
You can also select some stores with the option `--stores` and a comma separated list of store names:
`lein run -m ctia.task.settings --stores relaitonship,malware,indicator` 