### PR TITLE
Moved Investigation schemas from CTIM to CTIA

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,8 +32,8 @@
   :jvm-opts ["-Djava.awt.headless=true"
              "-Dlog.console.threshold=INFO"
              "-server"]
-  ; use `lein pom; mvn dependency:tree -Dverbose -Dexcludes=org.clojure:clojure`
-  ; to inspect conflicts.
+                                        ; use `lein pom; mvn dependency:tree -Dverbose -Dexcludes=org.clojure:clojure`
+                                        ; to inspect conflicts.
   :dependencies [[org.clojure/clojure ~clj-version]
                  [clj-time "0.15.2"]
                  [org.clojure/core.async "0.7.559"]
@@ -48,7 +48,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                  
+                 
                  [threatgrid/ctim "1.0.16"]
                  [threatgrid/clj-momo "0.3.4"]
 
@@ -56,8 +56,8 @@
 
                  ;; Web server
                  [metosin/compojure-api "1.1.13" ]
-                 ; optional dep for compojure-api's dep ring-middleware-format
-                 ; see: https://github.com/ngrunwald/ring-middleware-format/issues/74
+                                        ; optional dep for compojure-api's dep ring-middleware-format
+                                        ; see: https://github.com/ngrunwald/ring-middleware-format/issues/74
                  [com.ibm.icu/icu4j "65.1"]
                  [metosin/ring-swagger "0.26.2"]
                  [metosin/ring-swagger-ui "3.24.3"]
@@ -88,7 +88,7 @@
                  [io.netty/netty-resolver "4.1.42.Final"] ;riemann-clojure-client > org.apache.zookeeper/zookeeper
                  [com.google.protobuf/protobuf-java "3.11.1"] ;riemann-clojure-client > threatgrid:ctim, metrics-clojure-riemann, org.onyxplatform/onyx-kafka
                  [riemann-clojure-client "0.5.1"]
-                 ; https://stackoverflow.com/a/43574427
+                                        ; https://stackoverflow.com/a/43574427
                  [jakarta.xml.bind/jakarta.xml.bind-api "2.3.2"]
 
                  ;; Docs
@@ -137,7 +137,7 @@
                                   (:out (clojure.java.shell/sh
                                          "git" "symbolic-ref" "--short" "HEAD")))})}]
 
-  :global-vars {*warn-on-reflection* true}
+  :global-vars {*warn-on-reflection* false}
   :profiles {:dev {:dependencies [[cheshire ~cheshire-version]
                                   [org.clojure/test.check ~test-check-version]
                                   [com.gfredericks/test.chuck ~test-chuck-version]
@@ -178,7 +178,7 @@
                               :namespaces [ctia.bulk.routes-bench]}
                              {:name :migration
                               :namespaces [ctia.tasks.migrate-es-stores-bench]}]}
-  ; use `lein deps :plugins-tree` to inspect conflicts
+                                        ; use `lein deps :plugins-tree` to inspect conflicts
   :plugins [[lein-shell "0.5.0"]
             [org.clojure/clojure ~clj-version] ;override perforate
             [perforate ~perforate-version]]

--- a/project.clj
+++ b/project.clj
@@ -32,8 +32,8 @@
   :jvm-opts ["-Djava.awt.headless=true"
              "-Dlog.console.threshold=INFO"
              "-server"]
