### PR TITLE
fix indicator search by tags

### DIFF
--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -126,7 +126,7 @@
    (st/optional-keys
     {:query s/Str
      :indicator_type s/Str
-     :tags s/Int
+     :tags s/Str
      :kill_chain_phases s/Str
      :producer s/Str
      :specification s/Str


### PR DESCRIPTION
This PR fixes Indicator search query schema. `tags` filter was defined as `s/Int` instead of `s/Str`.

<a name="qa">[§](#qa)</a> QA
============================

check that indicator search route properly filters documents by `tags` field.
