### PR TITLE
CTIA metrics on remaining entities

### DIFF
--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -96,6 +96,19 @@
    PagingParams
    ActorFieldsParam))
 
+(def actor-enumerable-fields
+  [:source
+   :actor_type
+   :motivation
+   :sophistication
+   :confidence
+   :intended_effect])
+
+(def actor-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
 (def actor-routes
   (entity-crud-routes
    {:entity :actor
@@ -114,7 +127,10 @@
     :put-capabilities :create-actor
     :delete-capabilities :delete-actor
     :search-capabilities :search-actor
-    :external-id-capabilities :read-actor}))
+    :external-id-capabilities :read-actor
+    :can-aggregate? true
+    :histogram-fields actor-histogram-fields
+    :enumerable-fields actor-enumerable-fields}))
 
 (def capabilities
   #{:create-actor

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -158,7 +158,7 @@
   {:route-context "/attack-pattern"
    :tags ["Attack Pattern"]
    :entity :attack-pattern
-   :plural :attack_patterns
+   :plural :attack-patterns
    :new-spec :new-attack-pattern/map
    :schema AttackPattern
    :partial-schema PartialAttackPattern

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -94,6 +94,12 @@
 (s/defschema AttackPatternByExternalIdQueryParams
   (st/merge PagingParams AttackPatternFieldsParam))
 
+(def attack-pattern-enumerable-fields
+  [:source])
+
+(def attack-pattern-histogram-fields
+  [:timestamp])
+
 (def attack-pattern-routes
   (entity-crud-routes
    {:entity :attack-pattern
@@ -112,7 +118,10 @@
     :put-capabilities :create-attack-pattern
     :delete-capabilities :delete-attack-pattern
     :search-capabilities :search-attack-pattern
-    :external-id-capabilities :read-attack-pattern}))
+    :external-id-capabilities :read-attack-pattern
+    :can-aggregate? true
+    :histogram-fields attack-pattern-histogram-fields
+    :enumerable-fields attack-pattern-enumerable-fields}))
 
 (def AttackPatternType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -158,7 +158,7 @@
   {:route-context "/attack-pattern"
    :tags ["Attack Pattern"]
    :entity :attack-pattern
-   :plural :attack-patterns
+   :plural :attack_patterns
    :new-spec :new-attack-pattern/map
    :schema AttackPattern
    :partial-schema PartialAttackPattern

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -86,6 +86,17 @@
      :activity s/Str
      :sort_by  campaign-sort-fields})))
 
+(def campaign-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
+(def campaign-enumerable-fields
+  [:source
+   :campaign_type
+   :confidence
+   :status])
+
 (def CampaignGetParams CampaignFieldsParam)
 
 (s/defschema CampaignByExternalIdQueryParams
@@ -112,7 +123,10 @@
     :put-capabilities :create-campaign
     :delete-capabilities :delete-campaign
     :search-capabilities :search-campaign
-    :external-id-capabilities :read-campaign}))
+    :external-id-capabilities :read-campaign
+    :can-aggregate? true
+    :histogram-fields campaign-histogram-fields
+    :enumerable-fields campaign-enumerable-fields}))
 
 (def capabilities
   #{:create-campaign

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -296,6 +296,14 @@
 (def CasebookConnectionType
   (pagination/new-connection CasebookType))
 
+(def casebook-enumerable-fields
+  [:source
+   :observables.type
+   :observables.value])
+
+(def casebook-histogram-fields
+  [:timestamp])
+
 (def casebook-routes
   (routes
    casebook-operation-routes
@@ -312,13 +320,16 @@
      :search-q-params CasebookSearchParams
      :new-spec :new-casebook/map
      :realize-fn realize-casebook
+     :can-aggregate? true
      :get-capabilities :read-casebook
      :post-capabilities :create-casebook
      :put-capabilities :create-casebook
      :delete-capabilities :delete-casebook
      :search-capabilities :search-casebook
      :external-id-capabilities :read-casebook
-     :hide-delete? false})))
+     :hide-delete? false
+     :histogram-fields casebook-histogram-fields
+     :enumerable-fields casebook-enumerable-fields})))
 
 (def casebook-entity
   {:route-context "/casebook"

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -102,6 +102,17 @@
    PagingParams
    COAFieldsParam))
 
+(def coa-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
+(def coa-enumerable-fields
+  [:source
+   :efficacy
+   :cost
+   :coa_type])
+
 (def coa-routes
   (entity-crud-routes
    {:entity :coa
@@ -120,7 +131,10 @@
     :put-capabilities :create-coa
     :delete-capabilities :delete-coa
     :search-capabilities :search-coa
-    :external-id-capabilities :read-coa}))
+    :external-id-capabilities :read-coa
+    :can-aggregate? true
+    :histogram-fields coa-histogram-fields
+    :enumerable-fields coa-enumerable-fields}))
 
 (def capabilities
   #{:create-coa

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -127,7 +127,7 @@
   {:route-context "/identity-assertion"
    :tags ["Identity Assertion"]
    :entity :identity-assertion
-   :plural :identity-assertions
+   :plural :identity_assertions
    :new-spec :new-identity-assertion/map
    :schema IdentityAssertion
    :partial-schema PartialIdentityAssertion

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -79,6 +79,15 @@
      :assertions.value s/Str
      :sort_by identity-assertion-sort-fields})))
 