-                                        ; use `lein pom; mvn dependency:tree -Dverbose -Dexcludes=org.clojure:clojure`
-                                        ; to inspect conflicts.
+  ; use `lein pom; mvn dependency:tree -Dverbose -Dexcludes=org.clojure:clojure`
+  ; to inspect conflicts.
   :dependencies [[org.clojure/clojure ~clj-version]
                  [clj-time "0.15.2"]
                  [org.clojure/core.async "0.7.559"]
@@ -48,7 +48,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 
+                  
                  [threatgrid/ctim "1.0.16"]
                  [threatgrid/clj-momo "0.3.4"]
 
@@ -56,8 +56,8 @@
 
                  ;; Web server
                  [metosin/compojure-api "1.1.13" ]
-                                        ; optional dep for compojure-api's dep ring-middleware-format
-                                        ; see: https://github.com/ngrunwald/ring-middleware-format/issues/74
+                 ; optional dep for compojure-api's dep ring-middleware-format
+                 ; see: https://github.com/ngrunwald/ring-middleware-format/issues/74
                  [com.ibm.icu/icu4j "65.1"]
                  [metosin/ring-swagger "0.26.2"]
                  [metosin/ring-swagger-ui "3.24.3"]
@@ -88,7 +88,7 @@
                  [io.netty/netty-resolver "4.1.42.Final"] ;riemann-clojure-client > org.apache.zookeeper/zookeeper
                  [com.google.protobuf/protobuf-java "3.11.1"] ;riemann-clojure-client > threatgrid:ctim, metrics-clojure-riemann, org.onyxplatform/onyx-kafka
                  [riemann-clojure-client "0.5.1"]
-                                        ; https://stackoverflow.com/a/43574427
+                 ; https://stackoverflow.com/a/43574427
                  [jakarta.xml.bind/jakarta.xml.bind-api "2.3.2"]
 
                  ;; Docs
@@ -137,7 +137,7 @@
                                   (:out (clojure.java.shell/sh
                                          "git" "symbolic-ref" "--short" "HEAD")))})}]
 
-  :global-vars {*warn-on-reflection* false}
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev {:dependencies [[cheshire ~cheshire-version]
                                   [org.clojure/test.check ~test-check-version]
                                   [com.gfredericks/test.chuck ~test-chuck-version]
@@ -178,7 +178,7 @@
                               :namespaces [ctia.bulk.routes-bench]}
                              {:name :migration
                               :namespaces [ctia.tasks.migrate-es-stores-bench]}]}
-                                        ; use `lein deps :plugins-tree` to inspect conflicts
+  ; use `lein deps :plugins-tree` to inspect conflicts
   :plugins [[lein-shell "0.5.0"]
             [org.clojure/clojure ~clj-version] ;override perforate
             [perforate ~perforate-version]]

--- a/src/ctia/entity/entities.clj
+++ b/src/ctia/entity/entities.clj
@@ -10,7 +10,6 @@
     [vulnerability :refer [vulnerability-entity]]
     [attack-pattern :refer [attack-pattern-entity]]
     [indicator :refer [indicator-entity]]
-    [investigation :refer [investigation-entity]]
     [incident :refer [incident-entity]]
     [malware :refer [malware-entity]]
     [tool :refer [tool-entity]]
@@ -25,7 +24,8 @@
     [relationship :refer [relationship-entity]]
     [identity :refer [identity-entity]]
     [feed :refer [feed-entity]]
