### PR TITLE
E3258: metric routes: topn, cardinality, histogram

### DIFF
--- a/doc/search-metrics.org
+++ b/doc/search-metrics.org
@@ -1,0 +1,146 @@
+#+TITLE: Search and Metrics
+#+AUTHOR: Cisco Threat Response Services
+#+PROPERTY:  eval no
+CTIA provides a way to search and extract metrics in CTIM entities.
+
+* Searching
+An entity search route is available through the endpoint ~GET /ctia/{entity-type}/search~.
+Search is enabled through 2 filtering means: a text query field that accepts free lucene queries, and field filters that enable users to filter on entities values.
+If you do not provide any filter, all documents are matched with TLP restrictions.
+
+For instance the following request enables the user to retrieve all the open incidents assigned to johndoe that were created since 2020/04/01:
+
+#+BEGIN_SRC
+GET /ctia/incident/search?assignee=johndoe&status=open&from=2020-04-01
+#+END_SRC
+
+The folloqing query searches all indicators matching the term "rat" in any field:
+
+#+BEGIN_SRC
+GET /ctia/indicator/search?query=rat
+#+END_SRC
+
+The following query searches all indicators matching the term "rat" in the field ~description~ field:
+
+#+BEGIN_SRC javascript
+GET /ctia/indicator/search?query=description:rat
+#+END_SRC
+
+The following query searches indicators with "android" in the title, having a high confidence, created since 2020/01/01. It combines both text and term filtering:
+
+#+BEGIN_SRC
+GET /ctia/indicator/search?query=title:android&confidence=high&from=2020-01-01
+#+END_SRC
+
+The result is returned in the form of list of matched entities:
+
+#+BEGIN_SRC javascript
+[
+ {"id": "indicator-1", "type": "indicator", "title": "Android problem", ...}
+ {"id": "indicator-2", "type": "indicator", "title": "Android rat", ...}
+ {"id": "indicator-3", "type": "indicator", "title": "Android malware", ...}
+ {"id": "indicator-4", "type": "indicator", "title": "Chrome on Android", ...}
+]
+#+END_SRC
+
+The search results can also be paginated using the ~limit~ and ~offset~ fields:
+The following example returns up to 5 entities after the 10th entities.
+#+BEGIN_SRC
+GET /ctia/incident/search?assignee=johndoe&limit=5&offset=15
+#+END_SRC
+The response header provides the necessary information to navigate in search results:
+1) ~x-total-hits~: indicates the total number of entities that match the search filters.
+2) ~x-previous~: indicates the values ~limit~ and ~offset~ values to access previous page (e.g. ~limit=5&offset=10~). This header element is not provided if there is no previous page.
+3) ~x-next~: indicates the values ~limit~ and ~offset~ values to access next page. It also provides the ~search_after~ value to use in order to deal with created values betweeen 2 search queries. (e.g. ~limit=5&offset=10&search_after=indicator-1384320~).  This header element is not provided if there is no next page.
+
+The entities are sorted by ascending creation order per default, but some other fields are also available to sort on (depending on each CTIM entity type).
+For instance you can search malicious judgments with high confidence matching "abuse.ch" and order results by descending ~disposition~:
+#+BEGIN_SRC
+GET /ctia/incident/search?query=abuse.ch&confidence=high&limit=10&sort_by=disposition&sort_order=desc
+#+END_SRC
+
+* Aggregating
+Aggregation metrics are available through the endpoint ~GET /CTIA/{entity-type}/metric/{metric-type}~.
+3 types of metrics are proposed: Top N, Cardinality, and Histogram, that can be selected with the corresponding route suffix ~{metric}~, respectively ~topn~, ~cardinality~, and ~histogram~.
+For each of these metrics we can choose the aggregated field, specific aggregation parameters and apply search filters to select the entities that will be aggregated.
+The search filters works identically as in search routes, with the possibility to filter on field values and with a textual query.
+Unlike in search, the ~from~ parameter is mandatory and a time window aggregated cannot exceed 1 year.
+Managed entity types are ~incident~, ~judgement~, and ~sighting~.
+
+** TOP N
+   Top N returns the most frequent values for a given field.
+This metric is available at the endpoint ~GET /CTIA/{entity-type}/metric/topn~.
+This metric is configurable with 3 parameters:
+- ~aggregate_on~: the name of the field which values will count and ordered. The available values are specified by type.
+- ~limit~: the maximum number of unique values to return. The default value is 10.
+- ~sort_order~: the order of the sort, valid values are ~asc~ or ~desc~. The default is ~desc~.
+ 
+The following example returns the number of incidents per status between since 2020/01/01 with the following query:
+
+#+BEGIN_SRC
+GET /ctia/incident/topn?&aggregate-on=status&limit=3&from=2020-01-01
+#+END_SRC
+it will return for instance
+#+BEGIN_SRC javascript
+{
+ "Closed": 12,
+ "Open": 6,
+ "New": 2
+}
+#+END_SRC
+
+The following request returns the top 20 observed values in judgements with malicious disposition, created between 2020/01/01 and 2020/04/01:
+
+#+BEGIN_SRC
+GET /ctia/judgement/topn?aggregate-on=observable.value&limit=20&from=2020-01-01&to2020-04-01&disposition=2
+#+END_SRC
+
+#+BEGIN_SRC javascript
+[
+ {"key": "abuse.ch", "value": 62},
+ {"key": "8.8.8.8", "value": 62},
+ {"key": "4964ab7e8d5959bb42b8ef78582082686dbe6565b010824785bc44595d8ebeee", "value": 38},
+ {"key": "https://www.badbabbad.net/worse.html", "value": 25},
+ ...
+]
+#+END_SRC
+
+** Cardinality
+   Cardinality count unique values for a given field, e.g. the number of unique observable values in judgments. 
+This metric is available at the endpoint ~GET /CTIA/{entity-type}/metric/cardinality~.
+This metric returns the exact values until 10000 unique values, but is based an the hyperLogLog algorithm above 10000 which approximates the exact result with an heuristic.
+This metric is configurable with the following parameter:
+- ~aggregate_on~: the name of the field which unique values are counted. The available values are specified by type.
+
+#+BEGIN_SRC
+GET /ctia/judgement/cardinality?aggregate-on=obsevable.value&from=2020-01-01
+#+END_SRC
+
+It will return an integer that represent the estimated number of unique values
+#+BEGIN_SRC javascript
+5391
+#+END_SRC
+** Histogram
+   This aggregation returns an histogram of entity count for a given datetime field and a granularity, e.g. the number of incidents per day.
+This metric is available at the endpoint ~GET /CTIA/{entity-type}/metric/histogram~.
+This metric is configurable with 2 parameters
+- ~aggregate_on~: the name of the date time field which will be used to determine the time range at which belongs each entity.
+- ~granularity~: the size of the time windows that will be returned. The possible values are ~hour~, ~day~, ~week~, ~month~.
+Note that for this aggregation, the ~from~ / ~ton~ filters are applied on the aggregated date instead of the creation date.
+
+The following example returns the number of opened incident per creation date since 2020/04/01:
+#+BEGIN_SRC
+GET /ctia/incident/histogram?aggregate-on=timestamp&granularity=day&status=Open&from=2020-04-01
+#+END_SRC
+it will return for instance
+#+BEGIN_SRC javascript
+[{"key": 2020-01-01", "value": 10},
+ {"key": 2020-01-02", "value": 0},
+ {"key": 2020-01-03", "value": 6},
+ {"key": 2020-01-04", "value": 2},
+ {"key": 2020-01-05", "value": 0},
+ {"key": 2020-01-06", "value": 1},
+ {"key": 2020-01-07", "value": 6},
+ {"key": 2020-01-08", "value": 4},
+ {"key": 2020-01-09", "value": 3}]
+#+END_SRC

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -4,9 +4,7 @@
    [ctia.bulk
     [core :refer [bulk-size create-bulk fetch-bulk get-bulk-max-size]]
     [schemas :refer [Bulk BulkRefs NewBulk]]]
-   [ctia.http.routes
-    [common :as common]
-    [crud :refer [wait_for->refresh]]]
+   [ctia.http.routes.common :as common]
    [ctia.schemas.core :refer [Reference]]
    [ring.util.http-response :refer :all]
    [schema.core :as s]))
@@ -42,7 +40,7 @@
           (common/created (create-bulk bulk
                                        {}
                                        login
-                                       (wait_for->refresh wait_for)))))
+                                       (common/wait_for->refresh wait_for)))))
 
   (GET "/" []
        :return (s/maybe Bulk)

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -80,13 +80,14 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    ActorFieldsParam
-   {:query s/Str
-    (s/optional-key :actor_type) s/Str
-    (s/optional-key :motivation) s/Str
-    (s/optional-key :sophistication) s/Str
-    (s/optional-key :intended_effect) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :sort_by)  actor-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :actor_type s/Str
+     :motivation s/Str
+     :sophistication s/Str
+     :intended_effect s/Str
+     :confidence s/Str
+     :sort_by  actor-sort-fields})))
 
 (def ActorGetParams ActorFieldsParam)
 

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -83,9 +83,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    AttackPatternFieldsParam
-   {:query s/Str}
    (st/optional-keys
-    {:kill_chain_phases.kill_chain_name s/Str
+    {:query s/Str
+     :kill_chain_phases.kill_chain_name s/Str
      :kill_chain_phases.phase_name s/Str
      :sort_by attack-pattern-sort-fields})))
 

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -79,11 +79,12 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    CampaignFieldsParam
-   {:query s/Str
-    (s/optional-key :campaign_type) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :activity) s/Str
-    (s/optional-key :sort_by)  campaign-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :campaign_type s/Str
+     :confidence s/Str
+     :activity s/Str
+     :sort_by  campaign-sort-fields})))
 
 (def CampaignGetParams CampaignFieldsParam)
 

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -3,8 +3,11 @@
             [ctia.domain.entities :refer [default-realize-fn un-store with-long-id]]
             [ctia.flows.crud :as flows]
             [ctia.http.routes
-             [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
-             [crud :refer [entity-crud-routes wait_for->refresh]]]
+             [common :refer [BaseEntityFilterParams
+                             PagingParams
+                             SourcableEntityFilterParams
+                             wait_for->refresh]]
+             [crud :refer [entity-crud-routes]]]
             [ctia.schemas
              [utils :as csu]
              [core :refer [Bundle def-acl-schema def-stored-schema]]
@@ -107,9 +110,10 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    CasebookFieldsParam
-   {:query s/Str
-    (s/optional-key :texts.text) s/Str
-    (s/optional-key :sort_by) casebook-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :texts.text s/Str
+     :sort_by casebook-sort-fields})))
 
 (def CasebookGetParams CasebookFieldsParam)
 

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -84,15 +84,16 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    COAFieldsParam
-   {:query s/Str
-    (s/optional-key :stage) s/Str
-    (s/optional-key :coa_type) s/Str
-    (s/optional-key :impact) s/Str
-    (s/optional-key :objective) s/Str
-    (s/optional-key :cost) s/Str
-    (s/optional-key :efficacy) s/Str
-    (s/optional-key :structured_coa_type) s/Str
-    (s/optional-key :sort_by) coa-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :stage s/Str
+     :coa_type s/Str
+     :impact s/Str
+     :objective s/Str
+     :cost s/Str
+     :efficacy s/Str
+     :structured_coa_type s/Str
+     :sort_by coa-sort-fields})))
 
 (def COAGetParams COAFieldsParam)
 

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -55,8 +55,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    DataTableFieldsParam
-   {:query s/Str
-    (s/optional-key :sort_by) datatable-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :sort_by datatable-sort-fields})))
 
 (def DataTableGetParams DataTableFieldsParam)
 

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -62,7 +62,7 @@
 
 (s/defschema EventSearchParams
   (st/merge
-   {:query s/Str}
+   {(s/optional-key :query) s/Str}
    PagingParams
    BaseEntityFilterParams
    EventFieldsParam))
