### PR TITLE
Construct test config thread-locally

### DIFF
--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -29,10 +29,13 @@
             [schema.core :as s]))
 
 (def ^:dynamic ^:private *current-app*)
-;; an even-sized vector of property key-val flattened pairs (like the
-;; first argument to #'with-properties) that will be
-;; used to override the default properties.
-(def ^:dynamic ^:private *properties-overrides* [])
+(def
+  ^:dynamic ^:private
+  *properties-overrides*
+  "An even-sized vector of property key-val flattened pairs (like the
+  first argument to #'with-properties) that will be
+  used to override the default properties."
+  [])
 (def ^:dynamic ^:private *config-transformers* [])
 
 (defn get-service-map [app svc-kw]
@@ -179,7 +182,7 @@
                   log/*logger-factory* lf]
       (f))))
 
-(defn- split-property-to-keywords [prop]
+(defn split-property-to-keywords [prop]
   (map keyword (str/split prop #"\.")))
 
 (defn build-transformed-init-config

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -71,33 +71,36 @@
      (fn [] (do ~@sexprs))))
 
 (defn fixture-properties:clean [f]
-  ;; Override any properties that are in the default properties file
-  ;; yet are unsafe/undesirable for tests
-  (with-properties ["ctia.auth.type"                            "allow-all"
-                    "ctia.access-control.default-tlp"           "green"
-                    "ctia.access-control.min-tlp"               "white"
-                    "ctia.access-control.max-record-visibility" "everyone"
-                    "ctia.encryption.key.filepath"              "resources/cert/ctia-encryption.key"
-                    "ctia.events.enabled"                        true
-                    "ctia.events.log"                            false
-                    "ctia.http.dev-reload"                       false
-                    "ctia.http.min-threads"                      9
-                    "ctia.http.max-threads"                      10
-                    "ctia.http.show.protocol"                    "http"
-                    "ctia.http.show.hostname"                    "localhost"
-                    "ctia.http.show.port"                        "57254"
-                    "ctia.http.show.path-prefix"                 ""
-                    "ctia.http.jwt.enabled"                      true
-                    "ctia.http.jwt.public-key-path"              "resources/cert/ctia-jwt.pub"
-                    "ctia.http.bulk.max-size"                    30000
-                    "ctia.hook.redis.enabled"                    false
-                    "ctia.hook.redis.channel-name"               "events-test"
-                    "ctia.metrics.riemann.enabled"               false
-                    "ctia.metrics.console.enabled"               false
-                    "ctia.metrics.jmx.enabled"                   false
-                    "ctia.versions.config"                       "test"]
-    ;; run tests
-    (f)))
+  ;; reset overrides, to preserve previous behavior when #'with-properties
+  ;; used to set actual System properties.
+  (binding [*properties-overrides* []]
+    ;; Override any properties that are in the default properties file
+    ;; yet are unsafe/undesirable for tests
+    (with-properties ["ctia.auth.type"                            "allow-all"
+                      "ctia.access-control.default-tlp"           "green"
+                      "ctia.access-control.min-tlp"               "white"
+                      "ctia.access-control.max-record-visibility" "everyone"
+                      "ctia.encryption.key.filepath"              "resources/cert/ctia-encryption.key"
+                      "ctia.events.enabled"                        true
+                      "ctia.events.log"                            false
+                      "ctia.http.dev-reload"                       false
+                      "ctia.http.min-threads"                      9
+                      "ctia.http.max-threads"                      10
+                      "ctia.http.show.protocol"                    "http"
+                      "ctia.http.show.hostname"                    "localhost"
+                      "ctia.http.show.port"                        "57254"
+                      "ctia.http.show.path-prefix"                 ""
+                      "ctia.http.jwt.enabled"                      true
+                      "ctia.http.jwt.public-key-path"              "resources/cert/ctia-jwt.pub"
+                      "ctia.http.bulk.max-size"                    30000
+                      "ctia.hook.redis.enabled"                    false
+                      "ctia.hook.redis.channel-name"               "events-test"
+                      "ctia.metrics.riemann.enabled"               false
+                      "ctia.metrics.console.enabled"               false
+                      "ctia.metrics.jmx.enabled"                   false
+                      "ctia.versions.config"                       "test"]
+      ;; run tests
+      (f))))
 
 (defn fixture-properties:cors [f]
   (with-properties

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -1,12 +1,12 @@
 (ns ctia.test-helpers.core
   (:refer-clojure :exclude [get])
   (:require [clj-momo.lib.net :as net]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :as mthh]]
+            [clj-momo.properties :refer [coerce-properties read-property-files]]
+            [clj-momo.test-helpers.http :as mthh]
             [clojure
              [walk :refer [prewalk]]]
             [clojure.spec.alpha :as cs]
+            [clojure.string :as str]
             [clojure.test :as test]
             [clojure.test.check.generators :as gen]
             [clojure.tools.logging :as log]
@@ -25,9 +25,14 @@
             [flanders
              [spec :as fs]
              [utils :as fu]]
-            [puppetlabs.trapperkeeper.app :as app]))
+            [puppetlabs.trapperkeeper.app :as app]
+            [schema.core :as s]))
 
 (def ^:dynamic ^:private *current-app*)
+;; an even-sized vector of property key-val flattened pairs (like the
+;; first argument to #'with-properties) that will be
+;; used to override the default properties.
+(def ^:dynamic ^:private *properties-overrides* [])
 (def ^:dynamic ^:private *config-transformers* [])
 
 (defn get-service-map [app svc-kw]
@@ -36,7 +41,6 @@
         m (svc-kw graph)]
     (assert (map? m) (str "No service " svc-kw ", found " (keys graph)))
     m))
-
 
 (defn with-config-transformer*
   "For use in a test fixture to dynamically transform a Trapperkeeper
@@ -47,17 +51,28 @@
   (binding [*config-transformers* (conj *config-transformers* tf)]
     (body-fn)))
 
-(def with-properties-vec
-  (mth/build-with-properties-vec-fn PropertiesSchema))
+(s/defn with-properties*
+  [properties-vec :- (s/pred vector?)
+   f :- (s/=> s/Any)]
+  (assert (not (thread-bound? #'*current-app*))
+          "Cannot override properties after TK app has started!")
+  (assert (even? (count properties-vec))
+          (str "Even count required for properties-vec, actual " (count properties-vec)))
+  (binding [*properties-overrides* (into *properties-overrides* properties-vec)]
+    (f)))
 
-(defmacro with-properties [properties-vec & sexprs]
-  `(with-properties-vec ~properties-vec
+(defmacro with-properties
+  "Simulates setting the specified System properties to configure
+  the creation of a TK app, except thread-locally.
+  
+  Note: Does not actually set System properties!"
+  [properties-vec & sexprs]
+  `(with-properties* ~properties-vec
      (fn [] (do ~@sexprs))))
 
 (defn fixture-properties:clean [f]
-  ;; Remove any set system properties, presumably from a previous test
-  ;; run
-  (mth/clear-properties PropertiesSchema)
+  (assert (empty? *properties-overrides*)
+          "Setting default properties should go first")
   ;; Override any properties that are in the default properties file
   ;; yet are unsafe/undesirable for tests
   (with-properties ["ctia.auth.type"                            "allow-all"
@@ -163,10 +178,36 @@
                   log/*logger-factory* lf]
       (f))))
 
-(defn build-transformed-init-config []
-  (reduce #(%2 %1)
-          (p/build-init-config)
-          *config-transformers*))
+(defn- split-property-to-keywords [prop]
+  (map keyword (str/split prop #"\.")))
+
+(defn build-transformed-init-config
+  "Builds a `config` map using just p/files, *properties-overrides*,
+  and *config-transformers*.
+  
+  Note that p/build-init-config uses p/files, System properties, and env vars.
+  This function emulates p/build-init-config in a thread-local fashion.
+  
+  Prefer over p/build-init-config during tests."
+  []
+  (assert (not (thread-bound? #'*current-app*))
+          "Building custom config while app bound!")
+  (let [init-props (read-property-files p/files)
+        properties-overrides *properties-overrides*
+        _ (assert (even? (count properties-overrides)))
+        transformed+coerced-props (->> (reduce (fn [m [k v]]
+                                                 (assoc m k v))
+                                               init-props
+                                               (partition 2 *properties-overrides*))
+                                       (coerce-properties PropertiesSchema))
+        init-config (reduce (fn [config [prop v]]
+                              (assoc-in config (split-property-to-keywords prop) v))
+                            {}
+                            transformed+coerced-props)
+        transformed-config (reduce #(%2 %1)
+                                   init-config
+                                   *config-transformers*)]
+    transformed-config))
 
 (defn build-get-in-config-fn []
   (assert (not (thread-bound? #'*current-app*)) "Building custom config while app bound!")

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -71,8 +71,6 @@
      (fn [] (do ~@sexprs))))
 
 (defn fixture-properties:clean [f]
-  (assert (empty? *properties-overrides*)
-          "Setting default properties should go first")
   ;; Override any properties that are in the default properties file
   ;; yet are unsafe/undesirable for tests
   (with-properties ["ctia.auth.type"                            "allow-all"

--- a/test/ctia/test_helpers/core_test.clj
+++ b/test/ctia/test_helpers/core_test.clj
@@ -52,12 +52,16 @@
           (sut/with-properties
             ["obviously.wrong.path" "val"]
             (sut/build-transformed-init-config)))))
-  (testing "with-properties overrides test properties without changing System properties"
-    (let [uuid (UUID/randomUUID)]
-      (sut/with-properties
-        ["ctia.auth.type" uuid]
-        (is (= (get-in (sut/build-transformed-init-config)
-                       [:ctia :auth :type])
-               uuid))
-        (is (not= (System/getProperty "ctia.auth.type")
-                  uuid))))))
+  (testing "with-properties overrides test properties without also setting System properties"
+    (sut/with-properties
+      ["ctia.auth.type" "foobar"]
+      (is (= (get-in (sut/build-transformed-init-config)
+                     [:ctia :auth :type])
+             :foobar))
+      ;; the old behavior of with-properties did the opposite,
+      ;; this test is a little crude and is mostly a sanity check.
+      ;; more sophisticated checks like
+      ;;  "properties are unchanged before/during/after with-properties"
+      ;; might be more flaky.
+      (is (not= (System/getProperty "ctia.auth.type")
+                "foobar")))))

--- a/test/ctia/test_helpers/core_test.clj
+++ b/test/ctia/test_helpers/core_test.clj
@@ -1,0 +1,63 @@
+(ns ctia.test-helpers.core-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ctia.test-helpers.core :as sut])
+  (:import [clojure.lang ExceptionInfo]
+           [java.util UUID]))
+
+(deftest build-transformed-init-config-test
+  (assert (empty? @#'sut/*config-transformers*))
+  (assert (empty? @#'sut/*properties-overrides*))
+  (testing "defaults to ctia-default.properties values"
+    (is (= (get-in (sut/build-transformed-init-config)
+                   [:ctia :auth :type])
+           :allow-all))
+    (is (= (get-in (sut/build-transformed-init-config)
+                   [:ctia :encryption :type])
+           :default)))
+  (testing "overrides using with-properties"
+    (sut/with-properties
+      ["ctia.auth.type" "foobar"]
+      (is (= (get-in (sut/build-transformed-init-config)
+                     [:ctia :auth :type])
+             :foobar))))
+  (testing "overrides using with-config-transformer*"
+    (sut/with-config-transformer*
+      #(assoc-in % [:ctia :auth :type] :foobar)
+      #(is (= (get-in (sut/build-transformed-init-config)
+                      [:ctia :auth :type])
+              :foobar))))
+  (testing "overrides using with-properties and with-config-transformer*"
+    (testing "both applied with disjoint paths"
+      (sut/with-properties
+        ["ctia.auth.type" "foobar1"]
+        (sut/with-config-transformer*
+          #(assoc-in % [:ctia :encryption :type] :foobar2)
+          #(let [config (sut/build-transformed-init-config)]
+             (is (= (get-in config [:ctia :auth :type])
+                    :foobar1))
+             (is (= (get-in config [:ctia :encryption :type])
+                    :foobar2))))))
+    (testing "with-config-transformer* wins with conflicting paths"
+      (sut/with-properties
+        ["ctia.auth.type" "foobar1"]
+        (sut/with-config-transformer*
+          #(assoc-in % [:ctia :auth :type] :foobar2)
+          #(is (= (get-in (sut/build-transformed-init-config)
+                          [:ctia :auth :type])
+                  :foobar2))))))
+  (testing "properties are corced to PropertiesSchema"
+    (is (thrown-with-msg?
+          ExceptionInfo
+          #"Value cannot be coerced to match schema: \{\"obviously.wrong.path\" disallowed-key\}"
+          (sut/with-properties
+            ["obviously.wrong.path" "val"]
+            (sut/build-transformed-init-config)))))
+  (testing "with-properties overrides test properties without changing System properties"
+    (let [uuid (UUID/randomUUID)]
+      (sut/with-properties
+        ["ctia.auth.type" uuid]
+        (is (= (get-in (sut/build-transformed-init-config)
+                       [:ctia :auth :type])
+               uuid))
+        (is (not= (System/getProperty "ctia.auth.type")
+                  uuid))))))

--- a/test/ctia/test_helpers/core_test.clj
+++ b/test/ctia/test_helpers/core_test.clj
@@ -4,64 +4,118 @@
   (:import [clojure.lang ExceptionInfo]
            [java.util UUID]))
 
+(deftest split-property-to-keywords-test
+  (is (= (sut/split-property-to-keywords
+           "a.b.c")
+         [:a :b :c])))
+
 (deftest build-transformed-init-config-test
   (assert (empty? @#'sut/*config-transformers*))
   (assert (empty? @#'sut/*properties-overrides*))
+  ;; TODO generate paths and vals from PropertiesSchema
   (testing "defaults to ctia-default.properties values"
-    (is (= (get-in (sut/build-transformed-init-config)
-                   [:ctia :auth :type])
-           :allow-all))
-    (is (= (get-in (sut/build-transformed-init-config)
-                   [:ctia :encryption :type])
-           :default)))
+    (doseq [:let [test-cases [{:ctia-path [:ctia :auth :type]
+                               :ctia-val :allow-all}
+                              {:ctia-path [:ctia :encryption :type]
+                               :ctia-val :default}]]
+            {:keys [ctia-path
+                    ctia-val] :as test-case} test-cases]
+      (testing test-case
+        (is (= (get-in (sut/build-transformed-init-config)
+                       ctia-path)
+               ctia-val)))))
   (testing "overrides using with-properties"
-    (sut/with-properties
-      ["ctia.auth.type" "foobar"]
-      (is (= (get-in (sut/build-transformed-init-config)
-                     [:ctia :auth :type])
-             :foobar))))
+    (doseq [:let [test-cases [{:ctia-property "ctia.auth.type"
+                               :foobar-str "foobar"}]]
+            {:keys [ctia-property
+                    foobar-str] :as test-case} test-cases
+            :let [ctia-path (sut/split-property-to-keywords ctia-property)
+                  foobar-kw (keyword foobar-str)]]
+      (testing test-case
+        (sut/with-properties
+          [ctia-property foobar-str]
+          (is (= (get-in (sut/build-transformed-init-config) ctia-path)
+                 foobar-kw))))))
   (testing "overrides using with-config-transformer*"
-    (sut/with-config-transformer*
-      #(assoc-in % [:ctia :auth :type] :foobar)
-      #(is (= (get-in (sut/build-transformed-init-config)
-                      [:ctia :auth :type])
-              :foobar))))
+    (doseq [:let [test-cases [{:ctia-path [:ctia :auth :type]
+                               :foobar-kw :foobar}]]
+            {:keys [ctia-path
+                    foobar-kw] :as test-case} test-cases]
+      (testing test-case
+        (sut/with-config-transformer*
+          #(assoc-in % ctia-path foobar-kw)
+          #(is (= (get-in (sut/build-transformed-init-config) ctia-path)
+                  foobar-kw))))))
   (testing "overrides using with-properties and with-config-transformer*"
-    (testing "both applied with disjoint paths"
-      (sut/with-properties
-        ["ctia.auth.type" "foobar1"]
-        (sut/with-config-transformer*
-          #(assoc-in % [:ctia :encryption :type] :foobar2)
-          #(let [config (sut/build-transformed-init-config)]
-             (is (= (get-in config [:ctia :auth :type])
-                    :foobar1))
-             (is (= (get-in config [:ctia :encryption :type])
-                    :foobar2))))))
-    (testing "with-config-transformer* wins with conflicting paths"
-      (sut/with-properties
-        ["ctia.auth.type" "foobar1"]
-        (sut/with-config-transformer*
-          #(assoc-in % [:ctia :auth :type] :foobar2)
-          #(is (= (get-in (sut/build-transformed-init-config)
-                          [:ctia :auth :type])
-                  :foobar2))))))
-  (testing "properties are corced to PropertiesSchema"
-    (is (thrown-with-msg?
-          ExceptionInfo
-          #"Value cannot be coerced to match schema: \{\"obviously.wrong.path\" disallowed-key\}"
+    (testing "both change config when called with different paths"
+      (doseq [:let [test-cases [{:ctia-property1 "ctia.auth.type"
+                                 :foobar1-str "foobar1"
+                                 :ctia-path2 [:ctia :encryption :type]
+                                 :foobar2-kw :foobar2}]]
+              {:keys [ctia-property1
+                      foobar1-str
+                      ctia-path2
+                      foobar2-kw] :as test-case} test-cases
+              :let [ctia-path1 (sut/split-property-to-keywords ctia-property1)
+                    foobar1-kw (keyword foobar1-str)
+                    _ (assert (not= ctia-path1 ctia-path2))]]
+        (testing test-case
           (sut/with-properties
-            ["obviously.wrong.path" "val"]
-            (sut/build-transformed-init-config)))))
+            [ctia-property1 foobar1-str]
+            (sut/with-config-transformer*
+              #(assoc-in % ctia-path2 foobar2-kw)
+              #(let [config (sut/build-transformed-init-config)]
+                 (is (= (get-in config ctia-path1)
+                        foobar1-kw))
+                 (is (= (get-in config ctia-path2)
+                        foobar2-kw))))))))
+    (testing "with-config-transformer* wins with conflicting paths"
+      (doseq [:let [test-cases [{:ctia-property "ctia.auth.type" 
+                                 :foobar1-str "foobar1"
+                                 :foobar2-kw :foobar2}]]
+              {:keys [ctia-property
+                      foobar1-str
+                      foobar2-kw] :as test-case} test-cases
+              :let [ctia-path (sut/split-property-to-keywords ctia-property)]]
+        (testing test-case
+          (sut/with-properties
+            [ctia-property foobar1-str]
+            (sut/with-config-transformer*
+              #(assoc-in % ctia-path foobar2-kw)
+              #(is (= (get-in (sut/build-transformed-init-config)
+                              ctia-path)
+                      foobar2-kw))))))))
+  (testing "properties are corced to PropertiesSchema"
+    (doseq [:let [test-cases [{:ctia-bad-path "obviously.wrong.path"
+                               :foobar-str "val"}]]
+            {:keys [ctia-bad-path
+                    foobar-str] :as test-case} test-cases]
+      (testing test-case
+        (is (thrown-with-msg?
+              ExceptionInfo
+              (re-pattern
+                (format "Value cannot be coerced to match schema: \\{\"%s\" disallowed-key\\}"
+                        ctia-bad-path))
+              (sut/with-properties
+                [ctia-bad-path foobar-str]
+                (sut/build-transformed-init-config)))))))
   (testing "with-properties overrides test properties without also setting System properties"
-    (sut/with-properties
-      ["ctia.auth.type" "foobar"]
-      (is (= (get-in (sut/build-transformed-init-config)
-                     [:ctia :auth :type])
-             :foobar))
-      ;; the old behavior of with-properties did the opposite,
-      ;; this test is a little crude and is mostly a sanity check.
-      ;; more sophisticated checks like
-      ;;  "properties are unchanged before/during/after with-properties"
-      ;; might be more flaky.
-      (is (not= (System/getProperty "ctia.auth.type")
-                "foobar")))))
+    (doseq [:let [test-cases [{:ctia-property "ctia.auth.type"
+                               :foobar-str "foobar"}]]
+            {:keys [ctia-property
+                    foobar-str] :as test-case} test-cases
+            :let [ctia-path (sut/split-property-to-keywords ctia-property)
+                  foobar-kw (keyword foobar-str)]]
+      (testing test-case
+        (sut/with-properties
+          [ctia-property foobar-str]
+          (is (= (get-in (sut/build-transformed-init-config)
+                         ctia-path)
+                 foobar-kw))
+          ;; the old behavior of with-properties did the opposite,
+          ;; this test is a little crude and is mostly a sanity check.
+          ;; more sophisticated checks like
+          ;;  "properties are unchanged before/during/after with-properties"
+          ;; might be more flaky.
+          (is (not= (System/getProperty ctia-property)
+                    foobar-str)))))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related https://github.com/threatgrid/iroh/issues/3986

This fixes a big blocker to parallelizing tests since `with-properties` sets global System properties which would make any two tests conflict. The approach is to implement `with-properties` using thread-local bindings instead, and to extract some of the original implementation for constructing the config map from `clj-momo`.

Eventually we will probably prefer merging config maps explicitly as in our other projects.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Construct test config thread-locally
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

