### PR TITLE
Move :once fixtures to :each for reliable auth in test

### DIFF
--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -20,12 +20,12 @@
             [ctim.domain.id :as id]
             [ring.adapter.jetty :as jetty]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
-                                    helpers/fixture-properties:cors
-                                    whoami-helpers/fixture-server]))
+(use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
+(use-fixtures :each (join-fixtures [helpers/fixture-properties:clean
+                                    helpers/fixture-properties:cors
+                                    whoami-helpers/fixture-server
+                                    whoami-helpers/fixture-reset-state]))
 
 (def new-judgement-1
   {:observable {:value "1.2.3.4"
@@ -198,8 +198,8 @@
                        :confidence "Low"
                        :source "test"
                        :tlp "green"
-                       :owner "Unknown"
-                       :groups ["Administrators"]
+                       :owner "foouser"
+                       :groups ["foogroup"]
                        :schema_version schema-version
                        :reason "This is a bad IP address that talked to some evil servers"
                        :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close https://github.com/threatgrid/ctia/issues/998

Context: this is in preparation to move away from using System properties to create the TK config for tests. This test was broken after the change, so the change is isolated in this PR.

This enables the tests in `ctia.entity.web-test` to be run in any order---as a consequence it also updates a broken test that was dependent on the order it was run wrt the other tests in `ctia.entity.web-test`.

I believe the root cause is the local helper `apply-fixtures` clearing the set properties [here](https://github.com/threatgrid/ctia/blob/master/test/ctia/entity/web_test.clj#L258), in particular the `ctia.auth.type` property is set to its default `allow-all` instead of `threatgrid`. This is only used by some of the tests. By moving the existing fixtures to `:each`, we get fresh properties each time.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Move :once fixtures to :each for reliable auth in test
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