@@ -158,7 +158,8 @@
      :can-post? false
      :can-get-by-external-id? false
      :search-capabilities :search-event
-     :delete-capabilities #{:delete-event :developer}})))
+     :delete-capabilities #{:delete-event :developer}
+     :date-field :timestamp})))
 
 (def event-entity
   {:new-spec map?

--- a/src/ctia/entity/event/crud.clj
+++ b/src/ctia/entity/event/crud.clj
@@ -6,12 +6,6 @@
    [ctia.stores.es.crud :as crud]
    [clj-momo.lib.es.schemas :refer [ESConnState]]))
 
-'(defn attach-bulk-fields [index event]
-  (assoc event
-         :_type "event"
-         :_id (:id event)
-         :_index index))
-
 (def ^:private handle-create-fn
   (crud/handle-create :event Event))
 

--- a/src/ctia/entity/event/crud.clj
+++ b/src/ctia/entity/event/crud.clj
@@ -4,12 +4,9 @@
    [ctia.entity.event.schemas
     :refer [Event PartialEvent]]
    [ctia.stores.es.crud :as crud]
-   [clj-momo.lib.es
-    [document :as document]
-    [schemas :refer [ESConnState SliceProperties]]
-    [slice :refer [get-slice-props]]]))
+   [clj-momo.lib.es.schemas :refer [ESConnState]]))
 
-(defn attach-bulk-fields [index event]
+'(defn attach-bulk-fields [index event]
   (assoc event
          :_type "event"
          :_id (:id event)
@@ -27,19 +24,15 @@
                     {}
                     {}))
 
-(def ^:private handle-list-fn
+(def handle-list
   (crud/handle-find :event Event))
 
-(s/defn handle-list
-  [state :- ESConnState
-   filter-map :- crud/FilterSchema
-   ident
-   params]
-  (handle-list-fn state
-                  filter-map
-                  ident
-                  params))
+(def handle-read
+  (crud/handle-read :event PartialEvent))
 
 (def handle-event-query-string-search
   (crud/handle-query-string-search
-   "event" PartialEvent))
+   :event PartialEvent))
+
+(def handle-aggregate
+  (crud/handle-aggregate :event))

--- a/src/ctia/entity/event/store.clj
+++ b/src/ctia/entity/event/store.clj
@@ -1,24 +1,23 @@
 (ns ctia.entity.event.store
   (:require
    [ctia.entity.event.schemas :refer [PartialEvent]]
-   [ctia.stores.es.crud :as es-crud]
    [ctia.store :refer :all]
-   [ctia.entity.event.crud
-    :refer [handle-list
-            handle-create
-            handle-event-query-string-search]]
+   [ctia.entity.event.crud :as crud]
    [ctia.store :refer [IEventStore]]))
 
 (defrecord EventStore [state]
   IStore
   (read-record [_ id ident params]
-    ((es-crud/handle-read :event PartialEvent) state id ident params))
+    (crud/handle-read state id ident params))
   IEventStore
   (create-events [this new-events]
-    (handle-create state new-events))
+    (crud/handle-create state new-events))
   (list-events [this filter-map ident params]
-    (handle-list state filter-map ident params))
+    (crud/handle-list state filter-map ident params))
   IQueryStringSearchableStore
-  (query-string-search [_ query filtermap ident params]
-    (handle-event-query-string-search
-     state query filtermap ident params)))
+  (query-string-search [_ search-query ident params]
+    (crud/handle-event-query-string-search
+     state search-query ident params))
+  (aggregate [_ search-query agg-query ident]
+    (crud/handle-aggregate
+     state search-query agg-query ident)))

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -93,6 +93,7 @@
      :external-id-capabilities :read-feedback
      :spec :new-feedback/map
      :can-search? false
+     :enumerable-fields []
      :can-update? false})))
 
 (def feedback-entity

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -71,12 +71,13 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    IdentityAssertionFieldsParam
-   {:query s/Str
-    (s/optional-key :identity.observables.type) s/Str
-    (s/optional-key :identity.observables.value) s/Str
-    (s/optional-key :assertions.name) s/Str
-    (s/optional-key :assertions.value) s/Str
-    (s/optional-key :sort_by) identity-assertion-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :identity.observables.type s/Str
+     :identity.observables.value s/Str
+     :assertions.name s/Str
+     :assertions.value s/Str
+     :sort_by identity-assertion-sort-fields})))
 
 (def IdentityAssertionGetParams IdentityAssertionFieldsParam)
 

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -113,7 +113,7 @@
 
 (def identity-assertion-entity
   {:route-context "/identity-assertion"
-   :tags ["IdentityAssertion"]
+   :tags ["Identity Assertion"]
    :entity :identity-assertion
    :plural :identity-assertions
    :new-spec :new-identity-assertion/map

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -8,9 +8,11 @@
             [ctia.flows.crud :as flows]
             [ctia.http.routes
              [common
-              :refer [BaseEntityFilterParams PagingParams
-                      SourcableEntityFilterParams]]
-             [crud :refer [entity-crud-routes wait_for->refresh]]]
+              :refer [BaseEntityFilterParams
+                      PagingParams
+                      SourcableEntityFilterParams
+                      wait_for->refresh]]
+             [crud :refer [entity-crud-routes]]]
             [ctia.schemas
              [core :refer [def-acl-schema def-stored-schema]]
              [sorting
@@ -165,6 +167,22 @@
 (def incident-sort-fields
   (apply s/enum incident-fields))
 
+(def incident-enumerable-fields
+  [:source
+   :confidence
+   :status
+   :discovery_method
+   :assignees])
+
+(def incident-histogram-fields
+  [:timestamp
+   :incident_time.opened
+   :incident_time.discovered
+   :incident_time.reported
+   :incident_time.remediated
+   :incident_time.closed
+   :incident_time.rejected])
+
 (s/defschema IncidentFieldsParam
   {(s/optional-key :fields) [incident-sort-fields]})
 
@@ -174,14 +192,15 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    IncidentFieldsParam
-   {:query s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :status) s/Str
-    (s/optional-key :discovery_method) s/Str
-    (s/optional-key :intended_effect) s/Str
-    (s/optional-key :categories) s/Str
-    (s/optional-key :sort_by) incident-sort-fields
-    (s/optional-key :assignees) s/Str}))
+   (st/optional-keys
+    {:query s/Str
+     :confidence s/Str
+     :status s/Str
+     :discovery_method s/Str
+     :intended_effect s/Str
+     :categories s/Str
+     :sort_by incident-sort-fields
+     :assignees s/Str})))
 
 (def IncidentGetParams IncidentFieldsParam)
 
@@ -206,6 +225,7 @@
      :search-q-params IncidentSearchParams
      :new-spec :new-incident/map
      :can-patch? true
+     :can-aggregate? true
      :realize-fn realize-incident
      :get-capabilities :read-incident
      :post-capabilities :create-incident
@@ -213,7 +233,9 @@
      :patch-capabilities :create-incident
      :delete-capabilities :delete-incident
      :search-capabilities :search-incident
-     :external-id-capabilities :read-incident})))
+     :external-id-capabilities :read-incident
+     :histogram-fields incident-histogram-fields
+     :enumerable-fields incident-enumerable-fields})))
 
 (def IncidentType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -110,14 +110,15 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    IndicatorFieldsParam
-   {:query s/Str
-    (s/optional-key :indicator_type) s/Str
-    (s/optional-key :tags) s/Int
-    (s/optional-key :kill_chain_phases) s/Str
-    (s/optional-key :producer) s/Str
-    (s/optional-key :specification) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :sort_by)  indicator-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :indicator_type s/Str
+     :tags s/Int
+     :kill_chain_phases s/Str
+     :producer s/Str
+     :specification s/Str
+     :confidence s/Str
+     :sort_by indicator-sort-fields})))
 
 (def IndicatorGetParams IndicatorFieldsParam)
 

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -95,7 +95,7 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    InvestigationFieldsParam
-   {:query s/Str}
+   {(s/optional-key :query) s/Str}
    {s/Keyword s/Any}))
 
 (def InvestigationGetParams InvestigationFieldsParam)

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -51,13 +51,14 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    JudgementFieldsParam
+   (st/optional-keys
    {:query s/Str
-    (s/optional-key :disposition_name) s/Str
-    (s/optional-key :disposition) s/Int
-    (s/optional-key :priority) s/Int
-    (s/optional-key :severity) s/Str
-    (s/optional-key :confidence) s/Str
-    (s/optional-key :sort_by) judgement-sort-fields}))
+    :disposition_name s/Str
+    :disposition s/Int
+    :priority s/Int
+    :severity s/Str
+    :confidence s/Str
+    :sort_by judgement-sort-fields})))
 
 (def JudgementGetParams JudgementFieldsParam)
 
@@ -91,7 +92,10 @@
     :delete-capabilities :delete-judgement
     :search-capabilities :search-judgement
     :external-id-capabilities :read-judgement
-    :can-update? true}))
+    :can-update? true
+    :can-aggregate? true
+    :histogram-fields js/judgement-histogram-fields
+    :enumerable-fields js/judgement-enumerable-fields}))
 
 (def capabilities
   #{:create-judgement

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -49,6 +49,7 @@
 (def handle-delete (crud/handle-delete :judgement PartialStoredJudgement))
 (def handle-list (crud/handle-find :judgement PartialStoredJudgement))
 (def handle-query-string-search (crud/handle-query-string-search :judgement PartialStoredJudgement))
+(def handle-aggregate (crud/handle-aggregate :judgement))
 
 (defn list-active-by-observable
   [state observable ident]
@@ -120,5 +121,7 @@
     (handle-calculate-verdict state observable ident))
 
   IQueryStringSearchableStore
-  (query-string-search [_ query filtermap ident params]
-    (handle-query-string-search state query filtermap ident params)))
+  (query-string-search [_ search-query ident params]
+    (handle-query-string-search state search-query ident params))
+  (aggregate [_ search-query agg-query ident]
+    (handle-aggregate state search-query agg-query ident)))

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -84,6 +84,20 @@
   (concat judgement-fields
           ["valid_time.start_time,timestamp"]))
 
