### PR TITLE
Fix investigation schema

### DIFF
--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -1,30 +1,14 @@
 (ns ctia.entity.investigation
-  (:require [ctia.domain.entities :refer [default-realize-fn]]
-            [ctia.store :refer :all]
-            [ctia.http.routes
-             [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
-             [crud :refer [entity-crud-routes]]]
-            [ctia.schemas
-             [utils :as csu]
-             [core :refer [def-stored-schema
-                           CTIAEntity]]
-             [sorting :as sorting]]
-            [ctia.schemas.graphql
-             [sorting :as graphql-sorting]
-             [flanders :as flanders]
-             [helpers :as g]
-             [pagination :as pagination]]
-            [ctia.stores.es
-             [mapping :as em]
-             [store :refer [def-es-store]]]
-            [ctia.entity.investigation.schemas :as inv]
-            [flanders
-             [schema :as f-schema]
-             [spec :as f-spec]
-             [utils :as fu]]
+  (:require [ctia.entity.investigation.schemas :as inv]
+            [ctia.http.routes.common
+             :refer
+             [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]]
+            [ctia.http.routes.crud :refer [entity-crud-routes]]
+            [ctia.schemas.sorting :as sorting]
+            [ctia.stores.es.mapping :as em]
+            [ctia.stores.es.store :refer [def-es-store]]
             [schema-tools.core :as st]
-            [schema.core :as s]
-            [ctia.schemas.graphql.ownership :as go]))
+            [schema.core :as s]))
 
 (def snapshot-action-fields-mapping
   {:object_ids em/token

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -17,7 +17,7 @@
             [ctia.stores.es
              [mapping :as em]
              [store :refer [def-es-store]]]
-            [ctim.schemas.investigation :as inv]
+            [ctia.entity.investigation.schemas :as inv]
             [flanders
              [schema :as f-schema]
              [spec :as f-spec]
@@ -25,36 +25,6 @@
             [schema-tools.core :as st]
             [schema.core :as s]
             [ctia.schemas.graphql.ownership :as go]))
-
-(s/defschema Investigation
-  (st/merge (f-schema/->schema inv/Investigation)
-            CTIAEntity
-            {s/Keyword s/Any}))
-
-(f-spec/->spec inv/Investigation "investigation")
-
-(s/defschema PartialInvestigation
-  (st/merge (f-schema/->schema (fu/optionalize-all inv/Investigation))
-            CTIAEntity
-            {s/Keyword s/Any}))
-
-(s/defschema PartialInvestigationList
-  [PartialInvestigation])
-
-(s/defschema NewInvestigation
-  (st/merge (f-schema/->schema inv/NewInvestigation)
-            CTIAEntity
-            {s/Keyword s/Any}))
-
-(f-spec/->spec inv/NewInvestigation "new-investigation")
-
-(def-stored-schema StoredInvestigation Investigation)
-
-(s/defschema PartialStoredInvestigation
-  (csu/optional-keys-schema StoredInvestigation))
-
-(def realize-investigation
-  (default-realize-fn "investigation" NewInvestigation StoredInvestigation))
 
 (def snapshot-action-fields-mapping
   {:object_ids em/token
@@ -73,8 +43,8 @@
      snapshot-action-fields-mapping)}})
 
 (def-es-store InvestigationStore :investigation
-  StoredInvestigation
-  PartialStoredInvestigation)
+  inv/StoredInvestigation
+  inv/PartialStoredInvestigation)
 
 (def investigation-fields
   (concat sorting/default-entity-sort-fields
@@ -113,29 +83,6 @@
    InvestigationFieldsParam
    PagingParams))
 
-(def InvestigationType
-  (let [{:keys [fields name description]}
-        (flanders/->graphql
-         (fu/optionalize-all inv/Investigation)
-         {})]
-    (g/new-object
-     name
-     description
-     []
-     (merge
-      fields go/graphql-ownership-fields))))
-
-(def investigation-order-arg
-  (graphql-sorting/order-by-arg
-   "InvestigationOrder"
-   "investigations"
-   (into {}
-         (map (juxt graphql-sorting/sorting-kw->enum-name name)
-              investigation-fields))))
-
-(def InvestigationConnectionType
-  (pagination/new-connection InvestigationType))
-
 (def investigation-enumerable-fields
   [:source])
 
