### PR TITLE
Record Visibility Property

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -46,10 +46,11 @@
 
    Setup entity access control settings
 
- | Property                        | Description                                                | Possible values                |
- |---------------------------------+------------------------------------------------------------+--------------------------------|
- | ctia.access-control.min-tlp     | set the minimum TLP value for posting a document           | =white= =green=  =amber= =red= |
- | ctia.access-control.default-tlp | set the TLP for a newly posted entity if none is specified | =white= =green= =amber= =red=  |
+ | Property                                  | Description                                                | Possible values                |
+ |-------------------------------------------+------------------------------------------------------------+--------------------------------|
+ | ctia.access-control.min-tlp               | set the minimum TLP value for posting a document           | =white= =green=  =amber= =red= |
+ | ctia.access-control.default-tlp           | set the TLP for a newly posted entity if none is specified | =white= =green= =amber= =red=  |
+ | ctia.access-control.max-record-visibility | set the record max visibility for TLP Green/White          | =everyone= =group=             |
 
 
 ** HTTP

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -5,6 +5,7 @@ ctia.auth.casebook.scope=casebook
 
 ctia.access-control.min-tlp green
 ctia.access-control.default-tlp green
+ctia.access-control.max-record-visibility everyone
 
 # You can optionaly require a specific API key
 #ctia.auth.type=static

--- a/src/ctia/domain/access_control.clj
+++ b/src/ctia/domain/access_control.clj
@@ -27,6 +27,11 @@
     (nthrest tlps
              (.indexOf tlps min-tlp))))
 
+(defn max-record-visibility-everyone? []
+  (= "everyone"
+     (or (:max-record-visibility (get-access-control))
+         "everyone")))
+
 (defn allowed-tlp? [tlp]
   (some #{tlp} (allowed-tlps)))
 
@@ -48,11 +53,12 @@
 (s/defn authorized-group? :- s/Bool
   [doc ident]
   (boolean
-   (and (seq (:groups ident))
-        (seq (:authorized_groups doc))
-        (seq (clojure.set/intersection
-              (set (:groups ident))
-              (set (:authorized_groups doc)))))))
+   (and
+    (seq (:groups ident))
+    (seq (:authorized_groups doc))
+    (seq (clojure.set/intersection
+          (set (:groups ident))
+          (set (:authorized_groups doc)))))))
 
 (s/defn authorized-user? :- s/Bool
   [doc ident]
@@ -90,5 +96,6 @@
 (s/defn allow-read? :- s/Bool
   [doc ident]
   (boolean
-   (or (some #{(:tlp doc)} public-tlps)
+   (or (and (max-record-visibility-everyone?)
+            (some #{(:tlp doc)} public-tlps))
        (allow-write? doc ident))))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -143,8 +143,7 @@
            identity
            tempids
            prev-entity
-           realize-fn
-           enveloped-result?] :as fm} :- FlowMap]
+           realize-fn] :as fm} :- FlowMap]
   (let [login (auth/login identity)
         groups (auth/groups identity)]
     (assoc fm
@@ -307,7 +306,7 @@
   [entities long-id-fn]
   (->> entities
        (filter #(nil? (:error %)))
-       (map (fn [{:keys [error id] :as entity}]
+       (map (fn [{:keys [_ id] :as entity}]
               [id (:id (long-id-fn entity))]))
        (into {})))
 
@@ -345,7 +344,7 @@
 
 (s/defn ^:private make-result :- s/Any
   [{:keys [flow-type entities results
-           enveloped-result? tempids] :as fm} :- FlowMap]
+           enveloped-result? tempids]} :- FlowMap]
   (case flow-type
     :create (if enveloped-result?
               (cond-> {:data entities}

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -1,7 +1,7 @@
 (ns ctia.http.routes.crud
   (:require
    [clojure.string :refer [capitalize]]
-   [ctia.http.middleware.auth :refer :all]
+   [ctia.http.middleware.auth]
    [compojure.api.sweet :refer [DELETE GET POST PUT PATCH routes]]
    [ctia.domain.entities
     :refer
@@ -13,7 +13,15 @@
    [ctia.http.routes.common
     :refer
     [created filter-map-search-options paginated-ok search-options]]
-   [ctia.store :refer :all]
+   [ctia.store :refer [write-store
+                       read-store
+                       query-string-search-store
+                       query-string-search
+                       create-record
+                       delete-record
+                       read-record
+                       update-record
+                       list-records]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [ring.swagger.schema :refer [describe]]
    [schema.core :as s]))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -126,6 +126,8 @@
    (st/required-keys {"ctia.access-control.min-tlp" TLP
                       "ctia.access-control.default-tlp" TLP})
 
+   (st/optional-keys {"ctia.access-control.max-record-visibility" (s/enum "group" "everyone")})
+
    (st/optional-keys {"ctia.hook.kafka.enabled" s/Bool
                       "ctia.hook.kafka.compression.type" (s/enum "none" "gzip" "snappy" "lz4" "zstd")
                       "ctia.hook.kafka.ssl.enabled" s/Bool

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -1,7 +1,7 @@
 (ns ctia.stores.es.query
-  (:require [clj-momo.lib.es.query :as q]
-            [ctia.domain.access-control
-             :refer [public-tlps]]
+  (:require [ctia.domain.access-control
+             :refer [public-tlps
+                     max-record-visibility-everyone?]]
             [clojure.string :as str]))
 
 (defn find-restriction-query-part
@@ -11,23 +11,28 @@
         groups (map str/lower-case groups)]
     {:bool
      {:should
-      [{:terms {"tlp" public-tlps}}
-       ;; Document Owner
-       {:bool {:filter [{:term {"owner" login}}
-                        {:terms {"groups" groups}}]}}
+      (cond->>
+          [;; Document Owner
+           {:bool {:filter [{:term {"owner" login}}
+                            {:terms {"groups" groups}}]}}
 
-       ;; or if user is listed in authorized_users or authorized_groups field
-       {:term {"authorized_users" login}}
-       {:terms {"authorized_groups" groups}}
+           ;; or if user is listed in authorized_users or authorized_groups field
+           {:term {"authorized_users" login}}
+           {:terms {"authorized_groups" groups}}
 
-       ;; CTIM models with TLP amber that is owned by org BAR
-       {:bool {:must [{:term {"tlp" "amber"}}
-                      {:terms {"groups" groups}}]}}
+           ;; CTIM records with TLP equal or below amber that are owned by org BAR
+           {:bool {:must [{:terms {"tlp" (conj public-tlps "amber")}}
+                          {:terms {"groups" groups}}]}}
 
-       ;; CTIM models with TLP red that is owned by user FOO
-       {:bool {:must [{:term {"tlp" "red"}}
-                      {:term {"owner" login}}
-                      {:terms {"groups" groups}}]}}]}}))
+           ;; CTIM records with TLP red that is owned by user FOO
+           {:bool {:must [{:term {"tlp" "red"}}
+                          {:term {"owner" login}}
+                          {:terms {"groups" groups}}]}}]
+
+        ;; Any Green/White TLP if max-visibility is set to `everyone`
+        (max-record-visibility-everyone?)
+        (cons {:terms {"tlp" public-tlps}}))}}))
+
 
 (defn- unexpired-time-range
   "ES filter that matches objects which

--- a/test/ctia/domain/access_control_test.clj
+++ b/test/ctia/domain/access_control_test.clj
@@ -71,6 +71,9 @@
 
 ;; -- Read tests
 
+
+;; ---- Max record visibility everyone
+
 (deftest allow-read?-tlp-white-test
   (testing "white TLP should allow document read to everyone"
     (test-matching-user "white" sut/allow-read? true?)
@@ -114,6 +117,66 @@
     (test-authorized_groups-mismatch "red" sut/allow-read? false?)
     (test-authorized_users-match "red" sut/allow-read? true?)
     (test-authorized_groups-match "red" sut/allow-read? true?)))
+
+
+;; ---- Max record visibility group
+
+(defn with-max-record-visibility-group [f]
+  (swap! ctia.properties/properties
+         assoc-in [:ctia :access-control :max-record-visibility] "group")
+  (f)
+  (swap! ctia.properties/properties
+         assoc-in [:ctia :access-control :max-record-visibility] "everyone"))
+
+
+(deftest allow-read?-tlp-white-max-record-visibility-group-test
+  (with-max-record-visibility-group
+    #(testing "white TLP should disallow document read to everyone"
+       (test-matching-user "white" sut/allow-read? true?)
+       (test-matching-group "white" sut/allow-read? true?)
+       (test-user-group-mismatch "white" sut/allow-read? false?)
+       (test-no-group "white" sut/allow-read? false?)
+       (test-authorized_users-mismatch "white" sut/allow-read? false?)
+       (test-authorized_groups-mismatch "white" sut/allow-read? false?)
+       (test-authorized_users-match "white" sut/allow-read? true?)
+       (test-authorized_groups-match "white" sut/allow-read? true?))))
+
+(deftest allow-read?-tlp-green-max-record-visibility-group-test
+  (with-max-record-visibility-group
+    #(testing "green TLPs should disallow document read to everyone"
+       (test-matching-user "green" sut/allow-read? true?)
+       (test-matching-group "green" sut/allow-read? true?)
+       (test-no-group "green" sut/allow-read? false?)
+       (test-user-group-mismatch "green" sut/allow-read? false?)
+       (test-authorized_users-mismatch "green" sut/allow-read? false?)
+       (test-authorized_groups-mismatch "green" sut/allow-read? false?)
+       (test-authorized_users-match "green" sut/allow-read? true?)
+       (test-authorized_groups-match "green" sut/allow-read? true?))))
+
+(deftest allow-read?-tlp-amber-max-record-visibility-group-test
+  (with-max-record-visibility-group
+    #(testing "amber TLPs should allow document read to same group"
+       (test-matching-user "amber" sut/allow-read? true?)
+       (test-matching-group "amber" sut/allow-read? true?)
+       (test-no-group "amber" sut/allow-read? false?)
+       (test-user-group-mismatch "amber" sut/allow-read? false?)
+       (test-authorized_users-mismatch "amber" sut/allow-read? false?)
+       (test-authorized_groups-mismatch "amber" sut/allow-read? false?)
+       (test-authorized_users-match "amber" sut/allow-read? true?)
+       (test-authorized_groups-match "amber" sut/allow-read? true?))))
+
+(deftest allow-read?-tlp-red-max-record-visibility-group-test
+  (with-max-record-visibility-group
+    #(testing "red TLPs should allow document read to owner only"
+       (test-matching-user "red" sut/allow-read? true?)
+       (test-matching-group "red" sut/allow-read? false?)
+       (test-no-group "red" sut/allow-read? false?)
+       (test-user-group-mismatch "red" sut/allow-read? false?)
+       (test-authorized_users-mismatch "red" sut/allow-read? false?)
+       (test-authorized_groups-mismatch "red" sut/allow-read? false?)
+       (test-authorized_users-match "red" sut/allow-read? true?)
+       (test-authorized_groups-match "red" sut/allow-read? true?))))
+
 
 ;; -- Write tests
 

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -5,7 +5,34 @@
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [delete get post put]]
              [fake-whoami-service :as whoami-helpers]]
