### PR TITLE
ES7: migrate compatible functions to ductile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,7 +58,7 @@
 
                  [threatgrid/ctim "1.0.20"]
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.1.0-SNAPSHOT"]
+                 [threatgrid/ductile "0.1.0"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/project.clj
+++ b/project.clj
@@ -58,6 +58,7 @@
 
                  [threatgrid/ctim "1.0.20"]
                  [threatgrid/clj-momo "0.3.5"]
+                 [threatgrid/ductile "0.1.0-SNAPSHOT"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -7,8 +7,6 @@
    [schema-tools.core :as st]
    [schema.core :as s]
    [clj-momo.lib.clj-time.core :as t]
-   [clj-momo.lib.es
-    [slice :refer [get-slice-props]]]
    [ctia.entity.event.schemas
     :refer [Event PartialEvent PartialEventList EventBucket]]
    [ctia.http.routes

--- a/src/ctia/entity/event/crud.clj
+++ b/src/ctia/entity/event/crud.clj
@@ -25,10 +25,8 @@
   (crud/handle-read PartialEvent))
 
 (def handle-event-query-string-search
-  (crud/handle-query-string-search :event PartialEvent))
+  (crud/handle-query-string-search PartialEvent))
 
-(def handle-event-query-string-count
-  (crud/handle-query-string-count))
+(def handle-event-query-string-count crud/handle-query-string-count)
 
-(def handle-aggregate
-  (crud/handle-aggregate :event))
+(def handle-aggregate crud/handle-aggregate)

--- a/src/ctia/entity/event/crud.clj
+++ b/src/ctia/entity/event/crud.clj
@@ -19,18 +19,16 @@
                     {}))
 
 (def handle-list
-  (crud/handle-find :event Event))
+  (crud/handle-find Event))
 
 (def handle-read
-  (crud/handle-read :event PartialEvent))
+  (crud/handle-read PartialEvent))
 
 (def handle-event-query-string-search
-  (crud/handle-query-string-search
-   :event PartialEvent))
+  (crud/handle-query-string-search :event PartialEvent))
 
 (def handle-event-query-string-count
-  (crud/handle-query-string-count
-   :event))
+  (crud/handle-query-string-count))
 
 (def handle-aggregate
   (crud/handle-aggregate :event))