@@ -145,16 +92,16 @@
 (def investigation-routes
   (entity-crud-routes
    {:entity :investigation
-    :new-schema NewInvestigation
-    :entity-schema Investigation
-    :get-schema PartialInvestigation
+    :new-schema inv/NewInvestigation
+    :entity-schema inv/Investigation
+    :get-schema inv/PartialInvestigation
     :get-params InvestigationGetParams
-    :list-schema PartialInvestigationList
-    :search-schema PartialInvestigationList
+    :list-schema inv/PartialInvestigationList
+    :search-schema inv/PartialInvestigationList
     :external-id-q-params InvestigationsByExternalIdQueryParams
     :search-q-params InvestigationSearchParams
     :new-spec :new-investigation/map
-    :realize-fn realize-investigation
+    :realize-fn inv/realize-investigation
     :get-capabilities :read-investigation
     :post-capabilities :create-investigation
     :put-capabilities :create-investigation
@@ -178,13 +125,13 @@
    :entity :investigation
    :plural :investigations
    :new-spec :new-investigation/map
-   :schema Investigation
-   :partial-schema PartialInvestigation
-   :partial-list-schema PartialInvestigationList
-   :new-schema NewInvestigation
-   :stored-schema StoredInvestigation
-   :partial-stored-schema PartialStoredInvestigation
-   :realize-fn realize-investigation
+   :schema inv/Investigation
+   :partial-schema inv/PartialInvestigation
+   :partial-list-schema inv/PartialInvestigationList
+   :new-schema inv/NewInvestigation
+   :stored-schema inv/StoredInvestigation
+   :partial-stored-schema inv/PartialStoredInvestigation
+   :realize-fn inv/realize-investigation
    :es-store ->InvestigationStore
    :es-mapping investigation-mapping
    :routes investigation-routes

--- a/src/ctia/entity/investigation/examples.clj
+++ b/src/ctia/entity/investigation/examples.clj
@@ -21,7 +21,8 @@
    :investigated_observables ["sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"]
    :targets [{:type "endpoint"
               :observables [{:value "Demo_iOS_3", :type "hostname"}]
-              :observed_time {:start_time "2019-04-01T20:45:11.000Z"}
+              :observed_time {:start_time "2019-04-01T20:45:11.000Z"
+                              :end_time "2020-04-01T20:45:11.000Z"}
               :os "iOS 10.3 (1)"}]
    :title "investigation-title"
    :description "description"

--- a/src/ctia/entity/investigation/examples.clj
+++ b/src/ctia/entity/investigation/examples.clj
@@ -28,7 +28,10 @@
    :short_description "short desc"
    :source "a source"
    :source_uri "http://example.com/somewhere-else"
-   :tlp "green"})
+   :tlp "green"
+   ;; add extra actual fields that were actually inserted in the store due to the open schema.
+   "search-txt" "sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
+   "actions" "[{\"uuid\":\"cae31704-9454-4428-afac-711e41a7ae24\",\"state\":\"ok\",\"updated\":\"2019-01-02T17:48:32.099Z\",\"type\":\"collect\", ...}]"})
 
 (def investigation-minimal
   {:id "http://ex.tld/ctia/investigation/investigation-2805d697-66b3-4e14-9b32-179e7a72eab6"

--- a/src/ctia/entity/investigation/flanders_schemas.clj
+++ b/src/ctia/entity/investigation/flanders_schemas.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.investigation.flanders-schemas
   (:require [ctim.schemas.common :as c]
-            [flanders.core :as f :refer [def-entity-type def-eq]]))
+            [flanders.core :as f :refer [def-entity-type def-eq]]
+            [schema.core :as s]))
 
 (def type-identifier "investigation")
 
