### PR TITLE
Fix pagination

### DIFF
--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -137,6 +137,8 @@
           (fn [feeds]
             (map #(decrypt-feed % services) feeds))))
 
+(def fetch-limit 200)
+
 (s/defn fetch-feed [id s
                     {{:keys [get-in-config]} :ConfigService
                      {:keys [decrypt]} :IEncryption
@@ -171,7 +173,8 @@
                             list-records
                             {:all-of {:target_ref indicator_id}}
                             feed-identity
-                            {:fields [:source_ref]}
+                            {:fields [:source_ref]
+                             :limit fetch-limit}
                             services)
                            (keep :source_ref)
                            (map #(read-store :judgement

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -222,7 +222,7 @@ It returns the documents with full hits meta data including the real index in wh
         (throw (ex-info "You are not allowed to delete this document"
                         {:type :access-control-error}))))))
 
-(def default-sort-field :_doc)
+(def default-sort-field "_doc,id")
 
 (defn with-default-sort-field
   [params]

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.actors :refer [new-actor-maximal new-actor-minimal]]))
 
 (use-fixtures :once
@@ -72,11 +72,7 @@
                        test-for-each-store))
 
 (deftest test-actor-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/actor-entity
-                               {:entity-minimal new-actor-minimal
-                                :enumerable-fields sut/actor-enumerable-fields
-                                :date-fields sut/actor-histogram-fields})))))
+  (test-metric-routes (into sut/actor-entity
+                            {:entity-minimal new-actor-minimal
+                             :enumerable-fields sut/actor-enumerable-fields
+                             :date-fields sut/actor-histogram-fields})))

--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -104,14 +104,10 @@
         {"Authorization" "45c1f5e3f05d0"}
         asset-mapping/asset-mapping-fields)))))
 
-(deftest asset-metric-routes-test
-  ((:es-store store/store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (aggregate/test-metric-routes
-      (into asset-mapping/asset-mapping-entity
-            {:plural            :asset_mappings
-             :entity-minimal    new-asset-mapping-minimal
-             :enumerable-fields asset-mapping/asset-mapping-enumerable-fields
-             :date-fields       asset-mapping/asset-mapping-histogram-fields})))))
+(deftest asset-mapping-metric-routes-test
+  (aggregate/test-metric-routes
+   (into asset-mapping/asset-mapping-entity
+         {:plural            :asset_mappings
+          :entity-minimal    new-asset-mapping-minimal
+          :enumerable-fields asset-mapping/asset-mapping-enumerable-fields
+          :date-fields       asset-mapping/asset-mapping-histogram-fields})))

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -95,14 +95,10 @@
         {"Authorization" "45c1f5e3f05d0"}
         asset-properties/asset-properties-fields)))))
 
-(deftest asset-metric-routes-test
-  ((:es-store store/store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (aggregate/test-metric-routes
-      (into asset-properties/asset-properties-entity
-            {:plural            :asset_properties
-             :entity-minimal    new-asset-properties-minimal
-             :enumerable-fields asset-properties/asset-properties-enumerable-fields
-             :date-fields       asset-properties/asset-properties-histogram-fields})))))
+(deftest asset-properties-metric-routes-test
+  (aggregate/test-metric-routes
+   (into asset-properties/asset-properties-entity
+         {:plural            :asset_properties
+          :entity-minimal    new-asset-properties-minimal
+          :enumerable-fields asset-properties/asset-properties-enumerable-fields
+          :date-fields       asset-properties/asset-properties-histogram-fields})))

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -77,13 +77,9 @@
         asset/asset-fields)))))
 
 (deftest asset-metric-routes-test
-  ((:es-store store/store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (aggregate/test-metric-routes
-      (into asset/asset-entity
-            {:plural            :assets
-             :entity-minimal    new-asset-minimal
-             :enumerable-fields asset/asset-enumerable-fields
-             :date-fields       asset/asset-histogram-fields})))))
+  (aggregate/test-metric-routes
+   (into asset/asset-entity
+         {:plural            :assets
+          :entity-minimal    new-asset-minimal
+          :enumerable-fields asset/asset-enumerable-fields
+          :date-fields       asset/asset-histogram-fields})))

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.attack-patterns
              :refer
              [new-attack-pattern-maximal new-attack-pattern-minimal]]))
