### PR TITLE
Fixed kafka version for Travis tests

### DIFF
--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "9200:9200"
       - "9300:9300"
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.3.2
     hostname: "zookeeper"
     environment:
       ZOOKEEPER_SERVER_ID: 1
@@ -25,7 +25,7 @@ services:
       - "2181:2181"
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.3.2
     hostname: "localhost"
     depends_on:
       - zookeeper


### PR DESCRIPTION
As the test branch currently fails to build with no difference from master the failure seems to be attributed to the build waiting endlessly for zk to be up, the cp-kafka and cp-zookeeper docker images have been updated 2 days ago and are untested with our setup, this PR sets their version to the previous stable images so the build runs again.