--- a/src/ctia/entity/identity.clj
+++ b/src/ctia/entity/identity.clj
@@ -55,7 +55,7 @@
 (s/defn handle-read :- (s/maybe Identity)
   [state :- ESConnState
    login :- s/Str]
-  (some-> (crud/get-doc-with-index state :identity login {})
+  (some-> (crud/get-doc-with-index state login {})
           :_source
           (update-in [:capabilities] capabilities->capabilities-set)
           (dissoc :id)))
@@ -64,7 +64,7 @@
   [state :- ESConnState
    login :- s/Str]
   (when-let [{index :_index}
-             (crud/get-doc-with-index state :identity login {})]
+             (crud/get-doc-with-index state login {})]
     (delete-doc (:conn state)
                 index
                 mapping

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -1,5 +1,5 @@
 (ns ctia.entity.judgement.es-store
-  (:require [clj-momo.lib.es.document :refer [search-docs]]
+  (:require [ductile.document :refer [search-docs]]
             [clj-momo.lib.time :as time]
             [ctia.domain.access-control :refer [allow-write?]]
             [ctia.entity.judgement.schemas
@@ -17,8 +17,6 @@
             [schema
              [coerce :as c]
              [core :as s]]))
-
-(def judgement-mapping "judgement")
 
 (def judgement-mapping-def
   {"judgement"
@@ -48,9 +46,9 @@
 (def handle-read (crud/handle-read PartialStoredJudgement))
 (def handle-delete (crud/handle-delete :judgement PartialStoredJudgement))
 (def handle-list (crud/handle-find PartialStoredJudgement))
-(def handle-query-string-search (crud/handle-query-string-search :judgement PartialStoredJudgement))
-(def handle-query-string-count (crud/handle-query-string-count))
-(def handle-aggregate (crud/handle-aggregate :judgement))
+(def handle-query-string-search (crud/handle-query-string-search PartialStoredJudgement))
+(def handle-query-string-count crud/handle-query-string-count)
+(def handle-aggregate crud/handle-aggregate)
 
 (defn list-active-by-observable
   [state observable ident get-in-config]
@@ -78,7 +76,6 @@
     (some->>
      (search-docs (:conn state)
                   (:index state)
-                  judgement-mapping
                   composed-query
                   nil
                   params)

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -45,11 +45,11 @@
 
 (def handle-create (crud/handle-create :judgement StoredJudgement))
 (def handle-update (crud/handle-update :judgement StoredJudgement))
-(def handle-read (crud/handle-read :judgement PartialStoredJudgement))
+(def handle-read (crud/handle-read PartialStoredJudgement))
 (def handle-delete (crud/handle-delete :judgement PartialStoredJudgement))
-(def handle-list (crud/handle-find :judgement PartialStoredJudgement))
+(def handle-list (crud/handle-find PartialStoredJudgement))
 (def handle-query-string-search (crud/handle-query-string-search :judgement PartialStoredJudgement))
-(def handle-query-string-count (crud/handle-query-string-count :judgement))
+(def handle-query-string-count (crud/handle-query-string-count))
 (def handle-aggregate (crud/handle-aggregate :judgement))
 
 (defn list-active-by-observable

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -54,9 +54,9 @@
 (def read-fn (crud/handle-read ESPartialStoredSighting))
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
 (def list-fn (crud/handle-find ESPartialStoredSighting))
-(def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
-(def handle-query-string-count (crud/handle-query-string-count))
-(def handle-aggregate (crud/handle-aggregate :sighting))
+(def handle-query-string-search (crud/handle-query-string-search ESPartialStoredSighting))
+(def handle-query-string-count crud/handle-query-string-count)
+(def handle-aggregate crud/handle-aggregate)
 
 (s/defn observable->observable-hash :- s/Str
   "transform an observable to a hash of the form type:value"

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -51,11 +51,11 @@
 (def es-coerce! (crud/coerce-to-fn [(s/maybe ESPartialStoredSighting)]))
 
 (def create-fn (crud/handle-create :sighting ESStoredSighting))
-(def read-fn (crud/handle-read :sighting ESPartialStoredSighting))
+(def read-fn (crud/handle-read ESPartialStoredSighting))
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
-(def list-fn (crud/handle-find :sighting ESPartialStoredSighting))
+(def list-fn (crud/handle-find ESPartialStoredSighting))
 (def handle-query-string-search (crud/handle-query-string-search :sighting ESPartialStoredSighting))
-(def handle-query-string-count (crud/handle-query-string-count :sighting))
+(def handle-query-string-count (crud/handle-query-string-count))
 (def handle-aggregate (crud/handle-aggregate :sighting))
 
 (s/defn observable->observable-hash :- s/Str

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -94,6 +94,8 @@
   {:compojure.api.exception/request-parsing ex/request-parsing-handler
    :compojure.api.exception/request-validation ex/request-validation-handler
    :compojure.api.exception/response-validation ex/response-validation-handler
+   ;; switch this value for switch to ES7
+   ;;:ductile.conn/es-query-parsing-error ex/es-query-parsing-error-handler
    :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
    :access-control-error ex/access-control-error-handler
    :invalid-tlp-error ex/invalid-tlp-error-handler

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -94,9 +94,7 @@
   {:compojure.api.exception/request-parsing ex/request-parsing-handler
    :compojure.api.exception/request-validation ex/request-validation-handler
    :compojure.api.exception/response-validation ex/response-validation-handler
-   ;; switch this value for switch to ES7
-   ;;:ductile.conn/es-query-parsing-error ex/es-query-parsing-error-handler
-   :clj-momo.lib.es.conn/es-query-parsing-error ex/es-query-parsing-error-handler
+   :ductile.conn/es-query-parsing-error ex/es-query-parsing-error-handler
    :access-control-error ex/access-control-error-handler
    :invalid-tlp-error ex/invalid-tlp-error-handler
    :realize-entity-error ex/realize-entity-error-handler

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -14,7 +14,7 @@
    [ctia.entity.judgement.schemas :refer [PartialJudgementList]]
    [ctia.entity.sighting.schemas :refer [PartialSightingList]]
    [ctia.http.routes.common :refer [paginated-ok PagingParams]]
-   [clj-momo.lib.es.pagination :as pag]
+   [ductile.pagination :as pag]
    [ctia.schemas.core :refer [APIHandlerServices ObservableTypeIdentifier Reference Verdict]]
    [ctim.domain.id :as id]
    [ring.swagger.schema :refer [describe]]

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -1,26 +1,28 @@
 (ns ctia.observable.routes
-  (:require
-   [compojure.api.core :refer [routes GET]]
-   [ctia.store :refer [calculate-verdict
-                       list-judgements-by-observable
-                       list-records
-                       list-sightings-by-observables]]
-   [ctia.domain.entities
-    :refer
-    [page-with-long-id short-id->long-id un-store-page]]
-   [ctia.entity
-    [judgement :refer [JudgementsByObservableQueryParams]]
-    [sighting :refer [SightingsByObservableQueryParams]]]
-   [ctia.entity.judgement.schemas :refer [PartialJudgementList]]
-   [ctia.entity.sighting.schemas :refer [PartialSightingList]]
-   [ctia.http.routes.common :refer [paginated-ok PagingParams]]
-   [ductile.pagination :as pag]
-   [ctia.schemas.core :refer [APIHandlerServices ObservableTypeIdentifier Reference Verdict]]
-   [ctim.domain.id :as id]
-   [ring.swagger.schema :refer [describe]]
-   [ring.util.http-response :refer [not-found ok]]
-   [schema-tools.core :as st]
-   [schema.core :as s]))
+  (:require [compojure.api.core :refer [GET routes]]
+            [ctia.domain.entities
+             :refer
+             [page-with-long-id short-id->long-id un-store-page]]
+            [ctia.entity.judgement :refer [JudgementsByObservableQueryParams]]
+            [ctia.entity.judgement.schemas :refer [PartialJudgementList]]
+            [ctia.entity.sighting :refer [SightingsByObservableQueryParams]]
+            [ctia.entity.sighting.schemas :refer [PartialSightingList]]
+            [ctia.http.routes.common :refer [paginated-ok PagingParams]]
+            [ctia.schemas.core
+             :refer
+             [APIHandlerServices ObservableTypeIdentifier Reference Verdict]]
+            [ctia.store
+             :refer
+             [calculate-verdict
+              list-judgements-by-observable
+              list-records
+              list-sightings-by-observables]]
+            [ctim.domain.id :as id]
+            [ductile.pagination :as pag]
+            [ring.swagger.schema :refer [describe]]
+            [ring.util.http-response :refer [not-found ok]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
 
 (s/defschema RefsByObservableQueryParams
   (st/assoc PagingParams
@@ -30,183 +32,183 @@
 (s/defn observable-routes [{{:keys [get-in-config]} :ConfigService
                             {:keys [read-store]} :StoreService
                             :as _services_} :- APIHandlerServices]
- (routes
-  (GET "/:observable_type/:observable_value/verdict" []
-       :tags ["Verdict"]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :return (s/maybe Verdict)
-       :summary (str "Returns the current Verdict associated with the specified "
-                     "observable.")
-       :capabilities :read-verdict
-       :auth-identity identity
-       :identity-map identity-map
-       (or (some-> (read-store :judgement
-                               calculate-verdict
+  (routes
+   (GET "/:observable_type/:observable_value/verdict" []
+     :tags ["Verdict"]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :return (s/maybe Verdict)
+     :summary (str "Returns the current Verdict associated with the specified "
+                   "observable.")
+     :capabilities :read-verdict
+     :auth-identity identity
+     :identity-map identity-map
+     (or (some-> (read-store :judgement
+                             calculate-verdict
+                             {:type observable_type
+                              :value observable_value}
+                             identity-map)
+                 (clojure.core/update :judgement_id short-id->long-id get-in-config)
+                 ok)
+         (not-found {:message "no verdict currently available for the supplied observable"})))
+
+   (GET "/:observable_type/:observable_value/judgements" []
+     :tags ["Judgement"]
+     :query [params JudgementsByObservableQueryParams]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :return PartialJudgementList
+     :summary "Returns the Judgements associated with the specified observable."
+     :capabilities :list-judgements
+     :auth-identity identity
+     :identity-map identity-map
+     (-> (read-store :judgement
+                     list-judgements-by-observable
+                     {:type observable_type
+                      :value observable_value}
+                     identity-map
+                     params)
+         (page-with-long-id get-in-config)
+         un-store-page
+         paginated-ok))
+
+   (GET "/:observable_type/:observable_value/judgements/indicators" []
+     :tags ["Indicator"]
+     :query [params RefsByObservableQueryParams]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :return (s/maybe [Reference])
+     :summary (str "Returns the Indicator references associated with the "
+                   "specified observable based on Judgement relationships.")
+     :capabilities #{:list-judgements :list-relationships}
+     :auth-identity identity
+     :identity-map identity-map
+     (paginated-ok
+      (let [http-show (get-in-config [:ctia :http :show])
+            judgements (:data (read-store
+                               :judgement
+                               list-judgements-by-observable
                                {:type observable_type
                                 :value observable_value}
-                               identity-map)
-                   (clojure.core/update :judgement_id short-id->long-id get-in-config)
-                   ok)
-           (not-found {:message "no verdict currently available for the supplied observable"})))
+                               identity-map
+                               {:fields [:id]}))
+            judgement-ids (->> judgements
+                               (map :id)
+                               (map #(id/short-id->id :judgement % http-show))
+                               (map id/long-id))
+            relationships (:data (read-store
+                                  :relationship
+                                  list-records
+                                  {:all-of {:source_ref judgement-ids}}
+                                  identity-map
+                                  {:fields [:target_ref]}))
+            indicator-ids (->> (map :target_ref relationships)
+                               (map #(id/long-id->id %))
+                               (filter #(= "indicator" (:type %)))
+                               (map #(id/long-id %))
+                               set)]
+        (-> indicator-ids
+            (pag/paginate params)
+            (pag/response {:offset (:offset params)
+                           :limit (:limit params)
+                           :total-hits (count indicator-ids)})))))
 
-  (GET "/:observable_type/:observable_value/judgements" []
-       :tags ["Judgement"]
-       :query [params JudgementsByObservableQueryParams]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :return PartialJudgementList
-       :summary "Returns the Judgements associated with the specified observable."
-       :capabilities :list-judgements
-       :auth-identity identity
-       :identity-map identity-map
-       (-> (read-store :judgement
-                       list-judgements-by-observable
-                       {:type observable_type
-                        :value observable_value}
-                       identity-map
-                       params)
-           (page-with-long-id get-in-config)
-           un-store-page
-           paginated-ok))
+   (GET "/:observable_type/:observable_value/sightings" []
+     :tags ["Sighting"]
+     :query [params SightingsByObservableQueryParams]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :capabilities :list-sightings
+     :auth-identity identity
+     :identity-map identity-map
+     :return PartialSightingList
+     :summary "Returns Sightings associated with the specified observable."
+     (-> (read-store :sighting
+                     list-sightings-by-observables
+                     [{:type observable_type
+                       :value observable_value}]
+                     identity-map
+                     params)
+         (page-with-long-id get-in-config)
+         un-store-page
+         paginated-ok))
 
-  (GET "/:observable_type/:observable_value/judgements/indicators" []
-       :tags ["Indicator"]
-       :query [params RefsByObservableQueryParams]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :return (s/maybe [Reference])
-       :summary (str "Returns the Indicator references associated with the "
-                     "specified observable based on Judgement relationships.")
-       :capabilities #{:list-judgements :list-relationships}
-       :auth-identity identity
-       :identity-map identity-map
-       (paginated-ok
-        (let [http-show (get-in-config [:ctia :http :show])
-              judgements (:data (read-store
-                                 :judgement
-                                 list-judgements-by-observable
-                                 {:type observable_type
-                                  :value observable_value}
-                                 identity-map
-                                 {:fields [:id]}))
-              judgement-ids (->> judgements
-                                 (map :id)
-                                 (map #(id/short-id->id :judgement % http-show))
-                                 (map id/long-id))
-              relationships (:data (read-store
-                                    :relationship
-                                    list-records
-                                    {:all-of {:source_ref judgement-ids}}
-                                    identity-map
-                                    {:fields [:target_ref]}))
-              indicator-ids (->> (map :target_ref relationships)
-                                 (map #(id/long-id->id %))
-                                 (filter #(= "indicator" (:type %)))
-                                 (map #(id/long-id %))
-                                 set)]
-          (-> indicator-ids
-              (pag/paginate params)
-              (pag/response {:offset (:offset params)
-                             :limit (:limit params)
-                             :hits (count indicator-ids)})))))
+   (GET "/:observable_type/:observable_value/sightings/indicators" []
+     :tags ["Indicator"]
+     :query [params RefsByObservableQueryParams]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :return (s/maybe [Reference])
+     :summary (str "Returns Indicator references associated with the "
+                   "specified observable based on Sighting relationships.")
+     :capabilities #{:list-sightings :list-relationships}
+     :auth-identity identity
+     :identity-map identity-map
+     (paginated-ok
+      (let [http-show (get-in-config [:ctia :http :show])
+            sightings (:data (read-store :sighting
+                                         list-sightings-by-observables
+                                         [{:type observable_type
+                                           :value observable_value}]
+                                         identity-map
+                                         {:fields [:id]}))
+            sighting-ids (->> sightings
+                              (map :id)
+                              (map #(id/short-id->id :sighting % http-show))
+                              (map id/long-id))
+            relationships (:data (read-store
+                                  :relationship
+                                  list-records
+                                  {:all-of {:source_ref sighting-ids}}
+                                  identity-map
+                                  {:fields [:target_ref]}))
+            indicator-ids (->> (map :target_ref relationships)
+                               (map #(id/long-id->id %))
+                               (filter #(= "indicator" (:type %)))
+                               (map #(id/long-id %))
+                               set)]
+        (-> indicator-ids
+            (pag/paginate params)
+            (pag/response {:offset (:offset params)
+                           :limit (:limit params)
+                           :total-hits (count indicator-ids)})))))
 
-  (GET "/:observable_type/:observable_value/sightings" []
-       :tags ["Sighting"]
-       :query [params SightingsByObservableQueryParams]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :capabilities :list-sightings
-       :auth-identity identity
-       :identity-map identity-map
-       :return PartialSightingList
-       :summary "Returns Sightings associated with the specified observable."
-       (-> (read-store :sighting
-                       list-sightings-by-observables
-                       [{:type observable_type
-                         :value observable_value}]
-                       identity-map
-                       params)
-           (page-with-long-id get-in-config)
-           un-store-page
-           paginated-ok))
-
-  (GET "/:observable_type/:observable_value/sightings/indicators" []
-       :tags ["Indicator"]
-       :query [params RefsByObservableQueryParams]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :return (s/maybe [Reference])
-       :summary (str "Returns Indicator references associated with the "
-                     "specified observable based on Sighting relationships.")
-       :capabilities #{:list-sightings :list-relationships}
-       :auth-identity identity
-       :identity-map identity-map
-       (paginated-ok
-        (let [http-show (get-in-config [:ctia :http :show])
-              sightings (:data (read-store :sighting
-                                           list-sightings-by-observables
-                                           [{:type observable_type
-                                             :value observable_value}]
-                                           identity-map
-                                           {:fields [:id]}))
-              sighting-ids (->> sightings
-                                (map :id)
-                                (map #(id/short-id->id :sighting % http-show))
-                                (map id/long-id))
-              relationships (:data (read-store
-                                    :relationship
-                                    list-records
-                                    {:all-of {:source_ref sighting-ids}}
-                                    identity-map
-                                    {:fields [:target_ref]}))
-              indicator-ids (->> (map :target_ref relationships)
-                                 (map #(id/long-id->id %))
-                                 (filter #(= "indicator" (:type %)))
-                                 (map #(id/long-id %))
-                                 set)]
-          (-> indicator-ids
-              (pag/paginate params)
-              (pag/response {:offset (:offset params)
-                             :limit (:limit params)
-                             :hits (count indicator-ids)})))))
-
-  (GET "/:observable_type/:observable_value/sightings/incidents" []
-       :tags ["Incident"]
-       :query [params RefsByObservableQueryParams]
-       :path-params [observable_type :- ObservableTypeIdentifier
-                     observable_value :- s/Str]
-       :return (s/maybe [Reference])
-       :summary (str "Returns Incident references associated with the "
-                     "specified observable based on Sighting relationships")
-       :capabilities #{:list-sightings :list-relationships}
-       :auth-identity identity
-       :identity-map identity-map
-       (paginated-ok
-        (let [http-show (get-in-config [:ctia :http :show])
-              sightings (:data (read-store :sighting
-                                           list-sightings-by-observables
-                                           [{:type observable_type
-                                             :value observable_value}]
-                                           identity-map
-                                           {:fields [:id]}))
-              sighting-ids (->> sightings
-                                (map :id)
-                                (map #(id/short-id->id :sighting % http-show))
-                                (map id/long-id))
-              relationships (:data (read-store
-                                    :relationship
-                                    list-records
-                                    {:all-of {:source_ref sighting-ids}}
-                                    identity-map
-                                    {:fields [:target_ref]}))
-              incident-ids (->> (map :target_ref relationships)
-                                (map #(id/long-id->id %))
-                                (filter #(= "incident" (:type %)))
-                                (map #(id/long-id %))
-                                set)]
-          (-> incident-ids
-              (pag/paginate params)
-              (pag/response {:offset (:offset params)
-                             :limit (:limit params)
-                             :hits (count incident-ids)})))))))
+   (GET "/:observable_type/:observable_value/sightings/incidents" []
+     :tags ["Incident"]
+     :query [params RefsByObservableQueryParams]
+     :path-params [observable_type :- ObservableTypeIdentifier
+                   observable_value :- s/Str]
+     :return (s/maybe [Reference])
+     :summary (str "Returns Incident references associated with the "
+                   "specified observable based on Sighting relationships")
+     :capabilities #{:list-sightings :list-relationships}
+     :auth-identity identity
+     :identity-map identity-map
+     (paginated-ok
+      (let [http-show (get-in-config [:ctia :http :show])
+            sightings (:data (read-store :sighting
+                                         list-sightings-by-observables
+                                         [{:type observable_type
+                                           :value observable_value}]
+                                         identity-map
+                                         {:fields [:id]}))
+            sighting-ids (->> sightings
+                              (map :id)
+                              (map #(id/short-id->id :sighting % http-show))
+                              (map id/long-id))
+            relationships (:data (read-store
+                                  :relationship
+                                  list-records
+                                  {:all-of {:source_ref sighting-ids}}
+                                  identity-map
+                                  {:fields [:target_ref]}))
+            incident-ids (->> (map :target_ref relationships)
+                              (map #(id/long-id->id %))
+                              (filter #(= "incident" (:type %)))
+                              (map #(id/long-id %))
+                              set)]
+        (-> incident-ids
+            (pag/paginate params)
+            (pag/response {:offset (:offset params)
+                           :limit (:limit params)
+                           :total-hits (count incident-ids)})))))))

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -4,7 +4,7 @@
             alternative properties file on the classpath or by\n
             setting system properties."}
     ctia.properties
-  (:require [clj-momo.lib.es.schemas :refer [Refresh]]
+  (:require [ductile.schemas :refer [Refresh]]
             [clj-momo.lib.schema :as mls]
             [clj-momo.properties :as mp]
             [ctia.store :as store]

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -1,8 +1,9 @@
 (ns ctia.stores.es.crud
-  (:require [ductile.document :as ductile.doc]
-            [clj-momo.lib.es
-             [document :as d]
+  (:require [ductile
+             [document :as ductile.doc]
              [query :as q]]
+            [clj-momo.lib.es
+             [document :as d]]
             [clojure.string :as string]
             [ctia.domain.access-control
              :refer
@@ -349,7 +350,6 @@ It returns the documents with full hits meta data including the real index in wh
       (let [query (make-search-query es-conn-state search-query ident)]
         (cond-> (coerce! (ductile.doc/query conn
                                   index
-                                  ;;(name mapping)
                                   query
                                   (-> params
                                       rename-sort-fields

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -334,7 +334,7 @@ It returns the documents with full hits meta data including the real index in wh
         (seq query-string) (conj es-query-string))}}))
 
 (defn handle-query-string-search
-  "Generate an ES query handler using some mapping and schema"
+  "Generate an ES query handler for given schema schema"
   [Model]
   (let [response-schema (list-response-schema Model)
         coerce! (coerce-to-fn response-schema)]
@@ -360,8 +360,8 @@ It returns the documents with full hits meta data including the real index in wh
                                            ident
                                            get-in-config))))))
 
-(s/defn handle-query-string-count :- s/Int
-  "ES count handler using some mapping and schema"
+(s/defn handle-query-string-count :- (s/pred nat-int?)
+  "ES count handler"
   [{conn :conn
     index :index
     :as es-conn-state} :- ESConnState
@@ -416,7 +416,7 @@ It returns the documents with full hits meta data including the real index in wh
                     buckets)))
 
 (s/defn handle-aggregate
-  "Generate an ES aggregation handler using some mapping and schema"
+  "Generate an ES aggregation handler for given schema"
   [{:keys [conn index] :as es-conn-state} :- ESConnState
    {:keys [filter-map] :as search-query} :- SearchQuery
    {:keys [agg-type] :as agg-query} :- AggQuery

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -5,8 +5,10 @@
    [clojure.set :refer [difference]]
    [ctia.stores.es.mapping :refer [store-settings]]
    [ctia.stores.es.schemas :refer [ESConnServices ESConnState]]
-   [clj-momo.lib.es
+   [ductile
     [conn :refer [connect]]
+    [index]]
+   [clj-momo.lib.es
     [index :as es-index]]
    [ctia.entity.entities :refer [entities]]
    [schema.core :as s]
@@ -94,7 +96,7 @@
 (defn get-existing-indices
   [conn index]
   ;; retrieve existing indices using wildcard to identify ambiguous index names
-  (let [existing (-> (es-index/get conn (str index "*"))
+  (let [existing (-> (ductile.index/get conn (str index "*"))
                      keys
                      set)
         index-pattern (re-pattern (str index "(-\\d{4}.\\d{2}.\\d{2}.*)?"))
@@ -123,9 +125,9 @@
     (when (and (:aliased props)
                (empty? existing-indices))
       ;;https://github.com/elastic/elasticsearch/pull/34499
-      (es-index/create! conn
-                        (format "<%s-{now/d}-000001>" index)
-                        (update config :aliases assoc (:write-index props) {})))
+      (ductile.index/create! conn
+                             (format "<%s-{now/d}-000001>" index)
+                             (update config :aliases assoc (:write-index props) {})))
     (if (and (:aliased props)
              (contains? existing-indices (keyword index)))
       (do (log/error "an existing unaliased store was configured as aliased. Switching from unaliased to aliased indices requires a migration."

--- a/src/ctia/stores/es/schemas.clj
+++ b/src/ctia/stores/es/schemas.clj
@@ -1,5 +1,5 @@
 (ns ctia.stores.es.schemas
-  (:require [clj-momo.lib.es.schemas] ;; no alias to avoid ESConnState clashes
+  (:require [ductile.schemas] ;; no alias to avoid ESConnState clashes
             [schema.core :as s]
             [schema-tools.core :as st]))
 
@@ -10,7 +10,7 @@
                                           (s/named s/Any 'default)])}})
 
 (s/defschema ESConnState
-  (st/merge 
+  (st/merge
     ;; disallows services
-    clj-momo.lib.es.schemas/ESConnState
+    ductile.schemas/ESConnState
     {:services ESConnServices}))

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -25,7 +25,7 @@
   `(defrecord ~store-name [~(symbol "state")]
      IStore
      (~(symbol "read-record") [_# id# ident# params#]
-      ((crud/handle-read ~entity ~partial-stored-schema)
+      ((crud/handle-read ~partial-stored-schema)
        ~(symbol "state")  id# ident# params#))
      (~(symbol "create-record") [_# new-actors# ident# params#]
       ((crud/handle-create ~entity ~stored-schema)
@@ -37,14 +37,14 @@
       ((crud/handle-delete ~entity ~stored-schema)
        ~(symbol "state") id# ident# params#))
      (~(symbol "list-records") [_# filter-map# ident# params#]
-      ((crud/handle-find ~entity ~partial-stored-schema)
+      ((crud/handle-find ~partial-stored-schema)
        ~(symbol "state") filter-map# ident# params#))
      IQueryStringSearchableStore
      (~(symbol "query-string-search") [_# search-query# ident# params#]
       ((crud/handle-query-string-search ~entity ~partial-stored-schema)
        ~(symbol "state") search-query# ident# params#))
      (~(symbol "query-string-count") [_# search-query# ident#]
-      ((crud/handle-query-string-count ~entity)
+      ((crud/handle-query-string-count)
        ~(symbol "state") search-query# ident#))
      (~(symbol "aggregate") [_# search-query# agg-query# ident#]
       ((crud/handle-aggregate ~entity)

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -41,13 +41,13 @@
        ~(symbol "state") filter-map# ident# params#))
      IQueryStringSearchableStore
      (~(symbol "query-string-search") [_# search-query# ident# params#]
-      ((crud/handle-query-string-search ~entity ~partial-stored-schema)
+      ((crud/handle-query-string-search ~partial-stored-schema)
        ~(symbol "state") search-query# ident# params#))
      (~(symbol "query-string-count") [_# search-query# ident#]
-      ((crud/handle-query-string-count)
+      (crud/handle-query-string-count
        ~(symbol "state") search-query# ident#))
      (~(symbol "aggregate") [_# search-query# agg-query# ident#]
-      ((crud/handle-aggregate ~entity)
+      (crud/handle-aggregate
        ~(symbol "state") search-query# agg-query# ident#))))
 
 (s/defschema StoreMap

--- a/src/ctia/task/check_es_stores.clj
+++ b/src/ctia/task/check_es_stores.clj
@@ -54,7 +54,7 @@
           :limit batch-size}
          (when sort-keys
            {:search_after sort-keys}))]
-    (es-doc/search-docs conn indexname mapping nil {} params)))
+    (es-doc/search-docs conn indexname nil {} params)))
 
 (defn check-store
   "check a single store"

--- a/src/ctia/task/check_es_stores.clj
+++ b/src/ctia/task/check_es_stores.clj
@@ -2,10 +2,9 @@
   (:require
    [ctia.stores.es.store
     :refer [store->map]]
-   [clj-momo.lib.es
+   [ductile
     [conn :as conn]
-    [document :as es-doc]
-    [index :as es-index]]
+    [document :as es-doc]]
    [clojure.string :as string]
    [clojure.tools.logging :as log]
    [ctia

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -1,5 +1,5 @@
 (ns ctia.task.migration.migrate-es-stores
-  (:require [clj-momo.lib.es.schemas :refer [ESConn ESQuery]]
+  (:require [ductile.schemas :refer [ESConn ESQuery]]
             [clj-momo.lib.time :as time]
             [clojure.pprint :as pp]
             [clojure.string :as string]

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -1,11 +1,6 @@
 (ns ctia.task.migration.store
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.lib.clj-time.core :as time]
-            [ductile.conn :as conn]
-            [ductile.document :as ductile.doc]
-            [ductile.index :as ductile.index]
-            [ductile.query :as ductile.query]
-            [ductile.schemas :refer [ESConn ESQuery Refresh]]
             [clj-momo.lib.es.document :as es-doc]
             [clj-momo.lib.es.index :as es-index]
             [clojure.set :as set]
@@ -14,16 +9,20 @@
             [ctia.init :refer [log-properties]]
             [ctia.lib.collection :refer [fmap]]
             [ctia.lib.utils :refer [service-subgraph]]
-            [ctia.properties :as p]
             [ctia.store :as store]
             [ctia.stores.es.crud :as crud]
             [ctia.stores.es.init :as es.init]
             [ctia.stores.es.mapping :as em]
             [ctia.stores.es.schemas :refer [ESConnServices ESConnState]]
             [ctia.stores.es.store :as es-store :refer [StoreMap]]
-            [ctia.task.rollover :refer [rollover-store]]
             [ctia.task.migration.migrations :refer [available-migrations]]
+            [ctia.task.rollover :refer [rollover-store]]
             [ctim.domain.id :refer [long-id->id]]
+            [ductile.conn :as conn]
+            [ductile.document :as ductile.doc]
+            ductile.index
+            ductile.query
+            [ductile.schemas :refer [ESConn ESQuery Refresh]]
             [schema-tools.core :as st]
             [schema.core :as s]))
 

--- a/src/ctia/task/rollover.clj
+++ b/src/ctia/task/rollover.clj
@@ -1,11 +1,11 @@
 (ns ctia.task.rollover
-  (:require [clj-momo.lib.es.index :as es-index]
-            [clojure.tools.logging :as log]
+  (:require [clojure.tools.logging :as log]
             [ctia.init :refer [start-ctia!*]]
             [ctia.store-service :as store-svc]
             [ctia.stores.es.schemas :refer [ESConnState]]
             [ctia.properties :as p]
             [puppetlabs.trapperkeeper.app :as app]
+            ductile.index
             [schema.core :as s])
   (:import clojure.lang.ExceptionInfo))
 
@@ -16,7 +16,7 @@
      conditions :rollover} :props} :- ESConnState]
   (when (and aliased (seq conditions))
     (let [{rolledover? :rolled_over :as response}
-          (es-index/rollover! conn write-index conditions)]
+          (ductile.index/rollover! conn write-index conditions)]
       (when rolledover?
         (log/info "rolled over: " (pr-str response)))
       response)))

--- a/src/ctia/task/settings.clj
+++ b/src/ctia/task/settings.clj
@@ -1,12 +1,9 @@
 (ns ctia.task.settings
-  (:import clojure.lang.ExceptionInfo)
   (:require [clojure.pprint :as pp]
             [clojure.string :as str]
             [clojure.tools.cli :refer [parse-opts]]
             [clojure.tools.logging :as log]
             [schema.core :as s]
-            [clj-momo.lib.es
-             [index :as es-index]]
             [ctia.stores.es.init :refer [init-es-conn! get-store-properties]]
             [ctia
              [init :refer [log-properties]]

--- a/src/ctia/task/update_mapping.clj
+++ b/src/ctia/task/update_mapping.clj
@@ -1,10 +1,8 @@
 (ns ctia.task.update-mapping
   "Updates the _mapping on an ES index."
-  (:require [clj-momo.lib.es.index :as es-index]
-            [clj-momo.lib.es.schemas :as es-schema]
-            [clojure.tools.cli :refer [parse-opts]]
-            [clojure.pprint :as pp]
+  (:require [clojure.pprint :as pp]
             [clojure.string :as str]
+            [clojure.tools.cli :refer [parse-opts]]
             [clojure.tools.logging :as log]
             [ctia.init :as init]
             [ctia.properties :as p]
@@ -12,8 +10,7 @@
             [ctia.store-service :as store-svc]
             [ctia.stores.es.init :as es-init]
             [puppetlabs.trapperkeeper.app :as app]
-            [schema.core :as s])
-  (:import [clojure.lang ExceptionInfo]))
+            [schema.core :as s]))
 
 (defn- update-mapping-state!
   [{:keys [conn index config] :as state}]

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -1,7 +1,7 @@
 (ns ctia.bulk.routes-test
   (:refer-clojure :exclude [get])
   (:require [cheshire.core :refer [parse-string]]
-            [clj-momo.lib.es.index :as es-index]
+            [ductile.index :as es-index]
             [clj-momo.test-helpers
              [core :as mth]
              [http :refer [encode]]]

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1,7 +1,7 @@
 (ns ctia.bundle.routes-test
   (:refer-clojure :exclude [get])
   (:require [ctim.schemas.common :refer [ctim-schema-version]]
-            [clj-momo.lib.es.index :as es-index]
+            [ductile.index :as es-index]
             [clj-momo.test-helpers
              [core :as mth]
              [http :refer [encode]]]

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -1,7 +1,7 @@
 (ns ctia.properties-test
   (:require [ctia.properties :as sut]
             [clojure.test :refer [deftest is testing]]
-            [clj-momo.lib.es.schemas :refer [Refresh]]
+            [ductile.schemas :refer [Refresh]]
             [schema.core :as s]))
 
 (deftest es-store-impl-properties-test

--- a/test/ctia/schemas/graphql/pagination_test.clj
+++ b/test/ctia/schemas/graphql/pagination_test.clj
@@ -2,7 +2,7 @@
   (:require [ctia.schemas.graphql.pagination :as sut]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [schema.test :as st]
-            [clj-momo.lib.es.pagination :as pag]))
+            [ductile.pagination :as pag]))
 
 (use-fixtures :once st/validate-schemas)
 
@@ -89,7 +89,7 @@
   (let [data (range offset (+ offset limit))]
     (pag/response data {:offset offset
                         :limit limit
-                        :hits hits})))
+                        :total-hits hits})))
 
 (deftest result->connection-response
   (testing "Forwards paging"

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -90,8 +90,8 @@
 (def read-fn (sut/handle-read s/Any))
 (def delete-fn (sut/handle-delete :sighting s/Any))
 (def search-fn (sut/handle-query-string-search s/Any))
-(def count-fn (sut/handle-query-string-count))
-(def aggregate-fn (sut/handle-aggregate :sighting))
+(def count-fn sut/handle-query-string-count)
+(def aggregate-fn sut/handle-aggregate)
 
 (def ident {:login "johndoe"
             :groups ["group1"]})

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -87,10 +87,10 @@
 
 (def create-fn (sut/handle-create :sighting s/Any))
 (def update-fn (sut/handle-update :sighting s/Any))
-(def read-fn (sut/handle-read :sighting s/Any))
+(def read-fn (sut/handle-read s/Any))
 (def delete-fn (sut/handle-delete :sighting s/Any))
-(def search-fn (sut/handle-query-string-search :sighting s/Any))
-(def count-fn (sut/handle-query-string-count :sighting))
+(def search-fn (sut/handle-query-string-search s/Any))
+(def count-fn (sut/handle-query-string-count))
 (def aggregate-fn (sut/handle-aggregate :sighting))
 
 (def ident {:login "johndoe"

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -1,19 +1,18 @@
 (ns ctia.stores.es.crud-test
-  (:require [clojure.test :as t :refer [is are testing deftest use-fixtures join-fixtures]]
-            [schema.core :as s]
-            [ctia.flows.crud :refer [gen-random-uuid]]
-            [clj-momo.lib.es.index :as es-index]
-            [clj-momo.lib.es.conn :as es-conn]
-            [clj-momo.test-helpers.core :as mth]
+  (:require [clj-momo.test-helpers.core :as mth]
             [clojure.instant :as inst]
-            [ctia.stores.es.query :refer [find-restriction-query-part]]
+            [clojure.test :as t
+             :refer
+             [are deftest is join-fixtures testing use-fixtures]]
+            [ctia.flows.crud :refer [gen-random-uuid]]
             [ctia.stores.es.crud :as sut]
             [ctia.stores.es.init :as init]
+            [ctia.stores.es.query :refer [find-restriction-query-part]]
             [ctia.task.rollover :refer [rollover-store]]
-            [ctim.examples.sightings :refer [sighting-minimal]]
-            [ctia.test-helpers
-             [core :as helpers]
-             [es :as es-helpers]]))
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.es :as es-helpers]
+            [ductile.index :as es-index]
+            [schema.core :as s]))
 
 (deftest ensure-document-id-in-map-test
   (is (= {:id "actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7"}

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -4,7 +4,7 @@
             [ctia.test-helpers.es :refer [->ESConnServices]]
             [clj-http.client :as http]
             [ctia.stores.es.mapping :as m]
-            [clj-momo.lib.es
+            [ductile
              [index :as index]
              [conn :as conn]]
             [clojure.test :refer [deftest testing is]]))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -1,45 +1,39 @@
 (ns ctia.task.migration.migrate-es-stores-test
-  (:require [clojure.java.io :as io]
+  (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
+            [clj-momo.lib.es.document :as es-doc]
+            [clj-momo.test-helpers.core :as mth]
+            [clojure.data :refer [diff]]
+            [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.string :as str]
-            [clojure.data :refer [diff]]
-            [clojure
-             [test :refer [deftest is join-fixtures testing use-fixtures]]
-             [walk :refer [keywordize-keys]]]
-            [clj-momo.test-helpers.core :as mth]
-            [clj-momo.lib.es
-             [query :as es-query]
-             [conn :refer [connect]]
-             [document :as es-doc]
-             [index :as es-index]]
-            [clj-momo.lib.clj-time
-             [coerce :as time-coerce]]
-            [ctim.domain.id :refer [long-id->id]]
-
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [clojure.walk :refer [keywordize-keys]]
             [ctia.entity.relationship.schemas :refer [StoredRelationship]]
-            [ctia.properties :as p]
-            [ctia.task.rollover :refer [rollover-stores]]
-            [ctia.task.migration
-             [migrate-es-stores :as sut]
-             [store :refer [setup!
-                            prefixed-index
-                            init-migration
-                            get-migration
-                            fetch-batch
-                            MigrationStoreServices]]]
-            [ctia.test-helpers
-             [fixtures :as fixt]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [put delete post-bulk with-atom-logger]]
-             [es :as es-helpers]
-             [fake-whoami-service :as whoami-helpers]
-             [migration :refer [app->MigrationStoreServices]]]
             [ctia.stores.es.store :refer [store->map]]
-            [schema.core :as s])
-  (:import (java.text SimpleDateFormat)
-           (java.util Date)
-           (java.lang AssertionError)
-           (clojure.lang ExceptionInfo)))
+            [ctia.task.migration.migrate-es-stores :as sut]
+            [ctia.task.migration.store
+             :refer
+             [fetch-batch get-migration init-migration prefixed-index setup!]]
+            [ctia.task.rollover :refer [rollover-stores]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core
+             :as
+             helpers
+             :refer
+             [delete post-bulk put with-atom-logger]]
+            [ctia.test-helpers.es :as es-helpers]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.fixtures :as fixt]
+            [ctia.test-helpers.migration :refer [app->MigrationStoreServices]]
+            [ctim.domain.id :refer [long-id->id]]
+            [ductile.conn :refer [connect]]
+            [ductile.document :as ductile.doc]
+            [ductile.index :as es-index]
+            [ductile.query :as es-query])
+  (:import clojure.lang.ExceptionInfo
+           java.lang.AssertionError
+           java.text.SimpleDateFormat
+           java.util.Date))
 
 (defn fixture-setup! [f]
   (let [app (helpers/get-current-app)
@@ -240,276 +234,273 @@
                                             "migration"
                                             "test-3"
                                             {})]
-        (doseq [store-type store-types]
-          (is (= (count (es-index/get (es-conn get-in-config)
-                                      (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*")))
-                 3)
-              "target indice should be rolledover during migration")
-          (es-index/get (es-conn get-in-config)
-                        (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*"))
-          (let [migrated-store (get-in migration-state [:stores store-type])
-                {:keys [source target]} migrated-store]
-            (is (= fixtures-nb (:total source)))
-            (is (= fixtures-nb (:migrated target))))))))))
+          (doseq [store-type store-types]
+            (is (= (count (es-index/get (es-conn get-in-config)
+                                        (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*")))
+                   3)
+                "target indice should be rolledover during migration")
+            (es-index/get (es-conn get-in-config)
+                          (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*"))
+            (let [migrated-store (get-in migration-state [:stores store-type])
+                  {:keys [source target]} migrated-store]
+              (is (= fixtures-nb (:total source)))
+              (is (= fixtures-nb (:migrated target))))))))))
 
 (def date-str->epoch-millis
   (comp time-coerce/to-long time-coerce/to-date-time))
 
 (deftest read-source-batch-test
- (with-each-fixtures identity app
-  (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+  (with-each-fixtures identity app
+    (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
+      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
 
-          storemap {:conn (es-conn get-in-config)
-                    :indexname "ctia_relationship"
-                    :mapping "relationship"
-                    :props {:write-index "ctia_relationship"}
-                    :type "relationship"
-                    :settings {}
-                    :config {}}
-          docs (map es-helpers/prepare-bulk-ops
-                    (line-seq rdr))
-          _ (es-helpers/load-bulk (es-conn get-in-config) docs)
-          no-meta-docs (map #(dissoc % :_index :_type :_id)
-                            docs)
-          docs-no-modified (filter #(nil? (:modified %))
-                                   no-meta-docs)
-          docs-100 (take 100 no-meta-docs)
-          missing-query {:bool {:must_not {:exists {:field :modified}}}}
-          ids-100-query {:ids {:values (map :id docs-100)}}
-          match-all-query {:match_all {}}
-          nb-skipped-ids 10
-          [last-skipped & expected-ids-docs] (->> (sort-by (juxt :modified :created :id)
-                                                           docs-100)
-                                                  (drop (dec nb-skipped-ids)))
-          {after-modified :modified
-           after-created :created
-           after-id :id} last-skipped
-          search_after [(date-str->epoch-millis after-modified)
-                        (date-str->epoch-millis after-created)
-                        after-id]
-          read-params-1 {:source-store storemap
-                         :batch-size 1000
-                         :query missing-query}
-          read-params-2 {:source-store storemap
-                         :batch-size 100
-                         :search_after search_after
-                         :query ids-100-query}
-          read-params-3 {:source-store storemap
-                         :batch-size 400
-                         :query match-all-query}
-          missing-res (sut/read-source-batch read-params-1)
-          ids-res (sut/read-source-batch read-params-2)
-          match-all-res (rest (iterate sut/read-source-batch read-params-3))]
+            storemap {:conn (es-conn get-in-config)
+                      :indexname "ctia_relationship"
+                      :mapping "relationship"
+                      :props {:write-index "ctia_relationship"}
+                      :type "relationship"
+                      :settings {}
+                      :config {}}
+            docs (map es-helpers/prepare-bulk-ops
+                      (line-seq rdr))
+            _ (es-helpers/load-bulk (es-conn get-in-config) docs)
+            no-meta-docs (map #(dissoc % :_index :_type :_id)
+                              docs)
+            docs-no-modified (filter #(nil? (:modified %))
+                                     no-meta-docs)
+            docs-100 (take 100 no-meta-docs)
+            missing-query {:bool {:must_not {:exists {:field :modified}}}}
+            ids-100-query {:ids {:values (map :id docs-100)}}
+            match-all-query {:match_all {}}
+            nb-skipped-ids 10
+            [last-skipped & expected-ids-docs] (->> (sort-by (juxt :modified :created :id)
+                                                             docs-100)
+                                                    (drop (dec nb-skipped-ids)))
+            {after-modified :modified
+             after-created :created
+             after-id :id} last-skipped
+            search_after [(date-str->epoch-millis after-modified)
+                          (date-str->epoch-millis after-created)
+                          after-id]
+            read-params-1 {:source-store storemap
+                           :batch-size 1000
+                           :query missing-query}
+            read-params-2 {:source-store storemap
+                           :batch-size 100
+                           :search_after search_after
+                           :query ids-100-query}
+            read-params-3 {:source-store storemap
+                           :batch-size 400
+                           :query match-all-query}
+            missing-res (sut/read-source-batch read-params-1)
+            ids-res (sut/read-source-batch read-params-2)
+            match-all-res (rest (iterate sut/read-source-batch read-params-3))]
 
-      (testing "queries should be used to select data"
-        (is (= (set docs-no-modified)
-               (set (:documents missing-res)))))
-      (testing "search_after should be properly taken into account"
-        (is (= (set expected-ids-docs)
-               (set (:documents ids-res))))
-        (is (= (- 100 nb-skipped-ids)
-               (count (:documents ids-res)))))
-      (testing "read source should return parameters for next call"
-        (is (= read-params-1
-               (dissoc missing-res :search_after :documents)))
-        (is (= (dissoc read-params-2 :search_after)
-               (dissoc ids-res :search_after :documents))))
-      (testing "read-source-batch shoould return nil when parameters map is nil or the query result is empty"
-        (is (= nil
-               (sut/read-source-batch nil)
-               (sut/read-source-batch (assoc read-params-1
-                                             :batch-size
-                                             0)))))
-      (testing "read-source-batch result should be usable to call read-source-batch again for scrolling given query"
-        (is (= '(400 400 200 0)
-               (->> (take 4 match-all-res)
-                    (map #(-> % :documents count)))))
-        (is (= (set no-meta-docs)
-               (->> (take 4 match-all-res)
-                    (map :documents)
-                    (apply concat)
-                    set))))))))
+        (testing "queries should be used to select data"
+          (is (= (set docs-no-modified)
+                 (set (:documents missing-res)))))
+        (testing "search_after should be properly taken into account"
+          (is (= (set expected-ids-docs)
+                 (set (:documents ids-res))))
+          (is (= (- 100 nb-skipped-ids)
+                 (count (:documents ids-res)))))
+        (testing "read source should return parameters for next call"
+          (is (= read-params-1
+                 (dissoc missing-res :search_after :documents)))
+          (is (= (dissoc read-params-2 :search_after)
+                 (dissoc ids-res :search_after :documents))))
+        (testing "read-source-batch shoould return nil when parameters map is nil or the query result is empty"
+          (is (= nil
+                 (sut/read-source-batch nil)
+                 (sut/read-source-batch (assoc read-params-1
+                                               :batch-size
+                                               0)))))
+        (testing "read-source-batch result should be usable to call read-source-batch again for scrolling given query"
+          (is (= '(400 400 200 0)
+                 (->> (take 4 match-all-res)
+                      (map #(-> % :documents count)))))
+          (is (= (set no-meta-docs)
+                 (->> (take 4 match-all-res)
+                      (map :documents)
+                      (apply concat)
+                      set))))))))
 
 (deftest read-source-test
- (with-each-fixtures identity app
-  (testing "read-source should produce a lazy seq from recursive read-source-batch calls"
-    (let [counter (atom 0)]
-      (with-redefs [sut/read-source-batch (fn [batch-params]
-                                            (when (< @counter 5)
-                                              (swap! counter inc)
-                                              (update batch-params :migrated-count inc)))]
-        (let [batches (map :migrated-count
-                           (sut/read-source {:migrated-count 0}))]
-          (is (= '(1 2) (take 2 batches)))
-          (is (= 2 @counter))
-          (is (= '(1 2 3 4 5) (take 10 batches)))
-          (is (= 5 @counter))))))))
+  (with-each-fixtures identity app
+    (testing "read-source should produce a lazy seq from recursive read-source-batch calls"
+      (let [counter (atom 0)]
+        (with-redefs [sut/read-source-batch (fn [batch-params]
+                                              (when (< @counter 5)
+                                                (swap! counter inc)
+                                                (update batch-params :migrated-count inc)))]
+          (let [batches (map :migrated-count
+                             (sut/read-source {:migrated-count 0}))]
+            (is (= '(1 2) (take 2 batches)))
+            (is (= 2 @counter))
+            (is (= '(1 2 3 4 5) (take 10 batches)))
+            (is (= 5 @counter))))))))
 
 (deftest write-target-test
- (with-each-fixtures identity app
-  (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
+  (with-each-fixtures identity app
+    (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
+      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+            services (app->MigrationStoreServices app)
 
-          prefix "0.0.1"
-          indexname "v0.0.1_ctia_relationship"
-          storemap {:conn (es-conn get-in-config)
-                    :indexname indexname
-                    :mapping "relationship"
-                    :props {:write-index indexname}
-                    :type "relationship"
-                    :settings {}
-                    :config {}}
-          list-coerce (sut/list-coerce-fn StoredRelationship)
-          migration-id "migration-1"
-          docs (map (comp :_source es-helpers/str->doc)
-                    (line-seq rdr))
-          base-params {:target-store storemap
-                       :entity-type :relationship
-                       :list-coerce list-coerce
-                       :migration-id migration-id
-                       :migrations (sut/compose-migrations [:__test])
-                       :batch-size 1000
-                       :migration-es-conn (es-conn get-in-config)
-                       :confirm? true}
-          test-fn (fn [total
-                       migrated-count
-                       msg
-                       {:keys [confirm?]
-                        :as override-params}]
-                    (init-migration {:migration-id migration-id
-                                     :prefix prefix
-                                     :store-keys [:relationship]
-                                     :confirm? true
-                                     :migrations [:__test]
-                                     :batch-size 1000
-                                     :buffer-size 3
-                                     :restart? false}
-                                    services)
-                    (let [test-docs (take total docs)
-                          search_after [(rand-int total)]
-                          batch-params  (-> (into base-params
-                                                  override-params)
-                                            (assoc :documents test-docs
-                                                   :search_after search_after))
-                          nb-migrated (sut/write-target migrated-count
-                                                        batch-params
-                                                        services)
-                          {target-state :target
-                           source-state :source} (-> (get-migration migration-id
-                                                                    (es-conn get-in-config)
-                                                                    services)
-                                                     :stores
-                                                     :relationship)
-                          _ (es-index/refresh! (es-conn get-in-config))
-                          migrated-docs (:data (es-doc/query (es-conn get-in-config)
-                                                             indexname
-                                                             "relationship"
-                                                             {:match_all {}}
-                                                             {:limit total}))]
-                      (testing msg
-                        (when-not confirm?
-                          (is (= (+ total migrated-count)
-                                 nb-migrated))
-                          (is (= (count migrated-docs)
-                                 (:migrated target-state))))
-                        (when confirm?
-                          (is (= (+ total migrated-count)
-                                 (+ (count migrated-docs) migrated-count)
-                                 nb-migrated
-                                 (:migrated target-state)))
-                          (is (= (set (map #(dissoc % :groups)
-                                           migrated-docs))
-                                 (set (map #(dissoc % :groups)
-                                           test-docs)))
-                              "write-target should only perform attended modifications")
-                          (is (every? #(= (:groups %)
-                                          ["migration-test"])
-                                      migrated-docs)
-                              "write-target should perform attended modifications on migrated documents")
-                          (is (= search_after
-                                 (:search_after source-state))
-                              "write-target should store last search_after in migration state")))))]
-      (test-fn 100
-               0
-               "write-target should properly modify documents, and write them in target index"
-               {:confirm? true})
+            prefix "0.0.1"
+            indexname "v0.0.1_ctia_relationship"
+            storemap {:conn (es-conn get-in-config)
+                      :indexname indexname
+                      :mapping "relationship"
+                      :props {:write-index indexname}
+                      :type "relationship"
+                      :settings {}
+                      :config {}}
+            list-coerce (sut/list-coerce-fn StoredRelationship)
+            migration-id "migration-1"
+            docs (map (comp :_source es-helpers/str->doc)
+                      (line-seq rdr))
+            base-params {:target-store storemap
+                         :entity-type :relationship
+                         :list-coerce list-coerce
+                         :migration-id migration-id
+                         :migrations (sut/compose-migrations [:__test])
+                         :batch-size 1000
+                         :migration-es-conn (es-conn get-in-config)
+                         :confirm? true}
+            test-fn (fn [total
+                         migrated-count
+                         msg
+                         {:keys [confirm?]
+                          :as override-params}]
+                      (init-migration {:migration-id migration-id
+                                       :prefix prefix
+                                       :store-keys [:relationship]
+                                       :confirm? true
+                                       :migrations [:__test]
+                                       :batch-size 1000
+                                       :buffer-size 3
+                                       :restart? false}
+                                      services)
+                      (let [test-docs (take total docs)
+                            search_after [(rand-int total)]
+                            batch-params  (-> (into base-params
+                                                    override-params)
+                                              (assoc :documents test-docs
+                                                     :search_after search_after))
+                            nb-migrated (sut/write-target migrated-count
+                                                          batch-params
+                                                          services)
+                            {target-state :target
+                             source-state :source} (-> (get-migration migration-id
+                                                                      (es-conn get-in-config)
+                                                                      services)
+                                                       :stores
+                                                       :relationship)
+                            _ (es-index/refresh! (es-conn get-in-config))
+                            migrated-docs (:data (ductile.doc/query (es-conn get-in-config)
+                                                                    indexname
+                                                                    {:match_all {}}
+                                                                    {:limit total}))]
+                        (testing msg
+                          (when-not confirm?
+                            (is (= (+ total migrated-count)
+                                   nb-migrated))
+                            (is (= (count migrated-docs)
+                                   (:migrated target-state))))
+                          (when confirm?
+                            (is (= (+ total migrated-count)
+                                   (+ (count migrated-docs) migrated-count)
+                                   nb-migrated
+                                   (:migrated target-state)))
+                            (is (= (set (map #(dissoc % :groups)
+                                             migrated-docs))
+                                   (set (map #(dissoc % :groups)
+                                             test-docs)))
+                                "write-target should only perform attended modifications")
+                            (is (every? #(= (:groups %)
+                                            ["migration-test"])
+                                        migrated-docs)
+                                "write-target should perform attended modifications on migrated documents")
+                            (is (= search_after
+                                   (:search_after source-state))
+                                "write-target should store last search_after in migration state")))))]
+        (test-fn 100
+                 0
+                 "write-target should properly modify documents, and write them in target index"
+                 {:confirm? true})
 
-      (test-fn 100
-               10
-               "write-target should properly accumulate migration count"
-               {:confirm? true})
+        (test-fn 100
+                 10
+                 "write-target should properly accumulate migration count"
+                 {:confirm? true})
 
-      (test-fn 100
-               0
-               "write-target should not write anything while properly simulating migration when `confirm?` is set to false"
-               {:confirm? false})))))
+        (test-fn 100
+                 0
+                 "write-target should not write anything while properly simulating migration when `confirm?` is set to false"
+                 {:confirm? false})))))
 
 (deftest sliced-migration-test
- (with-each-fixtures identity app
-  (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
+  (with-each-fixtures identity app
+    (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
+      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+            services (app->MigrationStoreServices app)
 
-          {wo-modified true
-           w-modified false} (->> (line-seq rdr)
-                                  (map es-helpers/prepare-bulk-ops)
-                                  (group-by #(nil? (:modified %))))
-          sorted-w-modified (sort-by :modified w-modified)
-          bulk-1 (concat wo-modified (take 500 sorted-w-modified))
-          bulk-2 (drop 500 sorted-w-modified)
-          logger-1 (atom [])
-          _ (es-helpers/load-bulk (es-conn get-in-config) bulk-1)
-          _ (with-atom-logger logger-1
-              (sut/migrate-store-indexes {:migration-id "migration-test-4"
-                                          :prefix       "0.0.0"
-                                          :migrations   [:__test]
-                                          :store-keys   [:relationship]
-                                          :batch-size   100
-                                          :buffer-size  3
-                                          :confirm?     true
-                                          :restart?     false}
-                                         services))
-          migration-state-1 (es-doc/get-doc (es-conn get-in-config)
-                                            (migration-index get-in-config)
-                                            "migration"
-                                            "migration-test-4"
-                                            {})
-          target-count-1 (es-doc/count-docs (es-conn get-in-config)
-                                            "v0.0.0_ctia_relationship"
-                                            "relationship"
-                                            nil)
-          _ (es-helpers/load-bulk (es-conn get-in-config) bulk-2)
-          _ (with-atom-logger logger-1
-              (sut/migrate-store-indexes {:migration-id "migration-test-4"
-                                          :prefix       "0.0.0"
-                                          :migrations   [:__test]
-                                          :store-keys   [:relationship]
-                                          :batch-size   100
-                                          :buffer-size  3
-                                          :confirm?     true
-                                          :restart?     true}
-                                         services))
-          target-count-2 (es-doc/count-docs (es-conn get-in-config)
-                                            "v0.0.0_ctia_relationship"
-                                            "relationship"
-                                            nil)
-          migration-state-2 (es-doc/get-doc (es-conn get-in-config)
-                                            (migration-index get-in-config)
-                                            "migration"
-                                            "migration-test-4"
-                                            {})]
-      (is (= (+ 500 (count wo-modified))
-             target-count-1
-             (get-in migration-state-1 [:stores :relationship :target :migrated])
-             (get-in migration-state-1 [:stores :relationship :source :total]))
-          "migration process should start with documents missing field used for bucketizing")
+            {wo-modified true
+             w-modified false} (->> (line-seq rdr)
+                                    (map es-helpers/prepare-bulk-ops)
+                                    (group-by #(nil? (:modified %))))
+            sorted-w-modified (sort-by :modified w-modified)
+            bulk-1 (concat wo-modified (take 500 sorted-w-modified))
+            bulk-2 (drop 500 sorted-w-modified)
+            logger-1 (atom [])
+            _ (es-helpers/load-bulk (es-conn get-in-config) bulk-1)
+            _ (with-atom-logger logger-1
+                (sut/migrate-store-indexes {:migration-id "migration-test-4"
+                                            :prefix       "0.0.0"
+                                            :migrations   [:__test]
+                                            :store-keys   [:relationship]
+                                            :batch-size   100
+                                            :buffer-size  3
+                                            :confirm?     true
+                                            :restart?     false}
+                                           services))
+            migration-state-1 (es-doc/get-doc (es-conn get-in-config)
+                                              (migration-index get-in-config)
+                                              "migration"
+                                              "migration-test-4"
+                                              {})
+            target-count-1 (ductile.doc/count-docs (es-conn get-in-config)
+                                                   "v0.0.0_ctia_relationship"
+                                                   nil)
+            _ (es-helpers/load-bulk (es-conn get-in-config) bulk-2)
+            _ (with-atom-logger logger-1
+                (sut/migrate-store-indexes {:migration-id "migration-test-4"
+                                            :prefix       "0.0.0"
+                                            :migrations   [:__test]
+                                            :store-keys   [:relationship]
+                                            :batch-size   100
+                                            :buffer-size  3
+                                            :confirm?     true
+                                            :restart?     true}
+                                           services))
+            target-count-2 (ductile.doc/count-docs (es-conn get-in-config)
+                                                   "v0.0.0_ctia_relationship"
+                                                   nil)
+            migration-state-2 (es-doc/get-doc (es-conn get-in-config)
+                                              (migration-index get-in-config)
+                                              "migration"
+                                              "migration-test-4"
+                                              {})]
+        (is (= (+ 500 (count wo-modified))
+               target-count-1
+               (get-in migration-state-1 [:stores :relationship :target :migrated])
+               (get-in migration-state-1 [:stores :relationship :source :total]))
+            "migration process should start with documents missing field used for bucketizing")
 
-      (is (= 1000
-             target-count-2
-             (get-in migration-state-2 [:stores :relationship :source :total]))
-          "migration process should complete the migration after restart")))))
+        (is (= 1000
+               target-count-2
+               (get-in migration-state-2 [:stores :relationship :source :total]))
+            "migration process should complete the migration after restart")))))
 
 (deftest migration-with-malformed-docs
  (with-each-fixtures identity app
@@ -533,40 +524,40 @@
                                           "foouser"
                                           "foogroup"
                                           "user")
-      ;; insert proper documents
-      (rollover-post-bulk all-stores)
-      ;; insert malformed documents
-      (doseq [store-type store-types]
-        (es-doc/create-doc (es-conn get-in-config)
-                           (str (get-in (es-props get-in-config) [store-type :indexname]) "-write")
-                           (name store-type)
-                           bad-doc
-                           "true"))
-      (with-atom-logger logger
-        (sut/migrate-store-indexes {:migration-id "test-3"
-                                    :prefix       "0.0.0"
-                                    :migrations   [:__test]
-                                    :store-keys   store-types
-                                    :batch-size   10
-                                    :buffer-size  3
-                                    :confirm?     true
-                                    :restart?     false}
-                                   services))
-      (let [messages (set @logger)
-            migration-state (es-doc/get-doc (es-conn get-in-config)
-                                            (migration-index get-in-config)
-                                            "migration"
-                                            "test-3"
-                                            {})]
+        ;; insert proper documents
+        (rollover-post-bulk all-stores)
+        ;; insert malformed documents
         (doseq [store-type store-types]
-          (let [migrated-store (get-in migration-state [:stores store-type])
-                {:keys [source target]} migrated-store]
-            (is (= (inc fixtures-nb) (:total source)))
-            (is (= fixtures-nb (:migrated target))))
-          (is (some #(str/starts-with? % (format "%s - Cannot migrate entity: {"
-                                                 (name store-type)))
-                    messages)
-              (format "malformed %s was not logged" store-type))))))))
+          (es-doc/create-doc (es-conn get-in-config)
+                             (str (get-in (es-props get-in-config) [store-type :indexname]) "-write")
+                             (name store-type)
+                             bad-doc
+                             "true"))
+        (with-atom-logger logger
+          (sut/migrate-store-indexes {:migration-id "test-3"
+                                      :prefix       "0.0.0"
+                                      :migrations   [:__test]
+                                      :store-keys   store-types
+                                      :batch-size   10
+                                      :buffer-size  3
+                                      :confirm?     true
+                                      :restart?     false}
+                                     services))
+        (let [messages (set @logger)
+              migration-state (es-doc/get-doc (es-conn get-in-config)
+                                              (migration-index get-in-config)
+                                              "migration"
+                                              "test-3"
+                                              {})]
+          (doseq [store-type store-types]
+            (let [migrated-store (get-in migration-state [:stores store-type])
+                  {:keys [source target]} migrated-store]
+              (is (= (inc fixtures-nb) (:total source)))
+              (is (= fixtures-nb (:migrated target))))
+            (is (some #(str/starts-with? % (format "%s - Cannot migrate entity: {"
+                                                   (name store-type)))
+                      messages)
+                (format "malformed %s was not logged" store-type))))))))
 
 
 (deftest test-migrate-store-indexes
@@ -609,247 +600,240 @@
     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           {:keys [all-stores]} (helpers/get-service-map app :StoreService)
           services (app->MigrationStoreServices app)
-
           logger (atom [])]
-      (with-atom-logger logger
-        (sut/migrate-store-indexes {:migration-id "test-2"
-                                    :prefix       "0.0.0"
-                                    :migrations   [:__test]
-                                    :store-keys   (keys (all-stores))
-                                    :batch-size   10
-                                    :buffer-size  3
-                                    :confirm?     true
-                                    :restart?     false}
-                                   services))
-      (testing "shall generate a proper migration state"
-        (let [migration-state (es-doc/get-doc (es-conn get-in-config)
-                                              (migration-index get-in-config)
-                                              "migration"
-                                              "test-2"
-                                              {})]
-          (is (= (set (keys (all-stores)))
-                 (set (keys (:stores migration-state)))))
-          (doseq [[entity-type migrated-store] (:stores migration-state)]
-            (let [{:keys [source target started completed]} migrated-store
-                  source-size
-                  (cond
-                    (= :identity entity-type) 1
-                    (= :event entity-type) (+ updates-nb
-                                              (* fixtures-nb
-                                                 (count minimal-examples)))
-                    (contains? example-types (keyword entity-type)) fixtures-nb
-                    :else 0)]
-              (is (= source-size (:total source))
-                  (str "source size match for " (:index source)))
-              (is (not (nil? started)))
-              (is (not (nil? completed)))
-              (is (<= (:migrated target) (:total source)))
-              (is (int? (:total source)))
-              (is (= (:index target)
-                     (prefixed-index (:index source) "0.0.0")))))))
-      (testing "shall produce valid logs"
-        (let [messages (set @logger)]
-          (is (contains? messages "set batch size: 10"))
-          (is (clojure.set/subset?
-               #{"campaign - finished migrating 100 documents"
-                 "indicator - finished migrating 100 documents"
-                 (format "event - finished migrating %s documents"
-                         (+ 1900 updates-nb))
-                 "actor - finished migrating 100 documents"
-                 "asset - finished migrating 100 documents"
-                 "relationship - finished migrating 100 documents"
-                 "incident - finished migrating 100 documents"
-                 "investigation - finished migrating 100 documents"
-                 "coa - finished migrating 100 documents"
-                 "identity - finished migrating 0 documents"
-                 "judgement - finished migrating 100 documents"
-                 "data-table - finished migrating 0 documents"
-                 "feedback - finished migrating 0 documents"
-                 "casebook - finished migrating 100 documents"
-                 "sighting - finished migrating 100 documents"
-                 "identity-assertion - finished migrating 0 documents"
-                 "attack-pattern - finished migrating 100 documents"
-                 "malware - finished migrating 100 documents"
-                 "target-record - finished migrating 100 documents"
-                 "tool - finished migrating 100 documents"
-                 "vulnerability - finished migrating 100 documents"
-                 "weakness - finished migrating 100 documents" }
-               messages))))
-
-      (testing "shall produce new indices with enough documents and the right transforms"
-        (let [{:keys [default
-                      asset
-                      target-record
-                      relationship
-                      judgement
-                      investigation
-                      coa
-                      tool
-                      attack-pattern
-                      malware
-                      incident
-                      indicator
-                      campaign
-                      sighting
-                      casebook
-                      actor
-                      vulnerability
-                      weakness]}
-              (get-in-config [:ctia :store :es])
-              date (Date.)
-              index-date (.format (SimpleDateFormat. "yyyy.MM.dd") date)
-              expected-event-indices {(format "v0.0.0_ctia_event-%s-000001" index-date)
-                                      1000
-                                      (format "v0.0.0_ctia_event-%s-000002" index-date)
-                                      (+ 900 updates-nb)}
-              expected-indices
-              (->> #{relationship
-                     target-record
-                     judgement
-                     coa
-                     attack-pattern
-                     malware
-                     tool
-                     incident
-                     indicator
-                     investigation
-                     campaign
-                     casebook
-                     sighting
-                     actor
-                     vulnerability
-                     weakness}
-                   (map (fn [k]
-                          {(format  "v0.0.0_%s-%s-000001" (:indexname k) index-date) 50
-                           (format  "v0.0.0_%s-%s-000002" (:indexname k) index-date) 50
-                           (format  "v0.0.0_%s-%s-000003" (:indexname k) index-date) 0}))
-                   (into expected-event-indices)
-                   keywordize-keys)
-              _ (es-index/refresh! (es-conn get-in-config))
-              formatted-cat-indices (es-helpers/get-cat-indices (:host default)
-                                                                (:port default))
-              result-indices (select-keys formatted-cat-indices
-                                          (keys expected-indices))]
-          (is (= expected-indices result-indices)
-              (let [[only-expected only-result _]
-                    (diff expected-indices result-indices)]
-                   (format "only in expected ==> %s\nonly in result ==> %s"
-                           only-expected
-                           only-result)))
-          (doseq [[index _]
-                  expected-indices]
-            (let [docs (->> (es-doc/search-docs (es-conn get-in-config) (name index) nil nil nil {})
-                            :data
-                            (map :groups))]
-              (is (every? #(= ["migration-test"] %)
-                          docs))))))
-      (testing "restart migration shall properly handle inserts, updates and deletes"
-        (let [;; retrieve the first 2 source indices for sighting store
-              {:keys [host port]} (get-in-config [:ctia :store :es :default])
-              [sighting-index-1 sighting-index-2]
-              (->> (es-helpers/get-cat-indices host port)
-                   keys
-                   (map name)
-                   (filter #(.contains ^String % "sighting"))
-                   sort
-                   (take 2))
-
-              ;; retrieve source entity to update, in first position of first index
-              es-sighting0 (-> (es-doc/query (es-conn get-in-config)
-                                             sighting-index-1
-                                             "sighting"
-                                             {:match_all {}}
-                                             {:sort_by "timestamp:asc"
-                                              :size 1})
-                               :data
-                               first)
-              ;; retrieve source entity to update, in first position of second index
-              es-sighting1 (-> (es-doc/query (es-conn get-in-config)
-                                             sighting-index-2
-                                             "sighting"
-                                             {:match_all {}}
-                                             {:sort_by "timestamp:asc"
-                                              :size 1})
-                               :data
-                               first)
-
-              ;; prepare new malwares
-              new-malwares (->> (fixt/n-examples :malware 3 false)
-                                (map #(assoc % :description "INSERTED"))
-                                (hash-map :malwares))
-
-              ;; retrieve 5 source entities to delete, in last positions of first index
-              es-sightings-1 (-> (es-doc/query (es-conn get-in-config)
-                                               sighting-index-1
-                                               "sighting"
-                                               {:match_all {}}
-                                               {:sort_by "timestamp:desc"
-                                                :limit 5})
-                                 :data)
-              ;; retrieve 5 source entities to delete, in last positions of second index
-              es-sightings-2 (-> (es-doc/query (es-conn get-in-config)
-                                               sighting-index-2
-                                               "sighting"
-                                               {:match_all {}}
-                                               {:sort_by "timestamp:desc"
-                                                :limit 5})
-                                 :data)
-              sightings (concat es-sightings-1 es-sightings-2)
-              sighting0-id (:id es-sighting0)
-              sighting1-id (:id es-sighting1)
-              sighting-ids (map :id sightings)
-              updated-sighting-body (-> (:sightings minimal-examples)
-                                        first
-                                        (dissoc :id)
-                                        (assoc :description "UPDATED"))]
-          ;; insert new entities in source store
-          (post-bulk new-malwares)
-          ;; modify entities in first and second source indices
-          (put (format "ctia/sighting/%s" sighting0-id)
-               :body updated-sighting-body
-               :headers {"Authorization" "45c1f5e3f05d0"})
-          (put (format "ctia/sighting/%s" sighting1-id)
-               :body updated-sighting-body
-               :headers {"Authorization" "45c1f5e3f05d0"})
-          ;; delete entities from first and second source indices
-          (doseq [sighting-id sighting-ids]
-            (delete (format "ctia/sighting/%s" sighting-id)
-                    :headers {"Authorization" "45c1f5e3f05d0"}))
+        (with-atom-logger logger
           (sut/migrate-store-indexes {:migration-id "test-2"
                                       :prefix       "0.0.0"
                                       :migrations   [:__test]
                                       :store-keys   (keys (all-stores))
-                                      ;; small batch to check proper delete paging
-                                      :batch-size   2
-                                      :buffer-size  1
+                                      :batch-size   10
+                                      :buffer-size  3
                                       :confirm?     true
-                                      :restart?     true}
-                                     services)
-          (let [migration-state (get-migration "test-2" (es-conn get-in-config) services)
-                malware-migration (get-in migration-state [:stores :malware])
-                sighting-migration (get-in migration-state [:stores :sighting])
-                malware-target-store (get-in malware-migration [:target :store])
-                {last-target-malwares :data} (fetch-batch malware-target-store 3 0 "desc" nil)
-                {:keys [conn indexname mapping]} (get-in sighting-migration [:target :store])
-                updated-sightings (-> (es-doc/query conn
-                                                    indexname
-                                                    mapping
-                                                    (es-query/ids [sighting0-id sighting1-id])
-                                                    {})
-                                      :data)
-                get-deleted-sightings (-> (es-doc/query conn
-                                                        indexname
-                                                        mapping
-                                                        (es-query/ids sighting-ids)
-                                                        {})
-                                          :data)]
-            (is (= (repeat 3 "INSERTED") (map :description last-target-malwares))
-                "inserted malwares must be found in target malware store")
+                                      :restart?     false}
+                                     services))
+        (testing "shall generate a proper migration state"
+          (let [migration-state (es-doc/get-doc (es-conn get-in-config)
+                                                (migration-index get-in-config)
+                                                "migration"
+                                                "test-2"
+                                                {})]
+            (is (= (set (keys (all-stores)))
+                   (set (keys (:stores migration-state)))))
+            (doseq [[entity-type migrated-store] (:stores migration-state)]
+              (let [{:keys [source target started completed]} migrated-store
+                    source-size
+                    (cond
+                      (= :identity entity-type) 1
+                      (= :event entity-type) (+ updates-nb
+                                                (* fixtures-nb
+                                                   (count minimal-examples)))
+                      (contains? example-types (keyword entity-type)) fixtures-nb
+                      :else 0)]
+                (is (= source-size (:total source))
+                    (str "source size match for " (:index source)))
+                (is (not (nil? started)))
+                (is (not (nil? completed)))
+                (is (<= (:migrated target) (:total source)))
+                (is (int? (:total source)))
+                (is (= (:index target)
+                       (prefixed-index (:index source) "0.0.0")))))))
+        (testing "shall produce valid logs"
+          (let [messages (set @logger)]
+            (is (contains? messages "set batch size: 10"))
+            (is (clojure.set/subset?
+                 #{"campaign - finished migrating 100 documents"
+                   "indicator - finished migrating 100 documents"
+                   (format "event - finished migrating %s documents"
+                           (+ 1900 updates-nb))
+                   "actor - finished migrating 100 documents"
+                   "asset - finished migrating 100 documents"
+                   "relationship - finished migrating 100 documents"
+                   "incident - finished migrating 100 documents"
+                   "investigation - finished migrating 100 documents"
+                   "coa - finished migrating 100 documents"
+                   "identity - finished migrating 0 documents"
+                   "judgement - finished migrating 100 documents"
+                   "data-table - finished migrating 0 documents"
+                   "feedback - finished migrating 0 documents"
+                   "casebook - finished migrating 100 documents"
+                   "sighting - finished migrating 100 documents"
+                   "identity-assertion - finished migrating 0 documents"
+                   "attack-pattern - finished migrating 100 documents"
+                   "malware - finished migrating 100 documents"
+                   "target-record - finished migrating 100 documents"
+                   "tool - finished migrating 100 documents"
+                   "vulnerability - finished migrating 100 documents"
+                   "weakness - finished migrating 100 documents" }
+                 messages))))
 
-            (is (= (repeat 2 "UPDATED") (map :description updated-sightings))
-                "updated document must be updated in target stores")
-            (is (empty? get-deleted-sightings)
-                "deleted document must not be in target stores"))))))))
+        (testing "shall produce new indices with enough documents and the right transforms"
+          (let [{:keys [default
+                        asset
+                        target-record
+                        relationship
+                        judgement
+                        investigation
+                        coa
+                        tool
+                        attack-pattern
+                        malware
+                        incident
+                        indicator
+                        campaign
+                        sighting
+                        casebook
+                        actor
+                        vulnerability
+                        weakness]}
+                (get-in-config [:ctia :store :es])
+                date (Date.)
+                index-date (.format (SimpleDateFormat. "yyyy.MM.dd") date)
+                expected-event-indices {(format "v0.0.0_ctia_event-%s-000001" index-date)
+                                        1000
+                                        (format "v0.0.0_ctia_event-%s-000002" index-date)
+                                        (+ 900 updates-nb)}
+                expected-indices
+                (->> #{relationship
+                       target-record
+                       judgement
+                       coa
+                       attack-pattern
+                       malware
+                       tool
+                       incident
+                       indicator
+                       investigation
+                       campaign
+                       casebook
+                       sighting
+                       actor
+                       vulnerability
+                       weakness}
+                     (map (fn [k]
+                            {(format  "v0.0.0_%s-%s-000001" (:indexname k) index-date) 50
+                             (format  "v0.0.0_%s-%s-000002" (:indexname k) index-date) 50
+                             (format  "v0.0.0_%s-%s-000003" (:indexname k) index-date) 0}))
+                     (into expected-event-indices)
+                     keywordize-keys)
+                _ (es-index/refresh! (es-conn get-in-config))
+                formatted-cat-indices (es-helpers/get-cat-indices (:host default)
+                                                                  (:port default))
+                result-indices (select-keys formatted-cat-indices
+                                            (keys expected-indices))]
+            (is (= expected-indices result-indices)
+                (let [[only-expected only-result _]
+                      (diff expected-indices result-indices)]
+                  (format "only in expected ==> %s\nonly in result ==> %s"
+                          only-expected
+                          only-result)))
+            (doseq [[index _]
+                    expected-indices]
+              (let [docs (->> (ductile.doc/search-docs (es-conn get-in-config) (name index) nil nil {})
+                              :data
+                              (map :groups))]
+                (is (every? #(= ["migration-test"] %)
+                            docs))))))
+        (testing "restart migration shall properly handle inserts, updates and deletes"
+          (let [;; retrieve the first 2 source indices for sighting store
+                {:keys [host port]} (get-in-config [:ctia :store :es :default])
+                [sighting-index-1 sighting-index-2]
+                (->> (es-helpers/get-cat-indices host port)
+                     keys
+                     (map name)
+                     (filter #(.contains ^String % "sighting"))
+                     sort
+                     (take 2))
+
+                ;; retrieve source entity to update, in first position of first index
+                es-sighting0 (-> (ductile.doc/query (es-conn get-in-config)
+                                                    sighting-index-1
+                                                    {:match_all {}}
+                                                    {:sort_by "timestamp:asc"
+                                                     :size 1})
+                                 :data
+                                 first)
+                ;; retrieve source entity to update, in first position of second index
+                es-sighting1 (-> (ductile.doc/query (es-conn get-in-config)
+                                                    sighting-index-2
+                                                    {:match_all {}}
+                                                    {:sort_by "timestamp:asc"
+                                                     :size 1})
+                                 :data
+                                 first)
+
+                ;; prepare new malwares
+                new-malwares (->> (fixt/n-examples :malware 3 false)
+                                  (map #(assoc % :description "INSERTED"))
+                                  (hash-map :malwares))
+
+                ;; retrieve 5 source entities to delete, in last positions of first index
+                es-sightings-1 (-> (ductile.doc/query (es-conn get-in-config)
+                                                      sighting-index-1
+                                                      {:match_all {}}
+                                                      {:sort_by "timestamp:desc"
+                                                       :limit 5})
+                                   :data)
+                ;; retrieve 5 source entities to delete, in last positions of second index
+                es-sightings-2 (-> (ductile.doc/query (es-conn get-in-config)
+                                                      sighting-index-2
+                                                      {:match_all {}}
+                                                      {:sort_by "timestamp:desc"
+                                                       :limit 5})
+                                   :data)
+                sightings (concat es-sightings-1 es-sightings-2)
+                sighting0-id (:id es-sighting0)
+                sighting1-id (:id es-sighting1)
+                sighting-ids (map :id sightings)
+                updated-sighting-body (-> (:sightings minimal-examples)
+                                          first
+                                          (dissoc :id)
+                                          (assoc :description "UPDATED"))]
+            ;; insert new entities in source store
+            (post-bulk new-malwares)
+            ;; modify entities in first and second source indices
+            (put (format "ctia/sighting/%s" sighting0-id)
+                 :body updated-sighting-body
+                 :headers {"Authorization" "45c1f5e3f05d0"})
+            (put (format "ctia/sighting/%s" sighting1-id)
+                 :body updated-sighting-body
+                 :headers {"Authorization" "45c1f5e3f05d0"})
+            ;; delete entities from first and second source indices
+            (doseq [sighting-id sighting-ids]
+              (delete (format "ctia/sighting/%s" sighting-id)
+                      :headers {"Authorization" "45c1f5e3f05d0"}))
+            (sut/migrate-store-indexes {:migration-id "test-2"
+                                        :prefix       "0.0.0"
+                                        :migrations   [:__test]
+                                        :store-keys   (keys (all-stores))
+                                        ;; small batch to check proper delete paging
+                                        :batch-size   2
+                                        :buffer-size  1
+                                        :confirm?     true
+                                        :restart?     true}
+                                       services)
+            (let [migration-state (get-migration "test-2" (es-conn get-in-config) services)
+                  malware-migration (get-in migration-state [:stores :malware])
+                  sighting-migration (get-in migration-state [:stores :sighting])
+                  malware-target-store (get-in malware-migration [:target :store])
+                  {last-target-malwares :data} (fetch-batch malware-target-store 3 0 "desc" nil)
+                  {:keys [conn indexname mapping]} (get-in sighting-migration [:target :store])
+                  updated-sightings (-> (ductile.doc/query conn
+                                                           indexname
+                                                           (es-query/ids [sighting0-id sighting1-id])
+                                                           {})
+                                        :data)
+                  get-deleted-sightings (-> (ductile.doc/query conn
+                                                               indexname
+                                                               (es-query/ids sighting-ids)
+                                                               {})
+                                            :data)]
+              (is (= (repeat 3 "INSERTED") (map :description last-target-malwares))
+                  "inserted malwares must be found in target malware store")
+
+              (is (= (repeat 2 "UPDATED") (map :description updated-sightings))
+                  "updated document must be updated in target stores")
+              (is (empty? get-deleted-sightings)
+                  "deleted document must not be in target stores"))))))))
 
 (defn load-test-fn
   [app maximal?]

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -29,7 +29,8 @@
             [ductile.conn :refer [connect]]
             [ductile.document :as ductile.doc]
             [ductile.index :as es-index]
-            [ductile.query :as es-query])
+            [ductile.query :as es-query]
+            [schema.core :as s])
   (:import clojure.lang.ExceptionInfo
            java.lang.AssertionError
            java.text.SimpleDateFormat

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -1,8 +1,9 @@
 (ns ctia.task.migration.store-test
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.lib.clj-time.core :as time]
-            [ductile.conn :refer [connect]]
-            [ductile.index :as ductile.index]
+            [ductile
+             [conn :refer [connect]]
+             [index :as ductile.index]]
             [clj-momo.lib.es.document :as es-doc]
             [clj-momo.test-helpers.core :as mth]
             [clojure.java.io :as io]

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -1,9 +1,9 @@
 (ns ctia.task.migration.store-test
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.lib.clj-time.core :as time]
-            [clj-momo.lib.es.conn :refer [connect]]
+            [ductile.conn :refer [connect]]
+            [ductile.index :as ductile.index]
             [clj-momo.lib.es.document :as es-doc]
-            [clj-momo.lib.es.index :as es-index]
             [clj-momo.test-helpers.core :as mth]
             [clojure.java.io :as io]
             [clojure.string :as str]
@@ -263,8 +263,8 @@
       (t)
       (finally
         (doto (es-conn get-in-config)
-          (es-index/delete! "v0.0.0*")
-          (es-index/delete! (str (migration-index get-in-config) "*")))))))
+          (ductile.index/delete! "v0.0.0*")
+          (ductile.index/delete! (str (migration-index get-in-config) "*")))))))
 
 (use-fixtures :each
   (join-fixtures [helpers/fixture-ctia
@@ -333,8 +333,8 @@
                         true (assoc :source-docs (drop nb source-docs))
                         rollover? (assoc :current-index-size 0)
                         (not rollover?) (update :current-index-size + nb))))]
-      (es-index/delete! (es-conn get-in-config) (str "*" storename "*"))
-      (es-index/create! (es-conn get-in-config)
+      (ductile.index/delete! (es-conn get-in-config) (str "*" storename "*"))
+      (ductile.index/create! (es-conn get-in-config)
                         (format "<%s-000001>" storename)
                         {:settings {:refresh_interval -1}
                          :aliases {write-alias {}}})
@@ -533,12 +533,12 @@
         sighting-ids-2 (->> (:sightings post-bulk-res-2)
                             (map #(-> % long-id->id :short-id))
                             (take 10))
-        _ (es-index/refresh! (es-conn get-in-config))
-        [malware-index-1 _] (->> (es-index/get (es-conn get-in-config) "ctia_malware*")
+        _ (ductile.index/refresh! (es-conn get-in-config))
+        [malware-index-1 _] (->> (ductile.index/get (es-conn get-in-config) "ctia_malware*")
                                  keys
                                  sort
                                  (map name))
-        [sighting-index-1 sighting-index-2] (->> (es-index/get (es-conn get-in-config) "ctia_sighting*")
+        [sighting-index-1 sighting-index-2] (->> (ductile.index/get (es-conn get-in-config) "ctia_sighting*")
                                                  keys
                                                  sort
                                                  (map name))
@@ -578,7 +578,7 @@
         {:keys [nb-errors]} (rollover-stores (all-stores))
         _ (is (= 0 nb-errors))
         post-bulk-res-2 (post-bulk examples)
-        _ (es-index/refresh! (es-conn get-in-config))
+        _ (ductile.index/refresh! (es-conn get-in-config))
 
         sighting-ids-1 (->> (:sightings post-bulk-res-1)
                             (map #(-> % long-id->id :short-id))
@@ -601,8 +601,8 @@
                           (assoc :description "UPDATED"))
                 :headers {"Authorization" "45c1f5e3f05d0"})
 
-        _ (es-index/refresh! (es-conn get-in-config))
-        [sighting-index-1 sighting-index-2] (->> (es-index/get (es-conn get-in-config) "ctia_sighting*")
+        _ (ductile.index/refresh! (es-conn get-in-config))
+        [sighting-index-1 sighting-index-2] (->> (ductile.index/get (es-conn get-in-config) "ctia_sighting*")
                                                  keys
                                                  sort
                                                  (map name))
@@ -655,14 +655,14 @@
       (sut/store-batch store sample-docs-1 services)
       (is (= 0 (sut/store-size store))
           "store-batch shall not refresh the index")
-      (es-index/refresh! (es-conn get-in-config) indexname)
+      (ductile.index/refresh! (es-conn get-in-config) indexname)
       (sut/store-batch store sample-docs-2 services)
       (is (= nb-docs-1 (sut/store-size store))
           "store-size shall return the number of first batch docs")
-      (es-index/refresh! (es-conn get-in-config) indexname)
+      (ductile.index/refresh! (es-conn get-in-config) indexname)
       (is (= (+ nb-docs-1 nb-docs-2) (sut/store-size store))
           "store size shall return the proper number of documents after second refresh")
-      (es-index/delete! (es-conn get-in-config) indexname))))
+      (ductile.index/delete! (es-conn get-in-config) indexname))))
 
 (deftest query-fetch-batch-test
   (testing "query-fetch-batch should property fetch and sort events on timestamp"
@@ -688,7 +688,7 @@
                                         :timestamp %
                                         :modified (rand-int 50))
                              (range 50 90))]
-      (es-index/create! (es-conn get-in-config)
+      (ductile.index/create! (es-conn get-in-config)
                         indexname
                         {:settings {:refresh_interval -1}
                          :mappings {:event {:properties {:id {:type "keyword"}
@@ -697,7 +697,7 @@
                                                          :modified em/integer-type}}}})
       (sut/store-batch event-store event-batch-1 services)
       (sut/store-batch event-store event-batch-2 services)
-      (es-index/refresh! (es-conn get-in-config) indexname)
+      (ductile.index/refresh! (es-conn get-in-config) indexname)
       (let [{fetched-no-query :data} (sut/fetch-batch event-store 80 0 nil nil)
             {fetched-batch-1 :data} (sut/query-fetch-batch {:term {:batch 1}}
                                                            event-store
@@ -749,10 +749,11 @@
           {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           services (app->MigrationStoreServices app)
 
-          indexname "test_index"
+          tool-indexname "tool_index"
+          malware-indexname "malware_index"
           tool-store {:conn (es-conn get-in-config)
-                      :indexname indexname
-                      :props {:write-index indexname}
+                      :indexname tool-indexname
+                      :props {:write-index tool-indexname}
                       :mapping "tool"
                       :type "tool"
                       :settings {}
@@ -763,9 +764,9 @@
                                      :created %)
                           (range 100))
           malware-store {:conn (es-conn get-in-config)
-                         :indexname indexname
+                         :indexname malware-indexname
                          :mapping "malware"
-                         :props {:write-index indexname}
+                         :props {:write-index malware-indexname}
                          :type "malware"
                          :settings {}
                          :config {}}
@@ -778,14 +779,17 @@
                     :timestamp em/integer-type
                     :created em/integer-type
                     :modified em/integer-type}]
-      (es-index/create! (es-conn get-in-config)
-                        indexname
+      (ductile.index/create! (es-conn get-in-config)
+                        tool-indexname
                         {:settings {:refresh_interval -1}
-                         :mappings {:malware {:properties mappings}
-                                    :tool {:properties mappings}}})
+                         :mappings {:tool {:properties mappings}}})
+      (ductile.index/create! (es-conn get-in-config)
+                        malware-indexname
+                        {:settings {:refresh_interval -1}
+                         :mappings {:malware {:properties mappings}}})
       (sut/store-batch tool-store tool-batch services)
       (sut/store-batch malware-store malware-batch services)
-      (es-index/refresh! (es-conn get-in-config) indexname)
+      (ductile.index/refresh! (es-conn get-in-config) "*")
       (let [{fetched-tool-asc :data} (sut/fetch-batch tool-store 80 0 "asc" nil)
             {fetched-tool-desc :data} (sut/fetch-batch tool-store 80 0 "desc" nil)
             {fetched-malware-asc :data} (sut/fetch-batch malware-store 80 0 "asc" nil)
@@ -795,7 +799,8 @@
         (is (apply < (map :modified (concat fetched-malware-asc))))
         (is (apply > (map :modified (concat fetched-malware-desc)))))))
 
-  (es-index/delete! (es-conn (helpers/current-get-in-config-fn)) "test_*"))
+  (ductile.index/delete! (es-conn (helpers/current-get-in-config-fn)) "tool_index")
+  (ductile.index/delete! (es-conn (helpers/current-get-in-config-fn)) "malware_index"))
 
 (deftest fetch-deletes-test
   (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
@@ -807,7 +812,7 @@
         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
         services (app->MigrationStoreServices app)
 
-        _ (es-index/refresh! (es-conn get-in-config)) ;; ensure indices refresh
+        _ (ductile.index/refresh! (es-conn get-in-config)) ;; ensure indices refresh
         [sighting1 sighting2] (:parsed-body (helpers/get "ctia/sighting/search"
                                                          :query-params {:limit 2 :query "*"}
                                                          :headers {"Authorization" "45c1f5e3f05d0"}))
@@ -825,7 +830,7 @@
         malware1-id (-> malware1 :id long-id->id :short-id)
         _ (delete (format "ctia/sighting/%s" sighting1-id)
                   :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (es-index/refresh! (es-conn get-in-config))
+        _ (ductile.index/refresh! (es-conn get-in-config))
         since (time/internal-now)
         _ (delete (format "ctia/sighting/%s" sighting2-id)
                   :headers {"Authorization" "45c1f5e3f05d0"})
@@ -873,7 +878,7 @@
           {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           services (app->MigrationStoreServices app)
 
-          _ (es-index/refresh! (es-conn get-in-config)) ; ensure indices refresh
+          _ (ductile.index/refresh! (es-conn get-in-config)) ; ensure indices refresh
           prefix "0.0.0"
           entity-types [:tool :malware :relationship]
           migration-id-1 "migration-1"
@@ -899,7 +904,7 @@
                                  (set entity-types)))
                           (doseq [entity-type entity-types]
                             (let [{:keys [source target started completed]} (get stores entity-type)
-                                  created-indices (es-index/get (es-conn get-in-config) (str (:index target) "*"))]
+                                  created-indices (ductile.index/get (es-conn get-in-config) (str (:index target) "*"))]
                               (is (= "-1"  (-> (vals created-indices)
                                                first
                                                :settings

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -1,5 +1,5 @@
 (ns ctia.task.rollover-test
-  (:require [clj-momo.lib.es.index :as es-index]
+  (:require [ductile.index :as es-index]
             [clojure.string :as string]
             [clojure.test :refer [deftest is join-fixtures use-fixtures]]
             [ctia.stores.es.init :as init]

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -3,7 +3,7 @@
             [ctia.properties :as p]
             [ctia.task.settings :as sut]
             [ctia.stores.es.init :as init]
-            [clj-momo.lib.es
+            [ductile
              [index :as es-index]
              [conn :as es-conn]]
             [ctia.test-helpers

--- a/test/ctia/task/update_mapping_test.clj
+++ b/test/ctia/task/update_mapping_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.task.update-mapping-test
-  (:require [clj-momo.lib.es.index :as es-index]
-            [clj-momo.lib.es.conn :as conn]
+  (:require [ductile
+             [index :as es-index]
+             [conn :as conn]]
             [clojure.string :as string]
             [clojure.test :refer [deftest is join-fixtures use-fixtures testing]]
             [ctia.task.rollover :as rollover]

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -139,7 +139,7 @@
                       "ctia.store.es.vulnerability.indexname" "ctia_vulnerability"
                       "ctia.store.es.weakness.indexname" "ctia_weakness"
 
-                      "ctia.store.actor" "es"
+                      "ctia.store.actor" "es7"
                       "ctia.store.asset" "es"
                       "ctia.store.asset-mapping" "es"
                       "ctia.store.asset-properties" "es"

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -2,9 +2,8 @@
   "ES test helpers"
   (:require [cheshire.core :as json]
             [clj-http.client :as http]
-            [clj-momo.lib.es
-             [document :as es-doc]
-             [index :as es-index]]
+            [ductile.index :as es-index]
+            [clj-momo.lib.es.document :as es-doc]
             [clojure.java.io :as io]
             [ctia
              [store :as store]]
@@ -139,7 +138,7 @@
                       "ctia.store.es.vulnerability.indexname" "ctia_vulnerability"
                       "ctia.store.es.weakness.indexname" "ctia_weakness"
 
-                      "ctia.store.actor" "es7"
+                      "ctia.store.actor" "es"
                       "ctia.store.asset" "es"
                       "ctia.store.asset-mapping" "es"
                       "ctia.store.asset-properties" "es"

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -325,14 +325,12 @@
 
 (defn test-query-string-search
   [entity query query-field example get-in-config]
-  ;; only when ES store
-  (when (= "es" (get-in-config [:ctia :store (keyword entity)]))
-    (if (= :description query-field)
-      (test-describable-search entity example get-in-config)
-      (ensure-one-document test-non-describable-search
-                           example
-                           entity
-                           query
-                           query-field))
-    (test-filter-by-id entity)
-    (test-from-to entity example)))
+  (if (= :description query-field)
+    (test-describable-search entity example get-in-config)
+    (ensure-one-document test-non-describable-search
+                         example
+                         entity
+                         query
+                         query-field))
+  (test-filter-by-id entity)
+  (test-from-to entity example))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #threatgrid/iroh/issues/4216
> Related #threatgrid/iroh/issues/3072

This PR replaces clj-momo by ductile when it's compatible. I identified below all the functions that require a compatibility mode.
I recommend to activate "Hide whitespace changes" for `ctia.observable.routes` in which I fixed an indentation issue.

* migrated:
  * ctia.stores.es.crud ns
    * get-doc-with-index
    * handle-read 
    * handle-find
    * handle-query-string-count
    * handle-query-string-search:
   Proposed a compabitlity failover in ductile for the extraction of the total count which is different from ES5 and ES7. This count is used in particular for the pagination.
    * handle-aggregate
  * ctia.task.migration.store ns
     * store-size (document count)
     * sliced-queries (document query)
     * query-fetch-batch (document query)
     * rollover (index refresh)
     * batch-delete (index refresh / document delete-by-query)
     * purge-store
    * create-target-store!
    * finalize-migration!
  * ctia.entity.judgement.es-store
    * document search
  * ctia.store.es.schemas
    * ESConnState schema
  * ctia.stores.es.init
     * get-existing-indices (index get)
     * init-es-conn! (create index)
  * ctia.http.handler
     * exception handlers es-query-parsing-error
  * ctia.task.rollover
    * rollover-store: index rollover
  * ctia.task.settings
    * rollover-store: index rollover
  * ctia.task.check-es-stores
  * ctia.observable.routes
   paginate
  * ctia.stores.es.init-test
   index / conn
  * ctia.bundle.routes-test
   index open! / close!
  * ctia.task.rollover-test
   index / conn
  * ctia.task.settings-test
   index / conn
  * ctia.task.update-mapping-test
   index / conn

* not migrated:
  * ctia.stores.es.crud ns
    * handle create:
    the `_type` field is required in ES5 `_bulk` endpoint (handle-create enable to create multiple documents).
    * handle-update / handle-delete:
The ES7 call is not compatible with the ES7 one that requires `_doc` in the URI instead of the type.
{"error":{"root_cause":[{"type":"invalid_type_name_exception","reason":"Document mapping type name can't start with '_', found: [_doc]"}],"type":"invalid_type_name_exception","reason":"Document mapping type name can't start with '_', found: [_doc]"},"status":400}{"error":{"root_cause":[{"type":"invalid_type_name_exception","reason":"Document mapping type name can't start with '_', found: [_doc]"}],"type":"invalid_type_name_exception","reason":"Document mapping type name can't start with '_', found: [_doc]"},"status":400}
  * ctia.task.migration.store ns
    * get-migration / update-migration-store / store-migration:
    the get / update document APIs require a `_doc` path element in ES7 that is ES5 refuses.
    * create-target-store!
    the index pattern template is different for `ductile.index/create-template`
  * ctia.entity.identiy
    * create / get /delete
    incompatible URIs
  * ctia.stores.es.init:
    * update-settings! / update-mapping! / upsert-template! 
    incompatibility between ES5 and ES7 format (ES5 requires type)
  * ctia.http.handler
    * Remove clj-momo query parsing ns error when after
  * ctia.stores.es.mapping-test
    * bulk-create-doc
  * ctia.task.migration.migrate-es-stores-test
   get-doc / create-doc / delete-doc
  * ctia.task.migration.store-test
   get-doc
  * ctia.test-helpers.es
   get-doc

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.