+(def judgement-enumerable-fields
+  [:disposition
+   :priority
+   :confidence
+   :severity
+   :observable.type
+   :observable.value])
+
+(def judgement-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
+
 (def judgements-by-observable-sort-fields
   (map name (conj judgement-fields
                   "disposition:asc,valid_time.start_time:desc"

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -97,7 +97,6 @@
    :valid_time.start_time
    :valid_time.end_time])
 
-
 (def judgements-by-observable-sort-fields
   (map name (conj judgement-fields
                   "disposition:asc,valid_time.start_time:desc"

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -81,9 +81,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    MalwareFieldsParam
-   {:query s/Str}
    (st/optional-keys
-    {:labels s/Str
+    {:query s/Str
+     :labels s/Str
      :kill_chain_phases.kill_chain_name s/Str
      :kill_chain_phases.phase_name s/Str
      :sort_by malware-sort-fields})))

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -58,11 +58,12 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    RelationshipFieldsParam
-   {:query s/Str
-    (s/optional-key :relationship_type) s/Str
-    (s/optional-key :source_ref) s/Str
-    (s/optional-key :target_ref) s/Str
-    (s/optional-key :sort_by)  relationship-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :relationship_type s/Str
+     :source_ref s/Str
+     :target_ref s/Str
+     :sort_by  relationship-sort-fields})))
 
 (s/defschema RelationshipGetParams RelationshipFieldsParam)
 

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -23,11 +23,12 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    SightingFieldsParam
-   {:query s/Str
-    (s/optional-key :sensor) s/Str
-    (s/optional-key :observables.value) s/Str
-    (s/optional-key :observables.type) s/Str
-    (s/optional-key :sort_by) sighting-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :sensor s/Str
+     :observables.value s/Str
+     :observables.type s/Str
+     :sort_by sighting-sort-fields})))
 
 (s/defschema SightingsByObservableQueryParams
   (st/merge
@@ -59,7 +60,10 @@
     :post-capabilities :create-sighting
     :put-capabilities :create-sighting
     :delete-capabilities :delete-sighting
-    :search-capabilities :search-sighting}))
+    :search-capabilities :search-sighting
+    :can-aggregate? true
+    :histogram-fields ss/sighting-histogram-fields
+    :enumerable-fields ss/sighting-enumerable-fields}))
 
 (def capabilities
   #{:create-sighting

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -55,6 +55,7 @@
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
 (def list-fn (crud/handle-find :sighting ESPartialStoredSighting))
 (def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
+(def handle-aggregate (crud/handle-aggregate :sighting))
 
 (s/defn observable->observable-hash :- s/Str
   "transform an observable to a hash of the form type:value"
@@ -134,9 +135,9 @@
 
 (s/defn handle-query-string-search-sightings
   :- PartialStoredSightingList
-  [state query filter-map ident params]
+  [state search-query ident params]
   (es-paginated-list->paginated-list
-   (handle-query-string-search state query filter-map ident params)))
+   (handle-query-string-search state search-query ident params)))
 
 (s/defn handle-list-by-observables
   :- PartialStoredSightingList
@@ -163,5 +164,7 @@
   (list-sightings-by-observables [_ observables ident params]
     (handle-list-by-observables state observables ident params))
   IQueryStringSearchableStore
-  (query-string-search [_ query filtermap ident params]
-    (handle-query-string-search-sightings state query filtermap ident params)))
+  (query-string-search [_ search-query ident params]
+    (handle-query-string-search-sightings state search-query ident params))
+  (aggregate [_ search-query agg-query ident]
+    (handle-aggregate state search-query agg-query ident)))

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -60,6 +60,16 @@
            :count
            :sensor]))
 
+(def sighting-histogram-fields
+  [:timestamp
+   :observed_time.start_time
+   :observed_time.end_time])
+
+(def sighting-enumerable-fields
+  [:source
+   :sensor
+   :observables.type])
+
 (def sighting-sort-fields
   (conj sighting-fields
         "observed_time.start_time,timestamp"))

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -44,9 +44,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    ToolFieldsParam
-   {:query s/Str}
    (st/optional-keys
-    {:labels s/Str
+    {:query s/Str
+     :labels s/Str
      :kill_chain_phases.kill_chain_name s/Str
      :kill_chain_phases.phase_name s/Str
      :tool_version s/Str

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -69,8 +69,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    VulnerabilityFieldsParam
-   {:query s/Str
-    (s/optional-key :sort_by)  vulnerability-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :sort_by  vulnerability-sort-fields})))
 
 (def VulnerabilityGetParams VulnerabilityFieldsParam)
 

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -84,8 +84,9 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    WeaknessFieldsParam
-   {:query s/Str
-    (s/optional-key :sort_by)  weakness-sort-fields}))
+   (st/optional-keys
+    {:query s/Str
+     :sort_by  weakness-sort-fields})))
 
 (def WeaknessGetParams WeaknessFieldsParam)
 

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [ctia.schemas.sorting :as sorting]
             [ring.swagger.schema :refer [describe]]
+            [clj-momo.lib.clj-time.core :as t]
             [ring.util
              [codec :as codec]
              [http-response :as http-res]
@@ -17,7 +18,18 @@
                      :search_after])
 
 (def filter-map-search-options
-  (conj search-options :query))
+  (conj search-options :query :from :to))
+
+(s/defschema BaseEntityFilterParams
+  {(s/optional-key :id) s/Str
+   (s/optional-key :from) s/Inst
+   (s/optional-key :to) s/Inst
+   (s/optional-key :revision) s/Int
+   (s/optional-key :language) s/Str
+   (s/optional-key :tlp) s/Str})
+
+(s/defschema SourcableEntityFilterParams
+  {(s/optional-key :source) s/Str})
 
 (s/defschema PagingParams
   "A schema defining the accepted paging and sorting related query parameters."
@@ -69,12 +81,35 @@
   [{:keys [id] :as resource}]
   (http-res/created id resource))
 
-(s/defschema BaseEntityFilterParams
-  {(s/optional-key :id) s/Str
-   (s/optional-key :revision) s/Int
-   (s/optional-key :language) s/Str
-   (s/optional-key :tlp) s/Str})
+(defn now [] (java.util.Date.))
 
-(s/defschema SourcableEntityFilterParams
-  {(s/optional-key :source) s/Str})
+(s/defn coerce-from :- s/Inst
+  "coerce from to limit interval querying to one year"
+  [from :- s/Inst
+   to :- (s/maybe s/Inst)]
+  (let [to-or-now (or to (now))
+        to-minus-one-year (t/minus to-or-now (t/years 1))]
+    (t/latest from to-minus-one-year)))
 
+(defn search-query
+  ([date-field search-params]
+   (search-query date-field
+                 search-params
+                 (fn [from to] from)))
+  ([date-field
+    {:keys [query from to] :as search-params}
+    coerce-from-fn]
+   (let [filter-map (apply dissoc search-params filter-map-search-options)]
+     (cond-> {}
+       (seq filter-map) (assoc :filter-map filter-map)
+       query (assoc :query-string query)
+       from (assoc-in [:date-range date-field :gte]
+                      (coerce-from-fn from to))
+       to (assoc-in [:date-range date-field :lt] to)))))
+
+(defn wait_for->refresh
+  [wait_for]
+  (case wait_for
+    true {:refresh "wait_for"}
+    false {:refresh "false"}
+    {}))

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -82,12 +82,14 @@
                                       :fields
                                       :limit
                                       :offset)
-                           {:from s/Inst}) ;; make from mandatory
+                           {:from s/Inst})
         aggregate-on-enumerable {:aggregate-on (apply s/enum (map name enumerable-fields))}
-        aggregate-on-date {:aggregate-on (apply s/enum (map name histogram-fields))}
+        histogram-filters {:aggregate-on (apply s/enum (map name histogram-fields))
+                           :from (describe s/Inst "Start date of the histogram. Filters the value of selected aggregated-on field.")
+                           (s/optional-key :to) (describe s/Inst "End date of the histogram. Filters the value of selected aggregated-on field.")}
         histogram-q-params (st/merge agg-search-schema
                                      HistogramParams
-                                     aggregate-on-date)
+                                     histogram-filters)
         cardinality-q-params (st/merge agg-search-schema
                                        aggregate-on-enumerable)
         topn-q-params (st/merge agg-search-schema

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :refer [capitalize]]
    [ctia.http.middleware.auth]
-   [compojure.api.sweet :refer [DELETE GET POST PUT PATCH routes]]
+   [compojure.api.sweet :refer [context DELETE GET POST PUT PATCH routes]]
    [ctia.domain.entities
     :refer
     [page-with-long-id
@@ -10,28 +10,29 @@
      un-store-page
      with-long-id]]
    [ctia.flows.crud :as flows]
-   [ctia.http.routes.common
-    :refer
-    [created filter-map-search-options paginated-ok search-options]]
+   [ctia.http.routes.common :refer [created
+                                    filter-map-search-options
+                                    paginated-ok
+                                    search-options
+                                    wait_for->refresh
+                                    search-query
+                                    coerce-from]]
    [ctia.store :refer [write-store
                        read-store
-                       query-string-search-store
                        query-string-search
+                       aggregate
                        create-record
                        delete-record
                        read-record
                        update-record
                        list-records]]
