### PR TITLE
fix ductile protocol parameter

### DIFF
--- a/doc/migration.md
+++ b/doc/migration.md
@@ -6,7 +6,7 @@ A migration state will be stored in a configured state to enable restart.
  - As the migration task copies indexes, make sure you have enough disk space before launching it.
  - Make sure the resulting indices from your prefix configuration don't match existing ones as they will be deleted.
  - Prepare the migration properties (ex: `ctia_migration.properties`):
-   - Keep current CTIA ES properties to read source indices: host, port, transport and current store indices.
+   - Keep current CTIA ES properties to read source indices: host, port, protocol and current store indices.
    - Define your migration properties and configure your target store properties (see migration properties below)
    - Modify `aliased`, `rollover`, and `shards` options according to the need of future indices. The migrated indices will be built with these options. Note that only `max_docs` rollover condition will be considered during migration.
    - Configure desired number of shards.
@@ -34,7 +34,7 @@ You can configure target stores similarly to source store by prefixing each stor
 ```
 ctia.migration.store.es.default.host=es-storage.int.iroh.site
 ctia.migration.store.es.default.port=443
-ctia.migration.store.es.default.transport=https
+ctia.migration.store.es.default.protocol=https
 ctia.migration.store.es.default.replicas=2
 ctia.migration.store.es.default.shards=10
 ctia.migration.store.es.default.refresh_interval=1s
@@ -53,7 +53,7 @@ Below is an example of simple migration properties to migrates `tool` and `sight
 # Use ES for all Stores
 ctia.store.es.default.host=es-storage.int.iroh.site
 ctia.store.es.default.port=443
-ctia.store.es.default.transport=https
+ctia.store.es.default.protocol=https
 ctia.store.es.default.replicas=1
 ctia.store.es.default.refresh_interval=1s
 ctia.store.es.default.default_operator=AND