-    [event :refer [event-entity]]]
+    [event :refer [event-entity]]
+    [investigation :refer [investigation-entity]]]
    [schema.core :as s]))
 
 (def entities

--- a/src/ctia/entity/investigation/examples.clj
+++ b/src/ctia/entity/investigation/examples.clj
@@ -1,0 +1,43 @@
+(ns ctia.entity.investigation.examples
+  (:require [ctim.schemas.common :as c]))
+
+(def investigation-maximal
+  {:id "http://ex.tld/ctia/investigation/investigation-2805d697-66b3-4e14-9b32-179e7a72eab6"
+   :type "investigation"
+   :schema_version c/ctim-schema-version
+   :revision 1
+   :external_ids [(str "http://ex.tld/ctia/investigation/investigation-"
+                       "f867a601-ac76-4491-a0d6-51968c9f9021")
+                  (str "http://ex.tld/ctia/investigation/investigation-"
+                       "53468a66-5d95-49b5-88ec-454bdf894db9")]
+   :external_references [{:source_name "source"
+                          :external_id "T1067"
+                          :url "https://ex.tld/wiki/T1067"
+                          :hashes ["#section1"]
+                          :description "Description text"}]
+   :timestamp #inst "2017-10-23T19:25:27.278-00:00"
+   :language "language"
+   :object_ids []
+   :investigated_observables []
+   :targets []
+   :title "investigation-title"
+   :description "description"
+   :short_description "short desc"
+   :source "a source"
+   :source_uri "http://example.com/somewhere-else"
+   :tlp "green"})
+
+(def investigation-minimal
+  {:id "http://ex.tld/ctia/investigation/investigation-2805d697-66b3-4e14-9b32-179e7a72eab6"
+   :source "a source"
+   :object_ids []
+   :investigated_observables []
+   :targets []
+   :schema_version c/ctim-schema-version
+   :type "investigation"})
+
+(def new-investigation-maximal
+  investigation-maximal)
+
+(def new-investigation-minimal
+  {:source "a source"})

--- a/src/ctia/entity/investigation/flanders_schemas.clj
+++ b/src/ctia/entity/investigation/flanders_schemas.clj
@@ -1,0 +1,29 @@
+(ns ctia.entity.investigation.flanders-schemas
+  (:require [ctim.schemas.common :as c]
+            [flanders.core :as f :refer [def-entity-type def-eq]]))
+
+(def type-identifier "investigation")
+
+(def-eq InvestigationIdentifier type-identifier)
+
+(def-entity-type Investigation
+  "Schema for an Investigation (a work in progress)"
+  c/base-entity-entries
+  c/sourced-object-entries
+  c/describable-entity-entries
+  (f/required-entries
+   (f/entry :type InvestigationIdentifier))
+  (f/optional-entries
+   (f/entry :actions (f/str)
+            :description "Investigation actions encoded as JSON (an array of objects).")
+   (f/entry :object_ids (f/seq-of (f/str)))
+   (f/entry :investigated_observables (f/seq-of (f/str)))
+   (f/entry :targets (f/seq-of c/IdentitySpecification)
+            :description "Investigated target devices")))
+
+(def-entity-type NewInvestigation
+  "Schema for submitting new Investigations"
+  (:entries Investigation)
+  c/base-new-entity-entries
+  (f/optional-entries
+   (f/entry :type InvestigationIdentifier)))

--- a/src/ctia/entity/investigation/graphql_schemas.clj
+++ b/src/ctia/entity/investigation/graphql_schemas.clj
@@ -5,6 +5,7 @@
              [flanders :as flanders]
              [helpers :as g]
              [pagination :as pagination]]
+            [ctia.schemas.graphql.refs :as refs]
             [ctia.entity.investigation.flanders-schemas :as f-inv]
             [ctia.entity.investigation :refer [investigation-fields]]
             [ctia.schemas.graphql.ownership :as go]))
@@ -13,7 +14,7 @@
   (let [{:keys [fields name description]}
         (flanders/->graphql
          (fu/optionalize-all f-inv/Investigation)
-         {})]
+         {refs/observable-type-name refs/ObservableTypeRef})]
     (g/new-object
      name
      description

--- a/src/ctia/entity/investigation/graphql_schemas.clj
+++ b/src/ctia/entity/investigation/graphql_schemas.clj
@@ -1,0 +1,34 @@
+(ns ctia.entity.investigation.graphql-schemas
+  (:require [flanders.utils :as fu]
+            [ctia.schemas.graphql
+             [sorting :as graphql-sorting]
+             [flanders :as flanders]
+             [helpers :as g]
+             [pagination :as pagination]]
+            [ctia.entity.investigation.flanders-schemas :as f-inv]
+            [ctia.entity.investigation :refer [investigation-fields]]
+            [ctia.schemas.graphql.ownership :as go]))
+
+(def InvestigationType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all f-inv/Investigation)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge
+      fields go/graphql-ownership-fields))))
+
+(def investigation-order-arg
+  (graphql-sorting/order-by-arg
+   "InvestigationOrder"
+   "investigations"
+   (into {}
+         (map (juxt graphql-sorting/sorting-kw->enum-name name)
+              investigation-fields))))
+
+(def InvestigationConnectionType
+  (pagination/new-connection InvestigationType))
+