+(def identity-assertion-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
+(def identity-assertion-enumerable-fields
+  [:identity.observables.value
+   :identity.observables.type])
+
 (def IdentityAssertionGetParams IdentityAssertionFieldsParam)
 
 (s/defschema IdentityAssertionByExternalIdQueryParams
@@ -103,7 +112,10 @@
     :put-capabilities :create-identity-assertion
     :delete-capabilities :delete-identity-assertion
     :search-capabilities :search-identity-assertion
-    :external-id-capabilities :read-identity-assertion}))
+    :external-id-capabilities :read-identity-assertion
+    :can-aggregate? true
+    :enumerable-fields identity-assertion-enumerable-fields
+    :histogram-fields identity-assertion-histogram-fields}))
 
 (def capabilities
   #{:create-identity-assertion

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -127,7 +127,7 @@
   {:route-context "/identity-assertion"
    :tags ["Identity Assertion"]
    :entity :identity-assertion
-   :plural :identity_assertions
+   :plural :identity-assertions
    :new-spec :new-identity-assertion/map
    :schema IdentityAssertion
    :partial-schema PartialIdentityAssertion

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -101,6 +101,19 @@
 (def indicator-sort-fields
   (apply s/enum indicator-fields))
 
+(def indicator-enumerable-fields
+  [:source
+   :indicator_type
+   :likely_impact
+   :confidence
+   :producer
+   :tags])
+
+(def indicator-histogram-fields
+  [:timestamp
+   :valid_time.start_time
+   :valid_time.end_time])
+
 (s/defschema IndicatorFieldsParam
   {(s/optional-key :fields) [indicator-sort-fields]})
 
@@ -149,7 +162,10 @@
     :put-capabilities :create-indicator
     :delete-capabilities :delete-indicator
     :search-capabilities :search-indicator
-    :external-id-capabilities :read-indicator}))
+    :external-id-capabilities :read-indicator
+    :can-aggregate? true
+    :histogram-fields indicator-histogram-fields
+    :enumerable-fields indicator-enumerable-fields}))
 
 (def capabilities
   #{:read-indicator

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -95,8 +95,7 @@
    BaseEntityFilterParams
    SourcableEntityFilterParams
    InvestigationFieldsParam
-   {(s/optional-key :query) s/Str}
-   {s/Keyword s/Any}))
+   {(s/optional-key :query) s/Str}))
 
 (def InvestigationGetParams InvestigationFieldsParam)
 
@@ -128,6 +127,12 @@
 (def InvestigationConnectionType
   (pagination/new-connection InvestigationType))
 
+(def investigation-enumerable-fields
+  [:source])
+
+(def investigation-histogram-fields
+  [:timestamp])
+
 (def investigation-routes
   (entity-crud-routes
    {:entity :investigation
@@ -146,7 +151,10 @@
     :put-capabilities :create-investigation
     :delete-capabilities :delete-investigation
     :search-capabilities :search-investigation
-    :external-id-capabilities :read-investigation}))
+    :external-id-capabilities :read-investigation
+    :can-aggregate? true
+    :histogram-fields investigation-histogram-fields
+    :enumerable-fields investigation-enumerable-fields}))
 
 (def capabilities
   #{:read-investigation

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -88,6 +88,13 @@
      :kill_chain_phases.phase_name s/Str
      :sort_by malware-sort-fields})))
 
+(def malware-histogram-fields
+  [:timestamp])
+
+(def malware-enumerable-fields
+  [:source
+   :labels])
+
 (s/defschema MalwareGetParams MalwareFieldsParam)
 
 (s/defschema MalwareByExternalIdQueryParams
@@ -125,7 +132,6 @@
 (def MalwareConnectionType
   (pagination/new-connection MalwareType))
 
-
 (def malware-routes
   (entity-crud-routes
    {:entity :malware
@@ -144,7 +150,10 @@
     :put-capabilities :create-malware
     :delete-capabilities :delete-malware
     :search-capabilities :search-malware
-    :external-id-capabilities :read-malware}))
+    :external-id-capabilities :read-malware
+    :can-aggregate? true
+    :histogram-fields malware-histogram-fields
+    :enumerable-fields malware-enumerable-fields}))
 
 (def malware-entity
   {:route-context "/malware"

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -137,6 +137,13 @@
                       un-store)]
               (created stored-relationship))))))
 
+(def relationship-histogram-fields
+  [:timestamp])
+
+(def relationship-enumerable-fields
+  [:source
+   :relationship_type])
+
 (def relationship-routes
   (entity-crud-routes
    {:entity :relationship
@@ -155,7 +162,10 @@
     :put-capabilities :create-relationship
     :delete-capabilities :delete-relationship
     :search-capabilities :search-relationship
-    :external-id-capabilities :read-relationship}))
+    :external-id-capabilities :read-relationship
+    :can-aggregate? true
+    :histogram-fields relationship-histogram-fields
+    :enumerable-fields relationship-enumerable-fields}))
 
 (def capabilities
   #{:create-relationship

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -52,6 +52,13 @@
      :tool_version s/Str
      :sort_by tool-sort-fields})))
 
