### PR TITLE
TK1.2: add service arguments to auth.threatgrid

### DIFF
--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -48,8 +48,8 @@
         (json/parse-string
          (:body response))))))
 
-(defn lookup-stored-identity [login]
-  (store/read-store :identity store/read-identity login))
+(defn lookup-stored-identity [login read-store]
+  (read-store :identity store/read-identity login))
 
 (defrecord ThreatgridAuthService [whoami-fn
                                   lookup-stored-identity-fn]
@@ -70,8 +70,8 @@
                                                    (get default-capabilities))}))))
         auth/denied-identity-singleton)))
 
-(defn make-auth-service []
-  (let [{:keys [whoami-url cache]} (p/get-in-global-properties [:ctia :auth :threatgrid])
+(defn make-auth-service [get-in-config lookup-stored-identity]
+  (let [{:keys [whoami-url cache]} (get-in-config [:ctia :auth :threatgrid])
         whoami-fn (make-whoami-fn whoami-url)]
     (->ThreatgridAuthService
      (if cache (memo whoami-fn) whoami-fn)


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related threatgrid/iroh#3986
Extracted from https://github.com/threatgrid/ctia/pull/924

Almost everything in `ctia.init` will be rewritten when we introduce Trapperkeeper--this adds some stubs in the meanwhile.

I'm using TK##.## to keep track of these PR's and their order. You can ignore them, or see the planned list [here](  https://github.com/threatgrid/ctia/pull/924#actualprs). If a PR is ready for review, assume you can review in any order.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: TK1.2: add service arguments to auth.threatgrid
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

