### PR TITLE
Fix a commented line in project.clj failing the build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -151,7 +151,7 @@
                    :no-gen #(not (:generative %))
                    :all #(not (:disabled %))}
 
-  ;; :java-source-paths ["hooks/ctia"]
+  :java-source-paths ["hooks/ctia"]
   :javac-options  ["-proc:none"] ;; remove a warning
   :filespecs [{:type :fn
                :fn (fn [_]


### PR DESCRIPTION
This fixes a leftover change from a previous PR that breaks master.