### PR TITLE
use `id` field for sorting

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -142,7 +142,7 @@ ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
-ctia.log.riemann.enabled=true
+ctia.log.riemann.enabled=false
 ctia.log.riemann.host=127.0.0.1
 ctia.log.riemann.port=5555
 ctia.log.riemann.interval-in-ms=1000 # every second

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -142,7 +142,7 @@ ctia.metrics.console.enabled=false
 ctia.metrics.console.interval=60 # every minute
 ctia.metrics.jmx.enabled=false
 
-ctia.log.riemann.enabled=false
+ctia.log.riemann.enabled=true
 ctia.log.riemann.host=127.0.0.1
 ctia.log.riemann.port=5555
 ctia.log.riemann.interval-in-ms=1000 # every second

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -1,32 +1,27 @@
 (ns ctia.task.migration.store
-  (:require [clojure.string :as string]
+  (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
+            [clj-momo.lib.clj-time.core :as time]
+            [clj-momo.lib.es.conn :as conn]
+            [clj-momo.lib.es.document :as es-doc]
+            [clj-momo.lib.es.index :as es-index]
+            [clj-momo.lib.es.query :as es-query]
+            [clj-momo.lib.es.schemas :refer [ESConn ESConnState ESQuery]]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [schema.core :as s]
-            [schema-tools.core :as st]
-            [clj-momo.lib.clj-time
-             [core :as time]
-             [coerce :as time-coerce]]
-            [clj-momo.lib.es
-             [schemas :refer [ESConn ESQuery ESConnState]]
-             [conn :as conn]
-             [document :as es-doc]
-             [query :as es-query]
-             [index :as es-index]]
-            [ctim.domain.id :refer [long-id->id]]
+            [ctia.init :refer [init-store-service! log-properties]]
             [ctia.lib.collection :refer [fmap]]
-            [ctia.stores.es
-             [crud :as crud]
-             [init :refer [init-store-conn
-                           init-es-conn!
-                           get-store-properties
-                           StoreProperties]]
-             [mapping :as em]
-             [store :refer [StoreMap] :as es-store]]
+            [ctia.properties :refer [init!]]
+            [ctia.store :refer [stores]]
+            [ctia.stores.es.crud :as crud]
+            [ctia.stores.es.init
+             :refer
+             [get-store-properties init-es-conn! init-store-conn StoreProperties]]
+            [ctia.stores.es.mapping :as em]
+            [ctia.stores.es.store :as es-store :refer [StoreMap]]
             [ctia.task.rollover :refer [rollover-store]]
-            [ctia
-             [init :refer [init-store-service! log-properties]]
-             [properties :refer [init!]]
-             [store :refer [stores]]]))
+            [ctim.domain.id :refer [long-id->id]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
 
 (def timeout (* 5 60000))
 (def es-max-retry 3)
@@ -392,7 +387,7 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
                         "identity" []
                         [{"modified" date-sort-order}
                          {"created" date-sort-order}])
-                      {"_uid" sort-order})
+                      {"id" sort-order})
         params
         (merge
          {:offset (or offset 0)

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -54,9 +54,8 @@
                                          (false? wait_for) "refresh=false")]
                           (is (some-> @es-params
                                       (string/includes? expected))
-                              (str msg (format " (%s|%s)" expected @es-params)))
+                              (str msg (format "(expected %s, actual: %s)" expected @es-params)))
                           (reset! es-params nil)))]
-
     (testing "testing wait_for values on entity creation"
       (let [test-create (fn [wait_for msg]
                           (let [path (cond-> (str "ctia/" entity)

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -29,9 +29,9 @@
         default-es-refresh (->> (p/get-in-global-properties
                                   [:ctia :store :es :default :refresh])
                                 (str "refresh="))
-        es-params (atom nil)
-        simple-handler (fn [{:keys [query-string]}]
-                         (reset! es-params query-string)
+        es-params (volatile! nil)
+        simple-handler (fn [{:keys [url query-string]}]
+                         (vreset! es-params query-string)
                          {:status 200
                           :headers {"Content-Type" "application/json"}
                           :body "{}"})
@@ -43,7 +43,7 @@
                                                      (parse-string true)
                                                      (get-in [:index :_type]))]
                                 (when-not (= "event" mapping-type)
-                                  (reset! es-params query-string))
+                                  (vreset! es-params query-string))
                                 {:status 200
                                  :headers {"Content-Type" "application/json"}
                                  :body "{}"}))}}
@@ -55,7 +55,7 @@
                           (is (some-> @es-params
                                       (string/includes? expected))
                               (str msg (format "(expected %s, actual: %s)" expected @es-params)))
-                          (reset! es-params nil)))]
+                          (vreset! es-params nil)))]
     (testing "testing wait_for values on entity creation"
       (let [test-create (fn [wait_for msg]
                           (let [path (cond-> (str "ctia/" entity)
@@ -84,8 +84,9 @@
                           (let [path (cond-> (format "ctia/%s/%s" entity entity-id)
                                        (boolean? wait_for) (str "?wait_for=" wait_for))
                                 updates (cond->> {update-field "modified"}
-                                          (= put method) (into new-record))]
-                            (with-global-fake-routes {#".*9200.*" {:put simple-handler}}
+                                          (= put method) (into new-record))
+                                es-index-uri-pattern (re-pattern (str ".*9200.*" entity-id ".*"))]
+                            (with-global-fake-routes {es-index-uri-pattern {:put simple-handler}}
                               (method path
                                       :body updates
                                       :headers headers))
@@ -118,9 +119,10 @@
                                                     :headers headers)
                                               :parsed-body
                                               entity->short-id)
+                                es-index-uri-pattern (re-pattern (str ".*9200.*" entity-id ".*"))
                                 path (cond-> (format "ctia/%s/%s" entity entity-id)
                                        (boolean? wait_for) (str "?wait_for=" wait_for))]
-                            (with-global-fake-routes {#".*9200.*" {:delete simple-handler}}
+                            (with-global-fake-routes {es-index-uri-pattern {:delete simple-handler}}
                               (delete path
                                       :headers headers))
                             (check-refresh wait_for msg)))]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->
> closes #https://github.com/threatgrid/iroh/issues/2870

the `id` field is of type `keyword` and stored as `doc_values` since the mapping migration. This PR makes the migration sort on `id` instead of `_uid` to definitively get rid of fielddata (sorting on `_uid` is performed with fielddata on elaticsearch 5.6, which thus consume a lot of memory due to the cardinality of this field.


<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

We should test the memory consumption in ES when migration a big index on INT (it should be significantly lower and it should not build fielddata which takes several minutes on big indices).

