### PR TITLE
Add explicit app arg for entity-crud-test and others

### DIFF
--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -20,7 +20,8 @@
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [get post]]
              [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store-with-app store-fixtures]]]
+             [store :refer [test-for-each-store-with-app
+                            test-selected-stores-with-app]]]
             [ctim.domain.id :as id]
             [ctim.examples.incidents :refer [new-incident-maximal]]))
 
@@ -194,11 +195,11 @@
 
 
 (deftest test-bulk-wait_for-test
-  ((:es-store store-fixtures)
-   (fn []
+  (test-selected-stores-with-app
+   #{:es-store}
+   (fn [app]
      (testing "POST /ctia/bulk with wait_for"
-       (let [app (helpers/get-current-app)
-             {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+       (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
 
              _ (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
              _ (whoami-helpers/set-whoami-response "45c1f5e3f05d0"

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -36,7 +36,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "actor"
+      {:app app
+       :entity "actor"
        :example new-actor-maximal
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -22,10 +22,9 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(defn additional-tests [{:keys [short-id]} asset-mapping-sample]
+(defn additional-tests [app {:keys [short-id]} asset-mapping-sample]
   (testing "GET /ctia/asset-mapping/search"
-   (let [app (helpers/get-current-app)
-         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
+   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
     (when (= "es" (get-in-config [:ctia :store :asset-mapping]))
       (are [term check-fn expected desc] (let [response (helpers/get
@@ -66,7 +65,8 @@
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
      (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
-      {:entity             "asset-mapping"
+      {:app                app
+       :entity             "asset-mapping"
        :example            new-asset-mapping-maximal
        :invalid-tests?     true
        :invalid-test-field :asset_ref

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -21,10 +21,9 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(defn additional-tests [{:keys [short-id]} asset-properties-sample]
+(defn additional-tests [app {:keys [short-id]} asset-properties-sample]
   (testing "GET /ctia/asset-properties/search"
-   (let [app (helpers/get-current-app)
-         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
+   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
     (when (= "es" (get-in-config [:ctia :store :asset-properties]))
       (are [term check-fn expected desc] (let [response (helpers/get
@@ -70,7 +69,8 @@
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
      (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
-      {:entity             "asset-properties"
+      {:app                app
+       :entity             "asset-properties"
        :example            new-asset-properties-maximal
        :invalid-tests?     true
        :invalid-test-field :asset_ref

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -19,7 +19,7 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(defn additional-tests [asset-id asset-sample]
+(defn additional-tests [app asset-id asset-sample]
   (testing "GET /ctia/asset/search"
     (do
       (are [term check-fn expected desc] (let [response (helpers/get (str "ctia/asset/search")
@@ -39,7 +39,8 @@
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
      (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
-      {:entity           "asset"
+      {:app              app
+       :entity           "asset"
        :example          new-asset-maximal
        :invalid-tests?   true
        :update-tests?    true

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -37,7 +37,8 @@
                                          "foogroup"
                                          "user")
 
-     (entity-crud-test {:entity "attack-pattern"
+     (entity-crud-test {:app app
+                        :entity "attack-pattern"
                         :example new-attack-pattern-maximal
                         :headers {:Authorization "45c1f5e3f05d0"}
                         :update-field :name

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -30,7 +30,8 @@
                                          "foogroup"
                                          "user")
 
-     (entity-crud-test {:entity "campaign"
+     (entity-crud-test {:app app
+                        :entity "campaign"
                         :example (assoc new-campaign-maximal :tlp "green")
                         :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -23,7 +23,7 @@
     [new-casebook-maximal new-casebook-minimal]]
    [ctim.schemas.common :refer [ctim-schema-version]]))
 
-(defn partial-operations-tests [casebook-id casebook]
+(defn partial-operations-tests [app casebook-id casebook]
   ;; observables
   (testing "POST /ctia/casebook/:id/observables :add"
     (let [new-observables [{:type "ip" :value "42.42.42.42"}]
@@ -316,7 +316,8 @@
                                          "foogroup"
                                          "user")
 
-     (entity-crud-test {:entity "casebook"
+     (entity-crud-test {:app app
+                        :entity "casebook"
                         :example new-casebook-maximal
                         :headers {:Authorization "45c1f5e3f05d0"}
                         :patch-tests? true

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -29,7 +29,8 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
-     (entity-crud-test {:entity "coa"
+     (entity-crud-test {:app app
+                        :entity "coa"
                         :example new-coa-maximal
                         :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/data_table_test.clj
+++ b/test/ctia/entity/data_table_test.clj
@@ -39,7 +39,8 @@
                                          "foouser"
                                          "foogroup"
                                          "user")
-     (entity-crud-test {:entity "data-table"
+     (entity-crud-test {:app app
+                        :entity "data-table"
                         :example new-data-table
                         :invalid-tests? false
                         :update-tests? false

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -136,7 +136,7 @@
 (use-fixtures :each
   whoami-helpers/fixture-reset-state)
 
-(defn feed-view-tests [feed-id feed]
+(defn feed-view-tests [app feed-id feed]
   (testing "GET /ctia/feed/:id/view?s=:secret"
     (let [feed-view-url-txt (:feed_view_url feed)
           feed-view-url-txt-wrong-secret (->> (drop-last feed-view-url-txt)
@@ -228,7 +228,8 @@
            "we successfully have an indicator id to test the view")
 
        (entity-crud-test
-        {:entity "feed"
+        {:app app
+         :entity "feed"
          :example (assoc new-feed-maximal
                          :indicator_id
                          indicator-id)

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -23,7 +23,7 @@
    :tlp "green"})
 
 (defn feedback-by-entity-id-test
-  [feedback-id _]
+  [app feedback-id _]
   (testing "GET /ctia/feedback?entity_id="
     (let [response (get (str "ctia/feedback")
                         :query-params {:entity_id "judgement-123"}
@@ -55,7 +55,8 @@
                                          "user")
 
      (entity-crud-test
-      {:entity "feedback"
+      {:app app
+       :entity "feedback"
        :example new-feedback
        :update-tests? false
        :invalid-tests? false

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -34,7 +34,7 @@
        ["http://ex.tld/ctia/identity-assertion/identity-assertion-123"
         "http://ex.tld/ctia/identity-assertion/identity-assertion-345"])))
 
-(defn additional-tests [identity-assertion-id _]
+(defn additional-tests [app identity-assertion-id _]
   (testing "GET /ctia/identity-assertion/search"
     (do
       (let [term "identity.observables.value:\"1.2.3.4\""
@@ -71,7 +71,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "identity-assertion"
+      {:app app
+       :entity "identity-assertion"
        :example new-identity-assertion-maximal
        :invalid-tests? false
        :update-tests? true

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -27,7 +27,7 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(defn partial-operations-tests [incident-id incident]
+(defn partial-operations-tests [app incident-id incident]
   (let [fixed-now (t/internal-now)]
     (helpers/fixture-with-fixed-time
      fixed-now
@@ -83,7 +83,8 @@
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
      (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (let [parameters {:entity "incident"
+     (let [parameters {:app app
+                       :entity "incident"
                        :patch-tests? true
                        :example new-incident-maximal
                        :headers {:Authorization "45c1f5e3f05d0"}

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -21,10 +21,9 @@
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
 
-(defn search-tests [_ indicator-sample]
+(defn search-tests [app _ indicator-sample]
   (testing "GET /ctia/indicator/search"
-   (let [app (helpers/get-current-app)
-         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
+   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
     (when (= "es" (get-in-config [:ctia :store :indicator]))
       (are [query check-fn expected desc]

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -63,7 +63,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "indicator"
+      {:app app
+       :entity "indicator"
        :example new-indicator-maximal
        :additional-tests search-tests
        :headers {:Authorization "45c1f5e3f05d0"}}))))

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -34,7 +34,8 @@
                                          "user")
 
      (entity-crud-test
-      {:entity "investigation"
+      {:app app
+       :entity "investigation"
        :example new-investigation-maximal
        :update-tests? false
        :invalid-tests? false

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -46,10 +46,9 @@
           :confidence "Low"
           :reason "This is a bad IP address that talked to some evil servers"}))
 
-(defn additional-tests [judgement-id _]
+(defn additional-tests [app judgement-id _]
   (testing "GET /ctia/judgement/search"
-   (let [app (helpers/get-current-app)
-         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
+   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
     (when (= "es" (get-in-config [:ctia :store :indicator]))
       (let [term "observable.value:\"1.2.3.4\""
@@ -154,7 +153,8 @@
                                          "user")
 
      (entity-crud-test
-      {:entity "judgement"
+      {:app app
+       :entity "judgement"
        :example new-judgement
        :update-tests? true
        :update-field :source

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -37,7 +37,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "malware"
+      {:app app
+       :entity "malware"
        :example new-malware-maximal
        ;; TODO seems like we forgot to add restrictions on ctim
        :invalid-tests? false

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -74,7 +74,8 @@
    (fn [app]
      (establish-user! app)
      (entity-crud-test
-      {:entity "relationship"
+      {:app app
+       :entity "relationship"
        :example new-relationship
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -47,7 +47,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "sighting"
+      {:app app
+       :entity "sighting"
        :example new-sighting-maximal
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -20,10 +20,9 @@
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)
 
-(defn additional-tests [_ target-record-sample]
+(defn additional-tests [app _ target-record-sample]
   (testing "GET /ctia/target-record/search"
-   (let [app (helpers/get-current-app)
-         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
+   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
     (when (= "es" (get-in-config [:ctia :store :target-record]))
       (let [{[target] :targets} target-record-sample
@@ -59,7 +58,8 @@
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
      (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
-      {:entity           "target-record"
+      {:app              app
+       :entity           "target-record"
        :example          new-target-record-maximal
        :invalid-tests?   true
        :update-tests?    true

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -38,7 +38,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "tool"
+      {:app app
+       :entity "tool"
        :example new-tool-maximal
        :invalid-test-field :name
        :update-field :description

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -36,7 +36,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "vulnerability"
+      {:app app
+       :entity "vulnerability"
        :example new-vulnerability-maximal
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -36,7 +36,8 @@
                                          "foogroup"
                                          "user")
      (entity-crud-test
-      {:entity "weakness"
+      {:app app
+       :entity "weakness"
        :example new-weakness-maximal
        :headers {:Authorization "45c1f5e3f05d0"}}))))
 

--- a/test/ctia/http/routes/observable/judgements_indicators_test.clj
+++ b/test/ctia/http/routes/observable/judgements_indicators_test.clj
@@ -25,8 +25,8 @@
                                          "user")
 
      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+           make-id #(make-id % get-in-config)
 
-           http-show (get-in-config [:ctia :http :show])
            judgement-1-id (make-id :judgement)
            judgement-2-id (make-id :judgement)
            judgement-3-id (make-id :judgement)

--- a/test/ctia/http/routes/observable/judgements_indicators_test.clj
+++ b/test/ctia/http/routes/observable/judgements_indicators_test.clj
@@ -24,8 +24,7 @@
                                          "foogroup"
                                          "user")
 
-     (let [app (helpers/get-current-app)
-           {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
 
            http-show (get-in-config [:ctia :http :show])
            judgement-1-id (make-id :judgement)

--- a/test/ctia/http/routes/observable/sightings_incidents_test.clj
+++ b/test/ctia/http/routes/observable/sightings_incidents_test.clj
@@ -25,7 +25,7 @@
                                          "user")
 
      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-           http-show (get-in-config [:ctia :http :show])
+           make-id #(make-id % get-in-config)
            sighting-1-id (make-id :sighting)
            sighting-2-id (make-id :sighting)
            sighting-3-id (make-id :sighting)

--- a/test/ctia/http/routes/observable/sightings_indicators_test.clj
+++ b/test/ctia/http/routes/observable/sightings_indicators_test.clj
@@ -25,8 +25,8 @@
                                          "user")
 
      (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+           make-id #(make-id % get-in-config)
 
-           http-show (get-in-config [:ctia :http :show])
            sighting-1-id (make-id :sighting)
            sighting-2-id (make-id :sighting)
            sighting-3-id (make-id :sighting)

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -29,7 +29,7 @@
            title "test"
            new-indicators (->> (csg/sample (cs/gen :new-indicator/map 5))
                                (map #(assoc % :title title))
-                               (map #(assoc % :id (url-id :indicator))))
+                               (map #(assoc % :id (url-id :indicator get-in-config))))
            created-indicators (map #(assert-post "ctia/indicator" %)
                                    new-indicators)
            new-judgements (->> (csg/sample (cs/gen :new-judgement/map) 5)
@@ -37,12 +37,12 @@
                                             :observable observable
                                             :disposition 5
                                             :disposition_name "Unknown"))
-                               (map #(assoc % :id (url-id :judgement))))
+                               (map #(assoc % :id (url-id :judgement get-in-config))))
            new-sightings (->> (csg/sample (cs/gen :new-sighting/map) 5)
                               (map #(-> (assoc %
                                                :observables [observable])
                                         (dissoc % :relations :data)))
-                              (map #(assoc % :id (url-id :sighting))))
+                              (map #(assoc % :id (url-id :sighting get-in-config))))
            route-pref (str "ctia/" (:type observable) "/" (:value observable))]
 
        (testing "setup: create sightings and their relationships with indicators"

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -45,7 +45,9 @@
       (Thread/sleep 100)   ;; wait until the go loop is done
       (let [scrubbed (-> (str sb)
                          (str/replace #"#inst \"[^\"]*\"" "#inst \"\"")
-                         (str/replace #":id event[^,]*" ":id event"))
+                         (str/replace #":id event[^,]*" ":id event")
+                         (str/replace #"Lifecycle worker completed :boot lifecycle task; awaiting next task.\s"
+                                      ""))
             expected
             "event: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-1, :type :test, :tlp green, :data 1}, :timestamp #inst \"\", :id test-1, :type event, :tlp green, :event_type :record-created}\nevent: {:owner tester, :groups [foo], :entity {:owner tester, :groups [foo], :id test-2, :type :test, :tlp green, :data 2}, :timestamp #inst \"\", :id test-2, :type event, :tlp green, :event_type :record-created}\n"]
         (is (= expected scrubbed))))))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -892,7 +892,7 @@
                (get-in state [:target :migrated]))))
       (es-index/delete! (es-conn get-in-config) (format "v%s*" prefix))
       (es-doc/delete-doc (es-conn get-in-config) "migration" migration-id "true")))
-  (es-index/delete! (es-conn (helpers/current-get-in-config-fn)) "ctia_*"))
+  (es-index/delete! (es-conn (helpers/current-get-in-config-fn app)) "ctia_*"))
 
 ;;(deftest ^:integration minimal-load-test
 ;; (with-each-fixtures identity app

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -8,7 +8,7 @@
              [auth :refer [all-capabilities]]
              [fake-whoami-service :as helpers.whoami]
              [core :as helpers.core]
-             [store :refer [store-fixtures]]]
+             [store :refer [test-selected-stores-with-app]]]
             [clojure.string :as string]
             [clojure.pprint :refer [pprint]]
             [schema-generators.generators :as g]
@@ -259,10 +259,10 @@
   ;; see ES details: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts
   (helpers.core/with-config-transformer*
     #(assoc-in % [:ctia :store :es :default :shards] 1)
-    #((:es-store store-fixtures)
-      (fn []
-        (let [app (helpers.core/get-current-app)
-              _ (helpers.core/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+    #(test-selected-stores-with-app
+      #{:es-store}
+      (fn [app]
+        (let [_ (helpers.core/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
               _ (helpers.whoami/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
               docs (generate-n-entity metric-params 100)]
           (with-redefs [;; ensure from coercion in proper one year range

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -314,12 +314,10 @@
 (defn make-id
   "Make a long style ID using CTIA code (eg with a random UUID).
   Returns an ID object."
-  [type-kw]
+  [type-kw get-in-config]
   (id/->id type-kw
            (crud/make-id (name type-kw))
-           ;; FIXME using current-get-in-config-fn here is a hack and should be refactored
-           ;; to function parameter once the initial TK setup is merged into master.
-           ((current-get-in-config-fn) [:ctia :http :show])))
+           (get-in-config [:ctia :http :show])))
 
 (defn entity->short-id
   [entity]
@@ -328,15 +326,13 @@
       :short-id))
 
 (defn url-id
-  ([type-kw]
-   (url-id (crud/make-id (name type-kw)) type-kw))
-  ([short-id type-kw]
+  ([type-kw get-in-config]
+   (url-id (crud/make-id (name type-kw)) type-kw get-in-config))
+  ([short-id type-kw get-in-config]
    (id/long-id
     (id/short-id->id (name type-kw)
                      short-id
-                     ;; FIXME using current-get-in-config-fn here is a hack and should be refactored
-                     ;; to function parameter once the initial TK setup is merged into master.
-                     ((current-get-in-config-fn) [:ctia :http :show])))))
+                     (get-in-config [:ctia :http :show])))))
 
 (def zero-uuid "00000000-0000-0000-0000-000000000000")
 
@@ -349,17 +345,6 @@
     (assert (<= id-cnt 8)
             "ID must be 8 chars or less")
     (str entity-name "-" id-str (subs zero-uuid id-cnt))))
-
-(defn fake-long-id
-  "Make a fake long style ID with a deterministic UUID.  Returns a
-  string."
-  [entity-name id]
-  (id/long-id
-   (id/->id (keyword entity-name)
-            (fake-short-id entity-name id)
-            ;; FIXME using current-get-in-config-fn here is a hack and should be refactored
-            ;; to function parameter once the initial TK setup is merged into master.
-            ((current-get-in-config-fn) [:ctia :http :show]))))
 
 (defmacro with-atom-logger
   [atom-logger & body]

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -138,7 +138,8 @@
                           "applied when wait_for is not specified"))))))
 
 (defn entity-crud-test
-  [{:keys [entity
+  [{:keys [app
+           entity
            example
            headers
            update-field
@@ -160,8 +161,8 @@
          patch-tests? false
          search-tests? true}
     :as params}]
- (let [app (helpers/get-current-app)
-       get-in-config (helpers/current-get-in-config-fn app)]
+ (assert app "Must pass :app to entity-crud-test")
+ (let [get-in-config (helpers/current-get-in-config-fn app)]
   (testing (str "POST /ctia/" entity)
     (let [new-record (dissoc example :id)
           {post-status :status
@@ -239,7 +240,8 @@
           ;; execute entity custom tests before deleting the fixture
           (testing "additional tests"
             (when additional-tests
-              (additional-tests record-id
+              (additional-tests app
+                                record-id
                                 (if update-tests?
                                   updated-record
                                   post-record))))))

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -11,13 +11,26 @@
                    helpers/fixture-ctia
                    es-helpers/fixture-delete-store-indexes])})
 
+(s/defn test-selected-stores-with-app
+  "Takes a 1-argument function which accepts a Trapperkeeper `app`
+  which should succeed for the stores named in the first argument."
+  [selected-stores
+   t :- (s/=> s/Any
+              (s/named s/Any 'app))]
+  (assert (set? selected-stores))
+  (doseq [:let [store-fixtures (select-keys store-fixtures selected-stores)
+                _ (assert (seq store-fixtures) "No stores selected")]
+          [store-key fixtures] store-fixtures]
+    (testing (name store-key)
+      (fixtures
+        (fn []
+          (t (helpers/get-current-app)))))))
+
 (s/defn test-for-each-store-with-app
   "Takes a 1-argument function which accepts a Trapperkeeper `app`
   which should succeed for all stores."
   [t :- (s/=> s/Any
               (s/named s/Any 'app))]
-  (doseq [[store-key fixtures] store-fixtures]
-    (testing (name store-key)
-      (fixtures
-        (fn []
-          (t (helpers/get-current-app)))))))
+  (test-for-each-store-with-app
+    (-> store-fixtures keys set)
+    t))

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -14,10 +14,10 @@
 (s/defn test-selected-stores-with-app
   "Takes a 1-argument function which accepts a Trapperkeeper `app`
   which should succeed for the stores named in the first argument."
-  [selected-stores
+  [selected-stores :- #{s/Keyword}
    t :- (s/=> s/Any
               (s/named s/Any 'app))]
-  (assert (set? selected-stores))
+  (assert (seq selected-stores) "Empty selected-stores")
   (doseq [:let [store-fixtures (select-keys store-fixtures selected-stores)
                 _ (assert (seq store-fixtures) "No stores selected")]
           [store-key fixtures] store-fixtures]
@@ -31,6 +31,5 @@
   which should succeed for all stores."
   [t :- (s/=> s/Any
               (s/named s/Any 'app))]
-  (test-selected-stores-with-app
-    (-> store-fixtures keys set)
-    t))
+  (test-selected-stores-with-app (-> store-fixtures keys set)
+                                 t))

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -31,6 +31,6 @@
   which should succeed for all stores."
   [t :- (s/=> s/Any
               (s/named s/Any 'app))]
-  (test-for-each-store-with-app
+  (test-selected-stores-with-app
     (-> store-fixtures keys set)
     t))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related https://github.com/threatgrid/iroh/issues/3986
Closes https://github.com/threatgrid/ctia/issues/930

Add an explicit app arg for `entity-crud-test` and add a `test-selected-stores-with-app` function that tests only a provided subset of store fixtures.

Also fixes a flaky logging test described by https://github.com/threatgrid/ctia/issues/930

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Add explicit app arg for entity-crud-test and others
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

