### PR TITLE
Cleanup project

### DIFF
--- a/CONTRIBUTING.org
+++ b/CONTRIBUTING.org
@@ -2,10 +2,10 @@
 
 * Introduction
 
-This document introduce how to minimize the friction between contributors.
-It is mainly written for developpers.
+This document introduces how to minimize the friction between contributors.
+It is mainly written for developers.
 
-So if you are a new developper in our team, welcome! Please read carrefully do
+So if you are a new developer in our team, welcome! Please read carrefully do
 not hesitate to reach out if you want to discuss something about this document.
 
 - coding style
@@ -122,7 +122,7 @@ You can test everything is working correctly by doing:
 #+BEGIN_SRC
 > docker-compose -f containers/dev/docker-compose.yml up -d
 > lein test
-> lein run
+> lein run -m ctia.main
 #+END_SRC
 
 *** Adding a new feature / fixing an issue
@@ -141,7 +141,7 @@ You can test everything is working correctly by doing:
 8. Make changes according to PR feedbacks
 9. Either use the =Squash & Merge button= in github or manually rebase.
 
-*** Deploiement
+*** Deployment
 
 We currently have three environments.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Using lein use this one:
 
 Running from a cloned repository:
 
-`lein run`
+`lein run -m ctia.main`
 
 ### Packaging and running as standalone jar
 

--- a/project.clj
+++ b/project.clj
@@ -140,7 +140,8 @@
                                   [prismatic/schema-generators ~schema-generators-version]]
                    :pedantic? :warn
 
