### PR TITLE
strenghten string generation in metric tests

### DIFF
--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -109,8 +109,7 @@
                                  {:aggregate-on (name field)})]
       (is (= expected
              (get-in (:data res) (parse-field field)))
-          (error-helper-msg
-           (sort-by count unique-values)))
+          (error-helper-msg unique-values))
       (check-from-to from to))))
 
 (defn- test-topn

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -73,11 +73,9 @@
 
 (defn- normalized-values
   [examples field]
-  (let [values (get-values examples field)
-        flattened (cond-> values
-                    (coll? (first values)) flatten-list-values)]
-    (map #(cond-> % (string? %) string/lower-case)
-         flattened)))
+  (let [values (get-values examples field)]
+    (cond-> values
+      (coll? (first values)) flatten-list-values)))
 
 (defn- check-from-to
   [from-str to-str]
@@ -201,6 +199,11 @@
           {}
           fields))
 
+(def string-generator
+  (->> (gen/sample gen/string-alphanumeric 20)
+       (map string/lower-case)
+       gen/elements))
+
 (defn generate-n-entity
   [{:keys [new-schema
            entity-minimal
@@ -212,9 +215,7 @@
     (doall
      (repeatedly n (fn [] (merge base-doc
                                  (g/generate enumerable-schema
-                                             {s/Str (gen/such-that #(< 3 (count %)) ;; easier value to simulate ES match
-                                                                   gen/string-alphanumeric
-                                                                   30)})
+                                             {s/Str string-generator})
                                  (generate-date-fields date-fields)))))))
 
 (defn test-metric-routes


### PR DESCRIPTION
> Related #https://github.com/threatgrid/ctia/issues/905

Sometime the metric tests fail on labels. I did not manage to reproduce this issue.
This PR strengthen the label generator and improve test failing messages to help understanding if it happens again. I do not close the issue since I cannot confirm that it solves the problem, but it will help ease to improve this label generation if necessary.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