@@ -75,12 +75,8 @@
                        test-for-each-store))
 
 (deftest test-attack-pattern-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/attack-pattern-entity
-                               {:plural :attack_patterns
-                                :entity-minimal new-attack-pattern-minimal
-                                :enumerable-fields sut/attack-pattern-enumerable-fields
-                                :date-fields sut/attack-pattern-histogram-fields})))))
+  (test-metric-routes (into sut/attack-pattern-entity
+                            {:plural :attack_patterns
+                             :entity-minimal new-attack-pattern-minimal
+                             :enumerable-fields sut/attack-pattern-enumerable-fields
+                             :date-fields sut/attack-pattern-histogram-fields})))

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.campaigns :as ex :refer [new-campaign-maximal new-campaign-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -67,11 +67,7 @@
                        test-for-each-store))
 
 (deftest test-campaign-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/campaign-entity
-                               {:entity-minimal new-campaign-minimal
-                                :enumerable-fields sut/campaign-enumerable-fields
-                                :date-fields sut/campaign-histogram-fields})))))
+  (test-metric-routes (into sut/campaign-entity
+                            {:entity-minimal new-campaign-minimal
+                             :enumerable-fields sut/campaign-enumerable-fields
+                             :date-fields sut/campaign-histogram-fields})))

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -17,7 +17,7 @@
     [field-selection :refer [field-selection-tests]]
     [http :refer [doc-id->rel-url]]
     [pagination :refer [pagination-test]]
-    [store :refer [test-for-each-store store-fixtures]]]
+    [store :refer [test-for-each-store]]]
    [ctim.examples.casebooks
     :refer
     [new-casebook-maximal new-casebook-minimal]]
@@ -355,11 +355,7 @@
                        test-for-each-store))
 
 (deftest test-casebook-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/casebook-entity
-                               {:entity-minimal new-casebook-minimal
-                                :enumerable-fields sut/casebook-enumerable-fields
-                                :date-fields sut/casebook-histogram-fields})))))
+  (test-metric-routes (into sut/casebook-entity
+                            {:entity-minimal new-casebook-minimal
+                             :enumerable-fields sut/casebook-enumerable-fields
+                             :date-fields sut/casebook-histogram-fields})))

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.coas :refer [new-coa-maximal new-coa-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -65,11 +65,7 @@
                        test-for-each-store))
 
 (deftest test-coa-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/coa-entity
-                               {:entity-minimal new-coa-minimal
-                                :enumerable-fields sut/coa-enumerable-fields
-                                :date-fields sut/coa-histogram-fields})))))
+  (test-metric-routes (into sut/coa-entity
+                            {:entity-minimal new-coa-minimal
+                             :enumerable-fields sut/coa-enumerable-fields
+                             :date-fields sut/coa-histogram-fields})))

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -455,17 +455,17 @@
                         q (uri/uri-encode
                             (format "entity.id:\"%s\"" initial-id))
                         results (map :fields
-                                     (:parsed-body (get (str "ctia/event/search?query=" q)
+                                     (:parsed-body (get (str "ctia/event/search?sort_by=timestamp&query=" q)
                                                         :content-type :json
                                                         :headers {"Authorization" "user1"})))]
-                    (is (= '[nil
-                             [{:field :assignees
-                               :action "added"
-                               :change {:after ["1"]}}]
-                             [{:field :assignees
-                               :action "modified"
-                               :change {:before ["1"], :after ["1" "2"]}}]
-                             [{:field :assignees
-                               :action "deleted"
-                               :change {:before ["1" "2"]}}]]
+                    (is (= [nil
+                            [{:field :assignees
+                              :action "added"
+                              :change {:after ["1"]}}]
+                            [{:field :assignees
+                              :action "modified"
+                              :change {:before ["1"], :after ["1" "2"]}}]
+                            [{:field :assignees
+                              :action "deleted"
+                              :change {:before ["1" "2"]}}]]
                            results)))))))))))))

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -1,5 +1,6 @@
 (ns ctia.entity.feed-test
   (:require
+   [ctia.entity.feed :as sut]
    [clojure.string :as string]
    [clj-momo.test-helpers.core :as mth]
    [clj-http.client :as client]
@@ -43,172 +44,88 @@
    :feed_type "indicator"
    :output :judgements})
 
