### PR TITLE
gitignore .lsp and .dir-locals-2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ resources/ctia.properties.*
 data/**/*.edn
 pom.xml
 /checkouts
+.dir-locals-2.el
+.lsp/


### PR DESCRIPTION
tiny change to reduce the local clutter.

from Emacs manual:
> You can also use .dir-locals-2.el; if found, Emacs loads it in addition to .dir-locals.el. This is useful when .dir-locals.el is under version control in a shared repository and can't be used for personal customizations.

If you're wondering what I have in there, so far it's just this:

`((nil . ((cider-repl-init-code . ("(ctia.init/start-ctia! :join? false, :silent? false)")))))`


No QA is needed.