### PR TITLE
Replace update-doc by index-doc when updating an entity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                                com.google.guava/guava
                                org.clojure/tools.reader
                                org.clojure/clojurescript]]
-                 [threatgrid/clj-momo "0.3.3-SNAPSHOT"]
+                 [threatgrid/clj-momo "0.3.3"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
                                com.google.guava/guava
                                org.clojure/tools.reader
                                org.clojure/clojurescript]]
-                 [threatgrid/clj-momo "0.3.2"]
+                 [threatgrid/clj-momo "0.3.3-SNAPSHOT"]
 
                  ;; Web server
                  [metosin/compojure-api ~compojure-api-version

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -152,11 +152,11 @@
       (when-let [{index :_index current-doc :_source}
                  (get-doc-with-index state mapping id {})]
         (if (allow-write? current-doc ident)
-          (coerce! (d/update-doc (:conn state)
+          (coerce! (d/index-doc (:conn state)
                                  index
                                  (name mapping)
-                                 (ensure-document-id id)
-                                 realized
+                                 (assoc realized
+                                        :id (ensure-document-id id))
                                  (or refresh
                                      (get-in state
                                              [:props :refresh]

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -591,7 +591,7 @@
                           docs))))))
       (testing "restart migration shall properly handle inserts, updates and deletes"
         (let [;; retrieve the first 2 source indices for sighting store
-              {:keys [host port]}(get-in @props/properties [:ctia :store :es :default])
+              {:keys [host port]} (get-in @props/properties [:ctia :store :es :default])
               [sighting-index-1 sighting-index-2]
               (->> (es-helpers/get-cat-indices host port)
                    keys

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -59,7 +59,6 @@
 
     (testing "testing wait_for values on entity creation"
       (let [test-create (fn [wait_for msg]
-                          (reset! es-params nil)
                           (let [path (cond-> (str "ctia/" entity)
                                        (boolean? wait_for) (str "?wait_for=" wait_for))]
                             (with-global-fake-routes bulk-routes
@@ -83,7 +82,6 @@
                           :parsed-body
                           entity->short-id)
             test-modify (fn [method wait_for msg]
-                          (reset! es-params nil)
                           (let [path (cond-> (format "ctia/%s/%s" entity entity-id)
                                        (boolean? wait_for) (str "?wait_for=" wait_for))
                                 updates (cond->> {update-field "modified"}
@@ -116,7 +114,6 @@
 
     (testing "testing wait_for values on entity deletion"
       (let [test-delete (fn [wait_for msg]
-                          (reset! es-params nil)
                           (let [entity-id (-> (post (str "ctia/" entity "?wait_for=true")
                                                     :body new-record
                                                     :headers headers)


### PR DESCRIPTION
> Closes threatgrid/iroh#3062
> Related to threatgrid/clj-momo#61

It was not possible to remove a field when updating an entity because the `handle-update` fn was using the `update-doc` fn of `clj-momo` which updates partial documents. This PR replaces `update-doc` by `index-doc` that updates the full document.

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. Creates an indicator with some `external_ids`
2. Get this indicator
3. Updates this indicator and remove the `external_ids` field
4. Get this indicator and check that the field has been removed

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Fix all API endpoints that update entities
```