### PR TITLE
Fix bundle import OOMs

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -22,7 +22,7 @@
    [ctim.domain.id :as id]
    [schema.core :as s]))
 
-(def find-by-external-ids-limit 1000)
+(def find-by-external-ids-limit 200)
 
 (def bundle-entity-keys
   (set (vals bulk/bulk-entity-mapping)))

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -78,22 +78,23 @@
 (defn all-pages
   "Retrieves all external ids using pagination."
   [entity-type external-ids auth-identity]
-  (loop [ext-ids external-ids
-         entities []]
-    (let [query {:all-of {:external_ids ext-ids}}
-          paging {:limit find-by-external-ids-limit}
-          {results :data
-           {next-page :next} :paging} (read-store entity-type
-                                                  list-fn
-                                                  query
-                                                  (auth/ident->map auth-identity)
-                                                  paging)
-          acc-entities (into entities results)
-          matched-ext-ids (set (mapcat :external_ids results))
-          remaining-ext-ids (remove matched-ext-ids ext-ids)]
-      (if next-page
-        (recur remaining-ext-ids acc-entities)
-        acc-entities))))
+  (lazy-seq
+   (loop [ext-ids external-ids
+          entities []]
+     (let [query {:all-of {:external_ids ext-ids}}
+           paging {:limit find-by-external-ids-limit}
+           {results :data
+            {next-page :next} :paging} (read-store entity-type
+                                                   list-fn
+                                                   query
+                                                   (auth/ident->map auth-identity)
+                                                   paging)
+           acc-entities (into entities results)
+           matched-ext-ids (set (mapcat :external_ids results))
+           remaining-ext-ids (remove matched-ext-ids ext-ids)]
+       (if next-page
+         (recur remaining-ext-ids acc-entities)
+         acc-entities)))))
 
 (defn find-by-external-ids
   [import-data entity-type auth-identity]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -89,7 +89,7 @@
                                                   (auth/ident->map auth-identity)
                                                   paging)
           acc-entities (into entities results)
-          matched-ext-ids (set (mapcat :external_ids results))
+          matched-ext-ids (into #{} (mapcat :external_ids results))
           remaining-ext-ids (remove matched-ext-ids ext-ids)]
       (if next-page
         (recur remaining-ext-ids acc-entities)

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -78,23 +78,22 @@
 (defn all-pages
   "Retrieves all external ids using pagination."
   [entity-type external-ids auth-identity]
-  (lazy-seq
-   (loop [ext-ids external-ids
-          entities []]
-     (let [query {:all-of {:external_ids ext-ids}}
-           paging {:limit find-by-external-ids-limit}
-           {results :data
-            {next-page :next} :paging} (read-store entity-type
-                                                   list-fn
-                                                   query
-                                                   (auth/ident->map auth-identity)
-                                                   paging)
-           acc-entities (into entities results)
-           matched-ext-ids (set (mapcat :external_ids results))
-           remaining-ext-ids (remove matched-ext-ids ext-ids)]
-       (if next-page
-         (recur remaining-ext-ids acc-entities)
-         acc-entities)))))
+  (loop [ext-ids external-ids
+         entities []]
+    (let [query {:all-of {:external_ids ext-ids}}
+          paging {:limit find-by-external-ids-limit}
+          {results :data
+           {next-page :next} :paging} (read-store entity-type
+                                                  list-fn
+                                                  query
+                                                  (auth/ident->map auth-identity)
+                                                  paging)
+          acc-entities (into entities results)
+          matched-ext-ids (set (mapcat :external_ids results))
+          remaining-ext-ids (remove matched-ext-ids ext-ids)]
+      (if next-page
+        (recur remaining-ext-ids acc-entities)
+        acc-entities))))
 
 (defn find-by-external-ids
   [import-data entity-type auth-identity]
@@ -104,12 +103,7 @@
                 (pr-str external-ids))
     (if (seq external-ids)
       (debug (format "Results for %s:" (pr-str external-ids))
-             (all-pages
-              (fn [paging]
-                (read-store entity-type list-fn
-                            {:all-of {:external_ids external-ids}}
-                            (auth/ident->map auth-identity)
-                            paging))))
+             (all-pages entity-type external-ids auth-identity))
       [])))
 
 (defn by-external-id

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -77,15 +77,22 @@
 
 (defn all-pages
   "Retrieves all external ids using pagination."
-  [f]
-  (loop [paging {:offset 0
-                 :limit find-by-external-ids-limit}
+  [entity-type external-ids auth-identity]
+  (loop [ext-ids external-ids
          entities []]
-    (let [{results :data
-           {next-page :next} :paging} (f paging)
-          acc-entities (into entities results)]
+    (let [query {:all-of {:external_ids ext-ids}}
+          paging {:limit find-by-external-ids-limit}
+          {results :data
+           {next-page :next} :paging} (read-store entity-type
+                                                  list-fn
+                                                  query
+                                                  (auth/ident->map auth-identity)
+                                                  paging)
+          acc-entities (into entities results)
+          matched-ext-ids (set (mapcat :external_ids results))
+          remaining-ext-ids (remove matched-ext-ids ext-ids)]
       (if next-page
-        (recur next-page acc-entities)
+        (recur remaining-ext-ids acc-entities)
         acc-entities))))
 
 (defn find-by-external-ids
@@ -156,8 +163,8 @@
    an error is reported."
   [{:keys [external_ids]
     :as entity-data} :- EntityImportData
-   find-by-external-ids]
-  (if-let [old-entities (mapcat find-by-external-ids external_ids)]
+   find-by-external-id]
+  (if-let [old-entities (mapcat find-by-external-id external_ids)]
     (let [old-entity (some-> old-entities
                              first
                              :entity

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -199,5 +199,3 @@
                              :external_ids external_ids}
                 :type :sighting
                 :external_ids external_ids}})))
-
-

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -199,3 +199,5 @@
                              :external_ids external_ids}
                 :type :sighting
                 :external_ids external_ids}})))
+
+

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -463,6 +463,7 @@
            max-matched (+ core/find-by-external-ids-limit
                           (count more-indicators))]
        (assert (= 200 (:status response-create)))
+       (assert (seq all-external-ids))
        (testing "all-pages should not retrieve more duplicates than find-by-external-ids-limit"
          (is (<= (count matched-entities)
                  max-matched))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #threatgrid/iroh/issues/4051

We previously noticed an increase in CTIA memory usage which did not cause any problem until recent OOM in PROD. The analysing of the hprofs memory dump shows that the OOM happens in the `ctia.core.bundle/find-by-external-ids` function:
![Screenshot 2020-08-21 at 14 51 22](https://user-images.githubusercontent.com/3592199/90925040-e2814400-e3f0-11ea-9745-67a6ec589813.png)
Up to million of duplicated entities were already created. However, during the deduplication process, the `bundle/import` retrieves in the `all-pages` function (called by `find-by-external-ids`) all the entities that match a list of external ids, including all the duplicates which end loading a huge amount of entities in memory.
It is very likely that it could be the cause of the observed OOM.
This PR optimizes the `all-pages` function by querying the subsequent pages with only the `external_-ids` that were not matched yet.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.