+            [ctia.domain.access-control :as cdac]
             [ctim.domain.id :as id]))
+
+;; === Access Control Test Scenario workflow: ===
+
+;; - Player 1 is isolated, Player 2-3 in same group
+;; - Each Player creates a Record with a given TLP
+;; - Test Player 2 attempts access on Player 1 R/W
+;; - Test Player 3 attempts access on Player 1 R/W
+;; - Test a List query for Each Player
+;; - Player 2 Attempts deleting Player 3 entity
+;; - Repost Deleted entities
+
+;; - Player 1 Allows Player 2
+
+;; - Test Player 2 attempts access on Player 1 R/W
+;; - Test Player 3 attempts access on Player 1 R/W
+;; - Test a List query for Each Player
+;; - Player 2 Attempts deleting Player 3 entity
+;; - Repost Deleted entities
+
+;; - Player 1 Allows Player 2-3 Group
+
+;; - Test Player 2 attempts access on Player 1 R/W
+;; - Test Player 3 attempts access on Player 1 R/W
+;; - Test a List query for Each Player
+;; - Player 2 Attempts deleting Player 3 entity
+
 
 (defn green-entity [entity]
   (assoc entity :tlp "green"))
@@ -26,31 +53,30 @@
           (:groups entity-2))))
 
 (defn crud-access-control-test
-  [entity
-   can-update?
-   can-delete?
-   {player-1-entity :parsed-body
-    player-1-entity-status :status}
-   {player-2-entity :parsed-body
-    player-2-entity-status :status}
-   {player-3-entity :parsed-body
-    player-3-entity-status :status}
+  [{:keys [entity
+           can-update?
+           can-delete?
+           player-1-creation
+           player-2-creation
+           player-3-creation
+           player-2-1-expected-read-statuses
+           player-2-1-expected-write-statuses
+           player-2-3-expected-read-statuses
+           player-2-3-expected-write-statuses
+           player-3-1-expected-read-statuses
+           player-3-1-expected-write-statuses
+           list-query
+           player-1-expected-entity-list
+           player-2-expected-entity-list
+           player-3-expected-entity-list]}]
 
-   player-2-1-expected-read-statuses
-   player-2-1-expected-write-statuses
-
-   player-2-3-expected-read-statuses
-   player-2-3-expected-write-statuses
-
-   player-3-1-expected-read-statuses
-   player-3-1-expected-write-statuses
-
-   list-query
-   player-1-expected-entity-list
-   player-2-expected-entity-list
-   player-3-expected-entity-list]
-
-  (let [player-1-entity-id
+  (let [{player-1-entity :parsed-body
+         player-1-entity-status :status} player-1-creation
+        {player-2-entity :parsed-body
+         player-2-entity-status :status} player-2-creation
+        {player-3-entity :parsed-body
+         player-3-entity-status :status} player-3-creation
+        player-1-entity-id
         (id/long-id->id (:id player-1-entity))
 
         player-2-entity-id
@@ -187,569 +213,767 @@
              #{player-2-3-entity-delete-status}
              player-2-3-expected-write-statuses))))))
 
