### PR TITLE
Issue-876: Update client-dev container deployment

### DIFF
--- a/containers/client-dev/README.md
+++ b/containers/client-dev/README.md
@@ -17,6 +17,7 @@ If your docker host OS is Linux,
 Elasticsearch 5x bootstrap checks the maximum map count configuration,
 tune it accordingly with `sudo sysctl -w vm.max_map_count=262144`
 
+NOTE: This project has been tested and works with Java 8. Java 9 have been tested and do not work.
 
 To run the latest containers from Docker HUB simply invoke docker-compose with this configuration:
 

--- a/containers/client-dev/docker-compose.yml
+++ b/containers/client-dev/docker-compose.yml
@@ -18,15 +18,10 @@ services:
     image: redis
     ports:
       - "6379:6379"
-
   elasticsearch-client-dev:
-    image: elasticsearch:5.1
+    image: elasticsearch:5.6.9
     environment:
-      ES_NETWORK_HOST: 0.0.0.0
-      ES_NODE_MASTER: "true"
-      ES_CLUSTER_NAME: elasticsearch
-    volumes:
-      - ./elasticsearch/data:/usr/share/elasticsearch/data
+      - cluster.name=elasticsearch
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
This commit will update the elasticsearch version in the
client-dev deployment to be in line with the client deployment.
Additionally, the README.md has been updated to reflect the
need for Java8.

> Close #876 

No QA is needed.

