### PR TITLE
E3223 improves rollover error management

### DIFF
--- a/src/ctia/task/rollover.clj
+++ b/src/ctia/task/rollover.clj
@@ -1,12 +1,10 @@
 (ns ctia.task.rollover
-  (:require [clojure.tools.cli :refer [parse-opts]]
-            [clojure.tools.logging :as log]
-
+  (:import [clojure.lang ExceptionInfo])
+  (:require [clojure.tools.logging :as log]
             [schema.core :as s]
             [clj-momo.lib.es
              [index :as es-index]
              [schemas :refer [ESConnState]]]
-
             [ctia.stores.es.crud :as es-crud]
             [ctia
              [init :refer [init-store-service! log-properties]]
@@ -19,24 +17,39 @@
     {:keys [write-index aliased]
      conditions :rollover} :props} :- ESConnState]
   (when (and aliased (seq conditions))
-    (try
-      (let [{rolledover? :rolled_over :as response}
-            (es-index/rollover! conn write-index conditions)]
-        (when rolledover?
-          (log/info "rolled over: " (pr-str response)))
-        response)
-      (catch clojure.lang.ExceptionInfo e
-        (log/warn "could not rollover, a concurrent rollover could be already running on that index"
-                  (pr-str (ex-data e)))))))
+    (let [{rolledover? :rolled_over :as response}
+          (es-index/rollover! conn write-index conditions)]
+      (when rolledover?
+        (log/info "rolled over: " (pr-str response)))
+      response)))
+
+(defn concat-rollover
+  [state [k store]]
+  (log/infof "requesting _rollover for store: %s" k)
+  (try
+    (->> (first store)
+         :state
+         (rollover-store)
+         (assoc state k))
+    (catch ExceptionInfo e
+      (log/error (format "could not rollover, a concurrent rollover could be already running on that index"
+                         k
+                         (pr-str (ex-data e))))
+      (update state :nb-errors inc))))
 
 (defn rollover-stores
   [stores]
-  (doseq [[k store] stores]
-    (log/infof "requesting _rollover for store: %s" k)
-    (rollover-store (-> store first :state))))
+  (reduce concat-rollover
+          {:nb-errors 0}
+          stores))
 
-(defn -main [& args]
+(defn -main [& _args]
   (init!)
   (log-properties)
   (init-store-service!)
-  (rollover-stores @stores))
+  (let [{:keys [nb-errors]
+         :as res} (rollover-stores @stores)]
+    (log/info "completed rollover task: " res)
+    (when (< 0 nb-errors)
+      (log/error "there was errors while rolling over stores")
+      (System/exit 1))))