+(defn test-access-control-entity-tlp-green-max-record-visibility-group
+  [{:keys [entity
+           new-entity
+           can-update?]
+    :as args}]
+
+  (with-redefs [cdac/max-record-visibility-everyone?
+                (constantly false)]
+    (testing "Green Max Record Visibility set to `Group`"
+      (is (false? (cdac/max-record-visibility-everyone?)))
+
+      (let [player-1-entity-post
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgpost"])
+                  :headers {"Authorization" "player-1-token"})
+
+            player-1-entity-repost
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost"])
+                  :headers {"Authorization" "player-1-token"})
+
+            player-1-entity-repost2
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost2"])
+                  :headers {"Authorization" "player-1-token"})
+
+            player-2-entity-post
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgpost"])
+                  :headers {"Authorization" "player-2-token"})
+
+            player-2-entity-repost
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost"])
+                  :headers {"Authorization" "player-2-token"})
+
+            player-2-entity-repost2
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost2"])
+                  :headers {"Authorization" "player-2-token"})
+
+            player-3-entity-post
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgpost"])
+                  :headers {"Authorization" "player-3-token"})
+
+            player-3-entity-repost
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost"])
+                  :headers {"Authorization" "player-3-token"})
+
+            player-3-entity-repost2
+            (post (format "ctia/%s" entity)
+                  :body (assoc (green-entity new-entity)
+                               :external_ids ["gmrvgrepost2"])
+                  :headers {"Authorization" "player-3-token"})]
+
+        (testing "green test setup is successful"
+          (is (= 201 (:status player-1-entity-post))
+              (str "HTTP status should be 201 "
+                   (pr-str player-1-entity-post)))
+          (is (= 201 (:status player-2-entity-post))
+              (str "HTTP status should be 201 "
+                   (pr-str player-2-entity-post)))
+          (is (= 201 (:status player-3-entity-post))
+              (str "HTTP status should be 201 "
+                   (pr-str player-3-entity-post))))
+
+        (crud-access-control-test
+         (into args
+               {:player-1-creation player-1-entity-post
+                :player-2-creation player-2-entity-post
+                :player-3-creation player-3-entity-post
+
+                :player-2-1-expected-read-statuses forbidden-statuses
+                :player-2-1-expected-write-statuses forbidden-statuses
+
+                :player-2-3-expected-read-statuses allowed-statuses
+                :player-2-3-expected-write-statuses allowed-statuses
+
+                :player-3-1-expected-read-statuses forbidden-statuses
+                :player-3-1-expected-write-statuses forbidden-statuses
+
+                :list-query "external_ids:gmrvgpost"
+                :player-1-expected-entity-list [(:parsed-body player-1-entity-post)]
+
+                :player-2-expected-entity-list [(:parsed-body player-2-entity-post)
+                                                (:parsed-body player-3-entity-post)]
+
+                :player-3-expected-entity-list [(:parsed-body player-2-entity-post)
+                                                (:parsed-body player-3-entity-post)]}))
+
+        ;; player1 and player2 repost deleted entities
+        (is (= 201 (:status player-1-entity-repost)))
+        (is (= 201 (:status player-2-entity-repost)))
+        (is (= 201 (:status player-3-entity-repost)))
+
+        (when can-update?
+          (let [player-1-entity-update
+                (put (format "ctia/%s/%s"
+                             entity
+                             (-> player-1-entity-repost
+                                 :parsed-body
+                                 :id
+                                 id/long-id->id
+                                 :short-id))
+                     :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
+                                  :authorized_users ["player2"])
+                     :headers {"Authorization" "player-1-token"})]
+
+            ;; player 1 allows player 2 (if record is updatable)
+            (crud-access-control-test
+             (into args
+                   {:player-1-creation player-1-entity-update
+                    :player-2-creation player-2-entity-repost
+                    :player-3-creation player-3-entity-repost
+
+                    :player-2-1-expected-read-statuses allowed-statuses
+                    :player-2-1-expected-write-statuses allowed-statuses
+
+                    :player-2-3-expected-read-statuses allowed-statuses
+                    :player-2-3-expected-write-statuses allowed-statuses
+
+                    :player-3-1-expected-read-statuses forbidden-statuses
+                    :player-3-1-expected-write-statuses forbidden-statuses
+
+                    :list-query "external_ids:gmrvgrepost"
+                    :player-1-expected-entity-list [(:parsed-body player-1-entity-update)]
+
+                    :player-2-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                    (:parsed-body player-2-entity-repost)
+                                                    (:parsed-body player-3-entity-repost)]
+
+                    :player-3-expected-entity-list [(:parsed-body player-2-entity-repost)
+                                                    (:parsed-body player-3-entity-repost)]}))))
+
+        ;; player1 and player2 repost deleted entities
+        (is (= 201 (:status player-1-entity-repost2)))
+        (is (= 201 (:status player-2-entity-repost2)))
+        (is (= 201 (:status player-3-entity-repost2)))
+
+        (when can-update?
+          (let [player-1-entity-update2
+                (put (format "ctia/%s/%s"
+                             entity
+                             (-> player-1-entity-repost2
+                                 :parsed-body
+                                 :id
+                                 id/long-id->id
+                                 :short-id))
+                     :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
+                                  :authorized_groups ["bargroup"])
+                     :headers {"Authorization" "player-1-token"})]
+            ;; player 1 allows player 2-3 group (if record is updatable)
+            (crud-access-control-test
+             (into args
+                   {:player-1-creation player-1-entity-update2
+                    :player-2-creation player-2-entity-repost2
+                    :player-3-creation player-3-entity-repost2
+
+                    :player-2-1-expected-read-statuses allowed-statuses
+                    :player-2-1-expected-write-statuses allowed-statuses
+
+                    :player-2-3-expected-read-statuses allowed-statuses
+                    :player-2-3-expected-write-statuses allowed-statuses
+
+                    :player-3-1-expected-read-statuses allowed-statuses
+                    :player-3-1-expected-write-statuses allowed-statuses
+
+                    :list-query "external_ids:gmrvgrepost2"
+                    :player-1-expected-entity-list [(:parsed-body player-1-entity-update2)]
+
+                    :player-2-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                    (:parsed-body player-2-entity-repost2)
+                                                    (:parsed-body player-3-entity-repost2)]
+
+                    :player-3-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                    (:parsed-body player-2-entity-repost2)
+                                                    (:parsed-body player-3-entity-repost2)]}))))))))
+
 (defn test-access-control-entity-tlp-green
-  [entity new-entity can-update? can-delete?]
-  (let [player-1-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["gpost"])
-              :headers {"Authorization" "player-1-token"})
+  [{:keys [entity
+           new-entity
+           can-update?]
+    :as args}]
 
-        player-1-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost"])
-              :headers {"Authorization" "player-1-token"})
+  (testing "TLP Green"
+    (let [player-1-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["gpost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-1-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost2"])
-              :headers {"Authorization" "player-1-token"})
+          player-1-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-2-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["gpost"])
-              :headers {"Authorization" "player-2-token"})
+          player-1-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost2"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-2-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["gpost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-2-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost2"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-3-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["gpost"])
-              :headers {"Authorization" "player-3-token"})
+          player-2-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost2"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-3-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost"])
-              :headers {"Authorization" "player-3-token"})
+          player-3-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["gpost"])
+                :headers {"Authorization" "player-3-token"})
 
