### PR TITLE
Move fixture-properties:clean function into default overrides

### DIFF
--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -29,7 +29,6 @@
     (t)))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     fixture-properties:small-max-bulk-size
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -7,8 +7,7 @@
             [ctia.test-helpers.core :as h]))
 
 (use-fixtures :once
-  (join-fixtures [h/fixture-properties:clean
-                  h/fixture-ctia-fast]))
+  (join-fixtures [h/fixture-ctia-fast]))
 
 (deftest local-entity?-test
   (are [x y] (= x (sut/local-entity? y (h/current-get-in-config-fn)))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -32,7 +32,6 @@
 (use-fixtures :once
   (join-fixtures
    [mth/fixture-schema-validation
-    helpers/fixture-properties:clean
     fixture-properties
     fixture-find-by-external-ids-limit
     whoami-helpers/fixture-server]))

--- a/test/ctia/encryption_test.clj
+++ b/test/ctia/encryption_test.clj
@@ -9,8 +9,7 @@
     [es :as es-helpers]]))
 
 (use-fixtures :once mth/fixture-schema-validation)
-(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     test-helpers/fixture-ctia-fast]))
 
 (deftest test-encryption-fns

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -17,7 +17,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -17,7 +17,6 @@
                                                   new-asset-mapping-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -16,7 +16,6 @@
                                                     new-asset-properties-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -14,7 +14,6 @@
             [ctim.examples.assets :refer [new-asset-minimal new-asset-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -18,7 +18,6 @@
              [new-attack-pattern-maximal new-attack-pattern-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -16,7 +16,6 @@
             [ctim.examples.campaigns :as ex :refer [new-campaign-maximal new-campaign-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -318,7 +318,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -16,7 +16,6 @@
             [ctim.examples.coas :refer [new-coa-maximal new-coa-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/data_table_test.clj
+++ b/test/ctia/entity/data_table_test.clj
@@ -10,7 +10,6 @@
             [ctim.schemas.common :as c]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/entities_test.clj
+++ b/test/ctia/entity/entities_test.clj
@@ -15,8 +15,7 @@
 #_
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
-                                    test-helpers/fixture-ctia-fast]))
+(use-fixtures :each test-helpers/fixture-ctia-fast)
 
 (defn gen-sample-entity
   [{:keys [new-spec]}]

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -26,7 +26,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -130,7 +130,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -34,7 +34,6 @@
              (map #(dissoc % :owner :groups) feedbacks))))))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -19,7 +19,6 @@
              [new-identity-assertion-maximal new-identity-assertion-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -21,7 +21,6 @@
              [new-incident-maximal new-incident-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -15,7 +15,6 @@
              [new-indicator-maximal new-indicator-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -18,7 +18,6 @@
               new-investigation-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -25,7 +25,6 @@
             [ctim.examples.judgements :as ex]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:cors
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -18,7 +18,6 @@
              [new-malware-maximal new-malware-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -24,7 +24,6 @@
              [relationships :refer [new-relationship-maximal new-relationship-minimal]]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -24,7 +24,6 @@
              [new-sighting-maximal new-sighting-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -15,7 +15,6 @@
                                                   new-target-record-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -19,7 +19,6 @@
             [ctia.entity.tool.schemas :as ts]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -17,7 +17,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -17,7 +17,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -264,7 +264,9 @@
   (let [fixture-fn
         (join-fixtures [helpers/fixture-log
                         helpers/fixture-properties:cors
-                        #(helpers/with-properties properties (%))
+                        #(helpers/with-properties
+                           (conj properties "ctia.auth.type" "allow-all")
+                           (%))
                         es-helpers/fixture-properties:es-store
                         helpers/fixture-ctia
                         es-helpers/fixture-delete-store-indexes])]

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -369,7 +369,7 @@
   (let [port (get-free-port)
         s (jetty/run-jetty handler {:port port
                                     :join? false
-                                    :min-threads 1})]
+                                    :min-threads 2})]
     (tst-fn port)
     (.stop s)))
 

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -22,8 +22,7 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each (join-fixtures [helpers/fixture-properties:clean
-                                    helpers/fixture-properties:cors
+(use-fixtures :each (join-fixtures [helpers/fixture-properties:cors
                                     whoami-helpers/fixture-server
                                     whoami-helpers/fixture-reset-state]))
 
@@ -261,10 +260,9 @@
      :bad-iss-jwt-2 (-> claims-2 (assoc :iss "IROH Auth") jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)}))
 
 (s/defn apply-fixtures-with-app
-  [properties f-with-app :-  (s/=> s/Any (s/=> s/Any (s/named s/Any 'app)))]
+  [properties f-with-app :- (s/=> s/Any (s/=> s/Any (s/named s/Any 'app)))]
   (let [fixture-fn
         (join-fixtures [helpers/fixture-log
-                        helpers/fixture-properties:clean
                         helpers/fixture-properties:cors
                         #(helpers/with-properties properties (%))
                         es-helpers/fixture-properties:es-store
@@ -369,7 +367,7 @@
   (let [port (get-free-port)
         s (jetty/run-jetty handler {:port port
                                     :join? false
-                                    :min-threads 2})]
+                                    :min-threads 1})]
     (tst-fn port)
     (.stop s)))
 

--- a/test/ctia/events_test.clj
+++ b/test/ctia/events_test.clj
@@ -15,8 +15,7 @@
 
 (use-fixtures :once st/validate-schemas)
 
-(use-fixtures :each (join-fixtures [helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     helpers/fixture-ctia-fast]))
 
 (deftest test-send-event

--- a/test/ctia/flows/events_test.clj
+++ b/test/ctia/flows/events_test.clj
@@ -15,8 +15,7 @@
 
 (deftest-for-each-fixture-with-app test-flow-event-creation
 
-  {:es-simple-index (join-fixtures [test-helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+  {:es-simple-index (join-fixtures [es-helpers/fixture-properties:es-store
                                     test-helpers/fixture-properties:events-enabled
                                     test-helpers/fixture-allow-all-auth
                                     test-helpers/fixture-ctia

--- a/test/ctia/flows/hooks/kafka_event_hook_test.clj
+++ b/test/ctia/flows/hooks/kafka_event_hook_test.clj
@@ -18,8 +18,7 @@
 (use-fixtures :once mth/fixture-schema-validation)
 
 (use-fixtures :each
-  (join-fixtures [test-helpers/fixture-properties:clean
-                  es-helpers/fixture-properties:es-store
+  (join-fixtures [es-helpers/fixture-properties:es-store
                   test-helpers/fixture-properties:kafka-hook
                   test-helpers/fixture-properties:events-enabled
                   test-helpers/fixture-allow-all-auth

--- a/test/ctia/flows/hooks/redis_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redis_event_hook_test.clj
@@ -14,8 +14,7 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     test-helpers/fixture-properties:redis-hook
                                     test-helpers/fixture-properties:events-enabled
                                     test-helpers/fixture-allow-all-auth

--- a/test/ctia/flows/hooks/redismq_event_hook_test.clj
+++ b/test/ctia/flows/hooks/redismq_event_hook_test.clj
@@ -21,8 +21,7 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     fixture-properties:redismq-hook
                                     test-helpers/fixture-properties:events-enabled
                                     test-helpers/fixture-allow-all-auth

--- a/test/ctia/flows/hooks_test.clj
+++ b/test/ctia/flows/hooks_test.clj
@@ -8,7 +8,6 @@
             [clojure.test :as t]))
 
 (t/use-fixtures :each (t/join-fixtures [mth/fixture-schema-validation
-                                        helpers/fixture-properties:clean
                                         es-helpers/fixture-properties:es-store
                                         helpers/fixture-ctia-fast]))
 

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -8,7 +8,6 @@
 
 (use-fixtures :once
   mth/fixture-schema-validation
-  th/fixture-properties:clean
   esh/fixture-properties:es-store
   th/fixture-ctia
   esh/fixture-delete-store-indexes

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -9,8 +9,7 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each (join-fixtures [helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     helpers/fixture-allow-all-auth
                                     helpers/fixture-ctia]))
 

--- a/test/ctia/http/handler/static_auth_anonymous_test.clj
+++ b/test/ctia/http/handler/static_auth_anonymous_test.clj
@@ -16,7 +16,6 @@
 (use-fixtures :once mth/fixture-schema-validation)
 
 (use-fixtures :each
-  helpers/fixture-properties:clean
   es-helpers/fixture-properties:es-store
   (helpers/fixture-properties:static-auth "kitara" "tearbending")
   fixture-anonymous-readonly-access

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -10,7 +10,6 @@
 (use-fixtures :once mth/fixture-schema-validation)
 
 (use-fixtures :each
-  helpers/fixture-properties:clean
   es-helpers/fixture-properties:es-store
   (helpers/fixture-properties:static-auth "kitara" "tearbending")
   helpers/fixture-ctia)

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -9,7 +9,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     es-helpers/fixture-properties:es-store
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -92,7 +92,6 @@
                              (s/named s/Any 'app)))]
   (let [fixture-fn
         (join-fixtures [reset-redis
-                        helpers/fixture-properties:clean
                         (helpers/fixture-properties:static-auth "user" "pwd")
                         #(helpers/with-properties properties (%))
                         es-helpers/fixture-properties:es-store

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.attack-patterns :refer [new-attack-pattern-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.incidents :refer [new-incident-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/investigation_test.clj
+++ b/test/ctia/http/routes/graphql/investigation_test.clj
@@ -11,7 +11,6 @@
             [ctia.test-helpers.store :refer [test-for-each-store-with-app]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/malware_test.clj
+++ b/test/ctia/http/routes/graphql/malware_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.malwares :refer [new-malware-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/tool_test.clj
+++ b/test/ctia/http/routes/graphql/tool_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.tools :refer [new-tool-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/vulnerability_test.clj
+++ b/test/ctia/http/routes/graphql/vulnerability_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.vulnerabilities :refer [new-vulnerability-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql/weakness_test.clj
+++ b/test/ctia/http/routes/graphql/weakness_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.weaknesses :refer [new-weakness-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -10,7 +10,6 @@
             [ctim.examples.casebooks :refer [new-casebook-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/observable/judgements_indicators_test.clj
+++ b/test/ctia/http/routes/observable/judgements_indicators_test.clj
@@ -10,7 +10,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/observable/judgements_test.clj
+++ b/test/ctia/http/routes/observable/judgements_test.clj
@@ -9,7 +9,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/observable/sightings_incidents_test.clj
+++ b/test/ctia/http/routes/observable/sightings_incidents_test.clj
@@ -10,7 +10,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/observable/sightings_indicators_test.clj
+++ b/test/ctia/http/routes/observable/sightings_indicators_test.clj
@@ -10,7 +10,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/observable/sightings_test.clj
+++ b/test/ctia/http/routes/observable/sightings_test.clj
@@ -8,7 +8,6 @@
              [store :refer [test-for-each-store-with-app]]]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -13,7 +13,6 @@
             [ctim.domain.id :as id]))
 
 (use-fixtures :once (join-fixtures [mht/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -14,7 +14,6 @@
 
 (use-fixtures :once
   mth/fixture-schema-validation
-  helpers/fixture-properties:clean
   helpers/fixture-allow-all-auth)
 
 (deftest ^:slow test-pagination-lists

--- a/test/ctia/http/routes/status_test.clj
+++ b/test/ctia/http/routes/status_test.clj
@@ -8,7 +8,6 @@
              [store :refer [test-for-each-store-with-app]]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/routes/swagger_json_test.clj
+++ b/test/ctia/http/routes/swagger_json_test.clj
@@ -4,7 +4,6 @@
             [ctia.test-helpers.core :as helpers]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     helpers/fixture-ctia]))
 
 (deftest test-swagger-json

--- a/test/ctia/http/routes/version_test.clj
+++ b/test/ctia/http/routes/version_test.clj
@@ -8,7 +8,6 @@
              [store :refer [test-for-each-store-with-app]]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
 (use-fixtures :each whoami-helpers/fixture-reset-state)

--- a/test/ctia/http/server_test.clj
+++ b/test/ctia/http/server_test.clj
@@ -8,9 +8,6 @@
 
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each
-  helpers/fixture-properties:clean)
-
 (deftest parse-external-endpoints-test
   (is (nil? (sut/parse-external-endpoints nil)))
 

--- a/test/ctia/lib/redis_test.clj
+++ b/test/ctia/lib/redis_test.clj
@@ -10,8 +10,7 @@
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
 (use-fixtures :each (join-fixtures
-                     [test-helpers/fixture-properties:clean
-                      es-helpers/fixture-properties:es-store
+                     [es-helpers/fixture-properties:es-store
                       test-helpers/fixture-ctia-fast]))
 
 (deftest redis-conf->conn-spec-test

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -9,8 +9,7 @@
             [clojure.string :as str]))
 
 (use-fixtures :once st/validate-schemas)
-(use-fixtures :each (join-fixtures [test-helpers/fixture-properties:clean
-                                    es-helpers/fixture-properties:es-store
+(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
                                     test-helpers/fixture-properties:events-logging
                                     test-helpers/fixture-ctia-fast]))
 

--- a/test/ctia/stores/identity_store_test.clj
+++ b/test/ctia/stores/identity_store_test.clj
@@ -1,14 +1,13 @@
 (ns ctia.stores.identity-store-test
   (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [ctia.store :as store]
             [ctia.store-service :as store-svc]
             [ctia.test-helpers
              [core :as helpers]
              [store :refer [test-for-each-store-with-app]]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-properties:clean]))
+(use-fixtures :once mth/fixture-schema-validation)
 
 (deftest test-read-identity
   (test-for-each-store-with-app

--- a/test/ctia/task/check_es_stores_test.clj
+++ b/test/ctia/task/check_es_stores_test.clj
@@ -35,7 +35,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store
                   whoami-helpers/fixture-server]))
 

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -46,7 +46,6 @@
   (join-fixtures [mth/fixture-schema-validation
                   whoami-helpers/fixture-server
                   whoami-helpers/fixture-reset-state
-                  helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 
 (defn es-props [get-in-config]

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -267,7 +267,9 @@
           (ductile.index/delete! (str (migration-index get-in-config) "*")))))))
 
 (use-fixtures :each
-  (join-fixtures [helpers/fixture-ctia
+  (join-fixtures [#(helpers/with-properties
+                     ["ctia.auth.type" "allow-all"]
+                     (helpers/fixture-ctia %))
                   es-helpers/fixture-delete-store-indexes
                   fixture-clean-migration]))
 

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -245,7 +245,6 @@
   (join-fixtures [mth/fixture-schema-validation
                   whoami-helpers/fixture-server
                   whoami-helpers/fixture-reset-state
-                  helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 
 (defn es-props [get-in-config]

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -15,7 +15,9 @@
                   es-helpers/fixture-properties:es-store]))
 
 (use-fixtures :each
-  (join-fixtures [helpers/fixture-ctia
+  (join-fixtures [#(helpers/with-properties
+                     ["ctia.auth.type" "allow-all"]
+                     (helpers/fixture-ctia %))
                   es-helpers/fixture-delete-store-indexes]))
 
 (def examples (fixt/bundle 100 false))

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -12,7 +12,6 @@
 (use-fixtures :once
   (join-fixtures [whoami-helpers/fixture-server
                   whoami-helpers/fixture-reset-state
-                  helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 
 (use-fixtures :each

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -7,7 +7,7 @@
              [index :as es-index]
              [conn :as es-conn]]
             [ctia.test-helpers
-             [core :as h :refer [fixture-ctia fixture-properties:clean]]
+             [core :as h :refer [fixture-ctia]]
              [es :refer [fixture-properties:es-store fixture-delete-store-indexes]]]))
 
 (defn fixture-update-stores [t]

--- a/test/ctia/task/update_mapping_test.clj
+++ b/test/ctia/task/update_mapping_test.clj
@@ -19,7 +19,6 @@
 (use-fixtures :once
   (join-fixtures [whoami-helpers/fixture-server
                   whoami-helpers/fixture-reset-state
-                  helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 
 (use-fixtures :each

--- a/test/ctia/test_helpers/benchmark.clj
+++ b/test/ctia/test_helpers/benchmark.clj
@@ -10,13 +10,12 @@
 (defn setup-ctia! [fixture]
   (let [http-port (net/available-port)
         app (fixture (fn []
-                       (helpers/fixture-properties:clean
-                         #(helpers/with-properties ["ctia.store.es.default.refresh" "false"
-                                                    "ctia.http.enabled" true
-                                                    "ctia.http.port" http-port
-                                                    "ctia.http.bulk.max-size" 100000
-                                                    "ctia.http.show.port" http-port]
-                            (start-ctia!)))))]
+                       (helpers/with-properties ["ctia.store.es.default.refresh" "false"
+                                                 "ctia.http.enabled" true
+                                                 "ctia.http.port" http-port
+                                                 "ctia.http.bulk.max-size" 100000
+                                                 "ctia.http.show.port" http-port]
+                         (start-ctia!))))]
     {:port http-port
      :app app}))
 

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -28,13 +28,40 @@
             [schema.core :as s]))
 
 (def ^:dynamic ^:private *current-app*)
+
 (def
   ^:dynamic ^:private
   *properties-overrides*
   "An even-sized vector of property key-val flattened pairs (like the
   first argument to #'with-properties) that will be
   used to override the default properties."
-  [])
+  ;; Default overrides for any properties that are in the default properties file
+  ;; yet are unsafe/undesirable for tests
+  ["ctia.auth.type"                            "allow-all"
+   "ctia.access-control.default-tlp"           "green"
+   "ctia.access-control.min-tlp"               "white"
+   "ctia.access-control.max-record-visibility" "everyone"
+   "ctia.encryption.key.filepath"              "resources/cert/ctia-encryption.key"
+   "ctia.events.enabled"                        true
+   "ctia.events.log"                            false
+   "ctia.http.dev-reload"                       false
+   "ctia.http.min-threads"                      1
+   "ctia.http.max-threads"                      10
+   "ctia.http.show.protocol"                    "http"
+   "ctia.http.show.hostname"                    "localhost"
+   "ctia.http.show.port"                        "57254"
+   "ctia.http.show.path-prefix"                 ""
+   "ctia.http.jwt.enabled"                      true
+   "ctia.http.jwt.public-key-path"              "resources/cert/ctia-jwt.pub"
+   "ctia.http.bulk.max-size"                    30000
+   "ctia.hook.redis.enabled"                    false
+   "ctia.hook.redis.channel-name"               "events-test"
+   "ctia.metrics.riemann.enabled"               false
+   "ctia.metrics.console.enabled"               false
+   "ctia.metrics.jmx.enabled"                   false
+   "ctia.versions.config"                       "test"])
+(assert (even? (count *properties-overrides*)))
+
 (def ^:dynamic ^:private *config-transformers* [])
 
 (defn get-service-map [app svc-kw]
@@ -71,38 +98,6 @@
   [properties-vec & sexprs]
   `(with-properties* ~properties-vec
      (fn [] (do ~@sexprs))))
-
-(defn fixture-properties:clean [f]
-  ;; reset overrides, to preserve previous behavior when #'with-properties
-  ;; used to set actual System properties.
-  (binding [*properties-overrides* []]
-    ;; Override any properties that are in the default properties file
-    ;; yet are unsafe/undesirable for tests
-    (with-properties ["ctia.auth.type"                            "allow-all"
-                      "ctia.access-control.default-tlp"           "green"
-                      "ctia.access-control.min-tlp"               "white"
-                      "ctia.access-control.max-record-visibility" "everyone"
-                      "ctia.encryption.key.filepath"              "resources/cert/ctia-encryption.key"
-                      "ctia.events.enabled"                        true
-                      "ctia.events.log"                            false
-                      "ctia.http.dev-reload"                       false
-                      "ctia.http.min-threads"                      9
-                      "ctia.http.max-threads"                      10
-                      "ctia.http.show.protocol"                    "http"
-                      "ctia.http.show.hostname"                    "localhost"
-                      "ctia.http.show.port"                        "57254"
-                      "ctia.http.show.path-prefix"                 ""
-                      "ctia.http.jwt.enabled"                      true
-                      "ctia.http.jwt.public-key-path"              "resources/cert/ctia-jwt.pub"
-                      "ctia.http.bulk.max-size"                    30000
-                      "ctia.hook.redis.enabled"                    false
-                      "ctia.hook.redis.channel-name"               "events-test"
-                      "ctia.metrics.riemann.enabled"               false
-                      "ctia.metrics.console.enabled"               false
-                      "ctia.metrics.jmx.enabled"                   false
-                      "ctia.versions.config"                       "test"]
-      ;; run tests
-      (f))))
 
 (defn fixture-properties:cors [f]
   (with-properties

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -45,7 +45,7 @@
    "ctia.events.enabled"                        true
    "ctia.events.log"                            false
    "ctia.http.dev-reload"                       false
-   "ctia.http.min-threads"                      1
+   "ctia.http.min-threads"                      9
    "ctia.http.max-threads"                      10
    "ctia.http.show.protocol"                    "http"
    "ctia.http.show.hostname"                    "localhost"

--- a/test/ctia/test_helpers/core_test.clj
+++ b/test/ctia/test_helpers/core_test.clj
@@ -11,7 +11,7 @@
 
 (deftest build-transformed-init-config-test
   (assert (empty? @#'sut/*config-transformers*))
-  (assert (empty? @#'sut/*properties-overrides*))
+  (assert (not (thread-bound? #'sut/*properties-overrides*)))
   ;; TODO generate paths and vals from PropertiesSchema
   (testing "defaults to ctia-default.properties values"
     (doseq [:let [test-cases [{:ctia-path [:ctia :auth :type]

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -79,7 +79,7 @@
     (reset! server (jetty/run-jetty (params/wrap-params
                                      (make-handler this))
                                     {:port port
-                                     :min-threads 9
+                                     :min-threads 1
                                      :max-threads 10
                                      :join? false})))
   (stop-server [_]

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -79,7 +79,7 @@
     (reset! server (jetty/run-jetty (params/wrap-params
                                      (make-handler this))
                                     {:port port
-                                     :min-threads 1
+                                     :min-threads 9
                                      :max-threads 10
                                      :join? false})))
   (stop-server [_]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related https://github.com/threatgrid/iroh/issues/3986

Deletes `fixture-properties:clean` and moves its overrides to be the default overrides for all tests. This removes some global spaghetti logic used to create test configs, and is a useful step towards more localised construction (rather than dynamic bindings).

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Move fixture-properties:clean function into default overrides
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