+(def indicator
+  {:description
+   "A lookup table for IPs (IPv4 and IPv6) that are considered suspicious by security analysts",
+   :tags ["Suspicious IPs"],
+   :valid_time
+   {:start_time "2019-05-03T21:48:25.801Z",
+    :end_time "2020-06-03T21:48:25.801Z"},
+   :producer "Talos",
+   :schema_version "1.0.11",
+   :type "indicator",
+   :source "Feed Indicator Example",
+   :external_ids
+   ["ctia-feed-indicator-test"],
+   :short_description
+   "Custom Suspicious IP Watchlist",
+   :title "Custom Suspicious IP Watchlist",
+   :indicator_type ["IP Watchlist"],
+   :source_uri
+   "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
+   :id
+   "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
+   :severity "High",
+   :tlp "amber",
+   :confidence "High"})
+
+(def judgements
+  (map #(let [transient-id (format "transient:esa-judgement-%03d" %)
+              ip (format "187.75.16.%d" %)]
+          {:id transient-id
+           :observable
+           {:type "ip" :value ip},
+           :valid_time
+           {:start_time "2019-03-01T19:22:45.531Z",
+            :end_time "2019-03-31T19:22:45.531Z"},
+           :schema_version "1.0.11",
+           :type "judgement",
+           :source "Feed Indicator Example",
+           :external_ids
+           ["ctia-feed-indicator-test"],
+           :disposition 2,
+           :source_uri
+           "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
+           :disposition_name "Malicious",
+           :priority 95,
+           :severity "High",
+           :tlp "amber",
+           :timestamp "2019-03-01T19:22:45.531Z",
+           :confidence "High"})
+       (range 100)))
+
+(def relationships
+  (map #(let [suffix (string/replace % #"transient:esa-judgement-" "")
+              transient-id (str "transient:esa-relationship-" suffix)]
+          {:id transient-id
+           :source_ref %
+           :schema_version "1.0.11",
+           :target_ref
+           "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
+           :type "relationship",
+           :external_ids
+           ["ctia-feed-indicator-test"],
+           :short_description
+           "Judgement is part of indicator - 'Custom Malicious IP Watchlist'",
+           :title "judgement/indicator relationship",
+           :external_references [],
+           :tlp "amber",
+           :timestamp "2019-05-08T18:03:32.785Z",
+           :relationship_type "element-of"})
+       (map :id judgements)))
+
+
 (def blocklist-bundle
   {:type "bundle",
    :source "Feed Indicator Example",
    :source_uri
    "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-   :indicators
-   [{:description
-     "A lookup table for IPs (IPv4 and IPv6) that are considered suspicious by security analysts",
-     :tags ["Suspicious IPs"],
-     :valid_time
-     {:start_time "2019-05-03T21:48:25.801Z",
-      :end_time "2020-06-03T21:48:25.801Z"},
-     :producer "Talos",
-     :schema_version "1.0.11",
-     :type "indicator",
-     :source "Feed Indicator Example",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :short_description
-     "Custom Suspicious IP Watchlist",
-     :title "Custom Suspicious IP Watchlist",
-     :indicator_type ["IP Watchlist"],
-     :source_uri
-     "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-     :id
-     "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
-     :severity "High",
-     :tlp "amber",
-     :confidence "High"}],
-   :judgements
-   [{:valid_time
-     {:start_time "2019-03-01T19:22:45.531Z",
-      :end_time "2019-03-31T19:22:45.531Z"},
-     :schema_version "1.0.11",
-     :observable
-     {:type "ip", :value "187.75.16.77"},
-     :type "judgement",
-     :source "Feed Indicator Example",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :disposition 2,
-     :source_uri
-     "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-     :disposition_name "Malicious",
-     :priority 95,
-     :id
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d400",
-     :severity "High",
-     :tlp "amber",
-     :timestamp "2019-03-01T19:22:45.531Z",
-     :confidence "High"}
-    {:valid_time
-     {:start_time "2019-03-01T19:22:45.531Z",
-      :end_time "2019-03-31T19:22:45.531Z"},
-     :schema_version "1.0.11",
-     :observable
-     {:type "ip", :value "187.75.16.76"},
-     :type "judgement",
-     :source "Feed Indicator Example",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :disposition 2,
-     :source_uri
-     "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-     :disposition_name "Malicious",
-     :priority 95,
-     :id
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d499",
-     :severity "High",
-     :tlp "amber",
-     :timestamp "2019-03-01T19:22:45.531Z",
-     :confidence "High"}
-    {:valid_time
-     {:start_time "2019-03-01T19:22:45.531Z",
-      :end_time "2019-03-31T19:22:45.531Z"},
-     :schema_version "1.0.11",
-     :observable
-     {:type "ip", :value "187.75.16.75"},
-     :type "judgement",
-     :source "Feed Indicator Example",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :disposition 2,
-     :source_uri
-     "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-     :disposition_name "Malicious",
-     :priority 95,
-     :id
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d498",
-     :severity "High",
-     :tlp "amber",
-     :timestamp "2019-03-01T19:22:45.531Z",
-     :confidence "High"}
-    {:valid_time
-     {:start_time "2019-03-01T19:22:45.531Z",
-      :end_time "2019-03-31T19:22:45.531Z"},
-     :schema_version "1.0.11",
-     :observable
-     {:type "ip", :value "187.75.16.75"},
-     :type "judgement",
-     :source "Feed Indicator Example",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :disposition 3,
-     :source_uri
-     "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-threat-intel-ctim.md",
-     :disposition_name "Suspicious",
-     :priority 95,
-     :id
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d500",
-     :severity "High",
-     :tlp "amber",
-     :timestamp "2019-03-01T19:22:45.531Z",
-     :confidence "High"}],
-   :relationships
-   [{:schema_version "1.0.11",
-     :target_ref
-     "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
-     :type "relationship",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :short_description
-     "Judgement is part of indicator - 'Custom Malicious IP Watchlist'",
-     :title "judgement/indicator relationship",
-     :external_references [],
-     :source_ref
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d500",
-     :id
-     "transient:esa-relationship-3c056c6ef8ace5057980b57f3eb07b916c84d94f7d1a340f41aba7630c459a5e",
-     :tlp "amber",
-     :timestamp "2019-05-08T18:03:32.785Z",
-     :relationship_type "element-of"}
-    {:schema_version "1.0.11",
-     :target_ref
-     "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
-     :type "relationship",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :short_description
-     "Judgement is part of indicator - 'Custom Malicious IP Watchlist'",
-     :title "judgement/indicator relationship",
-     :external_references [],
-     :source_ref
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d400",
-     :id
-     "transient:esa-relationship-3c056c6ef8ace5057980b57f3eb07b916c84d94f7d1a340f41aba7630c459a5d",
-     :tlp "amber",
-     :timestamp "2019-05-08T18:03:32.785Z",
-     :relationship_type "element-of"}
-    {:schema_version "1.0.11",
-     :target_ref
-     "transient:esa-indicator-ec95b042572a11894fffe553555c44f5c88c9199aad23a925bb959daa501338e",
-     :type "relationship",
-     :external_ids
-     ["ctia-feed-indicator-test"],
-     :short_description
-     "Judgement is part of indicator - 'Custom Suspicious IP Watchlist'",
-     :title "judgement/indicator relationship",
-     :external_references [],
-     :source_ref
-     "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d499",
-     :id
-     "transient:esa-relationship-4c056c6ef8ace5057980b57f3eb07b916c84d94f7d1a340f41aba7630c459a6d",
-     :tlp "amber",
-     :timestamp "2019-05-08T18:03:32.785Z",
-     :relationship_type "element-of"}]})
+   :indicators [indicator],
+   :judgements (let [duplicated-observable-value (-> judgements
+                                                     first
+                                                     (assoc :id "transient:esa-judgement-4340e8cc49ff428e21ad1467de4b40246eb0e3b8da96caa2f71f9fe54123d500"))]
+                 (conj judgements duplicated-observable-value ))
+   :relationships relationships})
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
@@ -232,7 +149,9 @@
           response-body-txt-wrong-secret (:body response-txt-wrong-secret)]
 
       (is (= 200 (:status response-txt)))
