### PR TITLE
updated client-dev docker-compose setup

### DIFF
--- a/containers/client-dev/README.md
+++ b/containers/client-dev/README.md
@@ -40,7 +40,7 @@ Created ~/path-to/ctia/target/ctia.jar
 
 ~/path-to/ctia$ cd containers/client-dev/
 
-~/path-to/ctia/containers/client-dev$ sudo docker-compose build
+~/path-to/ctia/containers/client-dev$ docker-compose build
 redis-client-dev uses an image, skipping
 elasticsearch-client-dev uses an image, skipping
 Building ctia

--- a/containers/client-dev/ctia/config/ctia.properties
+++ b/containers/client-dev/ctia/config/ctia.properties
@@ -2,3 +2,4 @@ ctia.store.es.default.host=elasticsearch-client-dev
 ctia.hook.redismq.host=redis-client-dev
 ctia.hook.redis.host=redis-client-dev
 ctia.http.jwt.enabled=false
+ctia.encryption.secret=all_your_bases_are_belong_to_us

--- a/containers/client-dev/ctia/config/ctia.properties
+++ b/containers/client-dev/ctia/config/ctia.properties
@@ -2,4 +2,4 @@ ctia.store.es.default.host=elasticsearch-client-dev
 ctia.hook.redismq.host=redis-client-dev
 ctia.hook.redis.host=redis-client-dev
 ctia.http.jwt.enabled=false
-ctia.encryption.secret=all_your_bases_are_belong_to_us
+ctia.encryption.secret=all_your_base_are_belong_to_us

--- a/containers/client-dev/docker-compose.yml
+++ b/containers/client-dev/docker-compose.yml
@@ -15,16 +15,14 @@ services:
       - elasticsearch-client-dev
 
   redis-client-dev:
-    image: redis
+    image: redis:5.0.5
     ports:
       - "6379:6379"
 
   elasticsearch-client-dev:
-    image: elasticsearch:5.1
+    image: elasticsearch:5.6.9
     environment:
-      ES_NETWORK_HOST: 0.0.0.0
-      ES_NODE_MASTER: "true"
-      ES_CLUSTER_NAME: elasticsearch
+      - cluster.name=elasticsearch
     volumes:
       - ./elasticsearch/data:/usr/share/elasticsearch/data
     ports:


### PR DESCRIPTION
With the recent changes to the ES setup and encryption support, the `client-dev` docker-compose setup was outdated resulting in a failure to start it from the official instructions,
this PR fixes it.

<a name="qa">[§](#qa)</a> QA
============================

No QA needed

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: updated docker-compose client-dev setup.
```