+(def tool-histogram-fields
+  [:timestamp])
+
+(def tool-enumerable-fields
+  [:source
+   :labels])
+
 (s/defschema ToolGetParams ToolFieldsParam)
 
 (s/defschema ToolByExternalIdQueryParams
@@ -82,7 +89,10 @@
     :put-capabilities :create-tool
     :delete-capabilities :delete-tool
     :search-capabilities :search-tool
-    :external-id-capabilities :read-tool}))
+    :external-id-capabilities :read-tool
+    :can-aggregate? true
+    :histogram-fields tool-histogram-fields
+    :enumerable-fields tool-enumerable-fields}))
 
 (def tool-entity
   {:route-context "/tool"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -105,6 +105,12 @@
 (def VulnerabilityConnectionType
   (pagination/new-connection VulnerabilityType))
 
+(def vulnerability-histogram-fields
+  [:timestamp])
+
+(def vulnerability-enumerable-fields
+  [:source])
+
 (def vulnerability-routes
   (entity-crud-routes
    {:entity :vulnerability
@@ -123,7 +129,10 @@
     :put-capabilities :create-vulnerability
     :delete-capabilities :delete-vulnerability
     :search-capabilities :search-vulnerability
-    :external-id-capabilities :read-vulnerability}))
+    :external-id-capabilities :read-vulnerability
+    :can-aggregate? true
+    :histogram-fields vulnerability-histogram-fields
+    :enumerable-fields vulnerability-enumerable-fields}))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -120,6 +120,24 @@
 (def WeaknessConnectionType
   (pagination/new-connection WeaknessType))
 
+(def weakness-histogram-fields
+  [:timestamp])
+
+(def weakness-enumerable-fields
+  [:source
+   :detection_methods.method
+   :architectures.name
+   :architectures.class
+   :languages.name
+   :languages.class
+   :paradigms.name
+   :functional_areas
+   :operating_systems.name
+   :operating_systems.class
+   :likelihood
+   :technologies.name
+   :technologies.prevalence])
+
 (def weakness-routes
   (entity-crud-routes
    {:entity :weakness
@@ -138,7 +156,10 @@
     :put-capabilities :create-weakness
     :delete-capabilities :delete-weakness
     :search-capabilities :search-weakness
-    :external-id-capabilities :read-weakness}))
+    :external-id-capabilities :read-weakness
+    :can-aggregate? true
+    :histogram-fields weakness-histogram-fields
+    :enumerable-fields weakness-enumerable-fields}))
 
 (def capabilities
   #{:create-weakness

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -79,11 +79,11 @@
   (let [entity-str (name entity)
         capitalized (capitalize entity-str)
         search-filters (st/dissoc search-q-params
-                                   :sort_by
-                                   :sort_order
-                                   :fields
-                                   :limit
-                                   :offset)
+                                  :sort_by
+                                  :sort_order
+                                  :fields
+                                  :limit
+                                  :offset)
         agg-search-schema (st/merge
                            search-filters
                            {:from s/Inst})

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.actor-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.actor :refer [actor-fields]]
+            [ctia.entity.actor :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.actors :refer [new-actor-maximal new-actor-minimal]]))
 
 (use-fixtures :once
@@ -56,12 +57,12 @@
         ["ctia/actor/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        actor-fields))
+        sut/actor-fields))
 
      (pagination-test
       "ctia/actor/search?query=*"
       {"Authorization" "45c1f5e3f05d0"}
-      actor-fields))))
+      sut/actor-fields))))
 
 (deftest test-actor-routes-access-control
   (test-for-each-store
@@ -70,3 +71,15 @@
                           new-actor-minimal
                           true
                           true))))
+
+(deftest test-actor-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :actor
+                          :plural :actors
+                          :entity-minimal new-actor-minimal
+                          :enumerable-fields sut/actor-enumerable-fields
+                          :date-fields sut/actor-histogram-fields
+                          :schema sut/NewActor}))))

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -77,9 +77,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :actor
-                          :plural :actors
-                          :entity-minimal new-actor-minimal
-                          :enumerable-fields sut/actor-enumerable-fields
-                          :date-fields sut/actor-histogram-fields
-                          :schema sut/NewActor}))))
+     (test-metric-routes (into sut/actor-entity
+                               {:entity-minimal new-actor-minimal
+                                :enumerable-fields sut/actor-enumerable-fields
+                                :date-fields sut/actor-histogram-fields})))))

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -81,6 +81,7 @@
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
      (test-metric-routes (into sut/attack-pattern-entity
-                               {:entity-minimal new-attack-pattern-minimal
+                               {:plural :attack_patterns
+                                :entity-minimal new-attack-pattern-minimal
                                 :enumerable-fields sut/attack-pattern-enumerable-fields
                                 :date-fields sut/attack-pattern-histogram-fields})))))

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.attack-pattern-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.attack-pattern :refer [attack-pattern-fields]]
+            [ctia.entity.attack-pattern :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk ]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.attack-patterns
              :refer
              [new-attack-pattern-maximal new-attack-pattern-minimal]]))
@@ -23,7 +24,7 @@
 (use-fixtures :each
   whoami-helpers/fixture-reset-state)
 
