### PR TITLE
TK3.8: change config "before" app starts in access-control-test

### DIFF
--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -65,12 +65,11 @@
       sut/actor-fields))))
 
 (deftest test-actor-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "actor"
-                          new-actor-minimal
-                          true
-                          true))))
+  (access-control-test "actor"
+                       new-actor-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-actor-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -68,12 +68,11 @@
         sut/attack-pattern-fields)))))
 
 (deftest attack-pattern-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "attack-pattern"
-                          new-attack-pattern-minimal
-                          true
-                          true))))
+  (access-control-test "attack-pattern"
+                       new-attack-pattern-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-attack-pattern-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -60,12 +60,11 @@
         sut/campaign-fields)))))
 
 (deftest test-campaign-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "campaign"
-                          ex/new-campaign-minimal
-                          true
-                          true))))
+  (access-control-test "campaign"
+                       ex/new-campaign-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-campaign-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -348,12 +348,11 @@
         sut/casebook-fields)))))
 
 (deftest test-casebook-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "casebook"
-                          new-casebook-minimal
-                          true
-                          true))))
+  (access-control-test "casebook"
+                       new-casebook-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-casebook-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -58,12 +58,11 @@
         sut/coa-fields)))))
 
 (deftest test-coa-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "coa"
-                          new-coa-minimal
-                          true
-                          true))))
+  (access-control-test "coa"
+                       new-coa-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-coa-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -331,9 +331,8 @@
         sort-restricted-feed-fields)))))
 
 (deftest test-feed-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "feed"
-                          new-feed-minimal
-                          true
-                          true))))
+  (access-control-test "feed"
+                       new-feed-minimal
+                       true
+                       true
+                       test-for-each-store))

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -5,7 +5,6 @@
             [ctia.entity.identity-assertion :as sut]
             [ctia.properties :as p]
             [ctia.test-helpers
-             [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [post-entity-bulk post-bulk]]
              [crud :refer [entity-crud-test]]

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -125,9 +125,8 @@
         sut/incident-fields)))))
 
 (deftest test-incident-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "incident"
-                          new-incident-minimal
-                          true
-                          true))))
+  (access-control-test "incident"
+                       new-incident-minimal
+                       true
+                       true
+                       test-for-each-store))

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -34,12 +34,11 @@
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 
 (deftest test-indicator-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "indicator"
-                          new-indicator-minimal
-                          true
-                          false))))
+  (access-control-test "indicator"
+                       new-indicator-minimal
+                       true
+                       false
+                       test-for-each-store))
 
 (deftest test-indicator-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -65,12 +65,11 @@
         sut/investigation-fields)))))
 
 (deftest test-investigation-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "investigation"
-                          new-investigation-minimal
-                          false
-                          true))))
+  (access-control-test "investigation"
+                       new-investigation-minimal
+                       false
+                       true
+                       test-for-each-store))
 
 (deftest test-investigation-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -368,9 +368,8 @@
         judgement-fields)))))
 
 (deftest test-judgement-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "judgement"
-                          ex/new-judgement-minimal
-                          true
-                          true))))
+  (access-control-test "judgement"
+                       ex/new-judgement-minimal
+                       true
+                       true
+                       test-for-each-store))

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -70,12 +70,11 @@
         sut/malware-fields)))))
 
 (deftest test-malware-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "malware"
-                          new-malware-minimal
-                          true
-                          true))))
+  (access-control-test "malware"
+                       new-malware-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-malware-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -102,12 +102,11 @@
         sut/relationship-fields)))))
 
 (deftest test-relationship-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "relationship"
-                          new-relationship-minimal
-                          true
-                          true))))
+  (access-control-test "relationship"
+                       new-relationship-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest links-routes-test
   (test-for-each-store

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -102,9 +102,8 @@
         sighting-fields)))))
 
 (deftest test-sighting-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "sighting"
-                          new-sighting-minimal
-                          true
-                          true))))
+  (access-control-test "sighting"
+                       new-sighting-minimal
+                       true
+                       true
+                       test-for-each-store))

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -68,12 +68,11 @@
         ts/tool-fields)))))
 
 (deftest test-tool-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "tool"
-                          new-tool-minimal
-                          true
-                          true))))
+  (access-control-test "tool"
+                       new-tool-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-tool-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -65,12 +65,11 @@
       sut/vulnerability-fields))))
 
 (deftest test-vulnerability-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "vulnerability"
-                          new-vulnerability-minimal
-                          true
-                          true))))
+  (access-control-test "vulnerability"
+                       new-vulnerability-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-vulnerability-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -65,12 +65,11 @@
       sut/weakness-fields))))
 
 (deftest test-weakness-routes-access-control
-  (test-for-each-store
-   (fn []
-     (access-control-test "weakness"
-                          new-weakness-minimal
-                          true
-                          true))))
+  (access-control-test "weakness"
+                       new-weakness-minimal
+                       true
+                       true
+                       test-for-each-store))
 
 (deftest test-weakness-metric-routes
   ((:es-store store-fixtures)

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -951,86 +951,110 @@
                                                   (:parsed-body player-3-entity-repost2)]})))))))
 
 (defn test-access-control-tlp-settings
-  [entity new-entity]
-  (testing "TLP Settings Enforcement"
-    (swap! (p/global-properties-atom) assoc-in
-           [:ctia :access-control]
-           {:default-tlp "amber"
-            :min-tlp "amber"})
+  [entity new-entity fixtures]
+  (helpers/with-config-transformer*
+    #(assoc-in % [:ctia :access-control] {:default-tlp "amber"
+                                          :min-tlp "amber"})
+    #(fixtures
+       (fn []
+         (testing "TLP Settings Enforcement"
+           (let [;; verify the with-config-transformer* call above--it's possible
+                 ;; a fixture could override it since we call it first
+                 get-in-config (helpers/current-get-in-config-fn)
+                 _ (assert (= (get-in-config [:ctia :access-control])
+                              {:default-tlp "amber"
+                               :min-tlp "amber"})
+                           (get-in-config [:ctia :access-control]))
+                 
+                 {status-default-tlp :status
+                  body-default-tlp :parsed-body}
+                 (post (format "ctia/%s" entity)
+                       :body (dissoc new-entity :tlp)
+                       :headers {"Authorization" "player-1-token"})
+                 {status-disallowed-tlp :status
+                  body-disallowed-tlp :parsed-body}
+                 (post (format "ctia/%s" entity)
+                       :body (assoc new-entity :tlp "white")
+                       :headers {"Authorization" "player-1-token"})]
 
-    (let [{status-default-tlp :status
-           body-default-tlp :parsed-body}
-          (post (format "ctia/%s" entity)
-                :body (dissoc new-entity :tlp)
-                :headers {"Authorization" "player-1-token"})
-          {status-disallowed-tlp :status
-           body-disallowed-tlp :parsed-body}
-          (post (format "ctia/%s" entity)
-                :body (assoc new-entity :tlp "white")
-                :headers {"Authorization" "player-1-token"})]
-
-      (is (= 201 status-default-tlp))
-      (is (= "amber" (:tlp body-default-tlp)))
+             (is (= 201 status-default-tlp))
+             (is (= "amber" (:tlp body-default-tlp)))
 
 
-      (is (= 400 status-disallowed-tlp))
-      (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
-             (:message body-disallowed-tlp))))))
+             (is (= 400 status-disallowed-tlp))
+             (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
+                    (:message body-disallowed-tlp)))))))))
 
