### PR TITLE
fix shellcheck url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jdk:
 
 before_install:
     # upgrade shellcheck (https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary)
-    - wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
+    - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
     - cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" "${BIN_DIR}"
     - shellcheck --version
     # run shellcheck


### PR DESCRIPTION
This PR fixes travis build that now fails with current message:

```
$ shellcheck --version

You are downloading ShellCheck from an outdated URL!

Please update to the new URL:

https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz

For more information, see:

https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(

The command "shellcheck --version" failed and exited with 1 during .
```

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.