-(deftest test-attack-pattern-routes
+(deftest test-attack-pattern-crud-routes
   (test-for-each-store
    (fn []
      (helpers/set-capabilities! "foouser"
@@ -58,13 +59,13 @@
        (pagination-test
         "ctia/attack-pattern/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        attack-pattern-fields)
+        sut/attack-pattern-fields)
 
        (field-selection-tests
         ["ctia/attack-pattern/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        attack-pattern-fields)))))
+        sut/attack-pattern-fields)))))
 
 (deftest attack-pattern-routes-access-control
   (test-for-each-store
@@ -73,3 +74,15 @@
                           new-attack-pattern-minimal
                           true
                           true))))
+
+(deftest test-attack-pattern-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :attack-pattern
+                          :plural :attack_patterns
+                          :entity-minimal new-attack-pattern-minimal
+                          :enumerable-fields sut/attack-pattern-enumerable-fields
+                          :date-fields sut/attack-pattern-histogram-fields
+                          :schema sut/NewAttackPattern}))))

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -80,9 +80,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :attack-pattern
-                          :plural :attack_patterns
-                          :entity-minimal new-attack-pattern-minimal
-                          :enumerable-fields sut/attack-pattern-enumerable-fields
-                          :date-fields sut/attack-pattern-histogram-fields
-                          :schema sut/NewAttackPattern}))))
+     (test-metric-routes (into sut/attack-pattern-entity
+                               {:entity-minimal new-attack-pattern-minimal
+                                :enumerable-fields sut/attack-pattern-enumerable-fields
+                                :date-fields sut/attack-pattern-histogram-fields})))))

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -1,18 +1,19 @@
 (ns ctia.entity.campaign-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.campaign :refer [campaign-fields]]
+            [ctia.entity.campaign :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
-            [ctim.examples.campaigns :as ex :refer [new-campaign-maximal]]))
+             [store :refer [test-for-each-store store-fixtures]]]
+            [ctim.examples.campaigns :as ex :refer [new-campaign-maximal new-campaign-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -50,13 +51,13 @@
        (pagination-test
         "ctia/campaign/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        campaign-fields)
+        sut/campaign-fields)
 
        (field-selection-tests
         ["ctia/campaign/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        campaign-fields)))))
+        sut/campaign-fields)))))
 
 (deftest test-campaign-routes-access-control
   (test-for-each-store
@@ -65,3 +66,15 @@
                           ex/new-campaign-minimal
                           true
                           true))))
+
+(deftest test-campaign-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :campaign
+                          :plural :campaigns
+                          :entity-minimal new-campaign-minimal
+                          :enumerable-fields sut/campaign-enumerable-fields
+                          :date-fields sut/campaign-histogram-fields
+                          :schema sut/NewCampaign}))))

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -72,9 +72,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :campaign
-                          :plural :campaigns
-                          :entity-minimal new-campaign-minimal
-                          :enumerable-fields sut/campaign-enumerable-fields
-                          :date-fields sut/campaign-histogram-fields
-                          :schema sut/NewCampaign}))))
+     (test-metric-routes (into sut/campaign-entity
+                               {:entity-minimal new-campaign-minimal
+                                :enumerable-fields sut/campaign-enumerable-fields
+                                :date-fields sut/campaign-histogram-fields})))))

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -360,9 +360,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :casebook
-                          :plural :casebooks
-                          :entity-minimal new-casebook-minimal
-                          :enumerable-fields sut/casebook-enumerable-fields
-                          :date-fields sut/casebook-histogram-fields
-                          :schema sut/NewCasebook}))))
+     (test-metric-routes (into sut/casebook-entity
+                               {:entity-minimal new-casebook-minimal
+                                :enumerable-fields sut/casebook-enumerable-fields
+                                :date-fields sut/casebook-histogram-fields})))))

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -70,9 +70,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :coa
-                          :plural :coas
-                          :entity-minimal new-coa-minimal
-                          :enumerable-fields sut/coa-enumerable-fields
-                          :date-fields sut/coa-histogram-fields
-                          :schema sut/NewCOA}))))
+     (test-metric-routes (into sut/coa-entity
+                               {:entity-minimal new-coa-minimal
+                                :enumerable-fields sut/coa-enumerable-fields
+                                :date-fields sut/coa-histogram-fields})))))

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -113,9 +113,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :identity-assertion
-                          :plural :identity_assertions
-                          :entity-minimal new-identity-assertion-minimal
-                          :enumerable-fields sut/identity-assertion-enumerable-fields
-                          :date-fields sut/identity-assertion-histogram-fields
-                          :schema sut/NewIdentityAssertion}))))
+     (test-metric-routes (into sut/identity-assertion-entity
+                               {:entity-minimal new-identity-assertion-minimal
+                                :enumerable-fields sut/identity-assertion-enumerable-fields
+                                :date-fields sut/identity-assertion-histogram-fields})))))

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -114,6 +114,7 @@
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
      (test-metric-routes (into sut/identity-assertion-entity
-                               {:entity-minimal new-identity-assertion-minimal
+                               {:plural :identity_assertions
+                                :entity-minimal new-identity-assertion-minimal
                                 :enumerable-fields sut/identity-assertion-enumerable-fields
                                 :date-fields sut/identity-assertion-histogram-fields})))))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -84,10 +84,6 @@
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
      (let [parameters {:entity "incident"
-                       :plural "incidents"
-                       :enumerable-fields sut/incident-enumerable-fields
-                       :date-fields sut/incident-histogram-fields
-                       :schema sut/NewIncident
                        :patch-tests? true
                        :example new-incident-maximal
                        :headers {:Authorization "45c1f5e3f05d0"}

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -95,12 +95,10 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes {:entity :incident
-                          :plural :incidents
-                          :entity-minimal new-incident-minimal
-                          :enumerable-fields sut/incident-enumerable-fields
-                          :date-fields sut/incident-histogram-fields
-                          :schema sut/NewIncident}))))
+     (test-metric-routes (into sut/incident-entity
+                               {:entity-minimal new-incident-minimal
+                                :enumerable-fields sut/incident-enumerable-fields
+                                :date-fields sut/incident-histogram-fields})))))
 
 (deftest test-incident-pagination-field-selection
   (test-for-each-store

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -46,10 +46,8 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" caps/all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :indicator
-                          :plural :indicators
-                          :entity-minimal new-indicator-minimal
-                          :enumerable-fields sut/indicator-enumerable-fields
-                          :date-fields sut/indicator-histogram-fields
-                          :schema sut/NewIndicator}))))
+     (test-metric-routes (into sut/indicator-entity
+                               {:entity-minimal new-indicator-minimal
+                                :enumerable-fields sut/indicator-enumerable-fields
+                                :date-fields sut/indicator-histogram-fields})))))
 

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -2,12 +2,14 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
             [ctia.auth.capabilities :as caps]
