### PR TITLE
Bundle: filter relationships by node types

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -160,7 +160,6 @@
    an error is reported."
   [{:keys [external_id]
     :as entity-data} :- EntityImportData
-   entity-type
    find-by-external-id]
   (if-let [old-entities (find-by-external-id external_id)]
     (let [old-entity (some-> old-entities
@@ -198,7 +197,7 @@
                                  (when external_id
                                    (get entities-by-external-id
                                         {:external_id external_id})))]
-    (map #(with-existing-entity % entity-type find-by-external-id-fn)
+    (map #(with-existing-entity % find-by-external-id-fn)
          import-data)))
 
 (s/defn prepare-import :- BundleImportData
@@ -235,7 +234,7 @@
 (s/defn with-bulk-result
   "Set the bulk result to the bundle import data"
   [bundle-import-data :- BundleImportData
-   {:keys [tempids] :as bulk-result}]
+   bulk-result]
   (map-kv (fn [k v]
             (let [{submitted true
                    not-submitted false} (group-by create? v)]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -345,8 +345,8 @@
   (let [edge-filters (->> (map #(hash-map % id) (set related_to))
                           (apply merge))
         node-filters (cond->> []
-                       source_type (cons (format "source_ref:*%s*" source_type))
-                       target_type (cons (format "target_ref:*%s*" target_type))
+                       source_type (cons (format "source_ref:*%s*" (name source_type)))
+                       target_type (cons (format "target_ref:*%s*" (name target_type)))
                        (not (or source_type
                                 target_type)) (cons "*")
                        :always (string/join " AND "))]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -347,11 +347,10 @@
         node-filters (cond->> []
                        source_type (cons (format "source_ref:*%s*" (name source_type)))
                        target_type (cons (format "target_ref:*%s*" (name target_type)))
-                       (not (or source_type
-                                target_type)) (cons "*")
                        :always (string/join " AND "))]
-    {:one-of edge-filters
-     :query node-filters}))
+    (into {:one-of edge-filters}
+          (when (seq node-filters)
+            {:query node-filters}))))
 
 (defn fetch-entity-relationships
   "given an entity id, fetch all related relationship"

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -8,25 +8,15 @@
                   import-bundle
                   export-bundle]]
     [schemas :refer [BundleImportResult
-                     NewBundleExport]]]
+                     NewBundleExport
+                     BundleExportIds
+                     BundleExportOptions
+                     BundleExportQuery]]]
    [ctia.schemas.core :refer [NewBundle]]
    [ring.util.http-response :refer [ok bad-request]]
    [schema.core :as s]
    [schema-tools.core :as st]))
 
-(s/defschema BundleExportOptions
-  (st/optional-keys
-   {:related_to [(s/enum :source_ref :target_ref)]
-    :source_type s/Str
-    :target_type s/Str
-    :include_related_entities s/Bool}))
-
-(s/defschema BundleExportIds
-  {:ids [s/Str]})
-
-(s/defschema BundleExportQuery
-  (merge BundleExportIds
-         BundleExportOptions))
 
 (def export-capabilities
   #{:list-campaigns

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -11,11 +11,15 @@
                      NewBundleExport]]]
    [ctia.schemas.core :refer [Bundle NewBundle]]
    [ring.util.http-response :refer :all]
-   [schema.core :as s]))
+   [schema.core :as s]
+   [schema-tools.core :as st]))
 
 (s/defschema BundleExportOptions
-  {(s/optional-key :related_to) [(s/enum :source_ref :target_ref)]
-   (s/optional-key :include_related_entities) s/Bool})
+  (st/optional-keys
+   {:related_to [(s/enum :source_ref :target_ref)]
+    :source_type s/Str
+    :target_type s/Str
+    :include_related_entities s/Bool}))
 
 (s/defschema BundleExportIds
   {:ids [s/Str]})
@@ -75,7 +79,7 @@
                      (:ids q)
                      identity-map
                      identity