-      (is (= "187.75.16.75\n187.75.16.76\n187.75.16.77"
+      (is (= (->> (map #(-> % :observable :value) judgements)
+                  sort
+                  (string/join "\n"))
              response-body-txt))
 
       (is (= 401 (:status response-txt-wrong-secret)))
@@ -252,16 +171,19 @@
                          :feed_view_url)))
 
           (let [feed-view-url (:feed_view_url updated-feed)
-                response (client/get feed-view-url
-                                     {:as :json})
+                response  (with-redefs [sut/fetch-limit 3] ;; < nb shards (5) < |judgements|
+                            (client/get feed-view-url
+                                        {:as :json}))
                 response-body (:body response)]
 
             (is (= 200 (:status response)))
+            (is (= (count judgements)
+                   (count (:judgements response-body))))
             (is (= (set (map :observable
-                             (:judgements blocklist-bundle)))
+                             judgements))
                    (set (map :observable
                              (:judgements response-body)))))
-            ;;teardown
+            ;;Teardown
             (is (= 200
                    (:status
                     (helpers/put (str "ctia/feed/" (:short-id feed-id))

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -171,7 +171,7 @@
                          :feed_view_url)))
 
           (let [feed-view-url (:feed_view_url updated-feed)
-                response  (with-redefs [sut/fetch-limit 3] ;; < nb shards (5) < |judgements|
+                response  (with-redefs [sut/fetch-limit 19] ;; < |judgements| and not a multipe of nb shards (5).
                             (client/get feed-view-url
                                         {:as :json}))
                 response-body (:body response)]
@@ -183,7 +183,7 @@
                              judgements))
                    (set (map :observable
                              (:judgements response-body)))))