--- a/src/ctia/task/rollover.clj
+++ b/src/ctia/task/rollover.clj
@@ -1,15 +1,12 @@
 (ns ctia.task.rollover
-  (:import [clojure.lang ExceptionInfo])
-  (:require [clojure.tools.logging :as log]
-            [schema.core :as s]
-            [clj-momo.lib.es
-             [index :as es-index]
-             [schemas :refer [ESConnState]]]
-            [ctia.stores.es.crud :as es-crud]
-            [ctia
-             [init :refer [init-store-service! log-properties]]
-             [properties :refer [properties init!]]
-             [store :refer [stores]]]))
+  (:require [clj-momo.lib.es.index :as es-index]
+            [clj-momo.lib.es.schemas :refer [ESConnState]]
+            [clojure.tools.logging :as log]
+            [ctia.init :refer [init-store-service! log-properties]]
+            [ctia.properties :refer [init!]]
+            [ctia.store :refer [stores]]
+            [schema.core :as s])
+  (:import clojure.lang.ExceptionInfo))
 
 (s/defn rollover-store
   "Sends rollover query on a store if paramater aliased and rollover conditions are configured."

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -1,18 +1,13 @@
 (ns ctia.task.rollover-test
-  (:require [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
-            [clj-momo.lib.es
-             [conn :refer [connect]]
-             [document :as es-doc]
-             [index :as es-index]]
+  (:require [clj-momo.lib.es.index :as es-index]
             [clojure.string :as string]
+            [clojure.test :refer [deftest is join-fixtures use-fixtures]]
             [ctia.stores.es.init :as init]
-            [ctia.properties :as props]
-            [ctia.test-helpers
-             [fixtures :as fixt]
-             [core :as helpers :refer [post-bulk delete]]
-             [es :as es-helpers]
-             [fake-whoami-service :as whoami-helpers]]
-            [ctia.task.rollover :as sut]))
+            [ctia.task.rollover :as sut]
+            [ctia.test-helpers.core :as helpers :refer [post-bulk]]
+            [ctia.test-helpers.es :as es-helpers]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.fixtures :as fixt]))
 
 (use-fixtures :once
   (join-fixtures [whoami-helpers/fixture-server
@@ -60,32 +55,32 @@
     (is (true? (:rolled_over (sut/rollover-store state-aliased))))
     (is (= 3 (count-index)))))
 
-;;(deftest rollover-stores-error-test
-;;  (with-redefs [es-index/rollover! (fn [_ alias _]
-;;                                     (if (string/starts-with? alias "ok_index")
-;;                                       {:rolled_over (rand-nth [true false])}
-;;                                       (throw (ex-info "that's baaaaaaaddd"
-;;                                                       {:code :unhappy}))))]
-;;    (let [ok-state (init/init-store-conn {:entity "sighting"
-;;                                          :indexname "ok_index"
-;;                                          :rollover {:max_docs 3}
-;;                                          :aliased true})
-;;          ko-state (init/init-store-conn {:entity "sighting"
-;;                                          :indexname "bbaaaaadddd_index"
-;;                                          :rollover {:max_docs 2}
-;;                                          :aliased true})
-;;          stores {:ok-type-1 [{:state ok-state}]
-;;                  :ok-type-2 [{:state ok-state}]
-;;                  :ok-type-3 [{:state ok-state}]
-;;                  :ko-type-1 [{:state ko-state}]
-;;                  :ko-type-2 [{:state ko-state}]}
-;;          {:keys [nb-errors
-;;                  ok-type-1
-;;                  ok-type-2
-;;                  ok-type-3
-;;                  ko-type-1
-;;                  ko-type-2]} (sut/rollover-stores stores)]
-;;      (is (= 2 nb-errors))
-;;      (is (every? nil? [ko-type-1 ko-type-2]))
-;;      (is (every? #(some? (:rolled_over %))
-;;                  [ok-type-1 ok-type-2 ok-type-3])))))
+(deftest rollover-stores-error-test
+  (with-redefs [es-index/rollover! (fn [_ alias _]
+                                     (if (string/starts-with? alias "ok_index")
+                                       {:rolled_over (rand-nth [true false])}
+                                       (throw (ex-info "that's baaaaaaaddd"
+                                                       {:code :unhappy}))))]
+    (let [ok-state (init/init-store-conn {:entity "sighting"
+                                          :indexname "ok_index"
+                                          :rollover {:max_docs 3}
+                                          :aliased true})
+          ko-state (init/init-store-conn {:entity "sighting"
+                                          :indexname "bbaaaaadddd_index"
+                                          :rollover {:max_docs 2}
+                                          :aliased true})
+          stores {:ok-type-1 [{:state ok-state}]
+                  :ok-type-2 [{:state ok-state}]
+                  :ok-type-3 [{:state ok-state}]
+                  :ko-type-1 [{:state ko-state}]
+                  :ko-type-2 [{:state ko-state}]}
+          {:keys [nb-errors
+                  ok-type-1
+                  ok-type-2
+                  ok-type-3
+                  ko-type-1
+                  ko-type-2]} (sut/rollover-stores stores)]
+      (is (= 2 nb-errors))
+      (is (every? nil? [ko-type-1 ko-type-2]))
+      (is (every? #(some? (:rolled_over %))
+                  [ok-type-1 ok-type-2 ok-type-3])))))

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -4,7 +4,7 @@
              [conn :refer [connect]]
              [document :as es-doc]
              [index :as es-index]]
-
+            [clojure.string :as string]
             [ctia.stores.es.init :as init]
             [ctia.properties :as props]
             [ctia.test-helpers
@@ -59,3 +59,33 @@
     (es-index/refresh! (:conn state-aliased))
     (is (true? (:rolled_over (sut/rollover-store state-aliased))))
     (is (= 3 (count-index)))))
+
+;;(deftest rollover-stores-error-test
+;;  (with-redefs [es-index/rollover! (fn [_ alias _]
+;;                                     (if (string/starts-with? alias "ok_index")
+;;                                       {:rolled_over (rand-nth [true false])}
+;;                                       (throw (ex-info "that's baaaaaaaddd"
+;;                                                       {:code :unhappy}))))]
+;;    (let [ok-state (init/init-store-conn {:entity "sighting"
+;;                                          :indexname "ok_index"
+;;                                          :rollover {:max_docs 3}
+;;                                          :aliased true})
+;;          ko-state (init/init-store-conn {:entity "sighting"
+;;                                          :indexname "bbaaaaadddd_index"
+;;                                          :rollover {:max_docs 2}
+;;                                          :aliased true})
+;;          stores {:ok-type-1 [{:state ok-state}]
+;;                  :ok-type-2 [{:state ok-state}]
+;;                  :ok-type-3 [{:state ok-state}]
+;;                  :ko-type-1 [{:state ko-state}]
+;;                  :ko-type-2 [{:state ko-state}]}
+;;          {:keys [nb-errors
+;;                  ok-type-1
+;;                  ok-type-2
+;;                  ok-type-3
+;;                  ko-type-1
+;;                  ko-type-2]} (sut/rollover-stores stores)]
+;;      (is (= 2 nb-errors))
+;;      (is (every? nil? [ko-type-1 ko-type-2]))
+;;      (is (every? #(some? (:rolled_over %))
+;;                  [ok-type-1 ok-type-2 ok-type-3])))))


### PR DESCRIPTION
> closes #threatgrid/iroh/issues/3223

That PR improves the logs and the error management of rollover task.
In case of failing to rollover any store, it completes the process with remaining store but exits with code 1.

<a name="qa">[§](#qa)</a> QA
============================
No QA is needed.

<a name="ops">[§](#ops)</a> Ops
===============================

The rollover task now exits with code 1 in case of errors.