+            [ctia.entity.indicator :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [core :as helpers]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.indicators
              :refer
              [new-indicator-maximal new-indicator-minimal]]))
@@ -18,7 +20,7 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(deftest test-indicator-routes
+(deftest test-indicator-crud-routes
   (test-for-each-store
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" caps/all-capabilities)
@@ -38,3 +40,16 @@
                           new-indicator-minimal
                           true
                           false))))
+
+(deftest test-indicator-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" caps/all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :indicator
+                          :plural :indicators
+                          :entity-minimal new-indicator-minimal
+                          :enumerable-fields sut/indicator-enumerable-fields
+                          :date-fields sut/indicator-histogram-fields
+                          :schema sut/NewIndicator}))))
+

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.investigation-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.investigation :refer [investigation-fields]]
+            [ctia.entity.investigation :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.investigations
              :refer
              [new-investigation-maximal new-investigation-minimal]]))
@@ -57,13 +58,13 @@
        (pagination-test
         "ctia/investigation/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        investigation-fields)
+        sut/investigation-fields)
 
        (field-selection-tests
         ["ctia/investigation/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        investigation-fields)))))
+        sut/investigation-fields)))))
 
 (deftest test-investigation-routes-access-control
   (test-for-each-store
@@ -72,3 +73,15 @@
                           new-investigation-minimal
                           false
                           true))))
+
+(deftest test-investigation-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :investigation
+                          :plural :investigations
+                          :entity-minimal new-investigation-minimal
+                          :enumerable-fields sut/investigation-enumerable-fields
+                          :date-fields sut/investigation-histogram-fields
+                          :schema sut/NewInvestigation}))))

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -79,9 +79,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :investigation
-                          :plural :investigations
-                          :entity-minimal new-investigation-minimal
-                          :enumerable-fields sut/investigation-enumerable-fields
-                          :date-fields sut/investigation-histogram-fields
-                          :schema sut/NewInvestigation}))))
+     (test-metric-routes (into sut/investigation-entity
+                               {:entity-minimal new-investigation-minimal
+                                :enumerable-fields sut/investigation-enumerable-fields
+                                :date-fields sut/investigation-histogram-fields})))))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -3,6 +3,7 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [ctia.domain.entities :refer [schema-version]]
+            [ctia.entity.judgement :as sut]
             [ctia.entity.judgement.schemas
              :refer
              [judgement-fields
@@ -165,12 +166,10 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes {:entity :judgement
-                          :plural :judgements
-                          :entity-minimal ex/new-judgement-minimal
-                          :enumerable-fields judgement-enumerable-fields
-                          :date-fields judgement-histogram-fields
-                          :schema NewJudgement}))))
+     (test-metric-routes (into sut/judgement-entity
+                               {:entity-minimal ex/new-judgement-minimal
+                                :enumerable-fields judgement-enumerable-fields
+                                :date-fields judgement-histogram-fields})))))
 
 (deftest test-judgement-routes-for-dispositon-determination
   (test-for-each-store

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -169,7 +169,7 @@
                           :plural :judgements
                           :entity-minimal ex/new-judgement-minimal
                           :enumerable-fields judgement-enumerable-fields
-                          :date-fields [:timestamp]
+                          :date-fields judgement-histogram-fields
                           :schema NewJudgement}))))
 
 (deftest test-judgement-routes-for-dispositon-determination

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -82,9 +82,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :malware
-                          :plural :malwares
-                          :entity-minimal new-malware-minimal
-                          :enumerable-fields sut/malware-enumerable-fields
-                          :date-fields sut/malware-histogram-fields
-                          :schema sut/NewMalware}))))
+     (test-metric-routes (into sut/malware-entity
+                               {:entity-minimal new-malware-minimal
+                                :enumerable-fields sut/malware-enumerable-fields
+                                :date-fields sut/malware-histogram-fields})))))

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.malware-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.malware :refer [malware-fields]]
+            [ctia.entity.malware :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.malwares
              :refer
              [new-malware-maximal new-malware-minimal]]))
