### PR TITLE
E3508: count endpoint

### DIFF
--- a/doc/search-metrics.org
+++ b/doc/search-metrics.org
@@ -93,9 +93,9 @@ GET /ctia/incident/topn?&aggregate-on=status&limit=3&from=2020-01-01
 #+END_SRC
 it will return for instance
 #+BEGIN_SRC javascript
-{"data": {"status": {"Closed": 12,
-                     "Open": 6,
-                     "New": 2}},
+{"data": {"status": [{"key": "Closed", "value": 12},
+                     {"key": "Open", "value": 6},
+                     {"key": "New", "value": 2}]},
  "type": "topn",
  "filters": {"from": "2020-01-01",
              "to": "2020-05-01"}}

--- a/doc/search-metrics.org
+++ b/doc/search-metrics.org
@@ -59,6 +59,17 @@ For instance you can search malicious judgments with high confidence matching "a
 GET /ctia/incident/search?query=abuse.ch&confidence=high&limit=10&sort_by=disposition&sort_order=desc
 #+END_SRC
 
+Finally you can only query entity count with the same filtering parameters through the endpoint ~GET /ctia/{entity-type}/search/count~.
+So reusing a previous search query example, one can count the indicators with "android" in the title, having a high confidence, created since 2020/01/01 with both text and term filtering:
+#+BEGIN_SRC
+GET /ctia/indicator/search/count?query=title:android&confidence=high&from=2020-01-01
+#+END_SRC
+
+The result will return directly the number of matched entities:
+#+BEGIN_SRC javascript
+38
+#+END_SRC
+
 * Aggregating
 Aggregation metrics are available through the endpoint ~GET /CTIA/{entity-type}/metric/{metric-type}~.
 3 types of metrics are proposed: Top N, Cardinality, and Histogram, that can be selected with the corresponding route suffix ~{metric}~, respectively ~topn~, ~cardinality~, and ~histogram~.

--- a/src/ctia/entity/event/crud.clj
+++ b/src/ctia/entity/event/crud.clj
@@ -28,5 +28,9 @@
   (crud/handle-query-string-search
    :event PartialEvent))
 
+(def handle-event-query-string-count
+  (crud/handle-query-string-count
+   :event))
+
 (def handle-aggregate
   (crud/handle-aggregate :event))

--- a/src/ctia/entity/event/store.clj
+++ b/src/ctia/entity/event/store.clj
@@ -18,6 +18,9 @@
   (query-string-search [_ search-query ident params]
     (crud/handle-event-query-string-search
      state search-query ident params))
+  (query-string-count [_ search-query ident]
+    (crud/handle-event-query-string-count
+     state search-query ident))
   (aggregate [_ search-query agg-query ident]
     (crud/handle-aggregate
      state search-query agg-query ident)))

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -75,14 +75,19 @@
 (s/defschema FeedFieldsParam
   {(s/optional-key :fields) [feed-sort-fields]})
 
-(s/defschema FeedSearchParams
+
+(s/defschema FeedCountParams
   (st/merge
-   PagingParams
    BaseEntityFilterParams
    FeedFieldsParam
    (st/optional-keys
-    {:query s/Str
-     :sort_by feed-sort-fields})))
+    {:query s/Str})))
+
+(s/defschema FeedSearchParams
+  (st/merge
+   FeedCountParams
+   PagingParams
+   {(s/optional-key :sort_by) feed-sort-fields}))
 
 (def FeedGetParams FeedFieldsParam)
 
@@ -312,6 +317,19 @@
          un-store-page
          decrypt-feed-page
          paginated-ok))
+
+   (GET "/search/count" []
+        :return s/Int
+        :summary "Count Feed entities matching given search filters."
+        :query [params FeedCountParams]
+        :capabilities :search-feed
+        :auth-identity identity
+        :identity-map identity-map
+        (ok (read-store
+             :feed
+             query-string-count
+             (search-query :created params)
+             identity-map)))
 
    (GET "/:id" []
      :return (s/maybe PartialFeed)

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -49,6 +49,7 @@
 (def handle-delete (crud/handle-delete :judgement PartialStoredJudgement))
 (def handle-list (crud/handle-find :judgement PartialStoredJudgement))
 (def handle-query-string-search (crud/handle-query-string-search :judgement PartialStoredJudgement))
+(def handle-query-string-count (crud/handle-query-string-count :judgement))
 (def handle-aggregate (crud/handle-aggregate :judgement))
 
 (defn list-active-by-observable
@@ -123,5 +124,7 @@
   IQueryStringSearchableStore
   (query-string-search [_ search-query ident params]
     (handle-query-string-search state search-query ident params))
+  (query-string-count [_ search-query ident]
+    (handle-query-string-count state search-query ident))
   (aggregate [_ search-query agg-query ident]
     (handle-aggregate state search-query agg-query ident)))

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -55,6 +55,7 @@
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
 (def list-fn (crud/handle-find :sighting ESPartialStoredSighting))
 (def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
+(def handle-query-string-count (crud/handle-query-string-count :sighting))
 (def handle-aggregate (crud/handle-aggregate :sighting))
 
 (s/defn observable->observable-hash :- s/Str
@@ -166,5 +167,7 @@
   IQueryStringSearchableStore
   (query-string-search [_ search-query ident params]
     (handle-query-string-search-sightings state search-query ident params))
+  (query-string-count [_ search-query ident]
+    (handle-query-string-count state search-query ident))
   (aggregate [_ search-query agg-query ident]
     (handle-aggregate state search-query agg-query ident)))

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -8,7 +8,7 @@
              [codec :as codec]
              [http-response :as http-res]
              [http-status :refer [ok]]]
-            [ctia.schemas.search-agg :refer [SearchQuery EnvelopedMetricResult]]
+            [ctia.schemas.search-agg :refer [SearchQuery MetricResult]]
             [schema.core :as s]))
 
 (def search-options [:sort_by
@@ -113,7 +113,7 @@
        (seq filter-map) (assoc :filter-map filter-map)
        query (assoc :query-string query)))))
 