--- a/src/ctia/entity/investigation/schemas.clj
+++ b/src/ctia/entity/investigation/schemas.clj
@@ -1,0 +1,31 @@
+(ns ctia.entity.investigation.schemas
+  (:require
+   [ctia.entity.investigation.flanders-schemas :as f-inv]
+   [ctia.domain.entities :refer [default-realize-fn]]
+   [flanders.utils :as fu]
+   [ctia.schemas
+    [utils :as csu]
+    [core :refer [def-acl-schema
+                  def-stored-schema]]]
+   [schema.core :as s]))
+
+(def-acl-schema Investigation f-inv/Investigation "investigation")
+
+(def-acl-schema PartialInvestigation
+  (fu/optionalize-all f-inv/Investigation)
+  "partial-investigation")
+
+(s/defschema PartialInvestigationList
+  [PartialInvestigation])
+
+(def-acl-schema NewInvestigation f-inv/NewInvestigation "new-investigation")
+
+(def-stored-schema StoredInvestigation Investigation)
+
+(s/defschema PartialStoredInvestigation
+  (csu/optional-keys-schema StoredInvestigation))
+
+(def realize-investigation
+  (default-realize-fn "investigation"
+                      NewInvestigation
+                      StoredInvestigation))

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -14,7 +14,7 @@
    [ctia.entity.indicator :as indicator
     :refer [IndicatorConnectionType
             IndicatorType]]
-   [ctia.entity.investigation :as investigation
+   [ctia.entity.investigation.graphql-schemas :as investigation
     :refer [InvestigationConnectionType
             InvestigationType]]
    [ctia.entity.casebook :as casebook
@@ -71,13 +71,13 @@
                                    p/connection-arguments)
                       :resolve (res/search-entity-resolver :attack-pattern)}
     :incident {:type IncidentType
-                :args search-by-id-args
-                :resolve (res/entity-by-id-resolver :incident)}
+               :args search-by-id-args
+               :resolve (res/entity-by-id-resolver :incident)}
     :incidents {:type IncidentConnectionType
-                 :args (merge common/lucene-query-arguments
-                              incident/incident-order-arg
-                              p/connection-arguments)
-                 :resolve (res/search-entity-resolver :incident)}
+                :args (merge common/lucene-query-arguments
+                             incident/incident-order-arg
+                             p/connection-arguments)
+                :resolve (res/search-entity-resolver :incident)}
     :indicator {:type IndicatorType
                 :args search-by-id-args
                 :resolve (res/entity-by-id-resolver :indicator)}

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -12,23 +12,13 @@
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
              [store :refer [test-for-each-store]]]
-            [ctim.examples.investigations]))
+            [ctia.entity.investigation.examples :refer
+             [new-investigation-maximal
+              new-investigation-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
-
-(def new-investigation-maximal
-  (assoc ctim.examples.investigations/new-investigation-maximal
-         :object_ids []
-         :investigated_observables []
-         :targets []))
-
-(def new-investigation-minimal
-  (assoc ctim.examples.investigations/new-investigation-minimal
-         :object_ids []
-         :investigated_observables []
-         :targets []))
 
 (use-fixtures :each
   whoami-helpers/fixture-reset-state)


### PR DESCRIPTION
Hi, I worked on your PR branch to help you move out the Investigation schemas from CTIM so they are now defined in CTIA only.

- Moved the entity schema definition out of CTIM to CTIA
- Split the entity definition ns into sub namespaces
- Moved the Investigation examples