-                     (select-keys q [:include_related_entities :related_to]))))
+                     q)))
 
            (POST "/export" []
                 :return NewBundleExport

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -1,7 +1,7 @@
 (ns ctia.bundle.routes
   (:refer-clojure :exclude [identity])
   (:require
-   [compojure.api.sweet :refer :all]
+   [compojure.api.sweet :refer [GET POST context defroutes describe]]
    [ctia.bundle
     [core :refer [bundle-max-size
                   bundle-size
@@ -9,8 +9,8 @@
                   export-bundle]]
     [schemas :refer [BundleImportResult
                      NewBundleExport]]]
-   [ctia.schemas.core :refer [Bundle NewBundle]]
-   [ring.util.http-response :refer :all]
+   [ctia.schemas.core :refer [NewBundle]]
+   [ring.util.http-response :refer [ok bad-request]]
    [schema.core :as s]
    [schema-tools.core :as st]))
 
@@ -93,7 +93,7 @@
                      (:ids b)
                      identity-map
                      identity
-                     (select-keys q [:include_related_entities :related_to]))))
+                     q)))
 
            (POST "/import" []
                  :return BundleImportResult

--- a/src/ctia/bundle/schemas.clj
+++ b/src/ctia/bundle/schemas.clj
@@ -1,7 +1,8 @@
 (ns ctia.bundle.schemas
   (:require [schema.core :as s]
+            [schema-tools.core :as st]
             [ctia.schemas.core :as csc]
-            [schema-tools.core :as st]))
+            [ctia.entity.entities :refer [entities]]))
 
 (s/defschema EntityImportResult
   (st/optional-keys
@@ -30,3 +31,23 @@
 
 (s/defschema NewBundleExport
   (st/open-schema csc/NewBundle))
+
+(s/defschema EntityTypes
+  (apply s/enum
+         (-> (keys entities)
+             set
+             (disj :relationship :event :identity))))
+
+(s/defschema BundleExportOptions
+  (st/optional-keys
+   {:related_to [(s/enum :source_ref :target_ref)]
+    :source_type EntityTypes
+    :target_type EntityTypes
+    :include_related_entities s/Bool}))
+
+(s/defschema BundleExportIds
+  {:ids [s/Str]})
+
+(s/defschema BundleExportQuery
+  (merge BundleExportIds
+         BundleExportOptions))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -222,7 +222,8 @@
 (s/defschema FilterSchema
   (st/optional-keys
    {:all-of {s/Any s/Any}
-    :one-of {s/Any s/Any}}))
+    :one-of {s/Any s/Any}
+    :query {s/Any s/Any}}))
 
 (def sort-fields-mapping
   "Mapping table for all fields which needs to be renamed
@@ -277,17 +278,19 @@
         coerce! (coerce-to-fn response-schema)]
     (s/fn :- response-schema
       [state :- ESConnState
-       filters :- FilterSchema
+       {:keys [all-of one-of query]
+        :or {all-of {} one-of {}}} :- FilterSchema
        ident
        params]
-      (let [{:keys [all-of one-of]
-             :or {all-of {} one-of {}}} filters
-            filter-val (conj (q/prepare-terms all-of)
+      (let [filter-val (conj (q/prepare-terms all-of)
                              (find-restriction-query-part ident))
-            bool-params (merge {:filter filter-val}
-                               (when (not-empty one-of)
-                                 {:should (q/prepare-terms one-of)
-                                  :minimum_should_match 1}))]
+
+            query_string  {:query_string {:query query}}
+            bool-params (cond-> {:filter filter-val}
+                          (seq one-of) (into
+                                        {:should (q/prepare-terms one-of)
+                                         :minimum_should_match 1})
+                          query (update :filter conj query_string))]
         (update
          (coerce! (d/query (:conn state)
                            (:index state)

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -223,7 +223,7 @@
   (st/optional-keys
    {:all-of {s/Any s/Any}
     :one-of {s/Any s/Any}
-    :query {s/Any s/Any}}))
+    :query s/Str}))
 
 (def sort-fields-mapping
   "Mapping table for all fields which needs to be renamed

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -1,6 +1,6 @@
 (ns ctia.bundle.core-test
   (:require [ctia.bundle.core :as sut]
-            [clojure.test :as t :refer [deftest use-fixtures are is]]
+            [clojure.test :as t :refer [deftest use-fixtures are is testing]]
             [ctia.test-helpers.core :as h]))
 
 (use-fixtures :once h/fixture-properties:clean)
@@ -15,3 +15,32 @@
 (deftest clean-bundle-test
   (is (= {:b '(1 2 3) :d '(1 3)}
          (sut/clean-bundle {:a '(nil) :b '(1 2 3) :c '() :d '(1 nil 3)}))))
+
+(deftest relationships-filters
+  (testing "relationships-filters should properly add related_to filters to handle edge direction"
+    (is (= {:source_ref "id"
+            :target_ref "id"}
+           (:one-of (sut/relationships-filters "id" {})))
+        "default related-_to param is #{:source_ref :target_ref}")
+    (is (= {:source_ref "id"}
+           (:one-of (sut/relationships-filters "id" {:related_to [:source_ref]}))))
+    (is (= {:target_ref "id"}
+           (:one-of (sut/relationships-filters "id" {:related_to [:target_ref]}))))
+    (is (= {:source_ref "id"
+            :target_ref "id"}
+           (:one-of (sut/relationships-filters "id" {:related_to [:source_ref :target_ref]})))))
+
+  (testing "relationships-filters should properly add query filters"
+    (is (= "source_ref:*malware*"
+           (:query (sut/relationships-filters "id" {:source_type :malware}))))
+    (is (= "target_ref:*sighting*"
+           (:query (sut/relationships-filters "id" {:target_type :sighting}))))
+    (is (= "target_ref:*sighting* AND source_ref:*malware*"
+           (:query (sut/relationships-filters "id" {:source_type :malware
+                                                    :target_type :sighting})))))
+
+  (testing "relationships-filters should return proper fields and combine filters"
+    (is (= {:one-of {:source_ref "id"}
+            :query "source_ref:*malware*"}
+           (sut/relationships-filters "id" {:source_type :malware
+                                            :related_to [:source_ref]})))))

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -1,6 +1,6 @@
 (ns ctia.bundle.core-test
   (:require [ctia.bundle.core :as sut]
-            [clojure.test :as t :refer [deftest testing use-fixtures are is]]
+            [clojure.test :as t :refer [deftest use-fixtures are is]]
             [ctia.test-helpers.core :as h]))
 
 (use-fixtures :once h/fixture-properties:clean)

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -569,7 +569,7 @@
 
          (is (= 2 (count (:sightings bundle-get-res-4))))
          (is (nil? (:indicators bundle-get-res-4)))
-         (is (= 402 (count (:relationships bundle-get-res-4))))
+         (is (= 0 (count (:relationships bundle-get-res-4))))
 
          (is (= bundle-get-res-3 bundle-get-res-5)
              "default related_to value should be [:source_ref :target_ref]")

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -76,7 +76,8 @@
    :confidence "High"})
 
 (defn mk-judgement []
-  {:observable {:type "ip",
+  {:id (id/make-transient-id nil)
+   :observable {:type "ip",
                 :value "10.0.0.1"}
    :source "source"
    :priority 99
@@ -626,18 +627,26 @@
          (is (= 3 (count (:relationships bundle-export-body))))
          (is (= 1 (count (:sightings bundle-export-body)))))))))
 
-(def bundle-related-fixture
+(def bundle-graph-fixture
   (let [indicator-1 (mk-indicator 1)
         indicator-2 (mk-indicator 2)
         indicator-3 (mk-indicator 3)
         sighting-1 (mk-sighting 1)
         sighting-2 (mk-sighting 2)
-        relationship-1 (mk-relationship 1 sighting-1 indicator-1 "member-of")
-        relationship-2 (mk-relationship 2 sighting-1 indicator-2 "member-of")
-        relationship-3 (mk-relationship 3 sighting-2 indicator-1 "member-of")
-        relationship-4 (mk-relationship 4 sighting-2 indicator-3 "member-of")]
+        incident-1 (mk-incident)
+        incident-2 (mk-incident)
+        relationship-1 (mk-relationship 1 sighting-1 indicator-1 "indicates")
+        relationship-2 (mk-relationship 2 sighting-1 indicator-2 "indicates")
+        relationship-3 (mk-relationship 3 sighting-2 indicator-1 "indicates")
+        relationship-4 (mk-relationship 4 sighting-2 indicator-3 "indicates")
+        relationship-5 (mk-relationship 5 sighting-2 incident-1 "member-of")
+        relationship-6 (mk-relationship 6 sighting-1 incident-2 "member-of")
+        relationship-7 (mk-relationship 7 sighting-2 incident-2 "member-of")
+        relationship-8 (mk-relationship 8 indicator-1 incident-2 "member-of")]
     {:type "bundle"
      :source "source"
+     :incidents #{incident-1
+                  incident-2}
      :indicators #{indicator-1
                    indicator-2
                    indicator-3}
@@ -645,8 +654,11 @@
      :relationships #{relationship-1
                       relationship-2
                       relationship-3
-                      relationship-4}}))
-
+                      relationship-4
+                      relationship-5
+                      relationship-6
+                      relationship-7
+                      relationship-8}}))
 
 (def fixture-many-relationships
   (let [indicators (map mk-indicator (range 300))
@@ -661,6 +673,7 @@
      :indicators (set indicators)
      :sightings #{sighting}
      :relationships (set relationships)}))
