### PR TITLE
Add route to link Incidents to Investigations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -137,7 +137,8 @@
                                   [org.clojure/test.check ~test-check-version]
                                   [com.gfredericks/test.chuck ~test-chuck-version]
                                   [clj-http-fake ~clj-http-fake-version]
-                                  [prismatic/schema-generators ~schema-generators-version]]
+                                  [prismatic/schema-generators ~schema-generators-version]
+                                  [org.clojure/math.combinatorics "0.1.6"]]
                    :pedantic? :warn
 
                    :resource-paths ["test/resources"]

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -81,7 +81,7 @@
    (s/optional-key :tlp) TLP})
 
 (def incident-link-route
-  (POST "/:id/link" [req]
+  (POST "/:id/link" []
         :return rs/Relationship
         :body [link-req IncidentLinkRequest
                {:description "an Incident Link request"}]
@@ -104,7 +104,7 @@
                 :casebook_id #{:read-casebook}
                 :investigation_id #{:read-investigation})
               _ (require-capability! additional-required-capabilities
-                                     (:identity req))
+                                     identity)
               incident (read-store :incident
                                    read-record
                                    id

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -141,7 +141,7 @@
   {:investigation_id Reference})
 
 (def incident-investigation-link-route
-  (POST "/:id/link" []
+  (POST "/:id/link-investigation" []
         :return rs/Relationship
         :body [link-req IncidentInvestigationLinkRequest
                {:description "an Incident Link request"}]
@@ -179,7 +179,7 @@
             :else
             (let [{:keys [investigation_id]} link-req
                   new-relationship
-                  {:source_ref casebook_id
+                  {:source_ref investigation_id
                    :target_ref target-ref
                    :relationship_type "related-to"}
                   stored-relationship

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -6,7 +6,8 @@
             [ctia.entity.casebook :refer [casebook-operation-routes]]
             [ctia.entity.incident :refer [incident-additional-routes]]
             [ctia.entity.feedback :refer [feedback-by-entity-route]]
-            [ctia.entity.relationship :refer [incident-casebook-link-route]]
+            [ctia.entity.relationship :refer [incident-casebook-link-route
+                                              incident-investigation-link-route]]
             [compojure.api
              [core :refer [middleware]]
              [routes :as api-routes]
@@ -208,7 +209,8 @@
                (context
                    "/incident" []
                  :tags ["Incident"]
-                 incident-casebook-link-route)
+                 incident-casebook-link-route
+                 incident-investigation-link-route)
                bundle-routes
                observable-routes
                metrics-routes

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -6,8 +6,7 @@
             [ctia.entity.casebook :refer [casebook-operation-routes]]
             [ctia.entity.incident :refer [incident-additional-routes]]
             [ctia.entity.feedback :refer [feedback-by-entity-route]]
-            [ctia.entity.relationship :refer [incident-casebook-link-route
-                                              incident-investigation-link-route]]
+            [ctia.entity.relationship :refer [incident-link-route]]
             [compojure.api
              [core :refer [middleware]]
              [routes :as api-routes]
@@ -209,8 +208,7 @@
                (context
                    "/incident" []
                  :tags ["Incident"]
-                 incident-casebook-link-route
-                 incident-investigation-link-route)
+                 incident-link-route)
                bundle-routes
                observable-routes
                metrics-routes

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -124,11 +124,6 @@
              (post "ctia/incident"
                    :body new-incident-minimal
                    :headers {"Authorization" "45c1f5e3f05d0"})
-             {investigation-body :parsed-body
-              investigation-status :status}
-             (post "ctia/investigation"
-                   :body new-investigation-minimal
-                   :headers {"Authorization" "45c1f5e3f05d0"})
 
              {wrong-incident-status :status
               wrong-incident-response :body}

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -19,7 +19,7 @@
             [ctim.examples
              [casebooks :refer [new-casebook-minimal]]
              [incidents :refer [new-incident-minimal]]
-             [investigation :refer [new-investigation-minimal]]
+             [investigations :refer [new-investigation-minimal]]
              [relationships :refer [new-relationship-maximal new-relationship-minimal]]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -210,9 +210,11 @@
                    :headers {"Authorization" "45c1f5e3f05d0"})
              _ (is (= 201 investigation-status))
 
+             link-suffix "/link-investigation"
+
              {wrong-incident-status :status
               wrong-incident-response :body}
-             (post (str "ctia/incident/" "r0pV4UNSjWyUYXUtpgQxooVR7HbjnMKB" "/link")
+             (post (str "ctia/incident/" "r0pV4UNSjWyUYXUtpgQxooVR7HbjnMKB" link-suffix)
                    :body {:investigation_id (:id investigation-body)}
                    :headers {"Authorization" "45c1f5e3f05d0"})
              _ (is (= 404 wrong-incident-status))
@@ -223,7 +225,7 @@
               wrong-investigation-response :body}
              (post (str "ctia/incident/" (-> (:id incident-body)
                                              long-id->id
-                                             :short-id) "/link")
+                                             :short-id) link-suffix)
                    :body {:investigation_id ":"}
                    :headers {"Authorization" "45c1f5e3f05d0"})
              _ (is (= 400 wrong-investigation-status))
@@ -234,7 +236,7 @@
               link-response :parsed-body}
              (post (str "ctia/incident/" (-> (:id incident-body)
                                              long-id->id
-                                             :short-id) "/link")
+                                             :short-id) link-suffix)
                    :body {:investigation_id (:id investigation-body)}
                    :headers {"Authorization" "45c1f5e3f05d0"})
              _ (is (= 201 link-status))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close https://github.com/threatgrid/iroh/issues/2431

Extends `/incident/:id/link` to also support linking to Investigations.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

This PR broadens the scope of the `/incident/:id/link` route. For a body, it now accepts *one of* an `investigation_id` or `casebook_id` field, as well as some other optional keys (at the moment, just `tlp`).

Please follow these steps to create a relationship between an incident and an investigation, and verify it was created.

1. Visit `https://private.intel.int.iroh.site/index.html#/Incident/post_ctia_incident__id__link` (or equivalent)
2. Add a known incident id to the `id` param.
3. Add a body of the form `{ "investigation_id" : "<known-investigation-id>", ...}` with any relevant optional keys, then execute.
4. The response should be `200` and contain an `id` field. This is the relationship that was created.
5. Verify the `id` returned in step 4 corresponds to a relationship from the incident id to the investigation id.

The previous step should also still work for linking casebooks, via the `casebook_id` field. This behavior should be unchanged.

Please also verify providing zero or more than one of `investigation_id` or `casebook_id` fields in the body of the `/incident/:id/link` route triggers a 400 error response. Error messages should also be descriptive enough to diagnose the problem immediately.


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Add route to link Incidents to Investigations
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