-        player-3-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (green-entity new-entity)
-                           :external_ids ["grepost2"])
-              :headers {"Authorization" "player-3-token"})]
+          player-3-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost"])
+                :headers {"Authorization" "player-3-token"})
 
-    (testing "green test setup is successful"
-      (is (= 201 (:status player-1-entity-post))
-          (str "HTTP status should be 201 "
-               (pr-str player-1-entity-post)))
-      (is (= 201 (:status player-2-entity-post))
-          (str "HTTP status should be 201 "
-               (pr-str player-2-entity-post)))
-      (is (= 201 (:status player-3-entity-post))
-          (str "HTTP status should be 201 "
-               (pr-str player-3-entity-post))))
+          player-3-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (green-entity new-entity)
+                             :external_ids ["grepost2"])
+                :headers {"Authorization" "player-3-token"})]
 
-    (crud-access-control-test entity
-                              can-update?
-                              can-delete?
-                              player-1-entity-post
-                              player-2-entity-post
-                              player-3-entity-post
+      (testing "green test setup is successful"
+        (is (= 201 (:status player-1-entity-post))
+            (str "HTTP status should be 201 "
+                 (pr-str player-1-entity-post)))
+        (is (= 201 (:status player-2-entity-post))
+            (str "HTTP status should be 201 "
+                 (pr-str player-2-entity-post)))
+        (is (= 201 (:status player-3-entity-post))
+            (str "HTTP status should be 201 "
+                 (pr-str player-3-entity-post))))
 
-                              allowed-statuses
-                              forbidden-statuses
+      (crud-access-control-test
+       (into args
+             {:player-1-creation player-1-entity-post
+              :player-2-creation player-2-entity-post
+              :player-3-creation player-3-entity-post
 
-                              allowed-statuses
-                              allowed-statuses
+              :player-2-1-expected-read-statuses allowed-statuses
+              :player-2-1-expected-write-statuses forbidden-statuses
 
-                              allowed-statuses
-                              forbidden-statuses
+              :player-2-3-expected-read-statuses allowed-statuses
+              :player-2-3-expected-write-statuses allowed-statuses
 
-                              "external_ids:gpost"
-                              [(:parsed-body player-1-entity-post)
-                               (:parsed-body player-2-entity-post)
-                               (:parsed-body player-3-entity-post)]
+              :player-3-1-expected-read-statuses allowed-statuses
+              :player-3-1-expected-write-statuses forbidden-statuses
 
-                              [(:parsed-body player-1-entity-post)
-                               (:parsed-body player-2-entity-post)
-                               (:parsed-body player-3-entity-post)]
+              :list-query "external_ids:gpost"
+              :player-1-expected-entity-list [(:parsed-body player-1-entity-post)
+                                              (:parsed-body player-2-entity-post)
+                                              (:parsed-body player-3-entity-post)]
 
-                              [(:parsed-body player-1-entity-post)
-                               (:parsed-body player-2-entity-post)
-                               (:parsed-body player-3-entity-post)])
+              :player-2-expected-entity-list [(:parsed-body player-1-entity-post)
+                                              (:parsed-body player-2-entity-post)
+                                              (:parsed-body player-3-entity-post)]
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost)))
-    (is (= 201 (:status player-2-entity-repost)))
-    (is (= 201 (:status player-3-entity-repost)))
+              :player-3-expected-entity-list [(:parsed-body player-1-entity-post)
+                                              (:parsed-body player-2-entity-post)
+                                              (:parsed-body player-3-entity-post)]}))
 
-    (when can-update?
-      (let [player-1-entity-update
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
-                              :authorized_users ["player2"])
-                 :headers {"Authorization" "player-1-token"})]
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost)))
+      (is (= 201 (:status player-2-entity-repost)))
+      (is (= 201 (:status player-3-entity-repost)))
 
