### PR TITLE
allow Kafka SSL configuration without Keystores

### DIFF
--- a/src/ctia/lib/kafka.clj
+++ b/src/ctia/lib/kafka.clj
@@ -19,17 +19,22 @@
   (boolean (:enabled ssl)))
 
 (defn make-ssl-opts [{:keys [ssl]}]
-  {"security.protocol" "ssl"
-   "ssl.truststore.location"
-   (get-in ssl [:truststore :location])
-   "ssl.truststore.password"
-   (get-in ssl [:truststore :password])
-   "ssl.keystore.location"
-   (get-in ssl [:keystore :location])
-   "ssl.keystore.password"
-   (get-in ssl [:keystore :password])
-   "ssl.key.password"
-   (get-in ssl [:key :password])})
+  (cond-> {"security.protocol" "ssl"}
+    (:truststore ssl)
+    (into {"ssl.truststore.location"
+           (get-in ssl [:truststore :location])
+           "ssl.truststore.password"
+           (get-in ssl [:truststore :password])})
+
+    (:keystore ssl)
+    (into {"ssl.keystore.location"
+           (get-in ssl [:keystore :location])
+           "ssl.keystore.password"
+           (get-in ssl [:keystore :password])})
+
+    (:key ssl)
+    (into {"ssl.key.password"
+           (get-in ssl [:key :password])})))
 
 (defn ^KafkaProducer build-producer [kafka-props]
   (let [producer-opts {}
@@ -62,7 +67,7 @@
     (let [records (.poll consumer timeout)]
       (doseq [record (if (string? name)
                        (.records records ^String name)
-                       ;unsure if this case is reachable
+                       ;;unsure if this case is reachable
                        (.records records ^TopicPartition name))]
         (f (okh/consumer-record->message decompress
                                          record)))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #
> Related #

This is a change to satisfy our internal Kafka configuration,
This allows setting up Kafka SSL configuration without using Keystores/secrets

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: allow setting up kafka SSL without keystores.

```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