@@ -60,13 +61,13 @@
        (pagination-test
         "ctia/malware/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        malware-fields)
+        sut/malware-fields)
 
        (field-selection-tests
         ["ctia/malware/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        malware-fields)))))
+        sut/malware-fields)))))
 
 (deftest test-malware-routes-access-control
   (test-for-each-store
@@ -75,3 +76,15 @@
                           new-malware-minimal
                           true
                           true))))
+
+(deftest test-malware-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :malware
+                          :plural :malwares
+                          :entity-minimal new-malware-minimal
+                          :enumerable-fields sut/malware-enumerable-fields
+                          :date-fields sut/malware-histogram-fields
+                          :schema sut/NewMalware}))))

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -186,9 +186,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :relationship
-                          :plural :relationships
-                          :entity-minimal new-relationship-minimal
-                          :enumerable-fields sut/relationship-enumerable-fields
-                          :date-fields sut/relationship-histogram-fields
-                          :schema rs/NewRelationship}))))
+     (test-metric-routes (into sut/relationship-entity
+                               {:entity-minimal new-relationship-minimal
+                                :enumerable-fields sut/relationship-enumerable-fields
+                                :date-fields sut/relationship-histogram-fields})))))

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -4,6 +4,7 @@
             [ctia.entity.sighting.schemas :refer [sighting-sort-fields
                                                   sighting-fields
                                                   sighting-enumerable-fields
+                                                  sighting-histogram-fields
                                                   NewSighting]]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
@@ -57,9 +58,8 @@
      (test-metric-routes {:entity :sighting
                           :plural :sightings
                           :entity-minimal new-sighting-minimal
-                          :enumerable-fields [:source
-                                              :sensor]
-                          :date-fields [:timestamp]
+                          :enumerable-fields sighting-enumerable-fields
+                          :date-fields sighting-histogram-fields
                           :schema NewSighting}))))
 
 (deftest test-sighting-pagination-field-selection

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.sighting-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
+            [ctia.entity.sighting :as sut]
             [ctia.entity.sighting.schemas :refer [sighting-sort-fields
                                                   sighting-fields
                                                   sighting-enumerable-fields
@@ -55,12 +56,10 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes {:entity :sighting
-                          :plural :sightings
-                          :entity-minimal new-sighting-minimal
-                          :enumerable-fields sighting-enumerable-fields
-                          :date-fields sighting-histogram-fields
-                          :schema NewSighting}))))
+     (test-metric-routes (into sut/sighting-entity
+                               {:entity-minimal new-sighting-minimal
+                                :enumerable-fields sighting-enumerable-fields
+                                :date-fields sighting-histogram-fields})))))
 
 (deftest test-sighting-pagination-field-selection
   (test-for-each-store

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -1,19 +1,22 @@
 (ns ctia.entity.tool-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.tool.schemas :refer [tool-fields]]
+            [ctia.entity.tool.schemas :as ts]
+            [ctia.entity.tool :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.tools :refer [new-tool-maximal
-                                         new-tool-minimal]]))
+                                         new-tool-minimal]]
+            [ctia.entity.tool.schemas :as ts]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     helpers/fixture-properties:clean
@@ -56,13 +59,13 @@
        (pagination-test
         "ctia/tool/search?query=*"
         {"Authorization" "45c1f5e3f05d0"}
-        tool-fields)
+        ts/tool-fields)
 
        (field-selection-tests
         ["ctia/tool/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        tool-fields)))))
+        ts/tool-fields)))))
 
 (deftest test-tool-routes-access-control
   (test-for-each-store
@@ -71,3 +74,15 @@
                           new-tool-minimal
                           true
                           true))))
+
+(deftest test-tool-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :tool
+                          :plural :tools
+                          :entity-minimal new-tool-minimal
+                          :enumerable-fields sut/tool-enumerable-fields
+                          :date-fields sut/tool-histogram-fields
+                          :schema ts/NewTool}))))

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -80,9 +80,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :tool
-                          :plural :tools
-                          :entity-minimal new-tool-minimal
-                          :enumerable-fields sut/tool-enumerable-fields
-                          :date-fields sut/tool-histogram-fields
-                          :schema ts/NewTool}))))
+     (test-metric-routes (into sut/tool-entity
+                               {:entity-minimal new-tool-minimal
+                                :enumerable-fields sut/tool-enumerable-fields
+                                :date-fields sut/tool-histogram-fields})))))

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.vulnerability-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.vulnerability :refer [vulnerability-fields]]
+            [ctia.entity.vulnerability :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.vulnerabilities :refer [new-vulnerability-maximal new-vulnerability-minimal]]))
 
 (use-fixtures :once
@@ -56,12 +57,12 @@
         ["ctia/vulnerability/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        vulnerability-fields))
+        sut/vulnerability-fields))
 
      (pagination-test
       "ctia/vulnerability/search?query=*"
       {"Authorization" "45c1f5e3f05d0"}
-      vulnerability-fields))))
+      sut/vulnerability-fields))))
 
 (deftest test-vulnerability-routes-access-control
   (test-for-each-store
@@ -70,3 +71,15 @@
                           new-vulnerability-minimal
                           true
                           true))))