@@ -14,10 +15,10 @@
   (f/required-entries
    (f/entry :type InvestigationIdentifier))
   (f/optional-entries
-   (f/entry :actions (f/str)
+   (f/entry :actions f/any-str
             :description "Investigation actions encoded as JSON (an array of objects).")
-   (f/entry :object_ids (f/seq-of (f/str)))
-   (f/entry :investigated_observables (f/seq-of (f/str)))
+   (f/entry :object_ids f/any-string-seq)
+   (f/entry :investigated_observables f/any-string-seq)
    (f/entry :targets (f/seq-of c/IdentitySpecification)
             :description "Investigated target devices")))
 

--- a/src/ctia/entity/investigation/schemas.clj
+++ b/src/ctia/entity/investigation/schemas.clj
@@ -5,20 +5,30 @@
    [flanders.utils :as fu]
    [ctia.schemas
     [utils :as csu]
-    [core :refer [def-acl-schema
+    [core :refer [def-advanced-acl-schema
                   def-stored-schema]]]
    [schema.core :as s]))
 
-(def-acl-schema Investigation f-inv/Investigation "investigation")
+(def-advanced-acl-schema
+  {:name-sym Investigation
+   :ddl f-inv/Investigation
+   :spec-kw-ns "investigation"
+   :open? true})
 
-(def-acl-schema PartialInvestigation
-  (fu/optionalize-all f-inv/Investigation)
-  "partial-investigation")
+(def-advanced-acl-schema
+  {:name-sym PartialInvestigation
+   :ddl (fu/optionalize-all f-inv/Investigation)
+   :spec-kw-ns "partial-investigation"
+   :open? true})
 
 (s/defschema PartialInvestigationList
   [PartialInvestigation])
 
-(def-acl-schema NewInvestigation f-inv/NewInvestigation "new-investigation")
+(def-advanced-acl-schema
+  {:name-sym NewInvestigation
+   :ddl f-inv/NewInvestigation
+   :spec-kw-ns "new-investigation"
+   :open? true})
 
 (def-stored-schema StoredInvestigation Investigation)
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -71,14 +71,23 @@
          ~sch
          CTIAStoredEntity)))))
 
-(defmacro def-acl-schema [name-sym ddl spec-kw-ns]
+(defmacro def-advanced-acl-schema [{:keys [name-sym
+                                           ddl
+                                           spec-kw-ns
+                                           open?]}]
   `(do
      (s/defschema ~name-sym
-       (csutils/recursive-open-schema-version
-        (st/merge
-         (f-schema/->schema ~ddl)
-         CTIAEntity)))
+       (cond-> (csutils/recursive-open-schema-version
+                (st/merge
+                 (f-schema/->schema ~ddl)
+                 CTIAEntity))
+         ~open? st/open-schema))
      (f-spec/->spec ~ddl ~spec-kw-ns)))
+
+(defmacro def-acl-schema [name-sym ddl spec-kw-ns]
+  `(def-advanced-acl-schema {:name-sym ~name-sym
+                             :ddl ~ddl
+                             :spec-kw-ns ~spec-kw-ns}))
 
 ;; verdict
 

--- a/test/ctia/http/routes/graphql/investigation_test.clj
+++ b/test/ctia/http/routes/graphql/investigation_test.clj
@@ -1,0 +1,84 @@
+(ns ctia.http.routes.graphql.investigation-test
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.entity.investigation :as inv]
+            [ctia.entity.investigation.examples :refer [investigation-maximal]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.fixtures :as fixt]
+            [ctia.test-helpers.graphql :as gh]
+            [ctia.test-helpers.store :refer [test-for-each-store]]))
+
+(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+                                    helpers/fixture-properties:clean
+                                    whoami-helpers/fixture-server]))
+
+(use-fixtures :each whoami-helpers/fixture-reset-state)
+
+(def ownership-data-fixture
+  {:owner "foouser"
+   :groups ["foogroup"]})
+
+(def investigation-1 (fixt/randomize investigation-maximal))
+(def investigation-2 (assoc
+                      (fixt/randomize investigation-maximal)
+                      :source "ngfw"))
+
+(defn select-graphql-fields
+  [investigation]
+  (select-keys investigation
+               [:id
+                :type
+                :schema_version
+                :title
+                :timestamp
+                :tlp
+                :source
+                :owner
+                :groups
+                :object_ids
+                :investigated_observables
+                :targets]))
+
+(deftest investigation-graphql-test
+  (test-for-each-store
+   (fn []
+     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [inv1 (select-graphql-fields
+                 (gh/create-object "investigation" investigation-1))
+           inv2 (select-graphql-fields
+                 (gh/create-object "investigation" investigation-2))
+           graphql-queries (slurp "test/data/queries.graphql")]
+       (testing "investigations query"
+         (testing "investigations connection"
+           (gh/connection-test "InvestigationsQueryTest"
+                               graphql-queries
+                               {"query" "*"}
+                               [:investigations]
+                               (map #(merge % ownership-data-fixture)
+                                    [inv1 inv2]))
+
+           (testing "sorting"
+             (gh/connection-sort-test
+              "InvestigationsQueryTest"
+              graphql-queries
+              {:query "*"}
+              [:investigations]
+              inv/investigation-fields)))
+         (testing "query argument"
+           (let [{:keys [data errors status]}
+                 (gh/query graphql-queries
+                           {:query "source:\"ngfw\""}
+                           "InvestigationsQueryTest")]
+             (is (= 200 status))
+             (is (empty? errors) "No errors")
+             (is (= 1 (get-in data [:investigations :totalCount]))
+                 "Only one investigation matches to the query")
+             (is (= [inv2]
+                    (get-in data [:investigations :nodes]))
+                 "The investigation matches the search query"))))))))