-        ;; player 1 allows player 2 (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update
-                                  player-2-entity-repost
-                                  player-3-entity-repost
+      (when can-update?
+        (let [player-1-entity-update
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
+                                :authorized_users ["player2"])
+                   :headers {"Authorization" "player-1-token"})]
 
-                                  allowed-statuses
-                                  allowed-statuses
+          ;; player 1 allows player 2 (if record is updatable)
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update
+                  :player-2-creation player-2-entity-repost
+                  :player-3-creation player-3-entity-repost
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  allowed-statuses
-                                  forbidden-statuses
+                  :player-2-3-expected-read-statuses allowed-statuses
+                  :player-2-3-expected-write-statuses allowed-statuses
 
-                                  "external_ids:grepost"
-                                  [(:parsed-body player-1-entity-update)
-                                   (:parsed-body player-2-entity-repost)
-                                   (:parsed-body player-3-entity-repost)]
+                  :player-3-1-expected-read-statuses allowed-statuses
+                  :player-3-1-expected-write-statuses forbidden-statuses
 
-                                  [(:parsed-body player-1-entity-update)
-                                   (:parsed-body player-2-entity-repost)
-                                   (:parsed-body player-3-entity-repost)]
+                  :list-query "external_ids:grepost"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                  (:parsed-body player-2-entity-repost)
+                                                  (:parsed-body player-3-entity-repost)]
 
-                                  [(:parsed-body player-1-entity-update)
-                                   (:parsed-body player-2-entity-repost)
-                                   (:parsed-body player-3-entity-repost)])))
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                  (:parsed-body player-2-entity-repost)
+                                                  (:parsed-body player-3-entity-repost)]
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost2)))
-    (is (= 201 (:status player-2-entity-repost2)))
-    (is (= 201 (:status player-3-entity-repost2)))
+                  :player-3-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                  (:parsed-body player-2-entity-repost)
+                                                  (:parsed-body player-3-entity-repost)]}))))
 
-    (when can-update?
-      (let [player-1-entity-update2
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost2
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
-                              :authorized_groups ["bargroup"])
-                 :headers {"Authorization" "player-1-token"})]
-        ;; player 1 allows player 2-3 group (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update2
-                                  player-2-entity-repost2
-                                  player-3-entity-repost2
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost2)))
+      (is (= 201 (:status player-2-entity-repost2)))
+      (is (= 201 (:status player-3-entity-repost2)))
 
-                                  allowed-statuses
-                                  allowed-statuses
+      (when can-update?
+        (let [player-1-entity-update2
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost2
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
+                                :authorized_groups ["bargroup"])
+                   :headers {"Authorization" "player-1-token"})]
+          ;; player 1 allows player 2-3 group (if record is updatable)
 
-                                  allowed-statuses
-                                  allowed-statuses
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update2
+                  :player-2-creation player-2-entity-repost2
+                  :player-3-creation player-3-entity-repost2
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  "external_ids:grepost2"
+                  :player-2-3-expected-read-statuses allowed-statuses
+                  :player-2-3-expected-write-statuses allowed-statuses
 
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)
-                                   (:parsed-body player-3-entity-repost2)]
+                  :player-3-1-expected-read-statuses allowed-statuses
+                  :player-3-1-expected-write-statuses forbidden-statuses
 
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)
-                                   (:parsed-body player-3-entity-repost2)]
+                  :list-query "external_ids:grepost2"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)
+                                                  (:parsed-body player-3-entity-repost2)]
 
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)
-                                   (:parsed-body player-3-entity-repost2)])))))
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)
+                                                  (:parsed-body player-3-entity-repost2)]
+
+                  :player-3-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)
+                                                  (:parsed-body player-3-entity-repost2)]})))))))
 
 (defn test-access-control-entity-tlp-amber
-  [entity new-entity can-update? can-delete?]
-  (let [player-1-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["apost"])
-              :headers {"Authorization" "player-1-token"})
+  [{:keys [entity
+           new-entity
+           can-update?]
+    :as args}]
 
-        player-1-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost"])
-              :headers {"Authorization" "player-1-token"})
+  (testing "TLP amber"
+    (let [player-1-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["apost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-1-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost2"])
-              :headers {"Authorization" "player-1-token"})
+          player-1-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-2-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["apost"])
-              :headers {"Authorization" "player-2-token"})
+          player-1-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost2"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-2-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["apost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-2-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost2"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-3-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["apost"])
-              :headers {"Authorization" "player-3-token"})
+          player-2-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost2"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-3-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost"])
-              :headers {"Authorization" "player-3-token"})
+          player-3-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["apost"])
+                :headers {"Authorization" "player-3-token"})
 
-        player-3-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (amber-entity new-entity)
-                           :external_ids ["arepost2"])
-              :headers {"Authorization" "player-3-token"})]
+          player-3-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost"])
+                :headers {"Authorization" "player-3-token"})
 
-    (testing "amber test setup is successful"
-      (is (= 201 (:status player-1-entity-post)))
-      (is (= 201 (:status player-2-entity-post)))
-      (is (= 201 (:status player-3-entity-post))))
+          player-3-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (amber-entity new-entity)
+                             :external_ids ["arepost2"])
+                :headers {"Authorization" "player-3-token"})]
 
-    (crud-access-control-test entity
-                              can-update?
-                              can-delete?
-                              player-1-entity-post
-                              player-2-entity-post
-                              player-3-entity-post
+      (testing "amber test setup is successful"
+        (is (= 201 (:status player-1-entity-post)))
+        (is (= 201 (:status player-2-entity-post)))
+        (is (= 201 (:status player-3-entity-post))))
 
-                              forbidden-statuses
-                              forbidden-statuses
+      (crud-access-control-test
+       (into args
+             {:player-1-creation player-1-entity-post
+              :player-2-creation player-2-entity-post
+              :player-3-creation player-3-entity-post
 
-                              allowed-statuses
-                              allowed-statuses
+              :player-2-1-expected-read-statuses forbidden-statuses
+              :player-2-1-expected-write-statuses forbidden-statuses
 
-                              forbidden-statuses
-                              forbidden-statuses
+              :player-2-3-expected-read-statuses allowed-statuses
+              :player-2-3-expected-write-statuses allowed-statuses
 
-                              "external_ids:apost"
-                              [(:parsed-body player-1-entity-post)]
+              :player-3-1-expected-read-statuses forbidden-statuses
+              :player-3-1-expected-write-statuses forbidden-statuses
 
-                              [(:parsed-body player-2-entity-post)
-                               (:parsed-body player-3-entity-post)]
+              :list-query "external_ids:apost"
+              :player-1-expected-entity-list [(:parsed-body player-1-entity-post)]
 
-                              [(:parsed-body player-2-entity-post)
-                               (:parsed-body player-3-entity-post)])
+              :player-2-expected-entity-list [(:parsed-body player-2-entity-post)
+                                              (:parsed-body player-3-entity-post)]
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost)))
-    (is (= 201 (:status player-2-entity-repost)))
-    (is (= 201 (:status player-3-entity-repost)))
+              :player-3-expected-entity-list [(:parsed-body player-2-entity-post)
+                                              (:parsed-body player-3-entity-post)]}))
 