+
+(deftest test-vulnerability-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :vulnerability
+                          :plural :vulnerabilities
+                          :entity-minimal new-vulnerability-minimal
+                          :enumerable-fields sut/vulnerability-enumerable-fields
+                          :date-fields sut/vulnerability-histogram-fields
+                          :schema sut/NewVulnerability}))))

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -77,9 +77,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :vulnerability
-                          :plural :vulnerabilities
-                          :entity-minimal new-vulnerability-minimal
-                          :enumerable-fields sut/vulnerability-enumerable-fields
-                          :date-fields sut/vulnerability-histogram-fields
-                          :schema sut/NewVulnerability}))))
+     (test-metric-routes (into sut/vulnerability-entity
+                               {:entity-minimal new-vulnerability-minimal
+                                :enumerable-fields sut/vulnerability-enumerable-fields
+                                :date-fields sut/vulnerability-histogram-fields})))))

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -77,9 +77,7 @@
    (fn []
      (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes {:entity :weakness
-                          :plural :weaknesses
-                          :entity-minimal new-weakness-minimal
-                          :enumerable-fields sut/weakness-enumerable-fields
-                          :date-fields sut/weakness-histogram-fields
-                          :schema sut/NewWeakness}))))
+     (test-metric-routes (into sut/weakness-entity
+                               {:entity-minimal new-weakness-minimal
+                                :enumerable-fields sut/weakness-enumerable-fields
+                                :date-fields sut/weakness-histogram-fields})))))

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -1,17 +1,18 @@
 (ns ctia.entity.weakness-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
-            [ctia.entity.weakness :refer [weakness-fields]]
+            [ctia.entity.weakness :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk]]
              [crud :refer [entity-crud-test]]
+             [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store]]]
+             [store :refer [test-for-each-store store-fixtures]]]
             [ctim.examples.weaknesses :refer [new-weakness-maximal new-weakness-minimal]]))
 
 (use-fixtures :once
@@ -56,12 +57,12 @@
         ["ctia/weakness/search?query=*"
          (doc-id->rel-url (first ids))]
         {"Authorization" "45c1f5e3f05d0"}
-        weakness-fields))
+        sut/weakness-fields))
 
      (pagination-test
       "ctia/weakness/search?query=*"
       {"Authorization" "45c1f5e3f05d0"}
-      weakness-fields))))
+      sut/weakness-fields))))
 
 (deftest test-weakness-routes-access-control
   (test-for-each-store
@@ -70,3 +71,15 @@
                           new-weakness-minimal
                           true
                           true))))