+
 
 (deftest bundle-max-relationships-test
   (test-for-each-store
@@ -685,7 +698,7 @@
          (is (= 500 (count (:relationships exported-bundle)))))))))
 
 
-(deftest bundle-export-related-to-test
+(deftest bundle-export-graph-test
   (test-for-each-store
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
@@ -693,10 +706,10 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
-     (testing "testing related_to filter: relationships should be joined only on attributes specified by related_to values (source_ref and/or target_ref)"
+     (testing "testing relationships filters"
        (let [bundle-res
              (:parsed-body (post "ctia/bundle/import"
-                                 :body bundle-related-fixture
+                                 :body bundle-graph-fixture
                                  :headers {"Authorization" "45c1f5e3f05d0"}))
 
              by-type (->> bundle-res :results (group-by :type))
@@ -705,17 +718,27 @@
               sighting-id-2] (->> (:sighting by-type)
                                   (sort-by :external_id)
                                   (map :id))
+
              [indicator-id-1
               indicator-id-2
               indicator-id-3] (->> (:indicator by-type)
                                    (sort-by :external_id)
                                    (map :id))
+             [incident-id-1
+              incident-id-2] (->> (:incident by-type)
+                                   (sort-by :external_id)
+                                   (map :id))
              [relationship-id-1
               relationship-id-2
               relationship-id-3
-              relationship-id-4] (->> (:relationship by-type)
+              relationship-id-4
+              relationship-id-5
+              relationship-id-6
+              relationship-id-7
+              relationship-id-8] (->> (:relationship by-type)
                                       (sort-by :external_id)
                                       (map :id))
+             ;; related to queries
              bundle-from-source
              (:parsed-body
               (get "ctia/bundle/export"
@@ -733,50 +756,81 @@
               (get "ctia/bundle/export"
                    :query-params {:ids [indicator-id-2]
                                   :related_to ["target_ref"]}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+
+             ;; node type filters
+             bundle-sighting-source
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [incident-id-2]
+                                  :source_type "sighting"}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+             bundle-incident-target
+             (:parsed-body
+              (get "ctia/bundle/export"
+                   :query-params {:ids [sighting-id-2]
+                                  :target_type "incident"}
                    :headers {"Authorization" "45c1f5e3f05d0"}))]
 
-         (is (= #{relationship-id-1
-                  relationship-id-2} (->> bundle-from-source
-                                          :relationships
-                                          (map :id)
-                                          set)))
-         (is (= #{indicator-id-1
-                  indicator-id-2} (->> bundle-from-source
-                                       :indicators
-                                       (map :id)
-                                       set)))
-         (is (= #{sighting-id-1} (->> bundle-from-source
-                                      :sightings
-                                      (map :id)
-                                      set)))
+         (testing "relationships should be joined only on attributes specified by related_to values (source_ref and/or target_ref)"
+           (is (= #{relationship-id-1
+                    relationship-id-2
+                    relationship-id-6} (->> bundle-from-source
+                                            :relationships
+                                            (map :id)
+                                            set)))
+           (is (= #{indicator-id-1
+                    indicator-id-2} (->> bundle-from-source
+                                         :indicators
+                                         (map :id)
+                                         set)))
+           (is (= #{sighting-id-1} (->> bundle-from-source
+                                        :sightings
+                                        (map :id)
+                                        set)))
 
-         (is (= #{indicator-id-1} (->> bundle-from-target-1
-                                       :indicators
-                                       (map :id)
-                                       set)))
-         (is (= #{relationship-id-1
-                  relationship-id-3} (->> bundle-from-target-1
-                                          :relationships
-                                          (map :id)
-                                          set)))
-         (is (= #{sighting-id-1
-                  sighting-id-2} (->> bundle-from-target-1
-                                      :sightings
-                                      (map :id)
-                                      set)))
+           (is (= #{indicator-id-1} (->> bundle-from-target-1
+                                         :indicators
+                                         (map :id)
+                                         set)))
+           (is (= #{relationship-id-1
+                    relationship-id-3} (->> bundle-from-target-1
+                                            :relationships
+                                            (map :id)
+                                            set)))
+           (is (= #{sighting-id-1
+                    sighting-id-2} (->> bundle-from-target-1
+                                        :sightings
+                                        (map :id)
+                                        set)))
 