@@ -128,7 +128,7 @@ A more advanced migration can in particular rename indices while ignoring given 
 ```
 ctia.migration.store.es.default.host=localhost
 ctia.migration.store.es.default.port=9200
-ctia.migration.store.es.default.transport=http
+ctia.migration.store.es.default.protocol=http
 ctia.migration.store.es.default.shards=1
 
 ctia.migration.store.es.tool.indexname=ctia_tool

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -63,7 +63,7 @@ ctia.store.es.default.host=127.0.0.1
 ctia.store.es.default.port=9200
 #ctia.store.es.default.host=es-storage.int.iroh.site
 #ctia.store.es.default.port=443
-#ctia.store.es.default.transport=https
+#ctia.store.es.default.protocol=https
 ctia.store.es.default.indexname=ctia_default
 ctia.store.es.default.replicas=1
 ctia.store.es.default.refresh_interval=1s
@@ -159,13 +159,13 @@ ctia.log.riemann.service-prefix=Dev CTIA
 ctia.migration.migration-id=migration-test
 ctia.migration.prefix=1.2.0
 ctia.migration.migrations=identity
-ctia.migration.store-keys=malware,tool
+ctia.migration.store-keys==malware,tool
 ctia.migration.batch-size=100
 ctia.migration.buffer-size=3
 
-#ctia.migration.store.es.default.host=localhost
-#ctia.migration.store.es.default.port=9200
-#ctia.migration.store.es.default.transport=http
+ctia.migration.store.es.default.host=localhost
+ctia.migration.store.es.default.port=9200
+ctia.migration.store.es.default.protocol=http
 #ctia.migration.store.es.default.replicas=1
 #ctia.migration.store.es.default.refresh_interval=1s
 #ctia.migration.store.es.default.default_operator=AND
@@ -175,7 +175,6 @@ ctia.migration.store.es.default.shards=1
 #ctia.migration.store.es.default.aliased=true
 
 ctia.migration.store.es.migration.indexname=ctia_migration
-#ctia.migration.store.es.tool.indexname=ctia_tool
 #ctia.migration.store.es.malware.indexname=v1.2.0_ctia_malware
 
 #ctia.hook.kafkrestart?    a.enabled=false

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -159,7 +159,7 @@ ctia.log.riemann.service-prefix=Dev CTIA
 ctia.migration.migration-id=migration-test
 ctia.migration.prefix=1.2.0
 ctia.migration.migrations=identity
-ctia.migration.store-keys==malware,tool
+ctia.migration.store-keys=malware,tool
 ctia.migration.batch-size=100
 ctia.migration.buffer-size=3
 

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -24,7 +24,7 @@
 (defn es-store-impl-properties [prefix store]
   {(str prefix store ".host") s/Str
    (str prefix store ".port") s/Int
-   (str prefix store ".transport") s/Keyword
+   (str prefix store ".protocol") s/Keyword
    (str prefix store ".clustername") s/Str
    (str prefix store ".indexname") s/Str
    (str prefix store ".refresh") Refresh

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -30,7 +30,7 @@
   (st/optional-keys
    {:host s/Str
     :port s/Int
-    :protocol s/Keyword
+    :protocol (s/enum :http :https)
     :indexname s/Str
     :refresh Refresh
     :refresh_interval  s/Str

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -30,7 +30,7 @@
   (st/optional-keys
    {:host s/Str
     :port s/Int
-    :transport s/Keyword
+    :protocol s/Keyword
     :indexname s/Str
     :refresh Refresh
     :refresh_interval  s/Str

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -8,7 +8,7 @@
   (testing "Stores ES properties are generated according to given prefix and entity name."
     (is (= {"ctia.store.es.malware.host" s/Str
             "ctia.store.es.malware.port" s/Int
-            "ctia.store.es.malware.transport" s/Keyword
+            "ctia.store.es.malware.protocol" s/Keyword
             "ctia.store.es.malware.clustername" s/Str
             "ctia.store.es.malware.indexname" s/Str
             "ctia.store.es.malware.refresh" Refresh
@@ -24,7 +24,7 @@
 
     (is (= {"prefix.sighting.host" s/Str
             "prefix.sighting.port" s/Int
-            "prefix.sighting.transport" s/Keyword
+            "prefix.sighting.protocol" s/Keyword
             "prefix.sighting.clustername" s/Str
             "prefix.sighting.indexname" s/Str
             "prefix.sighting.refresh" Refresh

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -969,7 +969,7 @@
 (deftest target-store-properties-test
   (let [default-es-props {:host "localhost"
                           :port 9200
-                          :transport "http"
+                          :protocol "http"
                           :indexname "ctia_default"
                           :replicas 1
                           :refresh_interval "1s"
@@ -985,7 +985,7 @@
 
         migration-cluster-props {:host "es7.iroh.site"
                                  :port 443
-                                 :transport "https"}
+                                 :protocol "https"}
 
         target-store-props {:indexname "custom-target-indexname"
                             :shards 4

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -17,7 +17,8 @@
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.fixtures :as fixt]
             [ctia.test-helpers.migration :refer [app->MigrationStoreServices]]
-            [ctim.domain.id :refer [long-id->id]])
+            [ctim.domain.id :refer [long-id->id]]
+            [schema.test :refer [validate-schemas]])
   (:import [java.util UUID]))
 
 (deftest prefixed-index-test
@@ -245,7 +246,8 @@
   (join-fixtures [mth/fixture-schema-validation
                   whoami-helpers/fixture-server
                   whoami-helpers/fixture-reset-state
-                  es-helpers/fixture-properties:es-store]))
+                  es-helpers/fixture-properties:es-store
+                  validate-schemas]))
 
 (defn es-props [get-in-config]
   (get-in-config [:ctia :store :es]))
@@ -969,7 +971,7 @@
 (deftest target-store-properties-test
   (let [default-es-props {:host "localhost"
                           :port 9200
-                          :protocol "http"
+                          :protocol :http
                           :indexname "ctia_default"
                           :replicas 1
                           :refresh_interval "1s"
@@ -985,7 +987,7 @@
 
         migration-cluster-props {:host "es7.iroh.site"
                                  :port 443
-                                 :protocol "https"}
+                                 :protocol :https}
 
         target-store-props {:indexname "custom-target-indexname"
                             :shards 4


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #threatgrid/iroh/issues/4216
> Related #threatgrid/iroh/issues/3072

This PR fixes what I broke :-).
Ductile uses a parameter `protocol` instead of `transport` to precise the uri protocol in the ESConn.
I was not used in CTIA tests neither in any of our deployed instances that use the default value (`http`). Thus this bug did not appear when I introduced ductile. 


<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

