### PR TITLE
move migration params in properties

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -149,7 +149,16 @@ ctia.log.riemann.interval-in-ms=1000 # every second
 ctia.log.riemann.batch-size=10
 ctia.log.riemann.service-prefix=Dev CTIA
 
-#ctia.hook.kafka.enabled=false
+ctia.migration.migration-id=migration-test
+ctia.migration.prefix=v1.2.0
+ctia.migration.migrations=identity
+ctia.migration.store-keys=malware,tool,sighting  
+ctia.migration.batch-size=100
+ctia.migration.buffer-size=3
+ctia.migration.confirm?=false
+ctia.migration.restart?=false
+
+#ctia.hook.kafkrestart?    a.enabled=false
 #ctia.hook.kafka.compression.type=gzip
 #ctia.hook.kafka.ssl.enabled=true
 #ctia.hook.kafka.ssl.truststore.location=containers/dev/truststore/kafka.truststore.jks

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -204,6 +204,16 @@
                       "ctia.log.riemann.batch-size" s/Int
                       "ctia.log.riemann.service-prefix" s/Str
 
+
+                      "ctia.migration.migration-id" s/Str
+                      "ctia.migration.prefix" s/Str
+                      "ctia.migration.migrations" s/Str
+                      "ctia.migration.store-keys" s/Str
+                      "ctia.migration.batch-size" s/Int
+                      "ctia.migration.buffer-size" s/Int
+                      "ctia.migration.confirm?" s/Bool
+                      "ctia.migration.restart?" s/Bool
+
                       "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
 

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -281,7 +281,10 @@
 
 (s/defn ^:always-validate check-migration-params
   [{:keys [prefix
+           restart?
            store-keys]} :- MigrationParams]
+  (when-not restart?
+    (assert prefix "Please provide an indexname prefix for target store creation"))
   (doseq [store-key store-keys]
     (let [index (p/get-in-global-properties [:ctia :store :es store-key :indexname])]
       (when (= (mst/prefixed-index index prefix)
@@ -292,16 +295,14 @@
   true)
 
 (s/defn ^:always-validate run-migration
-  [{:keys [prefix
-           restart?]
-    :as params} :- MigrationParams]
-  (when-not restart?
-    (assert prefix "Please provide an indexname prefix for target store creation"))
+  []
   (log/info "migrating all ES Stores")
   (try
     (mst/setup!)
-    (check-migration-params params)
-    (migrate-store-indexes params)
+    (doto (p/get-in-global-properties [:ctia :store :migration])
+      clojure.pprint/pprint
+      check-migration-params
+      migrate-store-indexes)
     (log/info "migration complete")
     (catch AssertionError e
        (log/error (.getMessage e)))
@@ -310,52 +311,5 @@
       (exit true)))
   (exit false))
 
-(def cli-options
-  ;; An option with a required argument
-  [["-i" "--id ID" "The ID of the migration state to create or restar"
-    :default (str "migration-" (UUID/randomUUID))]
-   ["-p" "--prefix PREFIX" "prefix of the newly created indices"]
-   ["-m" "--migrations MIGRATIONS" "a comma separated list of migration ids to apply"
-    :parse-fn #(map keyword (string/split % #","))]
-   ["-b" "--batch-size SIZE" "number of migrated documents per batch"
-    :default default-batch-size
-    :parse-fn read-string
-    :validate [#(< 0 %) "batch-size must be a positive number"]]
-   ["" "--buffer-size SIZE" "max number of batches in buffer between source and target"
-    :default default-buffer-size
-    :parse-fn read-string
-    :validate [#(< 0 %) "buffer-size must be a positive number"]]
-   ["-s" "--stores STORES" "comma separated list of stores to migrate"
-    :default (-> (keys @stores) set (disj :identity))
-    :parse-fn #(map keyword (string/split % #","))]
-   ["-c" "--confirm" "really do the migration?"]
-   ["-r" "--restart" "restart ongoing migration?"]
-   ["-h" "--help"]])
-
 (defn -main [& args]
-  (let [{:keys [options errors summary]} (parse-opts args cli-options)
-        {:keys [id
-                prefix
-                migrations
-                stores
-                batch-size
-                buffer-size
-                confirm
-                restart]} options]
-    (when errors
-      (binding  [*out* *err*]
-        (println (string/join "\n" errors))
-        (println summary))
-      (System/exit 1))
-    (when (:help options)
-      (println summary)
-      (System/exit 0))
-    (pp/pprint options)
-    (run-migration {:migration-id id
-                    :prefix       prefix
-                    :migrations   migrations
-                    :store-keys   stores
-                    :batch-size   batch-size
-                    :buffer-size  buffer-size
-                    :confirm?     confirm
-                    :restart?     restart})))
+  (run-migration ))

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -294,12 +294,20 @@
                         index))))))
   true)
 
-(s/defn ^:always-validate run-migration
+(s/defn get-migration-params :- MigrationParams
+  []
+  (let [string-to-coll #(map (comp keyword string/trim)
+                             (string/split % #","))]
+    (-> (p/get-in-global-properties [:ctia :migration])
+        (update :migrations string-to-coll)
+        (update :store-keys string-to-coll))))
+
+(s/defn run-migration
   []
   (log/info "migrating all ES Stores")
   (try
     (mst/setup!)
-    (doto (p/get-in-global-properties [:ctia :store :migration])
+    (doto (get-migration-params)
       clojure.pprint/pprint
       check-migration-params
       migrate-store-indexes)

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -158,6 +158,27 @@
     (testing "properly configured migration"
       (is (sut/check-migration-params migration-params)))))
 
+(deftest get-migration-params-test
+  (with-redefs [p/global-properties-atom
+                (let [migration-props {:buffer-size 3,
+                                       :batch-size 100,
+                                       :migration-id "migration-test",
+                                       :restart? false,
+                                       :store-keys "malware,  tool,sighting  ",
+                                       :migrations "identity",
+                                       :confirm? false,
+                                       :prefix "v1.2.0"}]
+                  (fn [] (atom {:ctia {:migration migration-props}})))]
+    (is (= (sut/get-migration-params)
+           {:buffer-size 3
+            :batch-size 100
+            :migration-id "migration-test"
+            :restart? false
+            :store-keys [:malware :tool :sighting]
+            :migrations [:identity]
+            :confirm? false
+            :prefix "v1.2.0"}))))
+
 (deftest migration-with-rollover
   (helpers/set-capabilities! "foouser"
                              ["foogroup"]

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -158,26 +158,23 @@
     (testing "properly configured migration"
       (is (sut/check-migration-params migration-params)))))
 
-(deftest get-migration-params-test
-  (with-redefs [p/global-properties-atom
-                (let [migration-props {:buffer-size 3,
-                                       :batch-size 100,
-                                       :migration-id "migration-test",
-                                       :restart? false,
-                                       :store-keys "malware,  tool,sighting  ",
-                                       :migrations "identity",
-                                       :confirm? false,
-                                       :prefix "v1.2.0"}]
-                  (fn [] (atom {:ctia {:migration migration-props}})))]
-    (is (= (sut/get-migration-params)
-           {:buffer-size 3
-            :batch-size 100
-            :migration-id "migration-test"
-            :restart? false
-            :store-keys [:malware :tool :sighting]
-            :migrations [:identity]
-            :confirm? false
-            :prefix "v1.2.0"}))))
+(deftest prepare-params-test
+  (let [migration-props {:buffer-size 3,
+                         :batch-size 100,
+                         :migration-id "migration-test",
+                         :restart? false,
+                         :store-keys "malware,  tool,sighting  ",
+                         :migrations "identity",
+                         :confirm? false,
+                         :prefix "v1.2.0"}
+        prepared (sut/prepare-params migration-props)]
+    (testing "prepare params should properly format migration properties"
+      (is (= (dissoc prepared :store-keys :migrations)
+             (dissoc migration-props :store-keys :migrations)))
+      (is (= (:store-keys prepared)
+             [:malware :tool :sighting]))
+      (is (= (:migrations prepared)
+             [:identity])))))
 
 (deftest migration-with-rollover
   (helpers/set-capabilities! "foouser"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #threatgrid/iroh#3072

This PR moves the migration parameters in properties. 
These parameters were passed through the command line argument. For the next migration we need to add more arguments, in particular arguments for the target cluster and it will excessively increase the command line. Thus we decided to move these parameters in configuration. 
This is in particular the first step toward decorrelating the source cluster properties and target cluster properties for the ES7 migration.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.