+;; the body of this function must change the current TK config
+;; via test-access-control-tlp-settings. This is only possible by starting a new app.
+;; Since apps are started by fixtures, this function accepts a fixture and 
+;; must not be called in a context wrapped by fixture-ctia (this is dynamically enforced).
 (defn access-control-test
   [entity
    new-entity
    can-update?
-   can-delete?]
-  (helpers/set-capabilities! "player1"
-                             ["foogroup"]
-                             "user"
-                             all-capabilities)
-  (helpers/set-capabilities! "player2"
-                             ["bargroup"]
-                             "user"
-                             all-capabilities)
-  (helpers/set-capabilities! "player3"
-                             ["bargroup"]
-                             "user"
-                             all-capabilities)
+   can-delete?
+   fixtures]
+  (let [fixtures (fn [f]
+                   (let [setup! (fn [] 
+                                  (helpers/set-capabilities! "player1"
+                                                             ["foogroup"]
+                                                             "user"
+                                                             all-capabilities)
+                                  (helpers/set-capabilities! "player2"
+                                                             ["bargroup"]
+                                                             "user"
+                                                             all-capabilities)
+                                  (helpers/set-capabilities! "player3"
+                                                             ["bargroup"]
+                                                             "user"
+                                                             all-capabilities)
 
-  (whoami-helpers/set-whoami-response "player-1-token"
-                                      "player1"
-                                      "foogroup"
-                                      "user")
-  (whoami-helpers/set-whoami-response "player-2-token"
-                                      "player2"
-                                      "bargroup"
-                                      "user")
-  (whoami-helpers/set-whoami-response "player-3-token"
-                                      "player3"
-                                      "bargroup"
-                                      "user")
+                                  (whoami-helpers/set-whoami-response "player-1-token"
+                                                                      "player1"
+                                                                      "foogroup"
+                                                                      "user")
+                                  (whoami-helpers/set-whoami-response "player-2-token"
+                                                                      "player2"
+                                                                      "bargroup"
+                                                                      "user")
+                                  (whoami-helpers/set-whoami-response "player-3-token"
+                                                                      "player3"
+                                                                      "bargroup"
+                                                                      "user"))]
+                     (fixtures
+                       (fn []
+                         (setup!)
+                         (f)))))
+        
+        test-default-config #(do (test-access-control-entity-tlp-green
+                                   {:entity entity
+                                    :new-entity new-entity
+                                    :can-update? can-update?
+                                    :can-delete? can-delete?})
 
-  (test-access-control-entity-tlp-green
-   {:entity entity
-    :new-entity new-entity
-    :can-update? can-update?
-    :can-delete? can-delete?})
+                                 (test-access-control-entity-tlp-green-max-record-visibility-group
+                                   {:entity entity
+                                    :new-entity new-entity
+                                    :can-update? can-update?
+                                    :can-delete? can-delete?})
 
-  (test-access-control-entity-tlp-green-max-record-visibility-group
-   {:entity entity
-    :new-entity new-entity
-    :can-update? can-update?
-    :can-delete? can-delete?})
+                                 (test-access-control-entity-tlp-amber
+                                   {:entity entity
+                                    :new-entity new-entity
+                                    :can-update? can-update?
+                                    :can-delete? can-delete?})
 
-  (test-access-control-entity-tlp-amber
-   {:entity entity
-    :new-entity new-entity
-    :can-update? can-update?
-    :can-delete? can-delete?})
-
-  (test-access-control-entity-tlp-red
-   {:entity entity
-    :new-entity new-entity
-    :can-update? can-update?
-    :can-delete? can-delete?})
-
-  (test-access-control-tlp-settings entity
-                                    new-entity))
+                                 (test-access-control-entity-tlp-red
+                                   {:entity entity
+                                    :new-entity new-entity
+                                    :can-update? can-update?
+                                    :can-delete? can-delete?}))]
+    ;; we don't need to change TK config here, so we can call
+    ;; the fixtures immediately.
+    (fixtures test-default-config)
+    ;; pass control to test-access-control-tlp-settings since it
+    ;; needs to change the TK config
+    (test-access-control-tlp-settings entity
+                                      new-entity
+                                      fixtures)))

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -955,35 +955,36 @@
   (helpers/with-config-transformer*
     #(assoc-in % [:ctia :access-control] {:default-tlp "amber"
                                           :min-tlp "amber"})