-         (is (= #{relationship-id-2} (->> bundle-from-target-2
-                                          :relationships
-                                          (map :id)
-                                          set)))
-         (is (= #{indicator-id-2} (->> bundle-from-target-2
-                                       :indicators
-                                       (map :id)
-                                       set)))
-         (is (= #{sighting-id-1} (->> bundle-from-target-2
-                                      :sightings
-                                      (map :id)
-                                      set))))))))
+           (is (= #{relationship-id-2} (->> bundle-from-target-2
+                                            :relationships
+                                            (map :id)
+                                            set)))
+           (is (= #{indicator-id-2} (->> bundle-from-target-2
+                                         :indicators
+                                         (map :id)
+                                         set)))
+           (is (= #{sighting-id-1} (->> bundle-from-target-2
+                                        :sightings
+                                        (map :id)
+                                        set))))
+         (testing "source_type and target_type should filter relationships nodes from their type"
+           (is (= #{sighting-id-1
+                    sighting-id-2} (->> bundle-sighting-source
+                                        :sightings
+                                        (map :id)
+                                        set)))
+           (is (nil?  (:indicators bundle-sighting-source)))
+
+
+           (is (= #{incident-id-1
+                    incident-id-2} (->> bundle-incident-target
+                                        :incidents
+                                        (map :id)
+                                        set)))
+           (is (nil?  (:indicators bundle-incident-target)))))))))
 
 (defn with-tlp-property-setting [tlp f]
   (with-redefs [ctia.properties/properties


### PR DESCRIPTION
> closes #threatgrid/iroh/issues/3051

This PR enables to filter relationships by nodes type (based on `source_ref` and `target_ref` fields) in bundle export.
That version is based on regex on source_type and target_type uris, since adding these instances types in the documents would require a migration of relationships index.

<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

You can now filter bundles with source and target types.

<a name="qa">[§](#qa)</a> QA
============================

1. import that bundle [bundle1.json.zip](https://github.com/threatgrid/ctia/files/3959819/bundle1.json.zip)
2. Note the id of the sighting id created with original id `transient:3`, and the id of the indicator.
3. Call bundle export with the id of the sighting id retrieved in step 2, and target_type=incident, it should retrieve the corresponding sighting, and the incident, but not the indicator.
4. Call bundle export with the id of sighting id retrieved in step 2, and target_type=indicator, it should retrieve the corresponding sighting, the inserted indicator, but not the incident.
5. Call bundle export with the id of indicator id retrieved in step 2, and source_type=sighting, it should retrieve that indicator, 2 inserted sightings 
6. Call bundle export with the id of indicator id retrieved in step 2, and source_type=sighting, it should retrieve that indicator and 2 inserted sightings but not the incident.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Bundle Export route now proposes to filter relationships by source and target types.
```