-    (when can-update?
-      (let [player-1-entity-update
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
-                              :authorized_users ["player2"])
-                 :headers {"Authorization" "player-1-token"})]
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost)))
+      (is (= 201 (:status player-2-entity-repost)))
+      (is (= 201 (:status player-3-entity-repost)))
 
-        ;; player 1 allows player 2 (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update
-                                  player-2-entity-repost
-                                  player-3-entity-repost
+      (when can-update?
+        (let [player-1-entity-update
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
+                                :authorized_users ["player2"])
+                   :headers {"Authorization" "player-1-token"})]
 
-                                  allowed-statuses
-                                  allowed-statuses
+          ;; player 1 allows player 2 (if record is updatable)
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update
+                  :player-2-creation player-2-entity-repost
+                  :player-3-creation player-3-entity-repost
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  forbidden-statuses
-                                  forbidden-statuses
+                  :player-2-3-expected-read-statuses allowed-statuses
+                  :player-2-3-expected-write-statuses allowed-statuses
 
-                                  "external_ids:arepost"
-                                  [(:parsed-body player-1-entity-update)]
+                  :player-3-1-expected-read-statuses forbidden-statuses
+                  :player-3-1-expected-write-statuses forbidden-statuses
 
-                                  [(:parsed-body player-1-entity-update)
-                                   (:parsed-body player-2-entity-repost)
-                                   (:parsed-body player-3-entity-repost)]
+                  :list-query "external_ids:arepost"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update)]
 
-                                  [(:parsed-body player-2-entity-repost)
-                                   (:parsed-body player-3-entity-repost)])))
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                  (:parsed-body player-2-entity-repost)
+                                                  (:parsed-body player-3-entity-repost)]
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost2)))
-    (is (= 201 (:status player-2-entity-repost2)))
-    (is (= 201 (:status player-3-entity-repost2)))
+                  :player-3-expected-entity-list [(:parsed-body player-2-entity-repost)
+                                                  (:parsed-body player-3-entity-repost)]}))))
 
-    (when can-update?
-      (let [player-1-entity-update2
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost2
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
-                              :authorized_groups ["bargroup"])
-                 :headers {"Authorization" "player-1-token"})]
-        ;; player 1 allows player 2-3 group (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update2
-                                  player-2-entity-repost2
-                                  player-3-entity-repost2
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost2)))
+      (is (= 201 (:status player-2-entity-repost2)))
+      (is (= 201 (:status player-3-entity-repost2)))
 
-                                  allowed-statuses
-                                  allowed-statuses
+      (when can-update?
+        (let [player-1-entity-update2
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost2
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
+                                :authorized_groups ["bargroup"])
+                   :headers {"Authorization" "player-1-token"})]
 
-                                  allowed-statuses
-                                  allowed-statuses
+          ;; player 1 allows player 2-3 group (if record is updatable)
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update2
+                  :player-2-creation player-2-entity-repost2
+                  :player-3-creation player-3-entity-repost2
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  "external_ids:arepost2"
-                                  [(:parsed-body player-1-entity-update2)]
+                  :player-2-3-expected-read-statuses allowed-statuses
+                  :player-2-3-expected-write-statuses allowed-statuses
 
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)
-                                   (:parsed-body player-3-entity-repost2)]
+                  :player-3-1-expected-read-statuses allowed-statuses
+                  :player-3-1-expected-write-statuses allowed-statuses
 
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)
-                                   (:parsed-body player-3-entity-repost2)])))))
+                  :list-query "external_ids:arepost2"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update2)]
+
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)
+                                                  (:parsed-body player-3-entity-repost2)]
+
+                  :player-3-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)
+                                                  (:parsed-body player-3-entity-repost2)]})))))))
 
 
 (defn test-access-control-entity-tlp-red
-  [entity new-entity can-update? can-delete?]
+  [{:keys [entity
+           new-entity
+           can-update?]
+    :as args}]
 
-  (let [player-1-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rpost"])
-              :headers {"Authorization" "player-1-token"})
+  (testing "TLP Red"
+    (let [player-1-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rpost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-1-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost"])
-              :headers {"Authorization" "player-1-token"})
+          player-1-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-1-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost2"])
-              :headers {"Authorization" "player-1-token"})
+          player-1-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost2"])
+                :headers {"Authorization" "player-1-token"})
 
-        player-2-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rpost"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rpost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-2-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-2-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost2"])
-              :headers {"Authorization" "player-2-token"})
+          player-2-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost2"])
+                :headers {"Authorization" "player-2-token"})
 
-        player-3-entity-post
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rpost"])
-              :headers {"Authorization" "player-3-token"})
+          player-3-entity-post
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rpost"])
+                :headers {"Authorization" "player-3-token"})
 
-        player-3-entity-repost
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost"])
-              :headers {"Authorization" "player-3-token"})
+          player-3-entity-repost
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost"])
+                :headers {"Authorization" "player-3-token"})
 
-        player-3-entity-repost2
-        (post (format "ctia/%s" entity)
-              :body (assoc (red-entity new-entity)
-                           :external_ids ["rrepost2"])
-              :headers {"Authorization" "player-3-token"})]
+          player-3-entity-repost2
+          (post (format "ctia/%s" entity)
+                :body (assoc (red-entity new-entity)
+                             :external_ids ["rrepost2"])
+                :headers {"Authorization" "player-3-token"})]
 
-    (testing "red test setup is successful"
-      (is (= 201 (:status player-1-entity-post)))
-      (is (= 201 (:status player-2-entity-post)))
-      (is (= 201 (:status player-3-entity-post))))
+      (testing "red test setup is successful"
+        (is (= 201 (:status player-1-entity-post)))
+        (is (= 201 (:status player-2-entity-post)))
+        (is (= 201 (:status player-3-entity-post))))
 