+   [ctia.schemas.search-agg :refer [HistogramParams
+                                    CardinalityParams
+                                    TopnParams]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [ring.swagger.schema :refer [describe]]
-   [schema.core :as s]))
-
-(defn wait_for->refresh
-  [wait_for]
-  (case wait_for
-    true {:refresh "wait_for"}
-    false {:refresh "false"}
-    {}))
+   [schema.core :as s]
+   [schema-tools.core :as st]))
 
 (defn entity-crud-routes
   [{:keys [entity
@@ -58,16 +59,41 @@
            can-update?
            can-patch?
            can-search?
-           can-get-by-external-id?]
+           can-aggregate?
+           can-get-by-external-id?
+           date-field
+           histogram-fields
+           enumerable-fields]
     :or {hide-delete? false
          can-post? true
          can-update? true
          can-patch? false
          can-search? true
-         can-get-by-external-id? true}}]
+         can-aggregate? false
+         can-get-by-external-id? true
+         date-field :created
+         histogram-fields [:created]}}]
   (let [entity-str (name entity)
-        capitalized (capitalize entity-str)]
-    (routes
+        capitalized (capitalize entity-str)
+        agg-search-schema (st/merge
+                           (st/dissoc search-q-params
+                                      :sort_by
+                                      :sort_order
+                                      :fields
+                                      :limit
+                                      :offset)
+                           {:from s/Inst}) ;; make from mandatory
+        aggregate-on-enumerable {:aggregate-on (apply s/enum (map name enumerable-fields))}
+        aggregate-on-date {:aggregate-on (apply s/enum (map name histogram-fields))}
+        histogram-q-params (st/merge agg-search-schema
+                                     HistogramParams
+                                     aggregate-on-date)
+        cardinality-q-params (st/merge agg-search-schema
+                                       aggregate-on-enumerable)
+        topn-q-params (st/merge agg-search-schema
+                                TopnParams
+                                aggregate-on-enumerable)]
+        (routes
      (when can-post?
        (POST "/" []
              :return entity-schema
@@ -186,17 +212,60 @@
             :capabilities search-capabilities
             :auth-identity identity
             :identity-map identity-map
-            (-> (query-string-search-store
+            (-> (read-store
                  entity
                  query-string-search
-                 (:query params)
-                 (apply dissoc params filter-map-search-options)
+                 (search-query date-field params)
                  identity-map
                  (select-keys params search-options))
                 page-with-long-id
                 un-store-page
                 paginated-ok)))
-
+     (when can-aggregate?
+       (context "/metric" []
+                :capabilities search-capabilities
+                :auth-identity identity
+                :identity-map identity-map
+                (GET "/histogram" []
+                     :return [{:key s/Str :value s/Int}]
+                     :summary (format "Histogram for a %s field" capitalized)
+                     :query [params histogram-q-params]
+                     (ok (read-store
+                          entity
+                          aggregate
+                          (search-query (keyword
+                                         (:aggregate-on params))
+                                        (st/select-schema params agg-search-schema)
+                                        coerce-from)
+                          (st/assoc (st/select-schema params HistogramParams)
+                                    :agg-type :histogram)
+                          identity-map)))
+                (GET "/topn" []
+                     :return [{:key s/Any :value s/Int}]
+                     :summary (format "Topn for a %s field" capitalized)
+                     :query [params topn-q-params]
+                     (ok (read-store
+                          entity
+                          aggregate
+                          (search-query date-field
+                                        (st/select-schema params agg-search-schema)
+                                        coerce-from)
+                          (st/assoc (st/select-schema params TopnParams)
+                                    :agg-type :topn)
+                          identity-map)))
+                (GET "/cardinality" []
+                     :return s/Int
+                     :summary (format "Cardinality for a %s field" capitalized)
+                     :query [params cardinality-q-params]
+                     (ok (read-store
+                          entity
+                          aggregate
+                          (search-query date-field
+                                        (st/select-schema params agg-search-schema)
+                                        coerce-from)
+                          (st/assoc (st/select-schema params CardinalityParams)
+                                    :agg-type :cardinality)
+                          identity-map)))))
      (GET "/:id" []
           :return (s/maybe get-schema)
           :summary (format "Gets a %s by ID" entity-str)

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -16,7 +16,7 @@
   (into {} (filter second m)))
 
 (s/defn ^:private search-entity :- pagination/Connection
-  "Performs a query-string-search-store operation for a given entity type"
+  "Performs a query-string-search operation for a given entity type"
   [entity-type :- s/Keyword
    query :- s/Str
    filtermap :- {s/Keyword (s/maybe s/Str)}
@@ -31,11 +31,11 @@
                                                 field-selection)))]
     (log/debugf "Search entity %s graphql args %s" entity-type args)
 
-    (some-> (query-string-search-store
+    (some-> (read-store
              entity-type
              query-string-search
-             query
-             (remove-map-empty-values filtermap)
+             {:query-string query
+              :filter-map (remove-map-empty-values filtermap)}
              ident
              params)
             with-long-id-fn

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -3,18 +3,23 @@
             [schema-tools.core :as st]))
 
 (s/defschema DateRange
+  "Date range query, includes lowerfrom and excludes to"
   {s/Keyword
    (st/optional-keys
     {:gte s/Inst
      :lt s/Inst})})
 
 (s/defschema SearchQuery
+  "components of a search query:
+   - query-string: free text search, with lucene syntax enabled"
   (st/optional-keys
    {:query-string s/Str
     :filter-map {s/Keyword s/Any}
     :date-range DateRange}))
 
-(s/defschema AggType (s/enum :histogram :topn :cardinality))
+(s/defschema AggType
+  "supported aggregation types"
+  (s/enum :histogram :topn :cardinality))
 
 (s/defschema AggCommonParams
   (st/merge

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -1,0 +1,62 @@
+(ns ctia.schemas.search-agg
+  (:require [schema.core :as s]
+            [schema-tools.core :as st]))
+
+(s/defschema DateRange
+  {s/Keyword
+   (st/optional-keys
+    {:gte s/Inst
+     :lt s/Inst})})
+
+(s/defschema SearchQuery
+  (st/optional-keys
+   {:query-string s/Str
+    :filter-map {s/Keyword s/Any}
+    :date-range DateRange}))
+
+(s/defschema AggType (s/enum :histogram :topn :cardinality))
+
+(s/defschema AggCommonParams
+  (st/merge
+   {:aggregate-on s/Str}))
+
+(s/defschema Timezone
+  (let [positives (map #(format "+%02d:00" %) (range 12))
+        negatives (map #(format "-%02d:00" %) (range 1 12))]
+    (->> (concat positives negatives)
+         (apply s/enum))))
+
+(s/defschema HistogramParams
+  (st/merge
+   AggCommonParams
+   {:granularity (s/enum :day :week :month)
+    (s/optional-key :timezone) Timezone}))
+
+(s/defschema HistogramQuery
+  (st/merge
+   {:agg-type (s/eq :histogram)}
+   HistogramParams))
+
+(s/defschema TopnParams
+  (st/merge
+   AggCommonParams
+   (st/optional-keys
+    {:limit s/Int
+     :sort_order (s/enum :asc :desc)})))
+
+(s/defschema TopnQuery
+  (st/merge
+   {:agg-type (s/eq :topn)}
+   TopnParams))
+
+(s/defschema CardinalityParams AggCommonParams)
+
+(s/defschema CardinalityQuery
+  (st/merge
+   {:agg-type (s/eq :cardinality)}
+   AggCommonParams))
+
+(s/defschema AggQuery
+  (st/open-schema
+   {:agg-type AggType
+    :aggregate-on s/Str}))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -25,7 +25,8 @@
   (list-events [this filtermap ident params]))
 
 (defprotocol IQueryStringSearchableStore
-  (query-string-search [this query filtermap ident params]))
+  (query-string-search [this search-query ident params])
+  (aggregate [this search-query agg-query ident]))
 
 (def empty-stores
   {:judgement []
@@ -56,9 +57,6 @@
   (first (doall (map #(apply write-fn % args) (store @stores)))))
 
 (defn read-store [store read-fn & args]
-  (apply read-fn (first (get @stores store)) args))
-
-(defn query-string-search-store [store read-fn & args]
   (apply read-fn (first (get @stores store)) args))
 
 (def read-fn read-record)

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -328,7 +328,7 @@ It returns the documents with full hits meta data including the real index in wh
       (cond-> [(find-restriction-query-part ident)]
         (seq filter-map) (into filter-terms)
         (seq date-range) (conj date-range-query)
-        (not-empty query-string) (conj es-query-string))}}))
+        (seq query-string) (conj es-query-string))}}))
 
 (defn handle-query-string-search
   "Generate an ES query handler using some mapping and schema"

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -11,6 +11,11 @@
               allow-read?
               allow-write?]]
             [ctia.lib.pagination :refer [list-response-schema]]
+            [ctia.schemas.search-agg :refer [SearchQuery
+                                             HistogramQuery
+                                             TopnQuery
+                                             CardinalityQuery
+                                             AggQuery]]
             [ctia.stores.es.query :refer [find-restriction-query-part]]
             [ring.swagger.coerce :as sc]
             [schema
@@ -121,7 +126,7 @@ It returns the documents with full hits meta data including the real index in wh
     (s/fn :- (s/maybe [Model])
       [{:keys [props] :as state} :- ESConnState
        models :- [Model]
-       _
+       _ident
        {:keys [refresh]}]
       (try
         (map #(build-create-result % coerce!)
@@ -306,32 +311,107 @@ It returns the documents with full hits meta data including the real index in wh
                                            access-control-filter-list
                                            ident))))))
 
