### PR TITLE
issue-1009: Add support for configurations in Vulnerability entity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -56,7 +56,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.0.20"]
+                 [threatgrid/ctim "1.0.21"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.1.0"]
 

--- a/src/ctia/entity/vulnerability/mapping.clj
+++ b/src/ctia/entity/vulnerability/mapping.clj
@@ -72,6 +72,28 @@
       :exploitability_score em/float-type
       :impact_score em/float-type}}}})
 
+(def cpe-match
+  {:properties
+   {:vulnerable em/boolean-type
+    :cpe23uri em/token
+    :versionStartIncluding em/token
+    :versionEndIncluding em/token
+    :versionStartExcluding em/token
+    :versionEndExcluding em/token}})
+
+(def configuration-node
+  {:properties
+   {:operator em/token
+    :children {:properties
+               {:operator em/token
+                :cpe_match cpe-match}}
+    :cpe_match cpe-match}})
+
+(def configurations
+  {:properties
+   {:CVE_data_version em/token
+    :nodes configuration-node}})
+
 (def vulnerability-mapping
   {"vulnerability"
    {:dynamic false
@@ -83,6 +105,7 @@
      em/stored-entity-mapping
      {:cve cve
       :impact impact
+      :configurations configurations
       :severity em/token
       :published_date em/ts
       :last_modified_date em/ts

--- a/test/data/vulnerability.graphql
+++ b/test/data/vulnerability.graphql
@@ -90,6 +90,9 @@ fragment vulnerabilityFields on Vulnerability {
   impact {
     ...impactFields
   }
+  configurations {
+    ...configurationFields
+  }
   published_date
   last_modified_date
   owner

--- a/test/data/vulnerability_fragments.graphql
+++ b/test/data/vulnerability_fragments.graphql
@@ -112,3 +112,29 @@ fragment impactFields on VulnerabilityImpact {
     ...cvssV3Fields
   }
 }
+
+fragment configurationFields on Configurations {
+  CVE_data_version
+  nodes {
+    operator
+    cpe_match {
+      vulnerable
+      cpe23Uri
+      versionStartIncluding
+      versionEndIncluding
+      versionStartExcluding
+      versionEndExcluding
+    }
+    children {
+      operator
+        cpe_match {
+        vulnerable
+        cpe23Uri
+        versionStartIncluding
+        versionEndIncluding
+        versionStartExcluding
+        versionEndExcluding
+      }
+    }
+  }
+}


### PR DESCRIPTION
> Close #1009 
> Related threatgrid/hydrant#361, threatgrid/ctim#302

Description - 
The National Vulnerability Database exposes configuration information for each vulnerability
it publishes. This configuration data specifies which systems and software are vulnerable to
the described entity. This PR is a continuation of the work done in CTIM to support importing
this data.

<a name="qa">[§](#qa)</a> QA
============================

Positive Case - 
Add the following vulnerability entity with a valid configuration section;
```
{
    "description": "drivers/net/usb/rtl8150.c in the Linux kernel 4.9.x before 4.9.11 interacts incorrectly with the CONFIG_VMAP_STACK option, which allows local users to cause a denial of service (system crash or memory corruption) or possibly have unspecified other impact by leveraging use of more than one virtual page for a DMA scatterlist.",
    "schema_version": "1.0.8",
    "published_date": "2017-04-23T05:59:00.000Z",
    "type": "vulnerability",
    "source": "National Vulnerability Database",
    "external_ids": [
      "hydrant-0f7500e428fce1bbc3edea55878a6de4c82cac7747fd828fc3397126e194f5e0"
    ],
    "title": "CVE-2017-8069",
    "source_uri": "https://nvd.nist.gov/",
    "language": "en",
    "id": "https://intel.amp.cisco.com:443/ctia/vulnerability/vulnerability-d50456c2-bd30-4c2a-b9e7-1f073a91b9b1",
    "tlp": "green",
    "groups": [
      "tenzin"
    ],
    "last_modified_date": "2017-04-27T18:13:00.000Z",
    "impact": {
      "cvss_v2": {
        "integrity_impact": "complete",
        "access_complexity": "low",
        "exploitability_score": 3.9,
        "impact_score": 10,
        "user_interaction_required": false,
        "obtain_other_privilege": false,
        "availability_impact": "complete",
        "access_vector": "local",
        "base_severity": "High",
        "confidentiality_impact": "complete",
        "authentication": "none",
        "base_score": 7.2,
        "obtain_user_privilege": false,
        "vector_string": "AV:L/AC:L/Au:N/C:C/I:C/A:C"
      },
      "cvss_v3": {
        "integrity_impact": "high",
        "user_interaction": "none",
        "privileges_required": "low",
        "exploitability_score": 1.8,
        "impact_score": 5.9,
        "availability_impact": "high",
        "scope": "unchanged",
        "base_severity": "high",
        "confidentiality_impact": "high",
        "base_score": 7.8,
        "vector_string": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
        "attack_vector": "local",
        "attack_complexity": "low"
      }
  },
    "configurations": {
        "CVE_data_version": "4.0",
        "nodes": [{
            "operator": "OR",
            "cpe_match": [
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.1:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.2:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.3:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.4:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.5:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.6:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.7:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.8:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.9:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:2.3:o:linux:linux_kernel:4.9.10:*:*:*:*:*:*:*"}
            ]}]},
    
    "owner": "Tenzin"
}
```

Negative Case - 
Add the following vulnerability with an invalid configuration section (incorrect cpe23Uri version in cpe_match strings)
```
{
    "description": "drivers/net/usb/rtl8150.c in the Linux kernel 4.9.x before 4.9.11 interacts incorrectly with the CONFIG_VMAP_STACK option, which allows local users to cause a denial of service (system crash or memory corruption) or possibly have unspecified other impact by leveraging use of more than one virtual page for a DMA scatterlist.",
    "schema_version": "1.0.8",
    "published_date": "2017-04-23T05:59:00.000Z",
    "type": "vulnerability",
    "source": "National Vulnerability Database",
    "external_ids": [
      "hydrant-0f7500e428fce1bbc3edea55878a6de4c82cac7747fd828fc3397126e194f5e0"
    ],
    "title": "CVE-2017-8069",
    "source_uri": "https://nvd.nist.gov/",
    "language": "en",
    "id": "https://intel.amp.cisco.com:443/ctia/vulnerability/vulnerability-d50456c2-bd30-4c2a-b9e7-1f073a91b9b1",
    "tlp": "green",
    "groups": [
      "tenzin"
    ],
    "last_modified_date": "2017-04-27T18:13:00.000Z",
    "impact": {
      "cvss_v2": {
        "integrity_impact": "complete",
        "access_complexity": "low",
        "exploitability_score": 3.9,
        "impact_score": 10,
        "user_interaction_required": false,
        "obtain_other_privilege": false,
        "availability_impact": "complete",
        "access_vector": "local",
        "base_severity": "High",
        "confidentiality_impact": "complete",
        "authentication": "none",
        "base_score": 7.2,
        "obtain_user_privilege": false,
        "vector_string": "AV:L/AC:L/Au:N/C:C/I:C/A:C"
      },
      "cvss_v3": {
        "integrity_impact": "high",
        "user_interaction": "none",
        "privileges_required": "low",
        "exploitability_score": 1.8,
        "impact_score": 5.9,
        "availability_impact": "high",
        "scope": "unchanged",
        "base_severity": "high",
        "confidentiality_impact": "high",
        "base_score": 7.8,
        "vector_string": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
        "attack_vector": "local",
        "attack_complexity": "low"
      }
  },
    "configurations": {
        "CVE_data_version": "4.0",
        "nodes": [{
            "operator": "OR",
            "cpe_match": [
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.1:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.2:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.3:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.4:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.5:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.6:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.7:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.8:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.9:*:*:*:*:*:*:*"},
                {"vulnerable": true,
                 "cpe23Uri": "cpe:3.3:o:linux:linux_kernel:4.9.10:*:*:*:*:*:*:*"}
            ]}]},
    
    "owner": "Tenzin"
}
```

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: CTIA now supports configurations data in Vulnerabilities entities.
public: CTIA now supports configurations data in Vulnerabilities entities.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

