### PR TITLE
Remove default external key prefix 3881

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -118,7 +118,6 @@ ctia.store.es.vulnerability.indexname=ctia_vulnerability
 ctia.store.es.weakness.indexname=ctia_weakness
 ctia.store.es.feed.indexname=ctia_feed
 
-ctia.store.external-key-prefixes=cisco-,ctia-
 ctia.store.bundle-refresh=wait_for
 ctia.store.bulk-refresh=false
 

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -31,8 +31,6 @@
   [id]
   (and id (re-matches id/transient-id-re id)))
 
-(def default-external-key-prefixes "ctia-")
-
 (defn debug [msg v]
   (log/debug msg v)
   v)
@@ -46,8 +44,10 @@
   "Returns the external ID that can be used to check whether an entity has
   already been imported or not."
   [external-ids key-prefixes]
-  (let [valid-external-ids (mapcat #(prefixed-external-ids % external-ids)
-                                   key-prefixes)]
+  (let [valid-external-ids (if (seq key-prefixes)
+                             (mapcat #(prefixed-external-ids % external-ids)
+                                     key-prefixes)
+                             external-ids)]
     (if (> (count valid-external-ids) 1)
       (log/warnf (str "More than 1 valid external ID has been found "
                       "(key-prefixes:%s | external-ids:%s)")
@@ -66,11 +66,7 @@
   [{:keys [id external_ids] :as entity}
    entity-type
    external-key-prefixes]
-  (let [key-prefixes (parse-key-prefixes
-                      (or external-key-prefixes
-                          (get-in @properties
-                                  [:ctia :store :external-key-prefixes]
-                                  default-external-key-prefixes)))
+  (let [key-prefixes (parse-key-prefixes external-key-prefixes)
         external_id (valid-external-id external_ids key-prefixes)]
     (when-not external_id
       (log/warnf "No valid external ID has been provided (id:%s)" id))

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -40,19 +40,19 @@
   [key-prefix external-ids]
   (filter #(string/starts-with? % key-prefix) external-ids))
 
-(s/defn valid-external-id :- (s/maybe s/Str)
-  "Returns the external ID that can be used to check whether an entity has
+(s/defn filter-external-ids :- [s/Str]
+  "Returns the external IDs that can be used to check whether an entity has
   already been imported or not."
   [external-ids key-prefixes]
-  (let [valid-external-ids (if (seq key-prefixes)
-                             (mapcat #(prefixed-external-ids % external-ids)
-                                     key-prefixes)
-                             external-ids)]
-    (if (> (count valid-external-ids) 1)
+  (let [valid-ext-ids (if (seq key-prefixes)
+                        (mapcat #(prefixed-external-ids % external-ids)
+                                key-prefixes)
+                        external-ids)]
+    (when (> (count valid-ext-ids) 1)
       (log/warnf (str "More than 1 valid external ID has been found "
                       "(key-prefixes:%s | external-ids:%s)")
-                 (pr-str key-prefixes) (pr-str external-ids))
-      (first valid-external-ids))))
+                 (pr-str key-prefixes) (pr-str external-ids)))
+    valid-ext-ids))
 
 (s/defn parse-key-prefixes :- [s/Str]
   "Parses a comma separated list of external ID prefixes"
@@ -67,13 +67,13 @@
    entity-type
    external-key-prefixes]
   (let [key-prefixes (parse-key-prefixes external-key-prefixes)
-        external_id (valid-external-id external_ids key-prefixes)]
-    (when-not external_id
+        filtered-ext-ids (filter-external-ids external_ids key-prefixes)]
+    (when-not (seq filtered-ext-ids)
       (log/warnf "No valid external ID has been provided (id:%s)" id))
     (cond-> {:new-entity entity
              :type entity-type}
       (transient-id? id) (assoc :original_id id)
-      external_id (assoc :external_id external_id))))
+      (seq filtered-ext-ids) (assoc :external_ids filtered-ext-ids))))
 
 (defn all-pages
   "Retrieves all external ids using pagination."
@@ -90,7 +90,7 @@
 
 (defn find-by-external-ids
   [import-data entity-type auth-identity]
-  (let [external-ids (keep :external_id import-data)]
+  (let [external-ids (mapcat :external_ids import-data)]
     (log/debugf "Searching %s matching these external_ids %s"
                 entity-type
                 (pr-str external-ids))
@@ -154,10 +154,10 @@
   "If the entity has already been imported, update the import data
    with its ID. If more than one old entity is linked to an external id,
    an error is reported."
-  [{:keys [external_id]
+  [{:keys [external_ids]
     :as entity-data} :- EntityImportData
-   find-by-external-id]
-  (if-let [old-entities (find-by-external-id external_id)]
+   find-by-external-ids]
+  (if-let [old-entities (mapcat find-by-external-ids external_ids)]
     (let [old-entity (some-> old-entities
                              first
                              :entity
@@ -167,8 +167,8 @@
         (log/warn
          (format
           (str "More than one entity is "
-               "linked to the external id %s (examples: %s)")
-          external_id
+               "linked to the external ids %s (examples: %s)")
+          external_ids
           (->> (take 10 old-entities) ;; prevent very large logs
                (map (comp :id :entity))
                pr-str))))

--- a/src/ctia/bundle/schemas.clj
+++ b/src/ctia/bundle/schemas.clj
@@ -10,7 +10,7 @@
     :original_id s/Str
     :result (s/enum "error" "created" "exists")
     :type s/Keyword
-    :external_id s/Str
+    :external_ids [s/Str]
     :error s/Any
     :msg s/Str}))
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -186,7 +186,6 @@
                       "ctia.log.riemann.batch-size" s/Int
                       "ctia.log.riemann.service-prefix" s/Str
 
-                      "ctia.store.external-key-prefixes" s/Str
                       "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
 

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -109,3 +109,93 @@
       [] ["not-matched"] false
       ["ctia-indicator-1"] ["ctia"] false
       ["ctia-indicator-1" "cisco-indicator-1"] ["ctia" "cisco"] true)))
+
+(deftest entity->import-data-test
+  (let [sighting-id (make-id "sighting")
+        external_ids ["ireaux-sighting-2"
+                      "ireaux-sighting-1"
+                      "ctia-sighting-1"]
+        test-fn (fn [{:keys [entity prefixes entity-type] :as _params}
+                     {:keys [log? output] :as _expected}]
+                  (with-log
+                    (let [res (sut/entity->import-data entity
+                                                       entity-type
+                                                       prefixes)]
+                      (is (= log?
+                             (logged? 'ctia.bundle.core
+                                      :warn
+                                      #"No valid external ID has been provided"))::test)
+                      (is (= output res)))))]
+    (are [msg params expected]
+        (testing msg
+          (test-fn params expected)
+          true)
+
+      "no external prefixes and no external_id"
+      {:entity {:id sighting-id}
+       :entity-type :sighting
+       :prefixes ""}
+      {:log? true
+       :output {:new-entity {:id sighting-id}
+                :type :sighting}}
+
+      "no prefixes, no external_id and transient id"
+      {:entity {:id "transient:sighting-1"}
+       :entity-type :sighting
+       :prefixes ""}
+      {:log? true
+       :output {:new-entity {:id "transient:sighting-1"}
+                :type :sighting
+                :original_id "transient:sighting-1"}}
+
+      "prefixes but no external_id"
+      {:entity {:id sighting-id}
+       :entity-type :sighting
+       :prefixes "ireaux-"}
+      {:log? true
+       :output {:new-entity {:id sighting-id}
+                :type :sighting}}
+
+      "all external_ids match one prefix"
+      {:entity {:id sighting-id
+                :external_ids external_ids}
+       :entity-type :sighting
+       :prefixes "ireaux-,ctia-"}
+      {:log? false
+       :output {:new-entity {:id sighting-id
+                             :external_ids external_ids}
+                :type :sighting
+                :external_ids external_ids}}
+
+      "external_ids, only some match external prefixes"
+      {:entity {:id sighting-id
+                :external_ids external_ids}
+       :entity-type :sighting
+       :prefixes "ireaux-"}
+      {:log? false
+       :output {:new-entity {:id sighting-id
+                             :external_ids external_ids}
+                :type :sighting
+                :external_ids ["ireaux-sighting-2"
+                               "ireaux-sighting-1"]}}
+
+      "external_ids that match none of provided external_ids"
+      {:entity {:id sighting-id
+                :external_ids external_ids}
+       :entity-type :sighting
+       :prefixes "unmatched-"}
+      {:log? true
+       :output {:new-entity {:id sighting-id
+                             :external_ids external_ids}
+                :type :sighting}}
+
+      "external_ids with no external prefixes should be preserved"
+      {:entity {:id sighting-id
+                :external_ids external_ids}
+       :entity-type :sighting
+       :prefixes ""}
+      {:log? false
+       :output {:new-entity {:id sighting-id
+                             :external_ids external_ids}
+                :type :sighting
+                :external_ids external_ids}})))

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -1,6 +1,6 @@
 (ns ctia.bundle.core-test
   (:require [ctia.bundle.core :as sut]
-            [clojure.tools.logging.test :refer [logged? with-log the-log]]
+            [clojure.tools.logging.test :refer [logged? with-log]]
             [ctia.domain.entities :as ent :refer [with-long-id]]
             [ctia.flows.crud :refer [make-id]]
             [clojure.test :as t :refer [deftest use-fixtures join-fixtures are is testing]]
@@ -93,8 +93,7 @@
                 :log? true}))))
 
 (deftest filter-external-ids-test
-  (let [external-ids ["ctia-indicator-1" "cisco-indicator-1" "indicator-1"]
-        test-fn (fn [prefixes expected log?])]
+  (let [external-ids ["ctia-indicator-1" "cisco-indicator-1" "indicator-1"]]
     (are [expected prefixes log?]
         (testing prefixes
           (with-log
@@ -103,7 +102,8 @@
             (is (= log?
                    (logged? 'ctia.bundle.core
                             :warn
-                            #"More than 1 valid external ID has been found")))))
+                            #"More than 1 valid external ID has been found"))))
+          true)
       external-ids [] true
       external-ids nil true
       [] ["not-matched"] false

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -440,8 +440,8 @@
                    :source "source"
                    :indicators (set (map mk-indicator (range nb-entities)))}
            response-create (post "ctia/bundle/import"
-                                   :body bundle
-                                   :headers {"Authorization" "45c1f5e3f05d0"})
+                                 :body bundle
+                                 :headers {"Authorization" "45c1f5e3f05d0"})
            bundle-result-create (:parsed-body response-create)
            response-update (post "ctia/bundle/import"
                                  :body bundle


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/threatgrid/iroh/issues/3881

This PR removes the default `external-key-prefixes` values (`ctia-` and `cisco-`), both in `ctia.bundle.core` ns and conf. 
It also enables the bundle to use all provided `external_ids` values to lookup for existing entities when no prefix is provided to filter them. 

<a name="qa">[§](#qa)</a> QA
============================

1. Create a new incident with external_ids `["ctia-1", "cisco-1", "tg-1"]` 
```javascript
{
  "type": "incident",
  "incident_time": {
    "opened": "2016-02-11T00:40:48.212Z"
  },
  "status": "Open",
  "confidence": "High",
  "external_ids": ["ctia-1", "cisco-1", "tg-1"]
}
```
2. Import the following bundle with `external-key-prefixes=swe`
``` javascript
{
 "incidents":
   [{
     "type": "incident",
     "incident_time": {
       "opened": "2016-02-11T00:40:48.212Z"
     },
     "status": "Open",
     "confidence": "High",
     "external_ids": ["ctia-1", "cisco-1"]
   }],
  "source": "QA"
}
```
the `result` field should have the value `created`

3. Import the following bundle without `external-key-prefixes` param
``` javascript
{
 "incidents":
   [{
     "type": "incident",
     "incident_time": {
       "opened": "2016-02-11T00:40:48.212Z"
     },
     "status": "Open",
     "confidence": "High",
     "external_ids": ["tg-1"]
   }],
  "source": "QA"
}
```
the `result` field should have the value `exists`

4. Import the following bundle with `external-key-prefixes=ctia-,tg-,cisco-`
``` javascript
{
 "incidents":
   [{
     "type": "incident",
     "incident_time": {
       "opened": "2016-02-11T00:40:48.212Z"
     },
     "status": "Open",
     "confidence": "High",
     "external_ids": ["ctia-1"]
   }],
  "source": "QA"
}
```
the `result` field should have the value `exists`

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: improved the entity resolution in CTIA bundle import, to limit entity duplicates.
```