+
+(s/defn make-search-query
+  [{{:keys [default_operator]} :props} :- ESConnState
+   {:keys [query-string filter-map date-range]} :- SearchQuery
+   ident]
+  (let [es-query-string {:query_string (into {:query query-string}
+                                             (when default_operator
+                                               {:default_operator default_operator}))}
+        date-range-query (when date-range
+                           {:range date-range})
+        filter-terms (-> (ensure-document-id-in-map filter-map)
+                         q/prepare-terms)]
+    {:bool
+     {:filter
+      (cond-> [(find-restriction-query-part ident)]
+        (seq filter-map) (into filter-terms)
+        (seq date-range) (conj date-range-query)
+        (not-empty query-string) (conj es-query-string))}}))
+
 (defn handle-query-string-search
-  "Generate an ES query string handler using some mapping and schema"
+  "Generate an ES query handler using some mapping and schema"
   [mapping Model]
   (let [response-schema (list-response-schema Model)
         coerce! (coerce-to-fn response-schema)]
     (s/fn :- response-schema
       [{conn :conn
         index :index
-        {:keys [default_operator]} :props} :- ESConnState
-       query :- s/Str
-       filter-map :- (s/maybe {s/Any s/Any})
+        :as es-conn-state} :- ESConnState
+       {:keys [filter-map] :as search-query} :- SearchQuery
        ident
        params]
-      (let [query_string (into {:query query}
-                               (when default_operator
-                                 {:default_operator default_operator}))]
-        (cond-> (coerce! (d/search-docs conn
-                                        index
-                                        (name mapping)
-                                        {:bool {:must [(find-restriction-query-part ident)
-                                                       {:query_string query_string}]}}
-                                        (ensure-document-id-in-map filter-map)
-                                        (-> params
-                                            rename-sort-fields
-                                            with-default-sort-field
-                                            make-es-read-params)))
+      (let [query (make-search-query es-conn-state search-query ident)]
+        (cond-> (coerce! (d/query conn
+                                  index
+                                  (name mapping)
+                                  query
+                                  (-> params
+                                      rename-sort-fields
+                                      with-default-sort-field
+                                      make-es-read-params)))
           (restricted-read? ident) (update :data
                                            access-control-filter-list
                                            ident))))))
+(s/defn make-histogram
+  [{:keys [aggregate-on granularity timezone]
+    :or {timezone "+00:00"}} :- HistogramQuery]
+  {:date_histogram
+   {:field aggregate-on
+    :interval granularity ;; TODO switch to calendar_interval with ES7
+    :time_zone timezone}})
+
+(s/defn make-topn
+  [{:keys [aggregate-on limit sort_order]
+    :or {limit 10 sort_order :desc}} :- TopnQuery]
+  {:terms
+   {:field aggregate-on
+    :size limit
+    :order {:_count sort_order}}})
+
+(s/defn make-cardinality
+  [{:keys [aggregate-on]} :- CardinalityQuery]
+  {:cardinality {:field aggregate-on
+                 :precision_threshold 10000}})
+
+(s/defn make-aggregation
+  [{:keys [agg-type] :as agg-query} :- AggQuery]
+  (let [agg-fn
+        (case agg-type
+              :topn make-topn
+              :cardinality make-cardinality
+              :histogram make-histogram
+              (throw (ex-info "invalid aggregation type" agg-type)))]
+    {:metric (agg-fn agg-query)}))
+
+(defn format-agg-result
+  [agg-type
+   {:keys [value buckets] :as _metric-res}]
+  (case agg-type
+    :cardinality value
+    :topn (map #(array-map :key (:key %)
+                           :value (:doc_count %))
+               buckets)
+    :histogram (map #(array-map :key (:key_as_string %)
+                                :value (:doc_count %))
+                    buckets)))
+
+(defn handle-aggregate
+  "Generate an ES aggregation handler using some mapping and schema"
+  [mapping]
+  (s/fn :- s/Any
+    [{:keys [conn index] :as es-conn-state} :- ESConnState
+     {:keys [filter-map] :as search-query} :- SearchQuery
+     {:keys [agg-type] :as agg-query} :- AggQuery
+     ident]
+    (let [query (make-search-query es-conn-state search-query ident)
+          agg (make-aggregation agg-query)
+          es-res (d/query conn
+                          index
+                          (name mapping)
+                          query
+                          agg
+                          {:limit 0})]
+      (format-agg-result agg-type
+                         (get-in es-res [:aggs :metric])))))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -20,19 +20,27 @@
   `(defrecord ~store-name [~(symbol "state")]
      IStore
      (~(symbol "read-record") [_# id# ident# params#]
-      ((crud/handle-read ~entity ~partial-stored-schema) ~(symbol "state")  id# ident# params#))
+      ((crud/handle-read ~entity ~partial-stored-schema)
+       ~(symbol "state")  id# ident# params#))
      (~(symbol "create-record") [_# new-actors# ident# params#]
-      ((crud/handle-create ~entity ~stored-schema) ~(symbol "state") new-actors# ident# params#))
+      ((crud/handle-create ~entity ~stored-schema)
+       ~(symbol "state") new-actors# ident# params#))
      (~(symbol "update-record") [_# id# actor# ident# params#]
-      ((crud/handle-update ~entity ~stored-schema) ~(symbol "state") id# actor# ident# params#))
+      ((crud/handle-update ~entity ~stored-schema)
+       ~(symbol "state") id# actor# ident# params#))
      (~(symbol "delete-record") [_# id# ident# params#]
-      ((crud/handle-delete ~entity ~stored-schema) ~(symbol "state") id# ident# params#))
+      ((crud/handle-delete ~entity ~stored-schema)
+       ~(symbol "state") id# ident# params#))
      (~(symbol "list-records") [_# filter-map# ident# params#]
-      ((crud/handle-find ~entity ~partial-stored-schema) ~(symbol "state") filter-map# ident# params#))
+      ((crud/handle-find ~entity ~partial-stored-schema)
+       ~(symbol "state") filter-map# ident# params#))
      IQueryStringSearchableStore
-     (~(symbol "query-string-search") [_# query# filtermap# ident# params#]
-      ((crud/handle-query-string-search ~entity
-                                        ~partial-stored-schema) ~(symbol "state") query# filtermap# ident# params#))))
+     (~(symbol "query-string-search") [_# search-query# ident# params#]
+      ((crud/handle-query-string-search ~entity ~partial-stored-schema)
+       ~(symbol "state") search-query# ident# params#))
+     (~(symbol "aggregate") [_# search-query# agg-query# ident#]
+      ((crud/handle-aggregate ~entity)
+       ~(symbol "state") search-query# agg-query# ident#))))
 
 (s/defschema StoreMap
   {:conn ESConn

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -5,17 +5,18 @@
              [core :as t]]
             [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
-            [ctia.entity.incident :refer [incident-fields]]
+            [ctia.entity.incident :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [patch post post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.incidents
              :refer
              [new-incident-maximal new-incident-minimal]]))
@@ -77,17 +78,33 @@
            (is (= (get-in updated-incident [:incident_time :remediated])
                   (tc/to-date fixed-now)))))))))
 
-(deftest test-incident-routes
+(deftest test-incident-crud-routes
   (test-for-each-store
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (entity-crud-test
-      {:entity "incident"
-       :patch-tests? true
-       :example new-incident-maximal
-       :headers {:Authorization "45c1f5e3f05d0"}
-       :additional-tests partial-operations-tests}))))
+     (let [parameters {:entity "incident"
+                       :plural "incidents"
+                       :enumerable-fields sut/incident-enumerable-fields
+                       :date-fields sut/incident-histogram-fields
+                       :schema sut/NewIncident
+                       :patch-tests? true
+                       :example new-incident-maximal
+                       :headers {:Authorization "45c1f5e3f05d0"}
+                       :additional-tests partial-operations-tests}]
+       (entity-crud-test parameters)))))
+
+(deftest test-incident-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
+     (test-metric-routes {:entity :incident
+                          :plural :incidents
+                          :entity-minimal new-incident-minimal
+                          :enumerable-fields sut/incident-enumerable-fields
+                          :date-fields sut/incident-histogram-fields
+                          :schema sut/NewIncident}))))
 
 (deftest test-incident-pagination-field-selection
   (test-for-each-store
@@ -105,13 +122,13 @@
        (pagination-test
         "ctia/incident/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        incident-fields)
+        sut/incident-fields)
 
        (field-selection-tests
         ["ctia/incident/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        incident-fields)))))
+        sut/incident-fields)))))
 
 (deftest test-incident-routes-access-control
   (test-for-each-store

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -1,0 +1,80 @@
+(ns ctia.http.routes.common-test
+  (:require [ctia.http.routes.common :as sut]
+            [clj-momo.lib.clj-time.coerce :as tc]
+            [clj-momo.lib.clj-time.core :as t]
+            [clojure.test :refer [is deftest]]))
+
+(deftest coerce-from
+  (with-redefs [sut/now (constantly (tc/from-string "2020-12-31"))]
+    (let [from (tc/from-string "2020-04-01")
+          to (tc/from-string "2020-06-01")]
+      (is (= (tc/from-string "2019-12-31")
+             (sut/coerce-from (tc/from-string "2019-12-30") nil)))
+      (is (= (tc/from-string "2019-06-01")
+             (sut/coerce-from (tc/from-string "2019-06-1") to)))
+      (is (= from
+             (sut/coerce-from from nil)))
+      (is (= from
+             (sut/coerce-from from to))))))
+
+(deftest search-query-test
+  (with-redefs [sut/now (constantly (tc/from-string "2020-12-31"))]
+    (let [from (tc/from-string "2020-04-01")
+          to (tc/from-string "2020-06-01")]
+      (is (= {:query-string "bad-domain"}
+             (sut/search-query :created {:query "bad-domain"})))
+      (is (= {:date-range {:created
+                           {:gte from
+                            :lt to}}}
+             (sut/search-query :created {:from from
+                                         :to to})))
+
+      (is (= {:date-range {:timestamp
+                           {:gte from
+                            :lt to}}}
+             (sut/search-query :timestamp {:from from
+                                           :to to})))
+      (is (= {:date-range {:created
+                           {:lt to}}}
+             (sut/search-query :created {:to to})))
+      (is (= {:date-range {:created
+                           {:gte from}}}
+             (sut/search-query :created {:from from})))
+      (is (= {:filter-map {:title "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:title "firefox exploit"
+                                         :disposition 2})))
+      (is (= {:query-string "bad-domain"
+              :filter-map {:title "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:query "bad-domain"
+                                         :disposition 2
+                                         :title "firefox exploit"})))
+      (is (= {:query-string "bad-domain"
+              :filter-map {:title "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:query "bad-domain"
+                                         :disposition 2
+                                         :title "firefox exploit"
+                                         :fields ["title"]
+                                         :sort_by "disposition"
+                                         :sort_order :desc})))
+      (is (= {:query-string "bad-domain"
+              :date-range {:created
+                           {:gte from
+                            :lt to}}
+              :filter-map {:title "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:query "bad-domain"
+                                         :from from
+                                         :to to
+                                         :disposition 2
+                                         :title "firefox exploit"
+                                         :fields ["title"]
+                                         :sort_by "disposition"
+                                         :sort_order :desc}))))))
+
+(deftest wait_for->refresh-test
+  (is (= {:refresh "wait_for"} (sut/wait_for->refresh true)))
+  (is (= {:refresh "false"} (sut/wait_for->refresh false)))
+  (is (= {} (sut/wait_for->refresh nil))))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -329,6 +329,7 @@
                    (search-fn es-conn-state q ident params))]
 
       (testing "Properly handle different search query options"
+        (assert (pos? (count high-t1-title1)))
         (is (= (count (concat high-t1-title1
                               medium-t1-title1))
                (count (:data (search {:query-string query-string}
@@ -337,12 +338,10 @@
                               medium-t1-title1))
                (count (:data (search {:date-range date-range}
                                      {})))))
-
         (is (= (count (concat high-t1-title1
                               high-t2-title2))
                (count (:data (search {:filter-map filter-map}
                                      {})))))
-
         (is (= (count high-t1-title1)
                (count (:data (search {:query-string query-string
                                       :date-range date-range
@@ -353,6 +352,8 @@
                                     {:limit 2})
               search-page-1 (search {:query-string query-string}
                                     (get-in search-page-0 [:paging :next]))]
+          (assert (some? (:data search-page-0)))
+          (assert (some? (:data search-page-1)))
           (is (= (count (concat high-t1-title1
                                 medium-t1-title1))
                  (get-in search-page-0 [:paging :total-hits])))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -1,10 +1,14 @@
 (ns ctia.stores.es.crud-test
   (:require [clojure.test :as t :refer [is are testing deftest use-fixtures join-fixtures]]
             [schema.core :as s]
+            [ctia.flows.crud :refer [gen-random-uuid]]
             [clj-momo.lib.es.index :as es-index]
+            [clj-momo.lib.es.conn :as es-conn]
+            [ctia.stores.es.query :refer [find-restriction-query-part]]
             [ctia.stores.es.crud :as sut]
             [ctia.stores.es.init :as init]
             [ctia.task.rollover :refer [rollover-store]]
+            [ctim.examples.sightings :refer [sighting-minimal]]
             [ctia.test-helpers
              [core :as helpers]
              [es :as es-helpers]]))
@@ -81,23 +85,33 @@
 (def update-fn (sut/handle-update :sighting s/Any))
 (def read-fn (sut/handle-read :sighting s/Any))
 (def delete-fn (sut/handle-delete :sighting s/Any))
-(def ident {:groups ["group1"]})
-(def base-sighting {:title "a sighting"
+(def search-fn (sut/handle-query-string-search :sighting s/Any))
+(def aggregate-fn (sut/handle-aggregate :sighting))
+
+(def ident {:login "johndoe"
+            :groups ["group1"]})
+(def base-sighting {:title "a sighting text title"
                     :tlp "green"
                     :groups ["group1"]})
+(def props-aliased {:entity :sighting
+                    :indexname "ctia_sighting"
+                    :host "localhost"
+                    :port 9200
+                    :aliased true
+                    :rollover {:max_docs 3}
+                    :refresh "true"})
+
+(def props-not-aliased {:entity :sighting
+                        :indexname "ctia_sighting"
+                        :host "localhost"
+                        :port 9200
+                        :refresh "true"})
 
 (deftest crud-aliased-test
-  (let [props-aliased {:entity :sighting
-                       :indexname "ctia_sighting"
-                       :host "localhost"
-                       :port 9200
-                       :aliased true
-                       :rollover {:max_docs 3}
-                       :refresh "true"}
-        state-aliased (init/init-es-conn! props-aliased)
+  (let [state-aliased (init/init-es-conn! props-aliased)
         count-index #(count (es-index/get (:conn state-aliased)
                                           (str (:index state-aliased) "*")))
-        base-sighting {:title "a sighting"
+        base-sighting {:title "a sighting text title"
                        :tlp "green"
                        :groups ["group1"]}]
 
@@ -162,15 +176,8 @@
                             ident
                             {}))))))
 
-
 (deftest crud-unaliased-test
-  (let [props-not-aliased {:entity :sighting
-                           :indexname "ctia_sighting"
-                           :host "localhost"
-                           :port 9200
-                           :refresh "true"}
-        state-not-aliased (init/init-es-conn! props-not-aliased)]
-
+  (let [state-not-aliased (init/init-es-conn! props-not-aliased)]
     (testing "crud operation should properly handle not aliased states"
       (create-fn state-not-aliased
                  (map #(assoc base-sighting
@@ -192,3 +199,238 @@
                             "sighting-1"
                             ident
                             {}))))))
+
+(deftest make-search-query-test
+  (let [es-conn-state (-> (init/init-es-conn! props-not-aliased)
+                          (update :props assoc :default_operator "AND"))
+        simple-access-ctrl-query {:terms {"groups" (:groups ident)}}]
+    (with-redefs [find-restriction-query-part (constantly simple-access-ctrl-query)]
+      (let [query-string "*"
+            es-query-string-AND {:query_string {:query query-string
+                                                :default_operator "AND"}}
+            es-query-string-no-op {:query_string {:query query-string}}
+            date-range {:created {:gte "2020-04-01T00:00:00.000Z"
+                                  :lt "2020-05-01T00:00:00.000Z"}}
+            es-date-range {:range date-range}
+            filter-map {"disposition" 2
+                        "observable.type" "domain"}
+            es-terms [{:terms {"disposition" (list 2)}}
+                      {:terms {"observable.type" (list "domain")}}]]
+        (is (= {:bool {:filter [simple-access-ctrl-query]}}
+               (sut/make-search-query es-conn-state
+                                      {}
+                                      ident)))
+        (is (= {:bool {:filter [simple-access-ctrl-query
+                                es-query-string-AND]}}
+               (sut/make-search-query es-conn-state
+                                      {:query-string query-string}
+                                      ident)))
+        (is (= {:bool {:filter [simple-access-ctrl-query
+                                es-query-string-no-op]}}
+               (sut/make-search-query (update es-conn-state :props dissoc :default_operator)
+                                      {:query-string query-string}
+                                      ident)))
+        (is (= {:bool {:filter [simple-access-ctrl-query
+                                es-date-range]}}
+               (sut/make-search-query es-conn-state
+                                      {:date-range date-range}
+                                      ident)))
+        (is (= {:bool {:filter (into
+                                [simple-access-ctrl-query]
+                                es-terms)}}
+               (sut/make-search-query es-conn-state
+                                      {:filter-map filter-map}
+                                      ident)))
+        (is (= {:bool {:filter (-> [simple-access-ctrl-query]
+                                   (into es-terms)
+                                   (into [es-date-range es-query-string-AND]))}}
+               (sut/make-search-query es-conn-state
+                                      {:query-string query-string
+                                       :date-range date-range
+                                       :filter-map filter-map}
+                                      ident)))))))
+
+(deftest make-aggregation-test
+  (is (= {:metric
+          {:date_histogram
+           {:field "the-date"
+            :interval :week
+            :time_zone "+02:00"}}}
+         (sut/make-aggregation {:agg-type :histogram
+                                :aggregate-on "the-date"
+                                :granularity :week
+                                :timezone "+02:00"})))
+  (is (= {:metric
+          {:terms
+           {:field "disposition"
+            :size 20
+            :order {:_count :desc}}}}
+         (sut/make-aggregation {:agg-type :topn
+                                :aggregate-on "disposition"
+                                :limit 20
+                                :sort_order :desc})))
+  (is (= {:metric
+          {:cardinality
+           {:field "observable.value"
+            :precision_threshold 10000}}}
+         (sut/make-aggregation {:agg-type :cardinality
+                                :aggregate-on "observable.value"}))))
+
+(defn generete-sightings
+  [nb confidence title timestamp]
+  (repeatedly nb
+              #(assoc base-sighting
+                      :id (gen-random-uuid)
+                      :confidence confidence
+                      :created timestamp
+                      :title title)))
+
+(def timestamp-1 "2020-04-01T00:00:00.000Z")
+(def timestamp-2 "2020-05-01T00:00:00.000Z")
+(def title1 "this is title1 sighting")
+(def title2 "this is title2 sighting")
+
+(def high-t1-title1 (generete-sightings 60
+                                        "High"
+                                        title1
+                                        timestamp-1))
+(def high-t2-title2 (generete-sightings 20
+                                        "High"
+                                        title2
+                                        timestamp-2))
+(def medium-t1-title1 (generete-sightings 10
+                                          "Medium"
+                                          title1
+                                          timestamp-1))
+(def low-t2-title2 (generete-sightings 5
+                                       "Low"
+                                       title2
+                                       timestamp-2))
+
+(def search-metrics-entities
+  (concat high-t1-title1
+          high-t2-title2
+          medium-t1-title1
+          low-t2-title2))
+
+(deftest handle-query-string-search-test
+  (testing "handle search shall properly apply query and params"
+    (let [es-conn-state (-> (init/init-es-conn! props-not-aliased)
+                            (update :props assoc :default_operator "AND"))
+          _ (create-fn es-conn-state
+                       search-metrics-entities
+                       ident
+                       {:refresh "true"})
+          query-string "title1"
+          date-range {:created {:gte timestamp-1
+                                :lt timestamp-2}}
+          filter-map {:confidence "High"}
+          search (fn [q params]
+                   (search-fn es-conn-state q ident params))]
+
+      (testing "Properly handle different search query options"
+        (is (= (count (concat high-t1-title1
+                              medium-t1-title1))
+               (count (:data (search {:query-string query-string}
+                                     {})))))
+        (is (= (count (concat high-t1-title1
+                              medium-t1-title1))
+               (count (:data (search {:date-range date-range}
+                                     {})))))
+
+        (is (= (count (concat high-t1-title1
+                              high-t2-title2))
+               (count (:data (search {:filter-map filter-map}
+                                     {})))))
+
+        (is (= (count high-t1-title1)
+               (count (:data (search {:query-string query-string
+                                      :date-range date-range
+                                      :filter-map filter-map}
+                                     {}))))))
+      (testing "Properly handle search params"
+        (let [search-page-0 (search {:query-string query-string}
+                                    {:limit 2})
+              search-page-1 (search {:query-string query-string}
+                                    (get-in search-page-0 [:paging :next]))]
+          (is (= (count (concat high-t1-title1
+                                medium-t1-title1))
+                 (get-in search-page-0 [:paging :total-hits])))
+          (is (= 2 (count (:data search-page-0))))
+          (is (not= (:data search-page-0)
+                    (:data search-page-1))))))))
+
+(deftest handle-aggregate-test
+  (testing "handle-aggregate"
+    (let [es-conn-state (-> (init/init-es-conn! props-not-aliased)
+                            (update :props assoc :default_operator "AND"))
+          _ (create-fn es-conn-state
+                       search-metrics-entities
+                       ident
+                       {:refresh "true"})
+          aggregate (fn [search-query agg-query]
+                      (aggregate-fn es-conn-state search-query agg-query ident))]
+
+      (testing "cardinality"
+        (is (= 3 (aggregate {:query-string "*"}
+                            {:agg-type :cardinality
+                             :aggregate-on "confidence"})))
+        (is (= 2 (aggregate {:query-string "confidence:(high OR medium)"}
+                            {:agg-type :cardinality
+                             :aggregate-on "confidence"}))
+            "query filters should be properly applied"))
+      (testing "histogram"
+        (is (= [{:key  "2020-03-01T00:00:00.000-01:00" :value 70}
+                {:key  "2020-04-01T00:00:00.000-01:00" :value 25}]
+               (aggregate {:query-string "*"}
+                          {:agg-type :histogram
+                           :aggregate-on "created"
+                           :granularity :month
+                           :timezone "-01:00"})))
+        (is (= [{:key timestamp-1 :value 60}
+                {:key timestamp-2 :value 20}]
+               (aggregate {:query-string "confidence:high"}
+                          {:agg-type :histogram
+                           :aggregate-on "created"
+                           :granularity :month
+                           :timezone "+00:00"}))
+               "query filters should be properly applied")
+        (is (= [{:key  "2020-04-01T00:00:00.000Z" :value 70}
+                {:key  "2020-05-01T00:00:00.000Z" :value 25}]
+               (aggregate {:query-string "*"}
+                          {:agg-type :histogram
+                           :aggregate-on "created"
+                           :granularity :month})
+               (aggregate {:query-string "*"}
+                          {:agg-type :histogram
+                           :aggregate-on "created"
+                           :granularity :month
+                           :timezone "+00:00"}))
+            "default timezone is UTC"))
+      (testing "topn"
+        (is (= [{:key "low":value 5}
+                {:key "medium" :value 10}]
+               (aggregate {:query-string "*"}
+                          {:agg-type :topn
+                           :aggregate-on "confidence"
+                           :limit 2
+                           :sort_order :asc})))
+        (is (= [{:key "high" :value 80}
+                {:key "medium" :value 10}
+                {:key "low":value 5}]
+               (aggregate {:query-string "*"}
+                          {:agg-type :topn
+                           :aggregate-on "confidence"})
+               (aggregate {:query-string "*"}
+                          {:agg-type :topn
+                           :aggregate-on "confidence"
+                           :limit 10
+                           :sort_order :desc}))
+            "default limit is 10, default sort_order is desc")
+        (is (= [{:key "high" :value 80}
+                {:key "low" :value 5}])
+            (aggregate {:query-string "confidence:(high OR low)"}
+                       {:agg-type :topn
+                        :aggregate-on "confidence"
+                        :limit 10
+                        :sort_order :desc}))))))

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -1,0 +1,172 @@
+(ns ctia.test-helpers.aggregate
+  (:require [clj-http.client :as client]
+            [clj-momo.lib.clj-time.core :as time]
+            [clj-momo.lib.clj-time.coerce :as tc]
+            [clj-momo.lib.clj-time.format :as tf]
+            [ctia.test-helpers.core :as hc]
+            [clojure.string :as string]
+            [schema-generators.generators :as g]
+            [ctia.http.routes.common :refer [now]]
+            [schema-tools.core :as st]
+            [ctia.test-helpers.fixtures :refer [n-examples]]
+            [clojure.walk :refer [keywordize-keys]]
+            [clojure.test :refer [deftest is testing]]))
+
+(defn metric-raw
+  [agg-type entity search-params agg-params]
+  (let [metric-uri (format "ctia/%s/metric/%s"
+                           (name entity)
+                           (name agg-type))]
+    (-> (hc/get metric-uri
+                :accept :json
+                :headers {"Authorization" "45c1f5e3f05d0"}
+                :query-params (into search-params agg-params))
+        :parsed-body
+        keywordize-keys)))
+
+(def cardinality (partial metric-raw :cardinality))
+(def histogram (partial metric-raw :histogram))
+(def topn (partial metric-raw :topn))
+
+(defn parse-field
+  [field]
+  (map keyword
+       (string/split (name field) #"\.")))
+
+(defn flatten-list-values
+  [values]
+  (apply concat
+         (map set values)))
+
+(defn- get-values
+  [examples field]
+  (let [parsed (parse-field field)]
+    (keep #(get-in % parsed) examples)))
+
+(defn- normalized-values
+  [examples field]
+  (let [values (get-values examples field)
+        flattened (cond-> values
+                    (vector? (first values)) flatten-list-values)]
+    (map string/lower-case flattened)))
+
+(defn- test-cardinality
+  "test one field cardinality, examples are already created."
+  [examples entity field]
+  (testing (format "cardinality %s %s" entity field)
+    (let [expected (-> (normalized-values examples field)
+                       set
+                       count)]
+      (is (= expected (cardinality entity
+                                   {:query "*"
+                                    :from "2020-01-01"}
+                                   {:aggregate-on (name field)}))))))
+
+(defn- test-topn
+  "test one field topn, examples are already created."
+  [examples entity field limit]
+  (testing (format "topn %s %s" entity field)
+    (let [expected (->> (normalized-values examples field)
+                        frequencies
+                        (sort-by val)
+                        reverse
+                        (take limit)
+                        vals)
+          res (topn entity
+                    {:from "2020-01-01"}
+                    {:aggregate-on (name field)
+                     :limit limit})]
+      (is (= expected (map :value res))))))
+
+(defn- to-granularity-first-day
+  [granularity date]
+  (let [first-day (cond-> date
+                    (= :month granularity) time/first-day-of-the-month)]
+    (time/date-time (time/year first-day)
+                    (time/month first-day)
+                    (time/day first-day))))
+
+(defn- make-histogram-res
+  [dates]
+  (->> (frequencies dates)
+       (sort-by key)
+       (map (fn [[k v]]
+              {:key (str k) :value v}))))
+
+(defn- test-histogram
+  "test one field histogram, examples are already created"
+  [examples entity field granularity]
+  (testing (format "histogram %s %s" entity field)
+    (let [parsed (parse-field field)
+          values (keep #(get-in % parsed) examples)
+          from-str "2020-03-01T00:00:00.000Z"
+          to-str "2020-10-01T00:00:00.000Z"
+          from (tf/parse from-str)
+          to (tf/parse to-str)
+          date-values (filter #(and (time/within? from to %)
+                                    (time/before? % to))
+                              (map tf/parse values))
+          res-days (map #(to-granularity-first-day granularity %)
+                        date-values)
+          expected (make-histogram-res res-days)]
+      (is (= expected
+             (filter #(pos? (:value %))
+                     (histogram entity
+                                {:from from-str
+                                 :to to-str}
+                                {:aggregate-on (name field)
+                                 :granularity (name granularity)})))))))
+
+(defn schema-enumerable-fields
+  [schema fields]
+  (->> (st/select-keys schema fields)
+       st/required-keys))
+
+(defn generate-date
+  []
+  (format "2020-%02d-%02dT%02d:00:00.000Z"
+          (inc (rand-int 11))
+          (inc (rand-int 28))
+          (rand-int 24)))
+
+(defn append-date-field
+  [doc field]
+  (let [prepared (parse-field field)]
+    (assoc-in doc prepared (generate-date))))
+
+(defn generate-date-fields
+  [fields]
+  (reduce append-date-field
+          {}
+          fields))
+
+(defn generate-n-entity
+  [{:keys [schema
+           entity-minimal
+           enumerable-fields
+           date-fields]}
+   n]
+  (let [enumerable-schema (schema-enumerable-fields schema enumerable-fields)
+        base-doc (dissoc entity-minimal :id)]
+    (doall
+     (repeatedly n (fn [] (merge base-doc
+                                 (g/generate enumerable-schema)
+                                 (generate-date-fields date-fields)))))))
+
+(defn test-metric-routes
+  [{:keys [entity
+           plural
+           enumerable-fields
+           date-fields] :as metric-params}]
+  (let [docs (generate-n-entity metric-params 10)]
+    (with-redefs [;; ensure from coercion in proper one year range
+                  now (-> (tc/from-string "2020-12-31")
+                          tc/to-date
+                          constantly)]
+      (hc/post-bulk {plural docs})
+      (doseq [field enumerable-fields]
+        (test-cardinality docs entity field)
+        (test-topn docs entity field 3))
+      (doseq [field date-fields]
+        (test-histogram docs entity field :day)
+        (test-histogram docs entity field :month)))))

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -5,6 +5,7 @@
             [clojure.tools.logging :refer [log*]]
             [ctim.domain.id :refer [long-id->id]]
             [ctia.properties :refer [properties]]
+            [clj-momo.lib.clj-time.coerce :as tc]
             [ctia.test-helpers.core :as helpers :refer [get post delete]]))
 
 (defn unique-word
@@ -14,28 +15,38 @@
       (str/replace "-" "")
       (->> (str base-word))))
 
-(defn search
-  ([search-uri query] (search search-uri
-                              query
-                              {"Authorization" "45c1f5e3f05d0"}))
-  ([search-uri query headers]
-   (get search-uri
-        :headers headers
-        :query-params {:query query})))
+(defn create-doc
+  [entity doc]
+  (post (str "ctia/" (name entity))
+        :body doc
+        :headers {"Authorization" "45c1f5e3f05d0"}))
+
+(defn delete-doc
+  [entity full-id]
+  (let [short-id (:short-id (long-id->id full-id))]
+    (delete (format "ctia/%s/%s" (name entity) short-id)
+            :headers {"Authorization" "45c1f5e3f05d0"})))
+
+(defn search-raw
+  [entity query-params]
+  (let [search-uri (format "ctia/%s/search" (name entity))]
+    (get search-uri
+         :headers {"Authorization" "45c1f5e3f05d0"}
+         :query-params query-params)))
+
+(defn search-text
+  [entity text]
+  (search-raw entity {:query text}))
 
 (defn search-ids
-  ([search-uri query] (search-ids search-uri
-                                  query
-                                  {"Authorization" "45c1f5e3f05d0"}))
-  ([search-uri query headers]
-   (->> (search search-uri query headers)
-        :parsed-body
-        (map :id)
-        set)))
+  [entity query]
+  (->> (search-text entity query)
+       :parsed-body
+       (map :id)
+       set))
 
 (defn test-describable-search [entity example]
   (let [;; generate matched and unmatched terms / entities
-        search-uri (format "ctia/%s/search" entity)
         capital-word (unique-word "CAPITAL")
         base-possessive-word "possessive"
         possessive-word (str base-possessive-word "'s")
@@ -58,16 +69,12 @@
                                     :description unmatched-text)
                              (dissoc :id))
         ;; 3 matched entities
-        matched-ids (->> #(post (str "ctia/" entity)
-                                :body matched-entity
-                                :headers {"Authorization" "45c1f5e3f05d0"})
+        matched-ids (->> #(create-doc entity matched-entity)
                          (repeatedly 3)
                          (map (comp :id :parsed-body))
                          set)
         ;; 2 unmatched entities
-        unmatched-ids (->> #(post (str "ctia/" entity)
-                                  :body unmatched-entity
-                                  :headers {"Authorization" "45c1f5e3f05d0"})
+        unmatched-ids (->> #(create-doc entity unmatched-entity)
                            (repeatedly 2)
                            (map (comp :id :parsed-body))
                            set)
@@ -76,27 +83,27 @@
                              "AND")]
 
     (if (= "AND" default_operator)
-      (is (empty? (search-ids search-uri (format "%s %s"
+      (is (empty? (search-ids entity (format "%s %s"
                                                  "word"
                                                  (unique-word "unmatched"))))
           (format "AND is default_operator for %s, it must match all words!"
                   entity))
-      (is (seq (search-ids search-uri (format "%s %s"
+      (is (seq (search-ids entity (format "%s %s"
                                               "word"
                                               (unique-word "unmatched"))))
           (format "OR is default_operator for %s, it must match all words!"
                   entity)))
 
     (testing "all field should match simple query"
-      (let [{:keys [status parsed-body]} (is (search search-uri "word"))]
+      (let [{:keys [status parsed-body]} (is (search-text entity "word"))]
         (is (= 200 status))
         (is matched-ids (map :_id parsed-body))))
 
     (testing "lowercase filter should be properly applied on describable fields"
-      (let [all-upper-ids (search-ids search-uri capital-word)
-            all-lower-ids (search-ids search-uri (str/lower-case capital-word))
-            description-upper-ids (search-ids search-uri (format "description:(%s)" capital-word))
-            description-lower-ids (search-ids search-uri (format "description:(%s)" capital-word))]
+      (let [all-upper-ids (search-ids entity capital-word)
+            all-lower-ids (search-ids entity (str/lower-case capital-word))
+            description-upper-ids (search-ids entity (format "description:(%s)" capital-word))
+            description-lower-ids (search-ids entity (format "description:(%s)" capital-word))]
         (is (= matched-ids
                all-upper-ids
                all-lower-ids
@@ -104,23 +111,23 @@
                description-lower-ids))))
 
     (testing "plural/single analysis should be properly applied on describable fields"
-      (is (= matched-ids (search-ids search-uri "word words wordS")))
-      (is (= matched-ids (search-ids search-uri "country countries countri")))
-      (is (empty? (search-ids search-uri "we")))
-      (is (empty? (search-ids search-uri "wor"))))
+      (is (= matched-ids (search-ids entity "word words wordS")))
+      (is (= matched-ids (search-ids entity "country countries countri")))
+      (is (empty? (search-ids entity "we")))
+      (is (empty? (search-ids entity "wor"))))
 
     ;; test stop word filtering
-    (is (= matched-ids (search-ids search-uri "the word"))
+    (is (= matched-ids (search-ids entity "the word"))
         "\"the\" is not in text but should be filtered out from query as a stop word")
-    (is (empty? (search-ids search-uri "description:\"property that attack\""))
+    (is (empty? (search-ids entity "description:\"property that attack\""))
         "search_quote analyzer in describabble fields shall preserve stop words")
-    (is (empty? (search-ids search-uri "\"property attack\""))
+    (is (empty? (search-ids entity "\"property attack\""))
         "filtering out stop words preserves tokens positions, thus \"property\" that does not precede \"attack\" with distance 1 as expected in query \"property attack\"")
     ;; test possessive filtering
-    (let [all-ids-1 (search-ids search-uri possessive-word)
-          all-ids-2 (search-ids search-uri base-possessive-word)
-          description-ids-1 (search-ids search-uri (format "description:(%s)" possessive-word))
-          description-ids-2 (search-ids search-uri (format "description:(%s)" base-possessive-word))]
+    (let [all-ids-1 (search-ids entity possessive-word)
+          all-ids-2 (search-ids entity base-possessive-word)
+          description-ids-1 (search-ids entity (format "description:(%s)" possessive-word))
+          description-ids-2 (search-ids entity (format "description:(%s)" base-possessive-word))]
       (is (= matched-ids
              all-ids-1
              all-ids-2
@@ -129,20 +136,20 @@
           "possessive filter should be properly applied on describable fields")
 
       (is (= matched-ids
-             (search-ids search-uri (str possessive-word " words")))
+             (search-ids entity (str possessive-word " words")))
           "possessive filter should be applied before stop word filter to remove s"))
 
     ;; test search on url
     (let [escaped-url (-> (str/replace url-word "/" "\\/")
                           (str/replace ":" "\\:"))
-          found-ids-escaped (search-ids search-uri escaped-url)]
+          found-ids-escaped (search-ids entity escaped-url)]
 
       (with-redefs [log* (fn [& _] nil)]
-        (is (= 400 (:status (search search-uri url-word)))
+        (is (= 400 (:status (search-text entity url-word)))
             "the following characters are reserved in lucene queries [+ - = && || > < ! ( ) { } [ ] ^ \" ~ * ? : \\ /], thus queries that do not escape them should fail"))
 
       (is (= matched-ids
-             (search-ids search-uri (format "\"%s\"" url-word)))
+             (search-ids entity (format "\"%s\"" url-word)))
           "surrounding with parenthesis should avoid parsing errors and forces to have all words in exact order without interleaved word")
       (if (= "AND" default_operator)
         (is (= matched-ids found-ids-escaped)
@@ -152,89 +159,129 @@
             ;; OR could match other test documents matching "http"
             "escaping reserved characters should avoid parsing errors and preserve behavior of OR"))
       (is (= matched-ids
-             (search-ids search-uri (str "description:" domain-word)))
+             (search-ids entity (str "description:" domain-word)))
           "tokenization of :description field should split urls on characters like \\/ \\: and thus enables search on url components")
       (is (= matched-ids
-             (search-ids search-uri (str "description:" base-domain))
-             (search-ids search-uri base-domain))
+             (search-ids entity (str "description:" base-domain))
+             (search-ids entity base-domain))
           "word delimiter filtering of :description should split tokens on \\. and thus enables search on domain components"))
 
     ;; test number fitering
     (is (= matched-ids
-           (search-ids search-uri "description:127.0.0.1")
-           (search-ids search-uri "127.0.0.1"))
+           (search-ids entity "description:127.0.0.1")
+           (search-ids entity "127.0.0.1"))
         "word delimiter filtering should preserve ips")
-    (is (empty? (search-ids search-uri "127"))
+    (is (empty? (search-ids entity "127"))
         "word delimiter filtering should preserve ips")
     (testing "word delimiter filtering should not split words on numbers"
       (is (= matched-ids
-             (search-ids search-uri "description:j2ee")
-             (search-ids search-uri "j2ee")))
-      (is (empty? (search-ids search-uri "j OR ee"))))
+             (search-ids entity "description:j2ee")
+             (search-ids entity "j2ee")))
+      (is (empty? (search-ids entity "j OR ee"))))
 
     ;; clean
-    (doseq [_id (concat matched-ids unmatched-ids)]
-      (let [delete-uri (->> (long-id->id _id)
-                            :short-id
-                            (format "ctia/%s/%s" entity))]
-        (delete delete-uri
-                :headers {"Authorization" "45c1f5e3f05d0"})))))
+    (doseq [full-id (concat matched-ids unmatched-ids)]
+      (delete-doc entity full-id))))
+
+(defn ensure-one-document
+  [f example entity & args]
+  (let [{{full-id :id} :parsed-body} (create-doc entity (dissoc example :id))]
+       (apply (partial f entity) args)
+       (delete-doc entity full-id)))
 
 (defn test-non-describable-search
   [entity query query-field]
-  (let [search-uri (format "ctia/%s/search" (name entity))]
-    (testing (format "GET %s" search-uri)
-      (let [response (search search-uri query)]
-        (is (= 200 (:status response)))
-        (is (= query (first (map query-field (:parsed-body response))))
-            "query term works"))
+  (testing "search term filter"
+    (let [response (search-text entity query)]
+      (is (= 200 (:status response)))
+      (is (= query (first (map query-field (:parsed-body response))))
+          "query term works"))
 
-      (with-redefs [log* (fn [& _] nil)]
-        ;; avoid unnecessary verbosity
-        (let [response (search search-uri "2607:f0d0:1002:0051:0000:0000:0000:0004")]
-          (is (= 400 (:status response)))))
+    (with-redefs [log* (fn [& _] nil)]
+      ;; avoid unnecessary verbosity
+      (let [response (search-text entity "2607:f0d0:1002:0051:0000:0000:0000:0004")]
+        (is (= 400 (:status response)))))
 
-      (let [response (get search-uri
-                          :headers {"Authorization" "45c1f5e3f05d0"}
-                          :query-params {"query" query
-                                         "tlp" "red"})]
-        (is (= 200 (:status response)))
-        (is (empty? (:parsed-body response))
-            "filters should be applied, and should discriminate"))
+    (let [response (search-raw entity {"query" query
+                                       "tlp" "red"})]
+      (is (= 200 (:status response)))
+      (is (empty? (:parsed-body response))
+          "filters should be applied, and should discriminate"))
 
-      (let [{:keys [status parsed-body]} (get search-uri
-                                              :headers {"Authorization" "45c1f5e3f05d0"}
-                                              :query-params {"query" query
-                                                             "tlp" "green"})]
-        (is (= 200 status))
-        (is (= 1 (count parsed-body))
-            "filters are applied, and match properly")))))
+    (let [{:keys [status parsed-body]} (search-raw entity {:query query
+                                                           :tlp "green"})
+          matched-fields {:tlp "green"
+                          (keyword query-field) query}]
+      (is (= 200 status))
+      (is (<= 1 (count parsed-body)))
+      (is (every? #(= (select-keys % [(keyword query-field) :tlp])
+                      matched-fields)
+                  parsed-body)
+          "filters are applied, and match properly"))))
 
 (defn test-filter-by-id
   [entity]
-  (let [search-uri (format "ctia/%s/search" (name entity))
-        {:keys [parsed-body status]} (search search-uri "*")
+  (let [{:keys [parsed-body status]} (search-text entity "*")
         first-entity (some-> parsed-body first)]
     (is (= 200 status))
     (is (some? first-entity))
     (testing "filter by long ID"
       (let [response
-            (get search-uri
-                 :headers {"Authorization" "45c1f5e3f05d0"}
-                 :query-params {"query" "*"
-                                "id" (:id first-entity)})]
+            (search-raw entity {"id" (:id first-entity)})]
         (is (= 200 (:status response)))
         (is (= first-entity (some-> response :parsed-body first)))))
     (testing "filter by short ID"
       (let [response
-            (get search-uri
-                 :headers {"Authorization" "45c1f5e3f05d0"}
-                 :query-params {"query" "*"
-                                "id" (-> (:id first-entity)
+            (search-raw entity {"id" (-> (:id first-entity)
                                          long-id->id
                                          :short-id)})]
         (is (= 200 (:status response)))
         (is (= first-entity (some-> response :parsed-body first)))))))
+
+(defn test-date-range
+  [entity date-range expected-ids msg]
+  (let [{:keys [status parsed-body]} (search-raw entity date-range)]
+    (testing msg
+      (is (= 200 status))
+      (is (= (set expected-ids)
+             (set (map :id parsed-body)))))))
+
+(defn test-from-to
+  [entity example]
+  (testing "check date range [from, to["
+    (let [;; insert first document
+          new-actor (dissoc example :id :timestamp)
+          {{id-1 :id timestamp-1 :timestamp} :parsed-body
+           :as create-result}
+          (create-doc entity new-actor)
+          date-time-1 (str (tc/to-date-time timestamp-1))
+
+          _ (test-date-range entity
+                             {:from date-time-1}
+                           [id-1]
+                           "date range should include from")
+
+          _ (test-date-range entity
+                             {:id id-1 ;; avoid previous results
+                              :to date-time-1}
+                             []
+                             "date range should exclude to")
+
+          ;; add another document
+          {{id-2 :id timestamp-2 :timestamp}  :parsed-body}
+          (create-doc entity  new-actor)
+          date-time-2 (str (tc/to-date-time timestamp-2))]
+      (test-date-range entity
+                       {:from date-time-1}
+                       [id-1 id-2]
+                       "date range should include from")
+      (test-date-range entity
+                       {:from date-time-1
+                        :to date-time-2}
+                       [id-1]
+                       "date range should include from and exclude to")
+      (delete-doc entity id-1)
+      (delete-doc entity id-2))))
 
 (defn test-query-string-search
   [entity query query-field example]
@@ -242,5 +289,10 @@
   (when (= "es" (get-in @properties [:ctia :store (keyword entity)]))
     (if (= :description query-field)
       (test-describable-search entity example)
-      (test-non-describable-search entity query query-field))
-    (test-filter-by-id entity)))
+      (ensure-one-document test-non-describable-search
+                           example
+                           entity
+                           query
+                           query-field))
+    (test-filter-by-id entity)
+    (test-from-to entity example)))


### PR DESCRIPTION
> related https://github.com/threatgrid/iroh/issues/3258

This PR implements 3 metric endpoints for incident, sighting and judgement: `topn`, `cardinality` and`histogram`.
Each of these routes contains an `aggregate-on` parameter which accepted values are specific to each entity type. Then each metric type has it's own specific paremeters.
This PR also enables us to filter both search and metric requests with a date range using new `from` and/or `to` parameters. 
This PR extends the `IQueryStringSearchableStore` with an `aggregate` method, which is implemented in the ES store using [terms](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-terms-aggregation.html), [cardinality](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-metrics-cardinality-aggregation.html) and [date histogram](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-datehistogram-aggregation.html) aggregations in Elasticsearch. Each of these aggregations is performed against the results of a search query which is identical to `search` route behavior.
The `query-string-search` method is slightly refactored with to add a `date-range` option. In order to avoid inflating the number of search parameters, all search parameters are now embedded in a `search-query` map with following schema:
``` clojure
(s/defschema SearchQuery
  (st/optional-keys
   {:query-string s/Str
    :filter-map {s/Keyword s/Any}
    :date-range DateRange}))
