### PR TITLE
do not obfuscate external-key-prefixes in events

### DIFF
--- a/src/ctia/lib/utils.clj
+++ b/src/ctia/lib/utils.clj
@@ -13,7 +13,6 @@
                                "pass"
                                "secret"
                                "tempfile"
-                               "customerKey"
                                "response-url"
                                "token"]]
     (re-pattern (str "(?i).*("
@@ -23,6 +22,10 @@
 ;; copied from log-helper.safe
 (def to-obfuscate-keys
   #{"jwt" "authorization"})
+
+;; put pattern exceptions here
+(def to-not-obfuscate-keys
+  #{"external-key-prefixes"})
 
 ;; copied from log-helper.safe
 (defn obfuscate?
@@ -37,6 +40,7 @@
                              (pr-str k))
                   (pr-str k)))]
     (cond
+      (contains? to-not-obfuscate-keys k-str) false
       (contains? to-obfuscate-keys k-str) (string? v)
       :else (some? (re-matches to-obfuscate-pattern k-str)))))
 

--- a/test/ctia/lib/utils_test.clj
+++ b/test/ctia/lib/utils_test.clj
@@ -4,14 +4,18 @@
 
 (def map-with-creds
   {:ctia
-   {"password" "abcd"
+   {"external-key-prefixes" "ctia-,tg-"
+    "CustomerKey" "1234-5678"
+    "password" "abcd"
     :auth
     {:static
      {:secret "1234"}}}})
 
 (def map-with-hidden-creds
   {:ctia
-   {"password" "********"
+   {"external-key-prefixes" "ctia-,tg-"
+    "CustomerKey" "********"
+    "password" "********"
     :auth
     {:static
      {:secret "********"}}}})


### PR DESCRIPTION
`bundle/import` route has a parameter `external-key-prefixes` which is obfuscated in events
``` javascript
{"external-key-prefixes" "********"}
```
It is obfuscated because we automatically obfuscate any field that contains some words reflecting potential secret content, including `key`.
I added a list of protected keys, any cleaner option is welcome.


<a name="qa">[§](#qa)</a> QA
============================

import a bundle with `external-key-prefixes` param. Checks that the corresponding event in kibana does not obfuscate the value of this parameter.