-    #(fixtures
-       (fn []
-         (testing "TLP Settings Enforcement"
-           (let [;; verify the with-config-transformer* call above--it's possible
-                 ;; a fixture could override it since we call it first
-                 get-in-config (helpers/current-get-in-config-fn)
-                 _ (assert (= (get-in-config [:ctia :access-control])
-                              {:default-tlp "amber"
-                               :min-tlp "amber"})
-                           (get-in-config [:ctia :access-control]))
-                 
-                 {status-default-tlp :status
-                  body-default-tlp :parsed-body}
-                 (post (format "ctia/%s" entity)
-                       :body (dissoc new-entity :tlp)
-                       :headers {"Authorization" "player-1-token"})
-                 {status-disallowed-tlp :status
-                  body-disallowed-tlp :parsed-body}
-                 (post (format "ctia/%s" entity)
-                       :body (assoc new-entity :tlp "white")
-                       :headers {"Authorization" "player-1-token"})]
+    (fn []
+      (fixtures
+        (fn []
+          (testing "TLP Settings Enforcement"
+            (let [;; verify the with-config-transformer* call above--it's possible
+                  ;; a fixture could override it since we call it first
+                  get-in-config (helpers/current-get-in-config-fn)
+                  _ (assert (= (get-in-config [:ctia :access-control])
+                               {:default-tlp "amber"
+                                :min-tlp "amber"})
+                            (get-in-config [:ctia :access-control]))
 
-             (is (= 201 status-default-tlp))
-             (is (= "amber" (:tlp body-default-tlp)))
+                  {status-default-tlp :status
+                   body-default-tlp :parsed-body}
+                  (post (format "ctia/%s" entity)
+                        :body (dissoc new-entity :tlp)
+                        :headers {"Authorization" "player-1-token"})
+                  {status-disallowed-tlp :status
+                   body-disallowed-tlp :parsed-body}
+                  (post (format "ctia/%s" entity)
+                        :body (assoc new-entity :tlp "white")
+                        :headers {"Authorization" "player-1-token"})]
+
+              (is (= 201 status-default-tlp))
+              (is (= "amber" (:tlp body-default-tlp)))
 
 
-             (is (= 400 status-disallowed-tlp))
-             (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
-                    (:message body-disallowed-tlp)))))))))
+              (is (= 400 status-disallowed-tlp))
+              (is (= "Invalid document TLP white, allowed TLPs are: amber,red"
+                     (:message body-disallowed-tlp))))))))))
 
 ;; the body of this function must change the current TK config
 ;; via test-access-control-tlp-settings. This is only possible by starting a new app.