```
There is many modifications that are only to enable `:query` to be optional.
The main modifications to focus on are the insertion of aggregation and from/to filters in following files: ` src/ctia/http/routes/crud.clj`, `src/ctia/http/routes/common.clj ` (search query build), `src/ctia/stores/es/crud.clj `. In test the whole logic to test metric routes is in this helper ns `test/ctia/test_helpers/aggregate.clj`, that generate examples of entities and call the 3 types of metric. The unit tests are performed at the lowest level. The route tests are mostly meant to check that parameters are properly passed to `handle-aggregate` in the ES store. `handle-aggregate` has its own tests that are responsible for checking the different intended behaviors.

<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

In CTIA, 3 metric endpoints are available for incident, sighting and judgement: `topn`, `histogram`, `cardinality`.

<a name="qa">[§](#qa)</a> QA
============================

## Metrics
1. Create an incident and note its timestamp to use it in next requests
2. Search incidents since the previous timestamp by replacing `{timestamp`} in that request:
`GET /ctia/incident/search?sort_by=timestamp&query=*from={timestamp}
Check that the result contains created entity.
3. Search incidents before the previous timestamp by replacing `{timestamp`} in that request:
`GET /ctia/incident/search?sort_by=timestamp&sort_order=desc&query=*to={timestamp}
Check that the result does not contain created entity (it should be empty if you can ensure that no incident have been created since step 1).
4. Search incidents since April 1 2020 and previous timestamp:
`GET /ctia/incident/search?sort_by=timestamp&sort_order=desc&query=*from="2020-04-01"&to={timestamp}
Check that the result does not contain created entity

