### PR TITLE
Asset properties  expire api

### DIFF
--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -48,7 +48,7 @@
         (:asset-ref asset-mapping-sample)
         "Searching Asset Mapping by asset-ref"))))
 
-  (testing "Expire valid-time"
+  (testing "Expire 'valid-time' field"
     (let [fixed-now (-> "2020-12-31" tc/from-string tc/to-date)]
       (helpers/fixture-with-fixed-time
        fixed-now
@@ -56,7 +56,7 @@
          (let [response (helpers/post
                          (str "ctia/asset-mapping/expire/" short-id)
                          :headers {"Authorization" "45c1f5e3f05d0"})]
-           (is (= 200 (:status response)) "PATCH asset-mapping/expire succeeds")
+           (is (= 200 (:status response)) "POST asset-mapping/expire succeeds")
            (is (= fixed-now (-> response :parsed-body :valid_time :end_time))
                ":valid_time properly reset")))))))
 

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -37,12 +37,12 @@
                                            ;; to prevent `are` from double-failing
                                            true)
 
-        "*"
+        (str "properties.name:\"" (-> asset-properties-sample :properties first :name) "\"")
         (fn [r] (-> r :parsed-body first :properties first :name))
         (-> asset-properties-sample :properties first :name)
         "Properties name match"
 
-        "*"
+        (str "properties.value:\"" (-> asset-properties-sample :properties first :value) "\"")
         (fn [r] (-> r :parsed-body first :properties first :value))
         (-> asset-properties-sample :properties first :value)
         "Properties value match"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #978 
> Related #977, #979 

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

1. Create an AssetProperties entity.

`asset_ref` field can be set to anything, it really doesn't matter for this specific test case. Besides, the system currently doesn't validate integrity, meaning it won't complain if you create an AssetProperties that references non-existing Asset.

 Make sure `valid_time.end_time` is sometime in the future.

    POST http://localhost:3000/ctia/asset-properties
    Content-type: application/json

    {
      "properties": [
        {
          "name": "cisco:securex:posture:score",
          "value": "23"
        },
        {
          "name": "asus:router:model",
          "value": "RT-AC68U"
        }
      ],
      "valid_time": {
        "start_time": "2020-01-11T00:40:48Z",
        "end_time": "2525-01-01T00:00:00Z"
      },
      "schema_version": "1.0",
      "revision": 1,
      "asset_ref": "http://localhost:3000/ctia/asset/asset-196bf624-5976-418e-b45e-978c6acb4a44",
      "type": "asset-properties",
      "source": "cisco:unified_connect",
      "external_ids": [
        "29a4b476-a187-4160-8b36-81f7a0dbf137"
      ],
      "external_references": [
        {
          "source_name": "source",
          "external_id": "T1061",
          "url": "https://ex.tld/wiki/T1061",
          "hashes": [
            "#section1"
          ],
          "description": "Description text"
        }
      ],
      "source_uri": "http://example.com/asset-properties",
      "language": "language",
      "tlp": "green",
      "timestamp": "2016-02-11T00:40:48Z"
    }



2. The endpoint returns an entity. Copy its "short id", e.g. `asset-properties-5c78d2ce-e121-4b93-a9b8-52de8942b8b6`

3. Call expire endpoint using that id:

        POST http://localhost:3000/ctia/asset-properties/expire/asset-properties-5c78d2ce-e121-4b93-a9b8-52de8942b8b6

4. Re-read the same entity:

        GET http://localhost:3000/ctia/asset-properties/asset-properties-5c78d2ce-e121-4b93-a9b8-52de8942b8b6

5. Check `valid_time.end_time` field, the value should be the date-time when it was changed

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