-    (crud-access-control-test entity
-                              can-update?
-                              can-delete?
-                              player-1-entity-post
-                              player-2-entity-post
-                              player-3-entity-post
+      (crud-access-control-test
+       (into args
+             {:player-1-creation player-1-entity-post
+              :player-2-creation player-2-entity-post
+              :player-3-creation player-3-entity-post
 
-                              forbidden-statuses
-                              forbidden-statuses
+              :player-2-1-expected-read-statuses forbidden-statuses
+              :player-2-1-expected-write-statuses forbidden-statuses
 
-                              forbidden-statuses
-                              forbidden-statuses
+              :player-2-3-expected-read-statuses forbidden-statuses
+              :player-2-3-expected-write-statuses forbidden-statuses
 
-                              forbidden-statuses
-                              forbidden-statuses
+              :player-3-1-expected-read-statuses forbidden-statuses
+              :player-3-1-expected-write-statuses forbidden-statuses
 
-                              "external_ids:rpost"
-                              [(:parsed-body player-1-entity-post)]
+              :list-query "external_ids:rpost"
+              :player-1-expected-entity-list [(:parsed-body player-1-entity-post)]
 
-                              [(:parsed-body player-2-entity-post)]
+              :player-2-expected-entity-list [(:parsed-body player-2-entity-post)]
 
-                              [(:parsed-body player-3-entity-post)])
+              :player-3-expected-entity-list [(:parsed-body player-3-entity-post)]}))
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost)))
-    (is (= 201 (:status player-2-entity-repost)))
-    (is (= 201 (:status player-3-entity-repost)))
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost)))
+      (is (= 201 (:status player-2-entity-repost)))
+      (is (= 201 (:status player-3-entity-repost)))
 
-    (when can-update?
-      (let [player-1-entity-update
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
-                              :authorized_users ["player2"])
-                 :headers {"Authorization" "player-1-token"})]
+      (when can-update?
+        (let [player-1-entity-update
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost) :id)
+                                :authorized_users ["player2"])
+                   :headers {"Authorization" "player-1-token"})]
 
-        ;; player 1 allows player 2 (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update
-                                  player-2-entity-repost
-                                  player-3-entity-repost
+          ;; player 1 allows player 2 (if record is updatable)
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update
+                  :player-2-creation player-2-entity-repost
+                  :player-3-creation player-3-entity-repost
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  forbidden-statuses
-                                  forbidden-statuses
+                  :player-2-3-expected-read-statuses forbidden-statuses
+                  :player-2-3-expected-write-statuses forbidden-statuses
 
-                                  forbidden-statuses
-                                  forbidden-statuses
+                  :player-3-1-expected-read-statuses forbidden-statuses
+                  :player-3-1-expected-write-statuses forbidden-statuses
 
-                                  "external_ids:rrepost"
-                                  [(:parsed-body player-1-entity-update)]
+                  :list-query "external_ids:rrepost"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update)]
 
-                                  [(:parsed-body player-1-entity-update)
-                                   (:parsed-body player-2-entity-repost)]
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update)
+                                                  (:parsed-body player-2-entity-repost)]
 
-                                  [(:parsed-body player-3-entity-repost)])))
+                  :player-3-expected-entity-list [(:parsed-body player-3-entity-repost)]}))))
 
-    ;; player1 and player2 repost deleted entities
-    (is (= 201 (:status player-1-entity-repost2)))
-    (is (= 201 (:status player-2-entity-repost2)))
-    (is (= 201 (:status player-3-entity-repost2)))
+      ;; player1 and player2 repost deleted entities
+      (is (= 201 (:status player-1-entity-repost2)))
+      (is (= 201 (:status player-2-entity-repost2)))
+      (is (= 201 (:status player-3-entity-repost2)))
 
-    (when can-update?
-      (let [player-1-entity-update2
-            (put (format "ctia/%s/%s"
-                         entity
-                         (-> player-1-entity-repost2
-                             :parsed-body
-                             :id
-                             id/long-id->id
-                             :short-id))
-                 :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
-                              :authorized_groups ["bargroup"])
-                 :headers {"Authorization" "player-1-token"})]
-        ;; player 1 allows player 2-3 group (if record is updatable)
-        (crud-access-control-test entity
-                                  can-update?
-                                  can-delete?
-                                  player-1-entity-update2
-                                  player-2-entity-repost2
-                                  player-3-entity-repost2
+      (when can-update?
+        (let [player-1-entity-update2
+              (put (format "ctia/%s/%s"
+                           entity
+                           (-> player-1-entity-repost2
+                               :parsed-body
+                               :id
+                               id/long-id->id
+                               :short-id))
+                   :body (assoc (dissoc (:parsed-body player-1-entity-repost2) :id)
+                                :authorized_groups ["bargroup"])
+                   :headers {"Authorization" "player-1-token"})]
+          ;; player 1 allows player 2-3 group (if record is updatable)
+          (crud-access-control-test
+           (into args
+                 {:player-1-creation player-1-entity-update2
+                  :player-2-creation player-2-entity-repost2
+                  :player-3-creation player-3-entity-repost2
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-2-1-expected-read-statuses allowed-statuses
+                  :player-2-1-expected-write-statuses allowed-statuses
 
-                                  forbidden-statuses
-                                  forbidden-statuses
+                  :player-2-3-expected-read-statuses forbidden-statuses
+                  :player-2-3-expected-write-statuses forbidden-statuses
 
-                                  allowed-statuses
-                                  allowed-statuses
+                  :player-3-1-expected-read-statuses allowed-statuses
+                  :player-3-1-expected-write-statuses allowed-statuses
 
-                                  "external_ids:rrepost2"
-                                  [(:parsed-body player-1-entity-update2)]
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-2-entity-repost2)]
-                                  [(:parsed-body player-1-entity-update2)
-                                   (:parsed-body player-3-entity-repost2)])))))
+                  :list-query "external_ids:rrepost2"
+                  :player-1-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-1-entity-update2)]
+
+                  :player-2-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-2-entity-repost2)]
+
+                  :player-3-expected-entity-list [(:parsed-body player-1-entity-update2)
+                                                  (:parsed-body player-3-entity-repost2)]})))))))
 
 (defn test-access-control-tlp-settings
   [entity new-entity]
-  (swap! ctia.properties/properties assoc-in
-         [:ctia :access-control]
-         {:default-tlp "amber"
-          :min-tlp "amber"})
+  (testing "TLP Settings Enforcement"
+    (swap! ctia.properties/properties assoc-in
+           [:ctia :access-control]
+           {:default-tlp "amber"
+            :min-tlp "amber"})
 
-  (let [{status-default-tlp :status
-         body-default-tlp :parsed-body}
-        (post (format "ctia/%s" entity)
-              :body (dissoc new-entity :tlp)
-              :headers {"Authorization" "player-1-token"})
-        {status-disallowed-tlp :status
-         body-disallowed-tlp :parsed-body}
-        (post (format "ctia/%s" entity)
-              :body (assoc new-entity :tlp "white")
-              :headers {"Authorization" "player-1-token"})]
+    (let [{status-default-tlp :status
+           body-default-tlp :parsed-body}
+          (post (format "ctia/%s" entity)
+                :body (dissoc new-entity :tlp)
+                :headers {"Authorization" "player-1-token"})
+          {status-disallowed-tlp :status
+           body-disallowed-tlp :parsed-body}
+          (post (format "ctia/%s" entity)
+                :body (assoc new-entity :tlp "white")
+                :headers {"Authorization" "player-1-token"})]
 
-    (is (= 201 status-default-tlp))
-    (is (= "amber" (:tlp body-default-tlp)))
+      (is (= 201 status-default-tlp))
+      (is (= "amber" (:tlp body-default-tlp)))
 
 
-    (is (= 400 status-disallowed-tlp))
-    (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
-           (:message body-disallowed-tlp)))))
+      (is (= 400 status-disallowed-tlp))
+      (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
+             (:message body-disallowed-tlp))))))
 
 (defn access-control-test
   [entity
@@ -782,20 +1006,29 @@
                                       "bargroup"
                                       "user")
 
-  (test-access-control-entity-tlp-green entity
-                                        new-entity
-                                        can-update?
-                                        can-delete?)
+  (test-access-control-entity-tlp-green
+   {:entity entity
+    :new-entity new-entity
+    :can-update? can-update?
+    :can-delete? can-delete?})
 
-  (test-access-control-entity-tlp-amber entity
-                                        new-entity
-                                        can-update?
-                                        can-delete?)
+  (test-access-control-entity-tlp-green-max-record-visibility-group
+   {:entity entity
+    :new-entity new-entity
+    :can-update? can-update?
+    :can-delete? can-delete?})
 
-  (test-access-control-entity-tlp-red entity
-                                      new-entity
-                                      can-update?
-                                      can-delete?)
+  (test-access-control-entity-tlp-amber
+   {:entity entity
+    :new-entity new-entity
+    :can-update? can-update?
+    :can-delete? can-delete?})
+
+  (test-access-control-entity-tlp-red
+   {:entity entity
+    :new-entity new-entity
+    :can-update? can-update?
+    :can-delete? can-delete?})
 
   (test-access-control-tlp-settings entity
                                     new-entity))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -5,7 +5,6 @@
              [core :as mth]
              [http :as mthh]]
             [clojure
-             [string :as str]
              [walk :refer [prewalk]]]
             [clojure.spec.alpha :as cs]
             [clojure.test.check.generators :as gen]