## Top N and Cardinality metrics

1. Log in with a user whose org has incident created in previous weeks.
2. create 20 incidents: 8 with status Open,  6 with status `Close`, 4 with status `New`, 2 with status `Stalled`.
4. note the most recent `timestamp` value that will be referenced as `{timestamp}` in next requests and has to be replaced with this value.
3. Ensure that the environment is isolated during that test.

###  Top N Metric

1. request top `status` values in incidents since `{timestamp}` 
`GET /ctia/incident/metric/topn/aggregate-on=status&query=*&from={timestamp}`
it should return:
``` javascript
[
  {"key": "open", "value": 8},
  {"key": "close", "value": 6},
  {"key": "new", "value": 4},
  {"key": "stalled", "value": 2}
]
```
2. request top 3 `status` values in incident since `{timestamp}` 
`GET /ctia/incident/metric/topn/aggregate-on=status&query=*&from={timestamp}&limit=3`
``` javascript
[
  {"key": "open", "value": 8},
  {"key": "close", "value": 6},
  {"key": "new", "value": 4}
]
```

### Cardinality

1. Retrieve the number of distinct `status` values in incidents since `{timestamp}`:
`GET /ctia/incident/metric/cardinality/aggregate-on=status&query=*&from={timestamp}`
Check that it returns `4`.