-                   :resource-paths ["test/resources"]}
+                   :resource-paths ["test/resources"]
+                   :source-paths ["dev"]}
              :jmx {:jvm-opts ["-Dcom.sun.management.jmxremote"
                               "-Dcom.sun.management.jmxremote.port=9010"
                               "-Dcom.sun.management.jmxremote.local.only=false"

--- a/project.clj
+++ b/project.clj
@@ -112,11 +112,7 @@
                  [com.graphql-java/graphql-java "9.7"]]
 
   :resource-paths ["resources" "doc"]
-  :aot [ctia.main]
-  :main ctia.main
   :classpath ".:resources"
-  :uberjar-name "ctia.jar"
-  :uberjar-exclusions [#"ctia\.properties"]
   :min-lein-version "2.9.1"
   :test-selectors {:es-store :es-store
                    :disabled :disabled
@@ -157,6 +153,10 @@
                                     [com.gfredericks/test.chuck ~test-chuck-version]
                                     [prismatic/schema-generators ~schema-generators-version]]
                      :source-paths ["src","test","benchmarks"]}
+             :uberjar {:aot [ctia.main]
+                       :main ctia.main
+                       :uberjar-name "ctia.jar"
+                       :uberjar-exclusions [#"ctia\.properties"]}
              :test {:jvm-opts ["-Dlog.console.threshold=WARN"]
                     :dependencies [[cheshire ~cheshire-version]
                                    [clj-http-fake ~clj-http-fake-version]

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -141,7 +141,8 @@
            refresh-url (str " " refresh-url)))
        ";"))
 
-(defn- ^Server new-jetty-instance
+(defn- new-jetty-instance
+  ^Server
   [{:keys [dev-reload
            max-threads
            min-threads

--- a/src/ctia/lib/kafka.clj
+++ b/src/ctia/lib/kafka.clj
@@ -36,7 +36,7 @@
     (into {"ssl.key.password"
            (get-in ssl [:key :password])})))
 
-(defn ^KafkaProducer build-producer [kafka-props]
+(defn build-producer ^KafkaProducer [kafka-props]
   (let [producer-opts {}
         {:keys [request-size compression]} kafka-props
         compression-type (:type compression)
@@ -51,7 +51,7 @@
                         (okh/byte-array-serializer)
                         (okh/byte-array-serializer))))
 
-(defn ^KafkaConsumer build-consumer [kafka-props]
+(defn build-consumer ^KafkaConsumer [kafka-props]
   (let [{:keys [request-size]} kafka-props
         address (get-in kafka-props [:zk :address])
         brokers (opk/find-brokers {:kafka/zookeeper address})

--- a/src/ctia/schemas/graphql/helpers.clj
+++ b/src/ctia/schemas/graphql/helpers.clj
@@ -139,9 +139,10 @@
 (defn fragment-definition? [x]
   (instance? FragmentDefinition x))
 
-(defn ^NamedNode resolve-fragment-selections
+(defn resolve-fragment-selections
   "if the given entity is a FragmentSpread
   return its definition else return the entity"
+  ^NamedNode
   [^NamedNode s fragments]
   (if (fragment-spread? s)
     (let [f-name (.getName s)]
@@ -221,7 +222,8 @@
 
                                         ;----- Input
 
-(defn ^GraphQLArgument new-argument
+(defn new-argument
+  ^GraphQLArgument
   [^String arg-name
    arg-type
    ^String arg-description
@@ -235,7 +237,8 @@
       (.defaultValue builder arg-default-value))
     (.build builder)))
 
-(defn ^GraphQLFieldDefinition$Builder add-args
+(defn add-args
+  ^GraphQLFieldDefinition$Builder
   [^GraphQLFieldDefinition$Builder field
    args]
   (doseq [[k {arg-type :type
@@ -250,7 +253,8 @@
       (.argument field narg)))
   field)
 
-(defn ^GraphQLInputObjectField new-input-field
+(defn new-input-field
+  ^GraphQLInputObjectField
   [^String field-name
    ^GraphQLInputType field-type
    ^String field-description
@@ -265,7 +269,8 @@
       (.defaultValue builder default-value))
     (.build builder)))
 
-(defn ^GraphQLInputObjectType$Builder add-input-fields
+(defn add-input-fields
+  ^GraphQLInputObjectType$Builder
   [^GraphQLInputObjectType$Builder builder
    fields]
   (doseq [[k {field-type :type
@@ -292,7 +297,8 @@
 
 ;;----- Output
 
-(defn ^GraphQLFieldDefinition new-field
+(defn new-field
+  ^GraphQLFieldDefinition
   [^String field-name
    ^GraphQLOutputType field-type
    ^String field-description
@@ -307,7 +313,8 @@
       (add-args field-args)
       .build))
 
-(defn ^GraphQLObjectType$Builder add-fields
+(defn add-fields
+  ^GraphQLObjectType$Builder
   [^GraphQLObjectType$Builder builder
    fields]
   (doseq [[k {field-type :type
@@ -348,9 +355,10 @@
            (swap! registry assoc object-name obj)
            obj)))))
 
-(defn ^TypeResolver fn->type-resolver
+(defn fn->type-resolver
   "Converts a function that takes the current object, the args
   and the global schema to a TypeResolver."
+  ^TypeResolver
   [f]
   (reify TypeResolver
     (getType [_ env]

--- a/src/ctia/shutdown.clj
+++ b/src/ctia/shutdown.clj
@@ -22,7 +22,7 @@
       (catch Exception excep
         (log/error excep (format "Shutdown hook %s failed" name))))))
 
-(defn ^Runnable shutdown-ctia-and-agents! []
+(defn shutdown-ctia-and-agents! ^Runnable []
   (log/warn "shutting down CTIA")
   (shutdown-ctia!)
   (log/warn "shutting down agents")

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -599,7 +599,11 @@ when confirm? is true, it stores this state and creates the target indices."
   ([migration-id :- s/Str
     store-key :- s/Keyword
     migrated-doc :- PartialMigratedStore]
-   (update-migration-store migration-id store-key migrated-doc @migration-es-conn))
+   (update-migration-store migration-id
+                           store-key
+                           migrated-doc
+                           (-> migration-es-conn deref (doto (assert "This atom is unset. Maybe some setup hasn't been performed?")))))
+  
   ([migration-id :- s/Str
     store-key :- s/Keyword
     migrated-doc :- PartialMigratedStore

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -44,15 +44,25 @@
                   helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 
-(setup!) ;; init migration conn and properties
-(def es-props (get-in @props/properties [:ctia :store :es]))
-(def es-conn (connect (:default es-props)))
-(def migration-index (get-in es-props [:migration :indexname]))
+;; This a is a `defn` to prevent side-effects at compile time
+(defn es-props []
+  (get-in @props/properties [:ctia :store :es]))
+
+;; This a is a `defn` to prevent side-effects at compile time
+(defn es-conn []
+  (connect (:default (es-props))))
+
+;; This a is a `defn` to prevent side-effects at compile time
+(defn migration-index []
+  (get-in (es-props) [:migration :indexname]))
 
 (defn fixture-clean-migration [t]
+  (defonce setup ;; ugly, but must be done in order to prevent an indefinitely blocking call (which can affect code reloading, or re-running this ns's tests)
+    (setup!) ;; init migration conn and properties
+    )
   (t)
-  (es-index/delete! es-conn "v0.0.0*")
-  (es-index/delete! es-conn (str migration-index "*")))
+  (es-index/delete! (es-conn) "v0.0.0*")
+  (es-index/delete! (es-conn) (str (migration-index) "*")))
 
 (use-fixtures :each
   (join-fixtures [helpers/fixture-ctia
@@ -150,8 +160,8 @@
       (rollover-post-bulk)
       ;; insert malformed documents
       (doseq [store-type store-types]
-        (es-index/get es-conn
-                      (str (get-in es-props [store-type :indexname]) "*")))
+        (es-index/get (es-conn)
+                      (str (get-in (es-props) [store-type :indexname]) "*")))
       (sut/migrate-store-indexes {:migration-id "test-3"
                                   :prefix       "0.0.0"
                                   :migrations   [:__test]
@@ -161,18 +171,18 @@
                                   :confirm?     true
                                   :restart?     false})
 
-      (let [migration-state (es-doc/get-doc es-conn
-                                            migration-index
+      (let [migration-state (es-doc/get-doc (es-conn)
+                                            (migration-index)
                                             "migration"
                                             "test-3"
                                             {})]
         (doseq [store-type store-types]
-          (is (= (count (es-index/get es-conn
-                                      (str "v0.0.0_" (get-in es-props [store-type :indexname]) "*")))
+          (is (= (count (es-index/get (es-conn)
+                                      (str "v0.0.0_" (get-in (es-props) [store-type :indexname]) "*")))
                  3)
               "target indice should be rolledover during migration")
-          (es-index/get es-conn
-                        (str "v0.0.0_" (get-in es-props [store-type :indexname]) "*"))
+          (es-index/get (es-conn)
+                        (str "v0.0.0_" (get-in (es-props) [store-type :indexname]) "*"))
           (let [migrated-store (get-in migration-state [:stores store-type])
                 {:keys [source target]} migrated-store]
             (is (= fixtures-nb (:total source)))
@@ -183,7 +193,7 @@
 
 (deftest read-source-batch-test
   (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [storemap {:conn es-conn
+    (let [storemap {:conn (es-conn)
                     :indexname "ctia_relationship"
                     :mapping "relationship"
                     :props {:write-index "ctia_relationship"}
@@ -192,7 +202,7 @@
                     :config {}}
           docs (map es-helpers/prepare-bulk-ops
                     (line-seq rdr))
-          _ (es-helpers/load-bulk es-conn docs)
+          _ (es-helpers/load-bulk (es-conn) docs)
           no-meta-docs (map #(dissoc % :_index :_type :_id)
                             docs)
           docs-no-modified (filter #(nil? (:modified %))
@@ -272,7 +282,7 @@
   (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
     (let [prefix "0.0.1"
           indexname "v0.0.1_ctia_relationship"
-          storemap {:conn es-conn
+          storemap {:conn (es-conn)
                     :indexname indexname
                     :mapping "relationship"
                     :props {:write-index indexname}
@@ -290,7 +300,7 @@
                        :migration-id migration-id
                        :migrations (sut/compose-migrations [:__test])
                        :batch-size 1000
-                       :migration-es-conn es-conn
+                       :migration-es-conn (es-conn)
                        :confirm? true}
           test-fn (fn [total
                        migrated-count
@@ -310,11 +320,11 @@
                           nb-migrated (sut/write-target migrated-count
                                                         batch-params)
                           {target-state :target
-                           source-state :source} (-> (get-migration migration-id es-conn)
+                           source-state :source} (-> (get-migration migration-id (es-conn))
                                                      :stores
                                                      :relationship)
-                          _ (es-index/refresh! es-conn)
-                          migrated-docs (:data (es-doc/query es-conn
+                          _ (es-index/refresh! (es-conn))
+                          migrated-docs (:data (es-doc/query (es-conn)
                                                              indexname
                                                              "relationship"
                                                              {:match_all {}}
@@ -367,7 +377,7 @@
           bulk-1 (concat wo-modified (take 500 sorted-w-modified))
           bulk-2 (drop 500 sorted-w-modified)
           logger-1 (atom [])
-          _ (es-helpers/load-bulk es-conn bulk-1)
+          _ (es-helpers/load-bulk (es-conn) bulk-1)
           _ (with-atom-logger logger-1
               (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                           :prefix       "0.0.0"
@@ -377,16 +387,16 @@
                                           :buffer-size  3
                                           :confirm?     true
                                           :restart?     false}))
-          migration-state-1 (es-doc/get-doc es-conn
-                                            migration-index
+          migration-state-1 (es-doc/get-doc (es-conn)
+                                            (migration-index)
                                             "migration"
                                             "migration-test-4"
                                             {})
-          target-count-1 (es-doc/count-docs es-conn
+          target-count-1 (es-doc/count-docs (es-conn)
                                             "v0.0.0_ctia_relationship"
                                             "relationship"
                                             nil)
-          _ (es-helpers/load-bulk es-conn bulk-2)
+          _ (es-helpers/load-bulk (es-conn) bulk-2)
           _ (with-atom-logger logger-1
               (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                           :prefix       "0.0.0"
@@ -396,12 +406,12 @@
                                           :buffer-size  3
                                           :confirm?     true
                                           :restart?     true}))
-          target-count-2 (es-doc/count-docs es-conn
+          target-count-2 (es-doc/count-docs (es-conn)
                                             "v0.0.0_ctia_relationship"
                                             "relationship"
                                             nil)
-          migration-state-2 (es-doc/get-doc es-conn
-                                            migration-index
+          migration-state-2 (es-doc/get-doc (es-conn)
+                                            (migration-index)
                                             "migration"
                                             "migration-test-4"
                                             {})]
@@ -436,8 +446,8 @@
       (rollover-post-bulk)
       ;; insert malformed documents
       (doseq [store-type store-types]
-        (es-doc/create-doc es-conn
-                           (str (get-in es-props [store-type :indexname]) "-write")
+        (es-doc/create-doc (es-conn)
+                           (str (get-in (es-props) [store-type :indexname]) "-write")
                            (name store-type)
                            bad-doc
                            "true"))
@@ -451,8 +461,8 @@
                                     :confirm?     true
                                     :restart?     false}))
       (let [messages (set @logger)
-            migration-state (es-doc/get-doc es-conn
-                                            migration-index
+            migration-state (es-doc/get-doc (es-conn)
+                                            (migration-index)
                                             "migration"
                                             "test-3"
                                             {})]
@@ -492,8 +502,8 @@
 
       (doseq [store (vals @stores)]
         (is (not (index-exists? store "0.0.0"))))
-      (is (nil? (seq (es-doc/get-doc es-conn
-                                     (get-in es-props [:migration :indexname])
+      (is (nil? (seq (es-doc/get-doc (es-conn)
+                                     (get-in (es-props) [:migration :indexname])
                                      "migration"
                                      "test-1"
                                      {}))))))
@@ -509,8 +519,8 @@
                                     :confirm?     true
                                     :restart?     false}))
       (testing "shall generate a proper migration state"
-        (let [migration-state (es-doc/get-doc es-conn
-                                              migration-index
+        (let [migration-state (es-doc/get-doc (es-conn)
+                                              (migration-index)
                                               "migration"
                                               "test-2"
                                               {})]
@@ -607,7 +617,7 @@
                            (format  "v0.0.0_%s-%s-000003" (:indexname k) index-date) 0}))
                    (into expected-event-indices)
                    keywordize-keys)
-              _ (es-index/refresh! es-conn)
+              _ (es-index/refresh! (es-conn))
               formatted-cat-indices (es-helpers/get-cat-indices (:host default)
                                                                 (:port default))]
           (is (= expected-indices
@@ -616,7 +626,7 @@
 
           (doseq [[index _]
                   expected-indices]
-            (let [docs (->> (es-doc/search-docs es-conn (name index) nil nil nil {})
+            (let [docs (->> (es-doc/search-docs (es-conn) (name index) nil nil nil {})
                             :data
                             (map :groups))]
               (is (every? #(= ["migration-test"] %)
@@ -633,7 +643,7 @@
                    (take 2))
 
               ;; retrieve source entity to update, in first position of first index
-              es-sighting0 (-> (es-doc/query es-conn
+              es-sighting0 (-> (es-doc/query (es-conn)
                                              sighting-index-1
                                              "sighting"
                                              {:match_all {}}
@@ -642,7 +652,7 @@
                                :data
                                first)
               ;; retrieve source entity to update, in first position of second index
-              es-sighting1 (-> (es-doc/query es-conn
+              es-sighting1 (-> (es-doc/query (es-conn)
                                              sighting-index-2
                                              "sighting"
                                              {:match_all {}}
@@ -657,7 +667,7 @@
                                 (hash-map :malwares))
 
               ;; retrieve 5 source entities to delete, in last positions of first index
-              es-sightings-1 (-> (es-doc/query es-conn
+              es-sightings-1 (-> (es-doc/query (es-conn)
                                                sighting-index-1
                                                "sighting"
                                                {:match_all {}}
@@ -665,7 +675,7 @@
                                                 :limit 5})
                                  :data)
               ;; retrieve 5 source entities to delete, in last positions of second index
-              es-sightings-2 (-> (es-doc/query es-conn
+              es-sightings-2 (-> (es-doc/query (es-conn)
                                                sighting-index-2
                                                "sighting"
                                                {:match_all {}}
@@ -702,7 +712,7 @@
                                       :buffer-size  1
                                       :confirm?     true
                                       :restart?     true})
-          (let [migration-state (get-migration "test-2" es-conn)
+          (let [migration-state (get-migration "test-2" (es-conn))
                 malware-migration (get-in migration-state [:stores :malware])
                 sighting-migration (get-in migration-state [:stores :sighting])
                 malware-target-store (get-in malware-migration [:target :store])
@@ -752,8 +762,8 @@
           end (System/currentTimeMillis)
           total (/ (- end start) 1000)
           doc-per-sec (/ total-docs total)
-          migration-state (es-doc/get-doc es-conn
-                                          migration-index
+          migration-state (es-doc/get-doc (es-conn)
+                                          (migration-index)
                                           "migration"
                                           migration-id
                                           {})]
@@ -763,9 +773,9 @@
         (is (= 20000
                (get-in state [:source :total])
                (get-in state [:target :migrated]))))
-      (es-index/delete! es-conn (format "v%s*" prefix))
-      (es-doc/delete-doc es-conn migration-index "migration" migration-id "true")))
-  (es-index/delete! es-conn "ctia_*"))
+      (es-index/delete! (es-conn) (format "v%s*" prefix))
+      (es-doc/delete-doc (es-conn) (migration-index) "migration" migration-id "true")))
+  (es-index/delete! (es-conn) "ctia_*"))
 
 ;;(deftest ^:integration minimal-load-test
 ;;  (testing "load testing with minimal entities"

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -48,9 +48,10 @@
 (defn es-props []
   (get-in @props/properties [:ctia :store :es]))
 
-;; This a is a `defn` to prevent side-effects at compile time
-(defn es-conn []
-  (connect (:default (es-props))))
+;; This a is a `delay` to prevent side-effects at compile time
+(def es-conn
+  (delay
+    (connect (:default (es-props)))))
 
 ;; This a is a `defn` to prevent side-effects at compile time
 (defn migration-index []
@@ -65,8 +66,8 @@
                               (setup!) ;; init migration conn and properties
                               :done)))
   (t)
-  (es-index/delete! (es-conn) "v0.0.0*")
-  (es-index/delete! (es-conn) (str (migration-index) "*")))
+  (es-index/delete! @es-conn "v0.0.0*")
+  (es-index/delete! @es-conn (str (migration-index) "*")))
 
 (use-fixtures :each
   (join-fixtures [helpers/fixture-ctia
@@ -164,7 +165,7 @@
       (rollover-post-bulk)
       ;; insert malformed documents
       (doseq [store-type store-types]
-        (es-index/get (es-conn)
+        (es-index/get @es-conn
                       (str (get-in (es-props) [store-type :indexname]) "*")))
       (sut/migrate-store-indexes {:migration-id "test-3"
                                   :prefix       "0.0.0"
@@ -175,17 +176,17 @@
                                   :confirm?     true
                                   :restart?     false})
 
-      (let [migration-state (es-doc/get-doc (es-conn)
+      (let [migration-state (es-doc/get-doc @es-conn
                                             (migration-index)
                                             "migration"
                                             "test-3"
                                             {})]
         (doseq [store-type store-types]
-          (is (= (count (es-index/get (es-conn)
+          (is (= (count (es-index/get @es-conn
                                       (str "v0.0.0_" (get-in (es-props) [store-type :indexname]) "*")))
                  3)
               "target indice should be rolledover during migration")
-          (es-index/get (es-conn)
+          (es-index/get @es-conn
                         (str "v0.0.0_" (get-in (es-props) [store-type :indexname]) "*"))
           (let [migrated-store (get-in migration-state [:stores store-type])
                 {:keys [source target]} migrated-store]
@@ -197,7 +198,7 @@
 
 (deftest read-source-batch-test
   (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [storemap {:conn (es-conn)
+    (let [storemap {:conn @es-conn
                     :indexname "ctia_relationship"
                     :mapping "relationship"
                     :props {:write-index "ctia_relationship"}
@@ -206,7 +207,7 @@
                     :config {}}
           docs (map es-helpers/prepare-bulk-ops
                     (line-seq rdr))
-          _ (es-helpers/load-bulk (es-conn) docs)
+          _ (es-helpers/load-bulk @es-conn docs)
           no-meta-docs (map #(dissoc % :_index :_type :_id)
                             docs)
           docs-no-modified (filter #(nil? (:modified %))
@@ -286,7 +287,7 @@
   (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
     (let [prefix "0.0.1"
           indexname "v0.0.1_ctia_relationship"
-          storemap {:conn (es-conn)
+          storemap {:conn @es-conn
                     :indexname indexname
                     :mapping "relationship"
                     :props {:write-index indexname}
@@ -304,7 +305,7 @@
                        :migration-id migration-id
                        :migrations (sut/compose-migrations [:__test])
                        :batch-size 1000
-                       :migration-es-conn (es-conn)
+                       :migration-es-conn @es-conn
                        :confirm? true}
           test-fn (fn [total
                        migrated-count
@@ -324,11 +325,11 @@
                           nb-migrated (sut/write-target migrated-count
                                                         batch-params)
                           {target-state :target
-                           source-state :source} (-> (get-migration migration-id (es-conn))
+                           source-state :source} (-> (get-migration migration-id @es-conn)
                                                      :stores
                                                      :relationship)
-                          _ (es-index/refresh! (es-conn))
-                          migrated-docs (:data (es-doc/query (es-conn)
+                          _ (es-index/refresh! @es-conn)
+                          migrated-docs (:data (es-doc/query @es-conn
                                                              indexname
                                                              "relationship"
                                                              {:match_all {}}
@@ -381,7 +382,7 @@
           bulk-1 (concat wo-modified (take 500 sorted-w-modified))
           bulk-2 (drop 500 sorted-w-modified)
           logger-1 (atom [])
-          _ (es-helpers/load-bulk (es-conn) bulk-1)
+          _ (es-helpers/load-bulk @es-conn bulk-1)
           _ (with-atom-logger logger-1
               (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                           :prefix       "0.0.0"
@@ -391,16 +392,16 @@
                                           :buffer-size  3
                                           :confirm?     true
                                           :restart?     false}))
-          migration-state-1 (es-doc/get-doc (es-conn)
+          migration-state-1 (es-doc/get-doc @es-conn
                                             (migration-index)
                                             "migration"
                                             "migration-test-4"
                                             {})
-          target-count-1 (es-doc/count-docs (es-conn)
+          target-count-1 (es-doc/count-docs @es-conn
                                             "v0.0.0_ctia_relationship"
                                             "relationship"
                                             nil)
-          _ (es-helpers/load-bulk (es-conn) bulk-2)
+          _ (es-helpers/load-bulk @es-conn bulk-2)
           _ (with-atom-logger logger-1
               (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                           :prefix       "0.0.0"
@@ -410,11 +411,11 @@
                                           :buffer-size  3
                                           :confirm?     true
                                           :restart?     true}))
-          target-count-2 (es-doc/count-docs (es-conn)
+          target-count-2 (es-doc/count-docs @es-conn
                                             "v0.0.0_ctia_relationship"
                                             "relationship"
                                             nil)
-          migration-state-2 (es-doc/get-doc (es-conn)
+          migration-state-2 (es-doc/get-doc @es-conn
                                             (migration-index)
                                             "migration"
                                             "migration-test-4"
@@ -450,7 +451,7 @@
       (rollover-post-bulk)
       ;; insert malformed documents
       (doseq [store-type store-types]
-        (es-doc/create-doc (es-conn)
+        (es-doc/create-doc @es-conn
                            (str (get-in (es-props) [store-type :indexname]) "-write")
                            (name store-type)
                            bad-doc
@@ -465,7 +466,7 @@
                                     :confirm?     true
                                     :restart?     false}))
       (let [messages (set @logger)
-            migration-state (es-doc/get-doc (es-conn)
+            migration-state (es-doc/get-doc @es-conn
                                             (migration-index)
                                             "migration"
                                             "test-3"
@@ -506,7 +507,7 @@
 
       (doseq [store (vals @stores)]
         (is (not (index-exists? store "0.0.0"))))
-      (is (nil? (seq (es-doc/get-doc (es-conn)
+      (is (nil? (seq (es-doc/get-doc @es-conn
                                      (get-in (es-props) [:migration :indexname])
                                      "migration"
                                      "test-1"
@@ -523,7 +524,7 @@
                                     :confirm?     true
                                     :restart?     false}))
       (testing "shall generate a proper migration state"
-        (let [migration-state (es-doc/get-doc (es-conn)
+        (let [migration-state (es-doc/get-doc @es-conn
                                               (migration-index)
                                               "migration"
                                               "test-2"
@@ -621,7 +622,7 @@
                            (format  "v0.0.0_%s-%s-000003" (:indexname k) index-date) 0}))
                    (into expected-event-indices)
                    keywordize-keys)
-              _ (es-index/refresh! (es-conn))
+              _ (es-index/refresh! @es-conn)
               formatted-cat-indices (es-helpers/get-cat-indices (:host default)
                                                                 (:port default))]
           (is (= expected-indices
@@ -630,7 +631,7 @@
 
           (doseq [[index _]
                   expected-indices]
-            (let [docs (->> (es-doc/search-docs (es-conn) (name index) nil nil nil {})
+            (let [docs (->> (es-doc/search-docs @es-conn (name index) nil nil nil {})
                             :data
                             (map :groups))]
               (is (every? #(= ["migration-test"] %)
@@ -647,7 +648,7 @@
                    (take 2))
 
               ;; retrieve source entity to update, in first position of first index
-              es-sighting0 (-> (es-doc/query (es-conn)
+              es-sighting0 (-> (es-doc/query @es-conn
                                              sighting-index-1
                                              "sighting"
                                              {:match_all {}}
@@ -656,7 +657,7 @@
                                :data
                                first)
               ;; retrieve source entity to update, in first position of second index
-              es-sighting1 (-> (es-doc/query (es-conn)
+              es-sighting1 (-> (es-doc/query @es-conn
                                              sighting-index-2
                                              "sighting"
                                              {:match_all {}}
@@ -671,7 +672,7 @@
                                 (hash-map :malwares))
 
               ;; retrieve 5 source entities to delete, in last positions of first index
-              es-sightings-1 (-> (es-doc/query (es-conn)
+              es-sightings-1 (-> (es-doc/query @es-conn
                                                sighting-index-1
                                                "sighting"
                                                {:match_all {}}
@@ -679,7 +680,7 @@
                                                 :limit 5})
                                  :data)
               ;; retrieve 5 source entities to delete, in last positions of second index
-              es-sightings-2 (-> (es-doc/query (es-conn)
+              es-sightings-2 (-> (es-doc/query @es-conn
                                                sighting-index-2
                                                "sighting"
                                                {:match_all {}}
@@ -716,7 +717,7 @@
                                       :buffer-size  1
                                       :confirm?     true
                                       :restart?     true})
-          (let [migration-state (get-migration "test-2" (es-conn))
+          (let [migration-state (get-migration "test-2" @es-conn)
                 malware-migration (get-in migration-state [:stores :malware])
                 sighting-migration (get-in migration-state [:stores :sighting])
                 malware-target-store (get-in malware-migration [:target :store])
@@ -766,7 +767,7 @@
           end (System/currentTimeMillis)
           total (/ (- end start) 1000)
           doc-per-sec (/ total-docs total)
-          migration-state (es-doc/get-doc (es-conn)
+          migration-state (es-doc/get-doc @es-conn
                                           (migration-index)
                                           "migration"
                                           migration-id
@@ -777,9 +778,9 @@
         (is (= 20000
                (get-in state [:source :total])
                (get-in state [:target :migrated]))))
-      (es-index/delete! (es-conn) (format "v%s*" prefix))
-      (es-doc/delete-doc (es-conn) (migration-index) "migration" migration-id "true")))
-  (es-index/delete! (es-conn) "ctia_*"))
+      (es-index/delete! @es-conn (format "v%s*" prefix))
+      (es-doc/delete-doc @es-conn (migration-index) "migration" migration-id "true")))
+  (es-index/delete! @es-conn "ctia_*"))
 
 ;;(deftest ^:integration minimal-load-test
 ;;  (testing "load testing with minimal entities"

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -56,10 +56,14 @@
 (defn migration-index []
   (get-in (es-props) [:migration :indexname]))
 
+(declare setup)
+
 (defn fixture-clean-migration [t]
-  (defonce setup ;; ugly, but must be done in order to prevent an indefinitely blocking call (which can affect code reloading, or re-running this ns's tests)
-    (setup!) ;; init migration conn and properties
-    )
+  (when-not setup
+     ;; ugly, but must be done in order to prevent an indefinitely blocking call (which can affect code reloading, or re-running this ns's tests))
+    (alter-var-root #'setup (fn [_]
+                              (setup!) ;; init migration conn and properties
+                              :done)))
   (t)
   (es-index/delete! (es-conn) "v0.0.0*")
   (es-index/delete! (es-conn) (str (migration-index) "*")))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -59,18 +59,22 @@
 
 (declare setup)
 
-(defn fixture-clean-migration [t]
+(defn fixture-setup [t]
   (when-not setup
-     ;; ugly, but must be done in order to prevent an indefinitely blocking call (which can affect code reloading, or re-running this ns's tests))
+    ;; ugly, but must be done in order to prevent an indefinitely blocking call (which can affect code reloading, or re-running this ns's tests))
     (alter-var-root #'setup (fn [_]
                               (setup!) ;; init migration conn and properties
                               :done)))
+  (t))
+
+(defn fixture-clean-migration [t]
   (t)
   (es-index/delete! @es-conn "v0.0.0*")
   (es-index/delete! @es-conn (str (migration-index) "*")))
 
 (use-fixtures :each
   (join-fixtures [helpers/fixture-ctia
+                  fixture-setup
                   es-helpers/fixture-delete-store-indexes
                   fixture-clean-migration]))
 

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -37,7 +37,7 @@
            (java.lang AssertionError)
            (clojure.lang ExceptionInfo)))
 
-(declare setup)
+(def setup nil)
 
 (defn fixture-setup [t]
   (when-not setup

--- a/test/ctia/test_helpers/benchmark.clj
+++ b/test/ctia/test_helpers/benchmark.clj
@@ -26,5 +26,5 @@
 (def delete-store-indexes esh/delete-store-indexes)
 
 (defn cleanup-ctia! []
-  (esh/delete-store-indexes)
+  (esh/delete-store-indexes false)
   #(shutdown/shutdown-ctia!))


### PR DESCRIPTION
A few fixes moslty oriented towards making `(refresh)` pass (if you happen to use it. Right now it's not set up - I inject `refresh` via Lein).

* `ctia.task.migration.migrate-es-stores-test`: prevent spawning a server at compile time
  * loading this ns from `(refresh)` would create a blocking http server.
* Correctly place return value type hints
  * https://gist.github.com/pjstadig/6fa4ebf465f6d438b4dcc2a5bfbb3db6
  * https://clojure.org/reference/java_interop#typehints (last paragraph)
* Move Uberjar aspects to the :uberjar profile
  * `:aot` and `:main` emit .class files even when developing/testing, which is a usual cause for opaque errors.
* `:dev` profile: add `:source-paths ["dev"]`
  * Necessary for user.clj to be possibly loaded via `(refresh)`
* Add a missing argument

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Cleanup project
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

