### PR TITLE
Migration: prevent misconfiguration.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -48,7 +48,6 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                  
                  [threatgrid/ctim "1.0.17"]
                  [threatgrid/clj-momo "0.3.5"]
 

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -283,9 +283,11 @@
            store-keys]} :- MigrationParams]
   (doseq [store-key store-keys]
     (let [index (get-in @properties [:ctia :store :es store-key :indexname])]
-      (assert (not= (mst/prefixed-index index prefix)
-                    index)
-              (format "the source and target indices are identical. The migration was misconfigured."))))
+      (when (= (mst/prefixed-index index prefix)
+               index)
+        (throw (AssertionError.
+                (format "the source and target indices are identical: %s. The migration was misconfigured."
+                        index))))))
   true)
 
 (s/defn ^:always-validate run-migration

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -546,7 +546,7 @@ when confirm? is true, it stores this state and creates the target indices."
     (when confirm?
       (store-migration migration (:conn es-conn-state))
       (doseq [[_ target-store] target-stores]
-              (create-target-store! target-store)))
+        (create-target-store! target-store)))
     migration))
 
 (s/defn with-store-map :- MigratedStore

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -222,7 +222,6 @@
                                      {:created "08-15-1953"
                                       :modified "04-29-2019"}))))
 
-
 (deftest get-target-stores-test
   (let [{:keys [tool malware]}
         (sut/get-target-stores "0.0.0" [:tool :malware])]
@@ -854,7 +853,6 @@
       (is (thrown? clojure.lang.ExceptionInfo
                    (sut/get-migration migration-id-1 es-conn))
           "migration-id-1 was not confirmed it should not exist and thus get-migration must raise a proper exception")
-
       (testing "stored document shall not contains object stores in source and target"
         (let [{:keys [stores]} (es-doc/get-doc es-conn
                                                "ctia_migration"


### PR DESCRIPTION
> close #threatgrid/iroh/issues/3766

This PR enables a migration to abort in case of misconfiguration:
- check if any of entity stores is configured with the same source and target indices.
- check the schema of the parameters.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="ops">[§](#ops)</a> Ops
===============================

The migration now aborts in case of misconfiguration when the source and target store are identical. We should plan to run it on INT before the release.
