### PR TITLE
bundle import, take first available existing entity if duplicates

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -166,23 +166,18 @@
                              first
                              :entity
                              with-long-id
-                             ent/un-store)
-          num-old-entities (count old-entities)]
+                             ent/un-store)]
+      (when (< (count old-entities) 1)
+        (log/warn
+         (format
+          (str "More than one entity is "
+               "linked to the external id %s (%s)")
+          external_id
+          (pr-str (map :id old-entities)))))
       (cond-> entity-data
         ;; only one entity linked to the external ID
-        (and old-entity
-             (= num-old-entities 1)) (assoc :result "exists"
-                                            ;;:old-entity old-entity
-                                            :id (:id old-entity))
-        ;; more than one entity linked to the external ID
-        (> num-old-entities 1)
-        (assoc :result "error"
-               :error
-               (format
-                (str "More than one entity is "
-                     "linked to the external id %s (%s)")
-                external_id
-                (pr-str (map :id old-entities))))))
+        old-entity (assoc :result "exists"
+                          :id (:id old-entity))))
     entity-data))
 
 (s/defn with-existing-entities :- [EntityImportData]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -167,13 +167,15 @@
                              :entity
                              with-long-id
                              ent/un-store)]
-      (when (< (count old-entities) 1)
+      (when (< 1 (count old-entities))
         (log/warn
          (format
           (str "More than one entity is "
-               "linked to the external id %s (%s)")
+               "linked to the external id %s (examples: %s)")
           external_id
-          (pr-str (map :id old-entities)))))
+          (->> (take 10 old-entities) ;; prevent very large logs
+               (map (comp :id :entity))
+               pr-str))))
       (cond-> entity-data
         ;; only one entity linked to the external ID
         old-entity (assoc :result "exists"

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -1,9 +1,13 @@
 (ns ctia.bundle.core-test
   (:require [ctia.bundle.core :as sut]
-            [clojure.test :as t :refer [deftest use-fixtures are is testing]]
+            [ctia.domain.entities :as ent :refer [with-long-id]]
+            [ctia.flows.crud :refer [make-id]]
+            [clojure.test :as t :refer [deftest use-fixtures join-fixtures are is testing]]
             [ctia.test-helpers.core :as h]))
 
-(use-fixtures :once h/fixture-properties:clean)
+(use-fixtures :once
+  (join-fixtures [h/fixture-properties:clean
+                  h/fixture-ctia-fast]))
 
 (deftest local-entity?-test
   (are [x y] (= x (sut/local-entity? y))
@@ -44,3 +48,33 @@
             :query "source_ref:*malware*"}
            (sut/relationships-filters "id" {:source_type :malware
                                             :related_to [:source_ref]})))))
+
+(deftest with-existing-entity-test
+  (testing "with-existing-entity"
+    (let [indicator-id-1 (make-id "indicator")
+          indicator-id-2 (make-id "indicator")
+          indicator-id-3 (make-id "indicator")]
+      (testing "1 existing external id"
+        (is (= (with-long-id {:result "exists"
+                              :external_id "swe-alarm-indicator-1"
+                              :id indicator-id-1})
+               (sut/with-existing-entity
+                 {:id "transient:1"
+                  :external_id "swe-alarm-indicator-1"}
+                 (constantly [{:entity {:id indicator-id-1}}])))))
+      (testing "more than 1 existing external id"
+        (is (= (with-long-id {:result "exists"
+                              :external_id "swe-alarm-indicator-2"
+                              :id indicator-id-2})
+               (sut/with-existing-entity
+                 {:id "transient:2"
+                  :external_id "swe-alarm-indicator-2"}
+                 (constantly [{:entity {:id indicator-id-2}}
+                              {:entity {:id indicator-id-1}}])))))
+      (testing "no existing external id"
+        (is (= {:id indicator-id-3
+                :external_id "swe-alarm-indicator-1"}
+               (sut/with-existing-entity
+                 {:id indicator-id-3
+                  :external_id "swe-alarm-indicator-1"}
+                 (constantly []))))))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/threatgrid/iroh/issues/3880

In `bundle/import` route, when duplicate entities are actually found, use the last provided entity to avoid further duplicate and notify it in the response about these duplicates.

<a name="qa">[§](#qa)</a> QA
============================

- use `bundle/import` route without the the `external-key-prefixes` value: `test` to import the following bundle:
[SWE Bundle.json.zip](https://github.com/threatgrid/ctia/files/4847617/SWE.Bundle.json.zip)
For all imported entities, the field `result` should have the value `created`.
- make the same request once again:
For all imported entities, the field `result` should have the value `created`.
- import the same bundle another time but with the `external-key-prefixes` value: `swe-alarm`:
For all imported entities, the field `result` should have the value `existing` with no error.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: enables CTIA `bundle/import` to deal with duplicated external ids.
```