@@ -1027,29 +1028,30 @@
                          (setup!)
                          (f)))))
         
-        test-default-config #(do (test-access-control-entity-tlp-green
-                                   {:entity entity
-                                    :new-entity new-entity
-                                    :can-update? can-update?
-                                    :can-delete? can-delete?})
+        test-default-config (fn []
+                              (test-access-control-entity-tlp-green
+                                {:entity entity
+                                 :new-entity new-entity
+                                 :can-update? can-update?
+                                 :can-delete? can-delete?})
 
-                                 (test-access-control-entity-tlp-green-max-record-visibility-group
-                                   {:entity entity
-                                    :new-entity new-entity
-                                    :can-update? can-update?
-                                    :can-delete? can-delete?})
+                              (test-access-control-entity-tlp-green-max-record-visibility-group
+                                {:entity entity
+                                 :new-entity new-entity
+                                 :can-update? can-update?
+                                 :can-delete? can-delete?})
 
-                                 (test-access-control-entity-tlp-amber
-                                   {:entity entity
-                                    :new-entity new-entity
-                                    :can-update? can-update?
-                                    :can-delete? can-delete?})
+                              (test-access-control-entity-tlp-amber
+                                {:entity entity
+                                 :new-entity new-entity
+                                 :can-update? can-update?
+                                 :can-delete? can-delete?})
 
-                                 (test-access-control-entity-tlp-red
-                                   {:entity entity
-                                    :new-entity new-entity
-                                    :can-update? can-update?
-                                    :can-delete? can-delete?}))]
+                              (test-access-control-entity-tlp-red
+                                {:entity entity
+                                 :new-entity new-entity
+                                 :can-update? can-update?
+                                 :can-delete? can-delete?}))]
     ;; we don't need to change TK config here, so we can call
     ;; the fixtures immediately.
     (fixtures test-default-config)

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -35,7 +35,7 @@
         old @a]
     (try
       (swap! a tf)
-      body-fn
+      (body-fn)
       (finally
         (reset! a old)))))
 

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -178,8 +178,8 @@
          ;;      before we integrate trapperkeeper. must go after
          ;;      `start-ctia!` because it calls `ctia.properties/init!`
          ;;      to update global properties with System properties,
-         ;;      and we want to update properties after that step.
-         (swap! (p/get-global-properties)
+         ;;      and we want to update the config _after_ that step.
+         (swap! (p/global-properties-atom)
                 (fn [init-config]
                   (reduce #(%2 %1)
                           init-config

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -28,6 +28,17 @@
 (def fixture-property
   (mth/build-fixture-property-fn PropertiesSchema))
 
+(defn with-config-transformer*
+  [tf body-fn]
+  ;; TODO stub, assumed single-threaded
+  (let [a (p/global-properties-atom)
+        old @a]
+    (try
+      (swap! a tf)
+      body-fn
+      (finally
+        (reset! a old)))))
+
 (def with-properties-vec
   (mth/build-with-properties-vec-fn PropertiesSchema))
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related: https://github.com/threatgrid/iroh/issues/3986

As it stands, CTIA's tests freely interleave "starting" CTIA (via fixtures) and changing its global configuration (via `p/global-properties-atom`).

With Trapperkeeper, configuration may only be changed at `app` startup, so as we move to TK some changes are needed to delay startup until all configuration changes are "in".

`access-control-test` expects to be run after CTIA has started, but it also changes the global configuration. This PR refactors it into a HOF taking fixtures so it can manage starting CTIA itself, and then adds configuration changes _before_ calling the fixtures that starts CTIA.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: TK3.8: access-control-test => HOF, add config transformers
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