-            ;;Teardown
+            ;;teardown
             (is (= 200
                    (:status
                     (helpers/put (str "ctia/feed/" (:short-id feed-id))

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -14,7 +14,7 @@
              [http :refer [api-key doc-id->rel-url]]
              [pagination :refer [pagination-test]]
              [core :as helpers :refer [get]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.identity-assertions
              :refer
              [new-identity-assertion-maximal new-identity-assertion-minimal]]))
@@ -109,12 +109,8 @@
         sut/identity-assertion-fields)))))
 
 (deftest test-identity-assertion-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/identity-assertion-entity
-                               {:plural :identity_assertions
-                                :entity-minimal new-identity-assertion-minimal
-                                :enumerable-fields sut/identity-assertion-enumerable-fields
-                                :date-fields sut/identity-assertion-histogram-fields})))))
+  (test-metric-routes (into sut/identity-assertion-entity
+                            {:plural :identity_assertions
+                             :entity-minimal new-identity-assertion-minimal
+                             :enumerable-fields sut/identity-assertion-enumerable-fields
+                             :date-fields sut/identity-assertion-histogram-fields})))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -16,7 +16,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.incidents
              :refer
              [new-incident-maximal new-incident-minimal]]))
@@ -91,14 +91,10 @@
        (entity-crud-test parameters)))))
 
 (deftest test-incident-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes (into sut/incident-entity
-                               {:entity-minimal new-incident-minimal
-                                :enumerable-fields sut/incident-enumerable-fields
-                                :date-fields sut/incident-histogram-fields})))))
+  (test-metric-routes (into sut/incident-entity
+                            {:entity-minimal new-incident-minimal
+                             :enumerable-fields sut/incident-enumerable-fields
+                             :date-fields sut/incident-histogram-fields})))
 
 (deftest test-incident-pagination-field-selection
   (test-for-each-store

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -9,7 +9,7 @@
              [crud :refer [entity-crud-test]]
              [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.indicators
              :refer
              [new-indicator-maximal new-indicator-minimal]]))
@@ -76,12 +76,8 @@
                        test-for-each-store))
 
 (deftest test-indicator-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" caps/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/indicator-entity
-                               {:entity-minimal new-indicator-minimal
-                                :enumerable-fields sut/indicator-enumerable-fields
-                                :date-fields sut/indicator-histogram-fields})))))
+  (test-metric-routes (into sut/indicator-entity
+                            {:entity-minimal new-indicator-minimal
+                             :enumerable-fields sut/indicator-enumerable-fields
+                             :date-fields sut/indicator-histogram-fields})))
 

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctia.entity.investigation.examples :refer
              [new-investigation-maximal
               new-investigation-minimal]]))