### Histogram

1. Retrieve the histogram of incidents on `timestamp` field since the first of April with a `day` granularity (`timestamp` is the aggregated field it, do not replace it with the date):
`GET /ctia/incident/metric/histogram/aggregate-on=timestamp&granularity=day&query=*&from="2020-04-1"`
Check that it returns values for different days in April, and at least 20 for current day.
2. Perform the same request with `month` granularity since the begining of the year:
`GET /ctia/incident/metric/histogram/aggregate-on=timestamp&granularity=month&query=*&from="2020-01-1"`
Check that it returns values for each first month day of any incident was created in that month (you can check value using the `from`/`to` field in search and check `total-hits` response header.
 
<a name="ops">[§](#ops)</a> Ops
===============================

This PR introduces metrics based on Elasticsearch aggregations: [terms](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-terms-aggregation.html), [cardinality](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-metrics-cardinality-aggregation.html) and [date histogram](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-datehistogram-aggregation.html).
I limited the date range aggregation to a maximum 1 year interval and manually selected fields that can be aggregated to limit potential troubles. However, we still need to check that these modifications have no impact on the cluster performances.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern:  A new metric endpoint is available for incident, sighting and judgement at `/CTIA/incident/aggregate`, `/CTIA/judgement/aggregate`, `/CTIA/sighting/aggregate`.
```