-(s/defn format-agg-result :- EnvelopedMetricResult
+(s/defn format-agg-result :- MetricResult
   [result
    agg-type
    aggregate-on

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -31,9 +31,7 @@
    [ctia.schemas.search-agg :refer [HistogramParams
                                     CardinalityParams
                                     TopnParams
-                                    EnvelopedTopnResult
-                                    EnvelopedCardinalityResult
-                                    EnvelopedHistogramResult]]
+                                    MetricResult]]
    [ring.util.http-response :refer [no-content not-found ok]]
    [ring.swagger.schema :refer [describe]]
    [schema.core :as s]
@@ -245,7 +243,7 @@
                 :auth-identity identity
                 :identity-map identity-map
                 (GET "/histogram" []
-                     :return EnvelopedHistogramResult
+                     :return MetricResult
                      :summary (format "Histogram for a %s field" capitalized)
                      :query [params histogram-q-params]
                      (let [aggregate-on (keyword (:aggregate-on params))
@@ -263,7 +261,7 @@
                            (format-agg-result :histogram aggregate-on search-q)
                            ok)))
                 (GET "/topn" []
-                     :return EnvelopedTopnResult
+                     :return MetricResult
                      :summary (format "Topn for a %s field" capitalized)
                      :query [params topn-q-params]
                      (let [aggregate-on (:aggregate-on params)
@@ -281,7 +279,7 @@
                            (format-agg-result :topn aggregate-on search-q)
                            ok)))
                 (GET "/cardinality" []
-                     :return EnvelopedCardinalityResult
+                     :return MetricResult
                      :summary (format "Cardinality for a %s field" capitalized)
                      :query [params cardinality-q-params]
                      (let [aggregate-on (:aggregate-on params)

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -67,43 +67,8 @@
     :aggregate-on s/Str}))
 
 (s/defschema MetricResult
-  {s/Keyword (s/if map?
-               (s/recursive #'MetricResult)
-               s/Any)})
-
-(s/defschema EnvelopedMetricResult
-  {:data MetricResult
+  {:data {s/Keyword s/Any}
    :type AggType
    :filters (st/open-schema
              {:from s/Inst
               :to s/Inst})})
-
-(s/defschema TopnResult
-  {s/Keyword (s/if map?
-               (s/recursive #'TopnResult)
-               [{:key s/Any :value s/Int}])})
-
-(s/defschema EnvelopedTopnResult
-  (st/merge
-   {:data TopnResult}
-   MetricResult))
-
-(s/defschema HistogramResult
-  {s/Keyword (s/if map?
-               (s/recursive #'HistogramResult)
-               [{:key s/Str :value s/Int}])})
-
-(s/defschema EnvelopedHistogramResult
-  (st/merge
-   {:data HistogramResult}
-   MetricResult))
-
-(s/defschema CardinalityResult
-  {s/Keyword (s/if map?
-               (s/recursive #'CardinalityResult)
-               s/Int)})
-
-(s/defschema EnvelopedCardinalityResult
-  (st/merge
-   {:data CardinalityResult}
-   MetricResult))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -26,6 +26,7 @@
 
 (defprotocol IQueryStringSearchableStore
   (query-string-search [this search-query ident params])
+  (query-string-count [this search-query ident])
   (aggregate [this search-query agg-query ident]))
 
 (def empty-stores

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -354,6 +354,22 @@ It returns the documents with full hits meta data including the real index in wh
           (restricted-read? ident) (update :data
                                            access-control-filter-list
                                            ident))))))
+
+(defn handle-query-string-count
+  "Generate an ES count handler using some mapping and schema"
+  [mapping]
+  (s/fn :- s/Int
+    [{conn :conn
+      index :index
+      :as es-conn-state} :- ESConnState
+     {:keys [filter-map] :as search-query} :- SearchQuery
+     ident]
+    (let [query (make-search-query es-conn-state search-query ident)]
+      (d/count-docs conn
+                    index
+                    (name mapping)
+                    query))))
+
 (s/defn make-histogram
   [{:keys [aggregate-on granularity timezone]
     :or {timezone "+00:00"}} :- HistogramQuery]

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -38,6 +38,9 @@
      (~(symbol "query-string-search") [_# search-query# ident# params#]
       ((crud/handle-query-string-search ~entity ~partial-stored-schema)
        ~(symbol "state") search-query# ident# params#))
+     (~(symbol "query-string-count") [_# search-query# ident#]
+      ((crud/handle-query-string-count ~entity)
+       ~(symbol "state") search-query# ident#))
      (~(symbol "aggregate") [_# search-query# agg-query# ident#]
       ((crud/handle-aggregate ~entity)
        ~(symbol "state") search-query# agg-query# ident#))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->
> **Epic** #https://github.com/threatgrid/iroh/issues/3508

This PR adds a `/ctia/{entity-type}/search/count` endpoint to enable clients to easily count the number of entities that match a given search query. It is more straightforward than using the `total-hits` header of `search` route, and since it is based on the ES `_count` endpoint it is less resource consuming on ES side (it does not load documents from disk and only aggregate count results of answering shards).

<a name="qa">[§](#qa)</a> QA
============================
This PR adds a `/ctia/{entity-type}/search/count` endpoint that count the number of matched entities with the same behavior than search. You could thus reuse your search test and check that the corresponding `count` returns same value than the `total-hits` header of the corresponding `search` response.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