--- a/test/ctia/http/routes/graphql/investigation_test.clj
+++ b/test/ctia/http/routes/graphql/investigation_test.clj
@@ -28,7 +28,6 @@
 (defn prepare-result
   [investigation]
   (dissoc investigation
-          :actions
           :search-txt))
 
 (deftest investigation-graphql-test

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -104,16 +104,6 @@
    "valid_time" {"start_time" "2016-05-11T00:40:48.000Z"
                  "end_time" "2025-07-11T00:40:48.000Z"}})
 
-(def investigation-1
-  {"source" "foo"
-   "timestamp" #inst "2042-01-01T00:00:00.000Z"
-   "title" "foo"})
-
-(def investigation-2
-  {"source" "bar"
-   "timestamp" #inst "2042-01-01T00:00:00.000Z"
-   "title" "foo"})
-
 (def sighting-1
   {"description" "Hostnames that have resolved to 194.87.217.88"
    "confidence" "High"
@@ -174,8 +164,6 @@
   (let [i1  (gh/create-object "indicator" indicator-1)
         i2  (gh/create-object "indicator" indicator-2)
         i3  (gh/create-object "indicator" indicator-3)
-        in1 (gh/create-object "investigation" investigation-1)
-        in2 (gh/create-object "investigation" investigation-2)
         j1  (gh/create-object "judgement" judgement-1)
         j2  (gh/create-object "judgement" judgement-2)
         j3  (gh/create-object "judgement" judgement-3)
@@ -232,8 +220,6 @@
     {:indicator-1 i1
      :indicator-2 i2
      :indicator-3 i3
-     :investigation-1 in1
-     :investigation-2 in2
      :judgement-1 j1
      :judgement-2 j2
      :judgement-3 j3
@@ -257,7 +243,6 @@
            indicator-1-id (get-in datamap [:indicator-1 :id])
            indicator-2-id (get-in datamap [:indicator-2 :id])
            indicator-3-id (get-in datamap [:indicator-3 :id])
-           investigation-1-id (get-in datamap [:investigation-1 :id])
            casebook-1-id (get-in datamap [:casebook-1 :id])
            judgement-1-id (get-in datamap [:judgement-1 :id])
            sighting-1-id (get-in datamap [:sighting-1 :id])
@@ -509,54 +494,6 @@
                (is (= [(:indicator-1 datamap)]
                       (get-in data [:indicators :nodes]))
                    "The indicator matches the search query"))))
-
-         (testing "investigation query"
-           (let [{:keys [data errors status]}
-                 (gh/query graphql-queries
-                           {:id investigation-1-id}
-                           "InvestigationQueryTest")]
-
-             (is (= 200 status))
-             (is (empty? errors) "No errors")
-
-             (testing "the investigation"
-               (is (= (:investigation-1 datamap)
-                      (:investigation data))))))
-
-         (testing "investigations query"
-           (testing "investigations connection"
-             (gh/connection-test "InvestigationsQueryTest"
-                                 graphql-queries
-                                 {"query" "*"}
-                                 [:investigations]
-                                 (map #(merge % ownership-data-fixture)
-                                      [(:investigation-1 datamap)
-                                       (:investigation-2 datamap)]))
-
-             (testing "sorting"
-               (gh/connection-sort-test
-                "InvestigationsQueryTest"
-                graphql-queries
-                {:query "*"}
-                [:investigations]
-                ctia.entity.investigation/investigation-fields)))
-
-
-
-           (testing "query argument"
-             (let [{:keys [data errors status]}
-                   (gh/query graphql-queries
-                             {:query "source:\"foo\""}
-                             "InvestigationsQueryTest")]
-               (is (= 200 status))
-               (is (empty? errors) "No errors")
-               (is (= 1 (get-in data [:investigations :totalCount]))
-                   "Only one investigation matches to the query")
-               (is (= [(:investigation-1 datamap)]
-                      (get-in data [:investigations :nodes]))
-                   "The investigation matches the search query"))))
-
-                                        ;------------------
 
          (testing "casebook query"
            (let [{:keys [data errors status]}

--- a/test/ctia/task/check_es_stores_test.clj
+++ b/test/ctia/task/check_es_stores_test.clj
@@ -10,7 +10,7 @@
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
             [ctim.domain.id :refer [make-transient-id]]
-            [ctia.entity.examples.investigations :refer [investigation-minimal]]
+            [ctia.entity.investigation.examples :refer [investigation-minimal]]
             [ctim.examples
              [actors :refer [actor-minimal]]
              [attack-patterns :refer [attack-pattern-minimal]]

--- a/test/ctia/task/check_es_stores_test.clj
+++ b/test/ctia/task/check_es_stores_test.clj
@@ -10,6 +10,7 @@
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
             [ctim.domain.id :refer [make-transient-id]]
+            [ctia.entity.examples.investigations :refer [investigation-minimal]]
             [ctim.examples
              [actors :refer [actor-minimal]]
              [attack-patterns :refer [attack-pattern-minimal]]
@@ -18,12 +19,10 @@
              [coas :refer [coa-minimal]]
              [incidents :refer [incident-minimal]]
              [indicators :refer [indicator-minimal]]
-             [investigations :refer [investigation-minimal]]
              [judgements :refer [judgement-minimal]]
              [malwares :refer [malware-minimal]]
              [relationships :refer [relationship-minimal]]
              [sightings :refer [sighting-minimal]]
-             [identity-assertions :refer [identity-assertion-minimal]]
              [tools :refer [tool-minimal]]
              [vulnerabilities :refer [vulnerability-minimal]]
              [weaknesses :refer [weakness-minimal]]]))

--- a/test/ctia/test_helpers/fixtures.clj
+++ b/test/ctia/test_helpers/fixtures.clj
@@ -1,5 +1,6 @@
 (ns ctia.test-helpers.fixtures
   (:require [ctim.domain.id :refer [make-transient-id]]
+            [ctia.entity.investigation.examples :refer [investigation-maximal investigation-minimal]]
             [ctim.examples
              [actors :refer [actor-maximal actor-minimal]]
              [attack-patterns :refer [attack-pattern-maximal attack-pattern-minimal]]
@@ -7,13 +8,11 @@
              [coas :refer [coa-maximal coa-minimal]]
              [incidents :refer [incident-maximal incident-minimal]]
              [indicators :refer [indicator-maximal indicator-minimal]]
-             [investigations :refer [investigation-maximal investigation-minimal]]
              [judgements :refer [judgement-maximal judgement-minimal]]
              [malwares :refer [malware-maximal malware-minimal]]
              [relationships :refer [relationship-maximal relationship-minimal]]
              [casebooks :refer [casebook-maximal casebook-minimal]]
              [sightings :refer [sighting-maximal sighting-minimal]]
-             [identity-assertions :refer [identity-assertion-maximal identity-assertion-minimal]]
              [tools :refer [tool-maximal tool-minimal]]
              [vulnerabilities :refer [vulnerability-maximal vulnerability-minimal]]
              [weaknesses :refer [weakness-maximal weakness-minimal]]]))

--- a/test/data/investigation.graphql
+++ b/test/data/investigation.graphql
@@ -51,6 +51,7 @@ fragment investigationFields on Investigation {
   groups
   external_ids
   external_references { ...externalReferenceFields}
+  actions
   object_ids
   investigated_observables
   targets { ...identitySpecificationFields }

--- a/test/data/investigation.graphql
+++ b/test/data/investigation.graphql
@@ -1,0 +1,80 @@
+fragment pageInfoFields on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
+
+fragment observableBaseFields on Observable {
+  type
+  value
+}
+
+fragment observedTimeFields on ObservedTime {
+  start_time
+  end_time
+}
+
+fragment identitySpecificationFields on IdentitySpecification {
+  type
+  os
+  observables {
+    ...observableBaseFields
+  }
+  observed_time {
+    ...observedTimeFields
+  }
+}
+
+fragment investigationFields on Investigation {
+  id
+  type
+  schema_version
+  revision
+  language
+  description
+  short_description
+  title
+  timestamp
+  tlp
+  source
+  source_uri
+  owner
+  groups
+  external_ids
+  external_references { ...externalReferenceFields}
+  object_ids
+  investigated_observables
+  targets { ...identitySpecificationFields }
+}
+
+query InvestigationsQueryTest($query: String, $after: String, $first: Int, $sort_field:InvestigationOrderField = ID, $sort_direction: OrderDirection = asc) {
+  investigations(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...investigationFields
+    }
+    edges {
+      node {
+        ...investigationFields
+      }
+    }
+  }
+}
+
+query InvestigationQueryTest($id: String!) {
+  investigation(id: $id) {
+    ...investigationFields
+  }
+}

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -242,55 +242,6 @@ fragment indicatorFields on Indicator {
   groups
 }
 
-query InvestigationQueryTest($id: String!) {
-  investigation(id: $id) {
-    ...investigationFields
-  }
-}
-
-query InvestigationsQueryTest($query: String, $after: String, $first: Int, $sort_field:InvestigationOrderField = ID, $sort_direction: OrderDirection = asc) {
-  investigations(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
-    totalCount
-    pageInfo {
-      ...pageInfoFields
-    }
-    nodes {
-      ...investigationFields
-    }
-    edges {
-      node {
-        ...investigationFields
-      }
-    }
-  }
-}
-
-fragment identitySpecificationFields on IdentitySpecification {
-  type
-  os
-  observables {
-    ...observableBaseFields
-  }
-  observed_time {
-    ...observedTimeFields
-  }
-}
-
-fragment investigationFields on Investigation {
-  id
-  type
-  schema_version
-  title
-  timestamp
-  tlp
-  source
-  owner
-  groups
-  object_ids
-  investigated_observables
-  targets { ...identitySpecificationFields }
-}
-
 query CasebookQueryTest($id: String!) {
   casebook(id: $id) {
     ...casebookFields

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -265,6 +265,17 @@ query InvestigationsQueryTest($query: String, $after: String, $first: Int, $sort
   }
 }
 
+fragment identitySpecificationFields on IdentitySpecification {
+  type
+  os
+  observables {
+    ...observableBaseFields
+  }
+  observed_time {
+    ...observedTimeFields
+  }
+}
+
 fragment investigationFields on Investigation {
   id
   type
@@ -275,6 +286,9 @@ fragment investigationFields on Investigation {
   source
   owner
   groups
+  object_ids
+  investigated_observables
+  targets { ...identitySpecificationFields }
 }
 
 query CasebookQueryTest($id: String!) {


### PR DESCRIPTION
This PR Fixes Investigation Schemas. CTIM flanders schemas were internalized in CTIA, but the former schema were not removed and thus actually used instead of the new schema. 
Since the former schema was open, it did not cause any trouble on added fields, but this was the cause of missing fields in grapqhl.

<a name="qa">[§](#qa)</a> QA
============================

The graphql endpoint should now enable to retrieve `object_ids`, `investigated_observables` and `targets`.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: fixed a bug in investigation graphql schema.
```