@@ -41,27 +40,28 @@
   (mth/clear-properties PropertiesSchema)
   ;; Override any properties that are in the default properties file
   ;; yet are unsafe/undesirable for tests
-  (with-properties ["ctia.auth.type"                  "allow-all"
-                    "ctia.access-control.default-tlp" "green"
-                    "ctia.access-control.min-tlp"     "white"
-                    "ctia.events.enabled"             true
-                    "ctia.events.log"                 false
-                    "ctia.http.dev-reload"            false
-                    "ctia.http.min-threads"           9
-                    "ctia.http.max-threads"           10
-                    "ctia.http.show.protocol"         "http"
-                    "ctia.http.show.hostname"         "localhost"
-                    "ctia.http.show.port"             "57254"
-                    "ctia.http.show.path-prefix"      ""
-                    "ctia.http.jwt.enabled"           true
-                    "ctia.http.jwt.public-key-path"   "resources/cert/ctia-jwt.pub"
-                    "ctia.http.bulk.max-size"         30000
-                    "ctia.hook.redis.enabled"         false
-                    "ctia.hook.redis.channel-name"    "events-test"
-                    "ctia.metrics.riemann.enabled"    false
-                    "ctia.metrics.console.enabled"    false
-                    "ctia.metrics.jmx.enabled"        false
-                    "ctia.versions.config"            "test"]
+  (with-properties ["ctia.auth.type"                            "allow-all"
+                    "ctia.access-control.default-tlp"           "green"
+                    "ctia.access-control.min-tlp"               "white"
+                    "ctia.access-control.max-record-visibility" "everyone"
+                    "ctia.events.enabled"                       true
+                    "ctia.events.log"                           false
+                    "ctia.http.dev-reload"                      false
+                    "ctia.http.min-threads"                     9
+                    "ctia.http.max-threads"                     10
+                    "ctia.http.show.protocol"                   "http"
+                    "ctia.http.show.hostname"                   "localhost"
+                    "ctia.http.show.port"                       "57254"
+                    "ctia.http.show.path-prefix"                ""
+                    "ctia.http.jwt.enabled"                     true
+                    "ctia.http.jwt.public-key-path"             "resources/cert/ctia-jwt.pub"
+                    "ctia.http.bulk.max-size"                   30000
+                    "ctia.hook.redis.enabled"                   false
+                    "ctia.hook.redis.channel-name"              "events-test"
+                    "ctia.metrics.riemann.enabled"              false
+                    "ctia.metrics.console.enabled"              false
+                    "ctia.metrics.jmx.enabled"                  false
+                    "ctia.versions.config"                      "test"]
     ;; run tests
     (f)))
 
@@ -305,9 +305,9 @@
   [atom-logger & body]
   `(let [patched-log#
          (fn [logger#
-             level#
-             throwable#
-             message#]
+              level#
+              throwable#
+              message#]
            (swap! ~atom-logger conj message#))]
      (with-redefs [clojure.tools.logging/log* patched-log#]
        ~@body)))


### PR DESCRIPTION
> Close https://github.com/threatgrid/iroh/issues/3059

This PR Allows changing the Visibility Rules in order to simulate separate instances per organisation
I also slightly refactored the access control test to improve clarity

<a name="qa">[§](#qa)</a> QA
============================

Setting this property to `group` changes the visibility rules for the records,
in this mode, documents using the `Green` or `White` `TLP` Setting will behave like `Amber`.

Setting it to `everyone` reverts back to the previous behaviour, Green/White is publicly visible

Test Scenario:

1. Post a document as User A setting the TLP to Green/White
2. Users sharing the same group should see the document (Read/List)
3. Users not sharing the group shouldn't see it (Read/List)

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Private Intel now disallows accessing Green/White TLP documents across organisations
```