@@ -72,11 +72,7 @@
                        test-for-each-store))
 
 (deftest test-investigation-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/investigation-entity
-                               {:entity-minimal new-investigation-minimal
-                                :enumerable-fields sut/investigation-enumerable-fields
-                                :date-fields sut/investigation-histogram-fields})))))
+  (test-metric-routes (into sut/investigation-entity
+                            {:entity-minimal new-investigation-minimal
+                             :enumerable-fields sut/investigation-enumerable-fields
+                             :date-fields sut/investigation-histogram-fields})))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -22,7 +22,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.judgements :as ex]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -164,14 +164,10 @@
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 
 (deftest test-judgement-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes (into sut/judgement-entity
-                               {:entity-minimal ex/new-judgement-minimal
-                                :enumerable-fields judgement-enumerable-fields
-                                :date-fields judgement-histogram-fields})))))
+  (test-metric-routes (into sut/judgement-entity
+                            {:entity-minimal ex/new-judgement-minimal
+                             :enumerable-fields judgement-enumerable-fields
+                             :date-fields judgement-histogram-fields})))
 
 (deftest test-judgement-routes-for-dispositon-determination
   (test-for-each-store

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.malwares
              :refer
              [new-malware-maximal new-malware-minimal]]))
@@ -77,11 +77,7 @@
                        test-for-each-store))
 
 (deftest test-malware-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/malware-entity
-                               {:entity-minimal new-malware-minimal
-                                :enumerable-fields sut/malware-enumerable-fields
-                                :date-fields sut/malware-histogram-fields})))))
+  (test-metric-routes (into sut/malware-entity
+                            {:entity-minimal new-malware-minimal
+                             :enumerable-fields sut/malware-enumerable-fields
+                             :date-fields sut/malware-histogram-fields})))

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -15,7 +15,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.domain.id :refer [long-id->id]]
             [ctim.examples
              [casebooks :refer [new-casebook-minimal]]
@@ -322,10 +322,7 @@
                       (read-string response)))))))))))
 
 (deftest test-relationship-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (establish-admin!)
-     (test-metric-routes (into sut/relationship-entity
-                               {:entity-minimal new-relationship-minimal
-                                :enumerable-fields sut/relationship-enumerable-fields
-                                :date-fields sut/relationship-histogram-fields})))))
+  (test-metric-routes (into sut/relationship-entity
+                            {:entity-minimal new-relationship-minimal
+                             :enumerable-fields sut/relationship-enumerable-fields
+                             :date-fields sut/relationship-histogram-fields})))

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -18,7 +18,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [api-key doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.sightings
              :refer
              [new-sighting-maximal new-sighting-minimal]]))
@@ -52,14 +52,10 @@
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 
 (deftest test-sighting-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (test-metric-routes (into sut/sighting-entity
-                               {:entity-minimal new-sighting-minimal
-                                :enumerable-fields sighting-enumerable-fields
-                                :date-fields sighting-histogram-fields})))))
+  (test-metric-routes (into sut/sighting-entity
+                            {:entity-minimal new-sighting-minimal
+                             :enumerable-fields sighting-enumerable-fields
+                             :date-fields sighting-histogram-fields})))
 
 (deftest test-sighting-pagination-field-selection
   (test-for-each-store

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -95,13 +95,9 @@
         target-record/target-record-fields)))))
 
 (deftest target-record-metric-routes-test
-  ((:es-store store/store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (aggregate/test-metric-routes
-      (into target-record/target-record-entity
-            {:plural            :target_records
-             :entity-minimal    new-target-record-minimal
-             :enumerable-fields target-record/target-record-enumerable-fields
-             :date-fields       target-record/target-record-histogram-fields})))))
+  (aggregate/test-metric-routes
+   (into target-record/target-record-entity
+         {:plural            :target_records
+          :entity-minimal    new-target-record-minimal
+          :enumerable-fields target-record/target-record-enumerable-fields
+          :date-fields       target-record/target-record-histogram-fields})))

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -13,7 +13,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.tools :refer [new-tool-maximal
                                          new-tool-minimal]]
             [ctia.entity.tool.schemas :as ts]))