+
+(deftest test-weakness-metric-routes
+  ((:es-store store-fixtures)
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
+     (test-metric-routes {:entity :weakness
+                          :plural :weaknesses
+                          :entity-minimal new-weakness-minimal
+                          :enumerable-fields sut/weakness-enumerable-fields
+                          :date-fields sut/weakness-histogram-fields
+                          :schema sut/NewWeakness}))))

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -202,12 +202,12 @@
           fields))
 
 (defn generate-n-entity
-  [{:keys [schema
+  [{:keys [new-schema
            entity-minimal
            enumerable-fields
            date-fields]}
    n]
-  (let [enumerable-schema (schema-enumerable-fields schema enumerable-fields)
+  (let [enumerable-schema (schema-enumerable-fields new-schema enumerable-fields)
         base-doc (dissoc entity-minimal :id)]
     (doall
      (repeatedly n (fn [] (merge base-doc

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -1,6 +1,5 @@
 (ns ctia.test-helpers.aggregate
-  (:require [clj-http.client :as client]
-            [clj-momo.lib.clj-time.core :as time]
+  (:require [clj-momo.lib.clj-time.core :as time]
             [clj-momo.lib.clj-time.coerce :as tc]
             [clj-momo.lib.clj-time.format :as tf]
             [ctia.test-helpers.core :as hc]
@@ -8,9 +7,10 @@
             [schema-generators.generators :as g]
             [ctia.http.routes.common :refer [now]]
             [schema-tools.core :as st]
-            [ctia.test-helpers.fixtures :refer [n-examples]]
             [clojure.walk :refer [keywordize-keys]]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.test :refer [is testing]]
+            [clojure.test.check.generators :as gen]
+            [schema.core :as s]))
 
 (defn metric-raw
   [agg-type entity search-params agg-params]
@@ -37,17 +37,45 @@
   [values]
   (mapcat set values))
 
+(defn l-get-in
+  "like get-in, but match keys in maps embedded in collections.
+  ~~~clojure
+  > (l-get-in {:a [{:b 2} {:b 3}]} [:a :b])
+    (2 3)
+  > (l-get-in {:a [2 3]} [:a])
+    [2 3]
+  > (l-get-in {:a {:b [2 3]}} [:a :b])
+    [2 3]
+  > (l-get-in {:a [{:b 2} {:b 3}]} [:a :b])
+    (2 3)
+  > (l-get-in {:a {:b 2 :c 3}} [:a :b])
+    2
+  > (l-get-in {:a {:d 2 :c 3}} [:a :b])
+    nil
+  > (l-get-in {:a [{:d 2} {:b 3}]} [:a :b])
+    (3)
+  ~~~"
+  [m ks]
+  (reduce (fn [acc k]
+            (cond
+              (map? acc) (get acc k)
+              (coll? acc) (seq (keep #(get % k) acc))
+              :else (reduced acc)))
+          m
+          ks))
+
 (defn- get-values
   [examples field]
   (let [parsed (parse-field field)]
-    (keep #(get-in % parsed) examples)))
+    (keep #(l-get-in % parsed) examples)))
 
 (defn- normalized-values
   [examples field]
   (let [values (get-values examples field)
         flattened (cond-> values
-                    (vector? (first values)) flatten-list-values)]
-    (map string/lower-case flattened)))
+                    (coll? (first values)) flatten-list-values)]
+    (map #(cond-> % (string? %) string/lower-case)
+         flattened)))
 
 (defn- check-from-to
   [from-str to-str]
@@ -145,20 +173,25 @@
 
 (defn schema-enumerable-fields
   [schema fields]
-  (->> (st/select-keys schema fields)
+  (->> (map (comp keyword first parse-field) fields)
+       (st/select-keys schema)
        st/required-keys))
 
 (defn generate-date
-  []
-  (format "2020-%02d-%02dT%02d:00:00.000Z"
-          (inc (rand-int 11))
-          (inc (rand-int 28))
-          (rand-int 24)))
+  [k]
+  (let [month (inc (case k
+                     :start_time (rand-int 6)
+                     :end_time (+ 6 (rand-int 6))
+                     (rand-int 11)))]
+    (format "2020-%02d-%02dT%02d:00:00.000Z"
+            month
+            (inc (rand-int 28))
+            (rand-int 24))))
 
 (defn append-date-field
   [doc field]
   (let [prepared (parse-field field)]
-    (assoc-in doc prepared (generate-date))))
+    (assoc-in doc prepared (generate-date (last prepared)))))
 
 (defn generate-date-fields
   [fields]
@@ -176,7 +209,10 @@
         base-doc (dissoc entity-minimal :id)]
     (doall
      (repeatedly n (fn [] (merge base-doc
-                                 (g/generate enumerable-schema)
+                                 (g/generate enumerable-schema
+                                             {s/Str (gen/such-that #(< 3 (count %)) ;; easier value to simulate ES match
+                                                                   gen/string-alphanumeric
+                                                                   30)})
                                  (generate-date-fields date-fields)))))))
 
 (defn test-metric-routes

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -37,24 +37,26 @@
   [values]
   (mapcat set values))
 
-(defn l-get-in
+(defn es-get-in
   "like get-in, but match keys in maps embedded in collections.
-  ~~~clojure
-  > (l-get-in {:a [{:b 2} {:b 3}]} [:a :b])
-    (2 3)
-  > (l-get-in {:a [2 3]} [:a])
-    [2 3]
-  > (l-get-in {:a {:b [2 3]}} [:a :b])
-    [2 3]
-  > (l-get-in {:a [{:b 2} {:b 3}]} [:a :b])
-    (2 3)
-  > (l-get-in {:a {:b 2 :c 3}} [:a :b])
-    2
-  > (l-get-in {:a {:d 2 :c 3}} [:a :b])
-    nil
-  > (l-get-in {:a [{:d 2} {:b 3}]} [:a :b])
-    (3)
-  ~~~"
+   This function is intended to simulate how ES match nested fields like a.b.
+   for instance (get-in {:a [{:b 2} {:b 3}]} [:a :b]) returns nil
+   while (es-get-in {:a [{:b 2} {:b 3}]} [:a :b]) returns '(2 3)"
+  {:test (fn []
+           (is (= (es-get-in {:a [{:b 2} {:b 3}]} [:a :b])
+                      '(2 3)))
+           (is (= (es-get-in {:a [2 3]} [:a])
+                      [2 3]))
+           (is (= (es-get-in {:a {:b [2 3]}} [:a :b])
+                      [2 3]))
+           (is (= (es-get-in {:a [{:b 2} {:b 3}]} [:a :b])
+                      '(2 3)))
+           (is (= (es-get-in {:a {:b 2 :c 3}} [:a :b])
+                      2))
+           (is (= (es-get-in {:a {:d 2 :c 3}} [:a :b])
+                      nil))
+           (is (= (es-get-in {:a [{:d 2} {:b 3}]} [:a :b])
+                      '(3))))}
   [m ks]
   (reduce (fn [acc k]
             (cond
@@ -67,7 +69,7 @@
 (defn- get-values
   [examples field]
   (let [parsed (parse-field field)]
-    (keep #(l-get-in % parsed) examples)))
+    (keep #(es-get-in % parsed) examples)))
 
 (defn- normalized-values
   [examples field]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #https://github.com/threatgrid/iroh/issues/3508
> Close #https://github.com/threatgrid/iroh/issues/3508

This PR enable metrics on other CTIA entities: Metrics were introduced for already searchable CTIM entities: Actor, AttackPattern, Campaign, Casebook, COA, IndentityAssertion, Indicator, Investigation, Malware, Relationship, Tool, Vulnerability and Weakness.
This PR also strenghtens generative testing on metric to avoid some random failures due too bad ES simulation.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

Metrics were introduced for already searchable CTIM entities: Actor, AttackPattern, Campaign, Casebook, COA, IndentityAssertion, Indicator, Investigation, Malware, Relationship, Tool, Vulnerability and Weakness.
This changes are only about activiting metric routes on specific fields. These routes work on the same code that were used in previous PR. Thus you should only check that metric routes return properly formatted results for each new entity and proposed fields for `aggregate-on` parameter.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: metric routes are now available for all entities.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

