### PR TITLE
adds direct lifecycle methods to start and stop server

### DIFF
--- a/src/ctia/main.clj
+++ b/src/ctia/main.clj
@@ -1,6 +1,7 @@
 (ns ctia.main
   (:gen-class)
   (:require
+   [ctia.http.server :as http-server]
    [ctia.init :refer [log-properties start-ctia!]]))
 
 (defn -main
@@ -8,3 +9,10 @@
   [& args]
   (start-ctia! :join? true
                :silent? false))
+
+(defn start []
+  (start-ctia! :join? false
+               :silent? false))
+
+(defn stop []
+  (#'http-server/stop!))


### PR DESCRIPTION
This is not to be merged "as is", at this point is more like a question.

 I would like to have direct "start" and "stop" methods so they can be hooked to CIDER. CIDER has `cider-ns-refresh-before-fn` and `cider-ns-refresh-after-fn` vars, so whenever you run `(cider-ns-refresh)`, it executes those functions. The problem with that - CIDER requires them to be in "direct" form so you set them like this `(setq cider-ns-refresh-before-fn "stop")`, that means, you need to expose functions that take no arguments.

So my question is: what would be the best place/way to expose those? Maybe someone can suggest a better approach?