@@ -75,11 +75,7 @@
                        test-for-each-store))
 
 (deftest test-tool-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/tool-entity
-                               {:entity-minimal new-tool-minimal
-                                :enumerable-fields sut/tool-enumerable-fields
-                                :date-fields sut/tool-histogram-fields})))))
+  (test-metric-routes (into sut/tool-entity
+                            {:entity-minimal new-tool-minimal
+                             :enumerable-fields sut/tool-enumerable-fields
+                             :date-fields sut/tool-histogram-fields})))

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.vulnerabilities :refer [new-vulnerability-maximal new-vulnerability-minimal]]))
 
 (use-fixtures :once
@@ -72,11 +72,7 @@
                        test-for-each-store))
 
 (deftest test-vulnerability-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/vulnerability-entity
-                               {:entity-minimal new-vulnerability-minimal
-                                :enumerable-fields sut/vulnerability-enumerable-fields
-                                :date-fields sut/vulnerability-histogram-fields})))))
+  (test-metric-routes (into sut/vulnerability-entity
+                            {:entity-minimal new-vulnerability-minimal
+                             :enumerable-fields sut/vulnerability-enumerable-fields
+                             :date-fields sut/vulnerability-histogram-fields})))

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -12,7 +12,7 @@
              [field-selection :refer [field-selection-tests]]
              [http :refer [doc-id->rel-url]]
              [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store store-fixtures]]]
+             [store :refer [test-for-each-store]]]
             [ctim.examples.weaknesses :refer [new-weakness-maximal new-weakness-minimal]]))
 
 (use-fixtures :once
@@ -72,11 +72,7 @@
                        test-for-each-store))
 
 (deftest test-weakness-metric-routes
-  ((:es-store store-fixtures)
-   (fn []
-     (helpers/set-capabilities! "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "Administrators" "user")
-     (test-metric-routes (into sut/weakness-entity
-                               {:entity-minimal new-weakness-minimal
-                                :enumerable-fields sut/weakness-enumerable-fields
-                                :date-fields sut/weakness-histogram-fields})))))
+  (test-metric-routes (into sut/weakness-entity
+                            {:entity-minimal new-weakness-minimal
+                             :enumerable-fields sut/weakness-enumerable-fields
+                             :date-fields sut/weakness-histogram-fields})))

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -256,7 +256,7 @@
            enumerable-fields
            date-fields] :as metric-params}]
   ;; enforce 1 shard to avoid ES terms approximation used by topn which is not simulated here by the manual aggregation here.
-  ;; see ES details: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts
+  ;; see ES details: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts
   (helpers.core/with-config-transformer*
     #(assoc-in % [:ctia :store :es :default :shards] 1)
     #((:es-store store-fixtures)

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -103,7 +103,7 @@
 
 (defn fixture-properties:es-store [t]
   ;; Note: These properties may be overwritten by ENV variables
-  (h/with-properties ["ctia.store.es.default.shards" 1
+  (h/with-properties ["ctia.store.es.default.shards" 5
                       "ctia.store.es.default.replicas" 1
                       "ctia.store.es.default.refresh" "true"
                       "ctia.store.es.default.refresh_interval" "1s"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #threatgrid/iroh/issues/4192

The inconsistent results in feeds are due to the `all-pages` function that performs a `search_after` based pagination using the default `sort_by` parameter. However this default value is base on `_doc` field which is unique per shard but not per index! Indeed this is a problem that can occur for any `search_after` pagination that will use the default `sort_by` value. 
This PR changes the default `sort_by` value to `_doc,id` that will first sort by `_doc` to ensure the order then by `id` for disambiguation. It also generalizes tests with multiple shards to better reflect production properties.

<a name="qa">[§](#qa)</a> QA
============================

1. Create feed data with a single bulk that contains all data of a "big" feed:
- 1 indicator
- 350 judgements
- 350 relationships linking every created judgments to the created indicator (judgement id as `source_ref` and indicator id as `target_ref`).
2. Create the feed instance for the previous indicator.
3. make 10 calls to corresponding view `/ctia/feed/{feed-id}/view?s={feed-share-token}` and check that the responses are always the same.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: fixed edge case pagination bug.
```