### PR TITLE
Better isolate fake whoami service

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -144,12 +144,12 @@ Rate limit related configuration
    Configure how CTIA is hosted,
    setting those values correctly is mandatory as it defines how entity ids are generated.
 
-| Property                   | Description                                            | Possible values |
-|----------------------------+--------------------------------------------------------+-----------------|
-| ctia.http.show.protocol    | is this instance hosted through http or https          | =http= =https=  |
-| ctia.http.show.hostname    | set the hostname used to access this instance          | string          |
-| ctia.http.show.path-prefix | set a path prefix if CTIA is not exposed at /          | string          |
-| ctia.http.show.port        | set the exposed http port. if 0, defaults to HTTP port | number          |
+| Property                   | Description                                   | Possible values |
+|----------------------------+-----------------------------------------------+-----------------|
+| ctia.http.show.protocol    | is this instance hosted through http or https | =http= =https=  |
+| ctia.http.show.hostname    | set the hostname used to access this instance | string          |
+| ctia.http.show.path-prefix | set a path prefix if CTIA is not exposed at / | string          |
+| ctia.http.show.port        | set the exposed http port                     | number          |
 
 
 *** Swagger

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -144,12 +144,12 @@ Rate limit related configuration
    Configure how CTIA is hosted,
    setting those values correctly is mandatory as it defines how entity ids are generated.
 
-| Property                   | Description                                   | Possible values |
-|----------------------------+-----------------------------------------------+-----------------|
-| ctia.http.show.protocol    | is this instance hosted through http or https | =http= =https=  |
-| ctia.http.show.hostname    | set the hostname used to access this instance | string          |
-| ctia.http.show.path-prefix | set a path prefix if CTIA is not exposed at / | string          |
-| ctia.http.show.port        | set the exposed http port                     | number          |
+| Property                   | Description                                            | Possible values |
+|----------------------------+--------------------------------------------------------+-----------------|
+| ctia.http.show.protocol    | is this instance hosted through http or https          | =http= =https=  |
+| ctia.http.show.hostname    | set the hostname used to access this instance          | string          |
+| ctia.http.show.path-prefix | set a path prefix if CTIA is not exposed at /          | string          |
+| ctia.http.show.port        | set the exposed http port. if 0, defaults to HTTP port | number          |
 
 
 *** Swagger

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -57,12 +57,11 @@
   (read-store :identity store/read-identity login))
 
 (defprotocol ThreatgridAuthWhoAmIURLService
-  (get-whoami-url [this]))
+  (get-whoami-url [this] "Return the current WhoAmI URL"))
 
 (tk/defservice threatgrid-auth-whoami-url-service
   ThreatgridAuthWhoAmIURLService
   [[:ConfigService get-in-config]]
-  ;; TODO unit test
   (get-whoami-url [_] (get-in-config [:ctia :auth :threatgrid :whoami-url])))
 
 (tk/defservice threatgrid-auth-service

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -62,6 +62,7 @@
 (tk/defservice threatgrid-auth-whoami-url-service
   ThreatgridAuthWhoAmIURLService
   [[:ConfigService get-in-config]]
+  ;; TODO unit test
   (get-whoami-url [_] (get-in-config [:ctia :auth :threatgrid :whoami-url])))
 
 (tk/defservice threatgrid-auth-service

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -68,7 +68,7 @@
                              :requested-service type}))))]
     (merge-with
       (fn [l r]
-        (throw (ex-info "Conflict!" {:left l :right r})))
+        (throw (ex-info "Service graph conflict!" {:left l :right r})))
       auth-svc
       encryption-svc
       {:EventsService events-svc/events-service

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -51,8 +51,8 @@
         auth-svc
         (case auth-service-type
           :allow-all {:IAuth allow-all/allow-all-auth-service}
-          :threatgrid {:IAuth threatgrid/threatgrid-auth-whoami-url-service
-                       :ThreatgridAuthWhoAmIURLService threatgrid/threatgrid-auth-service}
+          :threatgrid {:IAuth threatgrid/threatgrid-auth-service
+                       :ThreatgridAuthWhoAmIURLService threatgrid/threatgrid-auth-whoami-url-service}
           :static {:IAuth static-auth/static-auth-service}
           (throw (ex-info "Auth service not configured"
                           {:message "Unknown service"

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -37,15 +37,22 @@
               (do (newline)
                   (utils/safe-pprint config)))))
 
-(defn default-services
-  "Returns the default collection of CTIA services based on provided properties."
+(s/defn default-services-map
+  :- {(s/constrained s/Keyword simple-keyword?)
+      ;; could be (s/protocol puppetlabs.trapperkeeper.services/ServiceDefinition),
+      ;; but trapperkeeper claims the protocol is internal only
+      (s/pred some?)}
+  "Returns the default map of CTIA services based on provided properties.
+  Keys are the unqualified keyword names of each service protocol, values are
+  the defservice instances."
   [config]
   (let [{auth-service-type :type} (get-in config [:ctia :auth])
         auth-svc
         (case auth-service-type
-          :allow-all allow-all/allow-all-auth-service
-          :threatgrid threatgrid/threatgrid-auth-service
-          :static static-auth/static-auth-service
+          :allow-all {:IAuth allow-all/allow-all-auth-service}
+          :threatgrid {:IAuth threatgrid/threatgrid-auth-whoami-url-service
+                       :ThreatgridAuthWhoAmIURLService threatgrid/threatgrid-auth-service}
+          :static {:IAuth static-auth/static-auth-service}
           (throw (ex-info "Auth service not configured"
                           {:message "Unknown service"
                            :requested-service auth-service-type})))
@@ -53,25 +60,27 @@
         (let [{:keys [type] :as encryption-properties}
               (get-in config [:ctia :encryption])]
           (case type
-            :default encryption-default/default-encryption-service
+            :default {:IEncryption encryption-default/default-encryption-service}
             (throw (ex-info "Encryption service not configured"
                             {:message "Unknown service"
                              :requested-service type}))))]
-    (into
-      [auth-svc
-       encryption-svc
-       events-svc/events-service
-       store-svc/store-service
-       http-server-svc/ctia-http-server-service
-       hooks-svc/hooks-service
-       graphql-svc/graphql-service
-       graphql-registry-svc/graphql-named-type-registry-service
-       riemann/riemann-metrics-service
-       jmx/jmx-metrics-service
-       console/console-metrics-service]
+    (merge-with
+      (fn [l r]
+        (throw (ex-info "Conflict!" {:left l :right r})))
+      auth-svc
+      encryption-svc
+      {:EventsService events-svc/events-service
+       :StoreService store-svc/store-service
+       :CTIAHTTPServerService http-server-svc/ctia-http-server-service
+       :HooksService hooks-svc/hooks-service
+       :GraphQLService graphql-svc/graphql-service
+       :GraphQLNamedTypeRegistryService graphql-registry-svc/graphql-named-type-registry-service
+       :RiemannMetricsService riemann/riemann-metrics-service
+       :JMXMetricsService jmx/jmx-metrics-service
+       :ConsoleMetricsService console/console-metrics-service}
       ;; register event file logging only when enabled
       (when (get-in config [:ctia :events :log])
-        [event-logging/event-logging-service]))))
+        {:EventLoggingService event-logging/event-logging-service}))))
 
 (defn start-ctia!*
   "Lower-level Trapperkeeper booting function for
@@ -89,6 +98,7 @@
             (version/current-version))
 
   ;; trapperkeeper init
-  (let [config (p/build-init-config)]
-    (start-ctia!* {:services (default-services config)
+  (let [config (p/build-init-config)
+        services-map (default-services config)]
+    (start-ctia!* {:services (vals services-map)
                    :config config})))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -23,7 +23,8 @@
    [ctia.graphql-named-type-registry-service :as graphql-registry-svc]
    [ctia.flows.hooks-service :as hooks-svc]
    [ctia.http.server-service :as http-server-svc]
-   [puppetlabs.trapperkeeper.core :as tk]))
+   [puppetlabs.trapperkeeper.core :as tk]
+   [schema.core :as s]))
 
 (defn log-properties
   [config]
@@ -99,6 +100,6 @@
 
   ;; trapperkeeper init
   (let [config (p/build-init-config)
-        services-map (default-services config)]
+        services-map (default-services-map config)]
     (start-ctia!* {:services (vals services-map)
                    :config config})))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -105,5 +105,5 @@
    (let [config (or config
                     (p/build-init-config))]
      (start-ctia!* {:services (or services
-                                  (vals (default-services config)))
+                                  (vals (default-services-map config)))
                     :config config}))))

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -104,7 +104,6 @@
    ;; trapperkeeper init
    (let [config (or config
                     (p/build-init-config))]
-     (start-ctia!* {:services (vals
-                                (or services-map
-                                    (default-services config)))
+     (start-ctia!* {:services (or services
+                                  (vals (default-services config)))
                     :config config}))))

--- a/test/ctia/auth/threatgrid_test.clj
+++ b/test/ctia/auth/threatgrid_test.clj
@@ -1,21 +1,21 @@
 (ns ctia.auth.threatgrid-test
   (:require [ctia.auth.threatgrid :as sut]
-            [ctia.store-service-test :refer [store-services]]
+            [ctia.store-service-test :refer [store-service-map]]
             [clojure.test :refer [deftest is testing]]
             [puppetlabs.trapperkeeper.app :as app]
             [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]])
   (:import [java.util UUID]))
 
-(defn threatgrid-auth-whoami-url-services
+(defn threatgrid-auth-whoami-url-service-map
   "Service map for #'sut/threatgrid-auth-whoami-url-service"
   []
   {:ThreatgridAuthWhoAmIURLService sut/threatgrid-auth-whoami-url-service})
 
-(defn threatgrid-auth-services
+(defn threatgrid-auth-service-map
   "Service map for #'sut/threatgrid-auth-service"
   []
-  (merge (threatgrid-auth-whoami-url-services)
-         (store-services)
+  (merge (threatgrid-auth-whoami-url-service-map)
+         (store-service-map)
          {:IAuth sut/threatgrid-auth-service}))
 
 (deftest threatgrid-auth-whoami-url-service-test
@@ -23,7 +23,7 @@
                       (repeatedly 10
                                   #(str "https://cisco.com/" (UUID/randomUUID))))
                 (assert "Must define cases"))
-          :let [services (vals (threatgrid-auth-whoami-url-services))]]
+          :let [services (vals (threatgrid-auth-whoami-url-service-map))]]
     (testing ":whoami-url configuration corresponds to (get-whoami-url)"
       (with-app-with-config app services
         {:ctia {:auth {:threatgrid {:whoami-url url}}}}

--- a/test/ctia/auth/threatgrid_test.clj
+++ b/test/ctia/auth/threatgrid_test.clj
@@ -23,10 +23,7 @@
                       (repeatedly 10
                                   #(str "https://cisco.com/" (UUID/randomUUID))))
                 (assert "Must define cases"))
-          services (doto (not-empty
-                           (map vals [(threatgrid-auth-whoami-url-services)
-                                      (threatgrid-auth-services)]))
-                     (assert "Must define cases"))]
+          :let [services (vals (threatgrid-auth-whoami-url-services))]]
     (testing ":whoami-url configuration corresponds to (get-whoami-url)"
       (with-app-with-config app services
         {:ctia {:auth {:threatgrid {:whoami-url url}}}}

--- a/test/ctia/auth/threatgrid_test.clj
+++ b/test/ctia/auth/threatgrid_test.clj
@@ -1,0 +1,35 @@
+(ns ctia.auth.threatgrid-test
+  (:require [ctia.auth.threatgrid :as sut]
+            [ctia.store-service-test :refer [store-services]]
+            [clojure.test :refer [deftest is testing]]
+            [puppetlabs.trapperkeeper.app :as app]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]])
+  (:import [java.util UUID]))
+
+(defn threatgrid-auth-whoami-url-services
+  "Service map for #'sut/threatgrid-auth-whoami-url-service"
+  []
+  {:ThreatgridAuthWhoAmIURLService sut/threatgrid-auth-whoami-url-service})
+
+(defn threatgrid-auth-services
+  "Service map for #'sut/threatgrid-auth-service"
+  []
+  (merge (threatgrid-auth-whoami-url-services)
+         (store-services)
+         {:IAuth sut/threatgrid-auth-service}))
+
+(deftest threatgrid-auth-whoami-url-service-test
+  (doseq [url (doto (not-empty
+                      (repeatedly 10
+                                  #(str "https://cisco.com/" (UUID/randomUUID))))
+                (assert "Must define cases"))
+          services (doto (not-empty
+                           (map vals [(threatgrid-auth-whoami-url-services)
+                                      (threatgrid-auth-services)]))
+                     (assert "Must define cases"))]
+    (testing ":whoami-url configuration corresponds to (get-whoami-url)"
+      (with-app-with-config app services
+        {:ctia {:auth {:threatgrid {:whoami-url url}}}}
+        (let [{{:keys [get-whoami-url]} :ThreatgridAuthWhoAmIURLService} (app/service-graph app)]
+          (is (= (get-whoami-url)
+                 url)))))))

--- a/test/ctia/auth/threatgrid_test.clj
+++ b/test/ctia/auth/threatgrid_test.clj
@@ -19,10 +19,8 @@
          {:IAuth sut/threatgrid-auth-service}))
 
 (deftest threatgrid-auth-whoami-url-service-test
-  (doseq [url (doto (not-empty
-                      (repeatedly 10
-                                  #(str "https://cisco.com/" (UUID/randomUUID))))
-                (assert "Must define cases"))
+  (doseq [url (repeatedly 10
+                          #(str "https://cisco.com/" (UUID/randomUUID)))
           :let [services (vals (threatgrid-auth-whoami-url-service-map))]]
     (testing ":whoami-url configuration corresponds to (get-whoami-url)"
       (with-app-with-config app services

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -33,8 +33,6 @@
                                     fixture-properties:small-max-bulk-size
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn mk-new-actor [n]
   {:id (str "transient:actor-" n)
    :title (str "actor-" n)

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -200,10 +200,11 @@
        (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
 
              _ (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-             _ (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
-                                                 "foouser"
-                                                 "foogroup"
-                                                 "user")
+             _ (whoami-helpers/set-whoami-response app
+                                                   "45c1f5e3f05d0"
+                                                   "foouser"
+                                                   "foogroup"
+                                                   "user")
 
              default-es-refresh (->> (get-in-config
                                        [:ctia :store :es :default :refresh])
@@ -257,7 +258,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -341,7 +343,8 @@
    (fn [app]
     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -416,7 +419,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -459,7 +463,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -495,7 +500,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -37,9 +37,6 @@
     fixture-find-by-external-ids-limit
     whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (defn mk-sighting
   [n]
   {:id (id/make-transient-id nil)

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -209,7 +209,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -421,7 +422,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -458,7 +460,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -504,7 +507,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -572,7 +576,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -671,7 +676,8 @@
     (test-for-each-store-with-app
      (fn [app]
        (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-       (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+       (whoami-helpers/set-whoami-response app
+                                           "45c1f5e3f05d0"
                                            "foouser"
                                            "foogroup"
                                            "user")
@@ -771,7 +777,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -796,7 +803,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -963,7 +971,8 @@
    (test-for-each-store-with-app
     (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -987,7 +996,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -1022,7 +1032,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -20,9 +20,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-actor-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -31,7 +31,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -45,7 +46,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -65,7 +65,7 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
       {:app                app
        :entity             "asset-mapping"
@@ -84,7 +84,8 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -20,8 +20,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn additional-tests [app {:keys [short-id]} asset-mapping-sample]
   (testing "GET /ctia/asset-mapping/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -19,8 +19,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn additional-tests [app {:keys [short-id]} asset-properties-sample]
   (testing "GET /ctia/asset-properties/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -69,7 +69,7 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
       {:app                app
        :entity             "asset-properties"
@@ -88,7 +88,8 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -17,8 +17,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn additional-tests [app asset-id asset-sample]
   (testing "GET /ctia/asset/search"
     (do

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -38,7 +38,7 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
       {:app              app
        :entity           "asset"
@@ -54,7 +54,8 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -21,9 +21,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-attack-pattern-crud-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -32,7 +32,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -48,7 +49,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -19,8 +19,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-campaign-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/campaign_test.clj
+++ b/test/ctia/entity/campaign_test.clj
@@ -25,7 +25,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -39,7 +40,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -321,9 +321,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-casebook-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -332,7 +332,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -348,7 +349,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -19,8 +19,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-coa-crud-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -25,7 +25,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -38,7 +39,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/data_table_test.clj
+++ b/test/ctia/entity/data_table_test.clj
@@ -35,7 +35,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/data_table_test.clj
+++ b/test/ctia/entity/data_table_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def new-data-table
   {:type "data-table"
    :row_count 1

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -40,7 +40,8 @@
                                 ["group1"]
                                 "user1"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "user1"
+     (whoami-helpers/set-whoami-response app
+                                         "user1"
                                          "user1"
                                          "group1"
                                          "user1")
@@ -50,7 +51,8 @@
                                 ["group1"]
                                 "user2"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "user2"
+     (whoami-helpers/set-whoami-response app
+                                         "user2"
                                          "user2"
                                          "group1"
                                          "user2")
@@ -60,7 +62,8 @@
                                 ["group2"]
                                 "user3"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "user3"
+     (whoami-helpers/set-whoami-response app
+                                         "user3"
                                          "user3"
                                          "group2"
                                          "user3")
@@ -407,7 +410,8 @@
                                 ["group1"]
                                 "user1"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "user1"
+     (whoami-helpers/set-whoami-response app
+                                         "user1"
                                          "user1"
                                          "group1"
                                          "user1")

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -29,9 +29,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-event-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -133,9 +133,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (defn feed-view-tests [app feed-id feed]
   (testing "GET /ctia/feed/:id/view?s=:secret"
     (let [feed-view-url-txt (:feed_view_url feed)

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -212,7 +212,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -246,7 +247,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -44,12 +44,14 @@
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
      (helpers/set-capabilities! app "baruser" ["bargroup"] "user" #{})
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
 
-     (whoami-helpers/set-whoami-response "2222222222222"
+     (whoami-helpers/set-whoami-response app
+                                         "2222222222222"
                                          "baruser"
                                          "bargroup"
                                          "user")

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -37,8 +37,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-feedback-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -22,8 +22,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def new-identity-assertion
   (-> new-identity-assertion-maximal
       (dissoc :id)

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -69,7 +69,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response api-key
+     (whoami-helpers/set-whoami-response app
+                                         api-key
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -88,7 +89,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -85,7 +85,7 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
      (let [parameters {:app app
                        :entity "incident"
                        :patch-tests? true
@@ -104,7 +104,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -24,8 +24,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn partial-operations-tests [app incident-id incident]
   (let [fixed-now (t/internal-now)]
     (helpers/fixture-with-fixed-time

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -18,9 +18,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
-
 (defn search-tests [app _ indicator-sample]
   (testing "GET /ctia/indicator/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -58,7 +58,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" caps/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -21,9 +21,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-investigation-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/investigation_test.clj
+++ b/test/ctia/entity/investigation_test.clj
@@ -28,7 +28,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -45,7 +46,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -152,11 +152,13 @@
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroupi"] "user" all-capabilities)
      (helpers/set-capabilities! app "baruser"  ["bargroup"] "user" #{})
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
-     (whoami-helpers/set-whoami-response "2222222222222"
+     (whoami-helpers/set-whoami-response app
+                                         "2222222222222"
                                          "baruser"
                                          "bargroup"
                                          "user")
@@ -182,7 +184,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -354,7 +357,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -29,8 +29,6 @@
                                     helpers/fixture-properties:cors
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def new-judgement
   (merge ex/new-judgement-maximal
          {:observable {:value "1.2.3.4"

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -32,7 +32,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -50,7 +51,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/malware_test.clj
+++ b/test/ctia/entity/malware_test.clj
@@ -21,9 +21,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-malware-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -31,7 +31,8 @@
 
 (defn establish-user! [app]
   (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-  (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+  (whoami-helpers/set-whoami-response app
+                                      "45c1f5e3f05d0"
                                       "foouser"
                                       "foogroup"
                                       "user"))

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -27,8 +27,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn establish-user! [app]
   (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
   (whoami-helpers/set-whoami-response app

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -42,7 +42,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response api-key
+     (whoami-helpers/set-whoami-response app
+                                         api-key
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -62,7 +63,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -27,8 +27,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def new-sighting
   (-> new-sighting-maximal
       (dissoc :id)

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -18,8 +18,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (defn additional-tests [app _ target-record-sample]
   (testing "GET /ctia/target-record/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -57,7 +57,7 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response http/api-key "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
       {:app              app
        :entity           "target-record"
@@ -73,7 +73,8 @@
   (store/test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -22,9 +22,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-tool-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -33,7 +33,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -49,7 +50,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -20,9 +20,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-vulnerability-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/vulnerability_test.clj
+++ b/test/ctia/entity/vulnerability_test.clj
@@ -31,7 +31,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -45,7 +46,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -20,9 +20,6 @@
                   helpers/fixture-properties:clean
                   whoami-helpers/fixture-server]))
 
-(use-fixtures :each
-  whoami-helpers/fixture-reset-state)
-
 (deftest test-weakness-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/entity/weakness_test.clj
+++ b/test/ctia/entity/weakness_test.clj
@@ -31,7 +31,8 @@
                                 ["foogroup"]
                                 "user"
                                 all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -45,7 +46,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -24,8 +24,7 @@
 
 (use-fixtures :each (join-fixtures [helpers/fixture-properties:clean
                                     helpers/fixture-properties:cors
-                                    whoami-helpers/fixture-server
-                                    whoami-helpers/fixture-reset-state]))
+                                    whoami-helpers/fixture-server]))
 
 (def new-judgement-1
   {:observable {:value "1.2.3.4"

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -54,8 +54,8 @@
       (fn [app]
         (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
         (helpers/set-capabilities! app "baruser" ["bargroup"] "user" #{})
-        (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-        (whoami-helpers/set-whoami-response "2222222222222" "baruser" "bargroup" "user")
+        (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
+        (whoami-helpers/set-whoami-response app "2222222222222" "baruser" "bargroup" "user")
         (testing "Headers"
           (let [{judgement :parsed-body
                  status :status
@@ -161,8 +161,8 @@
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
      (helpers/set-capabilities! app "baruser" ["bargroup"] "user" #{})
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (whoami-helpers/set-whoami-response "2222222222222" "baruser" "bargroup" "user")
+     (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
+     (whoami-helpers/set-whoami-response app "2222222222222" "baruser" "bargroup" "user")
 
      (testing "POST /ctia/judgement"
        (let [{judgement :parsed-body

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -13,8 +13,7 @@
                                     es-helpers/fixture-properties:es-store
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each (join-fixtures [whoami-helpers/fixture-reset-state
-                                    helpers/fixture-ctia]))
+(use-fixtures :each helpers/fixture-ctia)
 
 (defn get-actor [app actor-id headers]
   (select-keys (GET app

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -26,7 +26,8 @@
   (testing "Cache control with ETags"
     (let [app (helpers/get-current-app)
           _ (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-          _ (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+          _ (whoami-helpers/set-whoami-response app
+                                                "45c1f5e3f05d0"
                                                 "foouser"
                                                 "foogroup"
                                                 "user")

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -74,7 +74,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def external-ref "http://external.com/ctia/attack-pattern/attack-pattern-ab053333-2ad2-41d0-a445-31e9b9c38caf")
 
 (def ownership-data-fixture

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -70,7 +70,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql/investigation_test.clj
+++ b/test/ctia/http/routes/graphql/investigation_test.clj
@@ -34,7 +34,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/investigation_test.clj
+++ b/test/ctia/http/routes/graphql/investigation_test.clj
@@ -14,8 +14,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql/malware_test.clj
+++ b/test/ctia/http/routes/graphql/malware_test.clj
@@ -63,7 +63,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/malware_test.clj
+++ b/test/ctia/http/routes/graphql/malware_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql/tool_test.clj
+++ b/test/ctia/http/routes/graphql/tool_test.clj
@@ -62,7 +62,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/tool_test.clj
+++ b/test/ctia/http/routes/graphql/tool_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql/vulnerability_test.clj
+++ b/test/ctia/http/routes/graphql/vulnerability_test.clj
@@ -66,7 +66,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/vulnerability_test.clj
+++ b/test/ctia/http/routes/graphql/vulnerability_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql/weakness_test.clj
+++ b/test/ctia/http/routes/graphql/weakness_test.clj
@@ -62,7 +62,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/graphql/weakness_test.clj
+++ b/test/ctia/http/routes/graphql/weakness_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:owner "foouser"
    :groups ["foogroup"]})

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (def ownership-data-fixture
   {:groups ["foogroup"]
    :owner "foouser"})

--- a/test/ctia/http/routes/graphql_test.clj
+++ b/test/ctia/http/routes/graphql_test.clj
@@ -240,12 +240,13 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
      (helpers/set-capabilities! app "baruser" ["bargroup"] "user" #{})
-     (whoami-helpers/set-whoami-response "2222222222222" "baruser" "bargroup" "user")
+     (whoami-helpers/set-whoami-response app "2222222222222" "baruser" "bargroup" "user")
 
      (let [datamap (initialize-graphql-data app)
            indicator-1-id (get-in datamap [:indicator-1 :id])

--- a/test/ctia/http/routes/observable/judgements_indicators_test.clj
+++ b/test/ctia/http/routes/observable/judgements_indicators_test.clj
@@ -18,7 +18,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/observable/judgements_test.clj
+++ b/test/ctia/http/routes/observable/judgements_test.clj
@@ -19,7 +19,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/observable/judgements_test.clj
+++ b/test/ctia/http/routes/observable/judgements_test.clj
@@ -13,8 +13,6 @@
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-observable-judgements-route
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/http/routes/observable/sightings_incidents_test.clj
+++ b/test/ctia/http/routes/observable/sightings_incidents_test.clj
@@ -18,7 +18,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/observable/sightings_indicators_test.clj
+++ b/test/ctia/http/routes/observable/sightings_indicators_test.clj
@@ -18,7 +18,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/observable/sightings_test.clj
+++ b/test/ctia/http/routes/observable/sightings_test.clj
@@ -12,8 +12,6 @@
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-sightings-route
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/http/routes/observable/sightings_test.clj
+++ b/test/ctia/http/routes/observable/sightings_test.clj
@@ -18,7 +18,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -17,8 +17,6 @@
                                     helpers/fixture-properties:events-enabled
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-observable-verdict-route
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -23,7 +23,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -139,7 +140,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -209,7 +211,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -315,7 +318,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")
@@ -489,17 +493,20 @@
      (helpers/set-capabilities! app "baruser" ["bargroup"] "user" all-capabilities)
      (helpers/set-capabilities! app "foobaruser" ["bargroup"] "user" all-capabilities)
 
-     (whoami-helpers/set-whoami-response "foouser"
+     (whoami-helpers/set-whoami-response app
+                                         "foouser"
                                          "foouser"
                                          "foogroup"
                                          "user")
 
-     (whoami-helpers/set-whoami-response "baruser"
+     (whoami-helpers/set-whoami-response app
+                                         "baruser"
                                          "baruser"
                                          "bargroup"
                                          "user")
 
-     (whoami-helpers/set-whoami-response "foobaruser"
+     (whoami-helpers/set-whoami-response app
+                                         "foobaruser"
                                          "foobaruser"
                                          "bargroup"
                                          "user")

--- a/test/ctia/http/routes/status_test.clj
+++ b/test/ctia/http/routes/status_test.clj
@@ -11,8 +11,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-status-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/http/routes/status_test.clj
+++ b/test/ctia/http/routes/status_test.clj
@@ -17,7 +17,8 @@
   (test-for-each-store-with-app
    (fn [app]
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
                                          "foouser"
                                          "foogroup"
                                          "user")

--- a/test/ctia/http/routes/version_test.clj
+++ b/test/ctia/http/routes/version_test.clj
@@ -11,8 +11,6 @@
                                     helpers/fixture-properties:clean
                                     whoami-helpers/fixture-server]))
 
-(use-fixtures :each whoami-helpers/fixture-reset-state)
-
 (deftest test-version-routes
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/store_service_test.clj
+++ b/test/ctia/store_service_test.clj
@@ -1,0 +1,7 @@
+(ns ctia.store-service-test
+  (:require [ctia.store-service :as sut]))
+
+(defn store-services
+  "Service map for #'sut/store-service"
+  []
+  {:StoreService sut/store-service})

--- a/test/ctia/store_service_test.clj
+++ b/test/ctia/store_service_test.clj
@@ -1,7 +1,7 @@
 (ns ctia.store-service-test
   (:require [ctia.store-service :as sut]))
 
-(defn store-services
+(defn store-service-map
   "Service map for #'sut/store-service"
   []
   {:StoreService sut/store-service})

--- a/test/ctia/task/check_es_stores_test.clj
+++ b/test/ctia/task/check_es_stores_test.clj
@@ -40,8 +40,7 @@
                   whoami-helpers/fixture-server]))
 
 (use-fixtures :each
-  (join-fixtures [whoami-helpers/fixture-reset-state
-                  helpers/fixture-ctia
+  (join-fixtures [helpers/fixture-ctia
                   es-helpers/fixture-delete-store-indexes]))
 
 (def fixtures-nb 100)

--- a/test/ctia/task/check_es_stores_test.clj
+++ b/test/ctia/task/check_es_stores_test.clj
@@ -87,7 +87,8 @@
                                      ["foogroup"]
                                      "user"
                                      all-capabilities)
-        _ (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+        _ (whoami-helpers/set-whoami-response app
+                                              "45c1f5e3f05d0"
                                               "foouser"
                                               "foogroup"
                                               "user")

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -45,7 +45,6 @@
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
                   whoami-helpers/fixture-server
-                  whoami-helpers/fixture-reset-state
                   helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -215,7 +215,8 @@
                                  ["foogroup"]
                                  "user"
                                  all-capabilities)
-      (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+      (whoami-helpers/set-whoami-response app
+                                          "45c1f5e3f05d0"
                                           "foouser"
                                           "foogroup"
                                           "user")
@@ -524,7 +525,8 @@
                                  ["foogroup"]
                                  "user"
                                  all-capabilities)
-      (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+      (whoami-helpers/set-whoami-response app
+                                          "45c1f5e3f05d0"
                                           "foouser"
                                           "foogroup"
                                           "user")
@@ -575,7 +577,8 @@
                                ["foogroup"]
                                "user"
                                all-capabilities)
-    (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+    (whoami-helpers/set-whoami-response app
+                                        "45c1f5e3f05d0"
                                         "foouser"
                                         "foogroup"
                                         "user")

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -243,7 +243,6 @@
 
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
-                  whoami-helpers/fixture-server
                   es-helpers/fixture-properties:es-store]))
 
 (defn es-props [get-in-config]
@@ -266,9 +265,7 @@
           (ductile.index/delete! (str (migration-index get-in-config) "*")))))))
 
 (use-fixtures :each
-  (join-fixtures [#(helpers/with-properties
-                     ["ctia.auth.type" "allow-all"]
-                     (helpers/fixture-ctia %))
+  (join-fixtures [helpers/fixture-ctia
                   es-helpers/fixture-delete-store-indexes
                   fixture-clean-migration]))
 
@@ -812,11 +809,6 @@
         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
         services (app->MigrationStoreServices app)
 
-        _ (whoami-helpers/set-whoami-response app
-                                              "45c1f5e3f05d0"
-                                              "foouser"
-                                              "foogroup"
-                                              "user")
         _ (POST-bulk app examples)
         _ (ductile.index/refresh! (es-conn get-in-config)) ;; ensure indices refresh
         [sighting1 sighting2] (:parsed-body (GET app

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -244,7 +244,6 @@
 (use-fixtures :once
   (join-fixtures [mth/fixture-schema-validation
                   whoami-helpers/fixture-server
-                  whoami-helpers/fixture-reset-state
                   helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -812,7 +812,8 @@
         {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
         services (app->MigrationStoreServices app)
 
-        _ (whoami-helpers/set-whoami-response "45c1f5e3f05d0"
+        _ (whoami-helpers/set-whoami-response app
+                                              "45c1f5e3f05d0"
                                               "foouser"
                                               "foogroup"
                                               "user")

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -11,7 +11,6 @@
 
 (use-fixtures :once
   (join-fixtures [whoami-helpers/fixture-server
-                  whoami-helpers/fixture-reset-state
                   helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 

--- a/test/ctia/task/update_mapping_test.clj
+++ b/test/ctia/task/update_mapping_test.clj
@@ -18,7 +18,6 @@
 
 (use-fixtures :once
   (join-fixtures [whoami-helpers/fixture-server
-                  whoami-helpers/fixture-reset-state
                   helpers/fixture-properties:clean
                   es-helpers/fixture-properties:es-store]))
 

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -1085,15 +1085,18 @@
                                                                       "user"
                                                                       all-capabilities)
 
-                                           (whoami-helpers/set-whoami-response "player-1-token"
+                                           (whoami-helpers/set-whoami-response app
+                                                                               "player-1-token"
                                                                                "player1"
                                                                                "foogroup"
                                                                                "user")
-                                           (whoami-helpers/set-whoami-response "player-2-token"
+                                           (whoami-helpers/set-whoami-response app
+                                                                               "player-2-token"
                                                                                "player2"
                                                                                "bargroup"
                                                                                "user")
-                                           (whoami-helpers/set-whoami-response "player-3-token"
+                                           (whoami-helpers/set-whoami-response app
+                                                                               "player-3-token"
                                                                                "player3"
                                                                                "bargroup"
                                                                                "user"))]

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -267,7 +267,7 @@
       #{:es-store}
       (fn [app]
         (let [_ (helpers.core/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-              _ (helpers.whoami/set-whoami-response "45c1f5e3f05d0" "foouser" "foogroup" "user")
+              _ (helpers.whoami/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
               docs (generate-n-entity metric-params 100)]
           (with-redefs [;; ensure from coercion in proper one year range
                         now (-> (tc/from-string "2020-12-31")

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -252,11 +252,14 @@
              services-map (let [services-map (init/default-services-map config)]
                             (cond-> services-map
                               (:ThreatgridAuthWhoAmIURLService services-map)
+                              ;; dynamic requires can be removed when #'with-properties is phased out or moved
                               (assoc
                                 :ThreatgridAuthWhoAmIURLService
-                                ;; dynamic require can be removed when #'with-properties is phased out
                                 @(requiring-resolve 
-                                   'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service))))
+                                   'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service)
+                                :IFakeWhoAmIServer
+                                @(requiring-resolve 
+                                   'ctia.test-helpers.fake-whoami-service/fake-whoami-service))))
              app (init/start-ctia!*
                    {:services (vals services-map)
                     :config config})]

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -249,17 +249,16 @@
                        "ctia.http.port" http-port
                        "ctia.http.show.port" http-port]
        (let [config (build-transformed-init-config)
-             services-map (let [services-map (init/default-services-map config)]
-                            (cond-> services-map
-                              (:ThreatgridAuthWhoAmIURLService services-map)
-                              ;; dynamic requires can be removed when #'with-properties is phased out or moved
-                              (assoc
-                                :ThreatgridAuthWhoAmIURLService
-                                @(requiring-resolve 
-                                   'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service)
-                                :IFakeWhoAmIServer
-                                @(requiring-resolve 
-                                   'ctia.test-helpers.fake-whoami-service/fake-whoami-service))))
+             services-map (cond-> (init/default-services-map config)
+                            (#{:threatgrid} (get-in config [:ctia :auth :type]))
+                            ;; dynamic requires can be removed when #'with-properties is phased out or moved
+                            (assoc
+                              :ThreatgridAuthWhoAmIURLService
+                              @(requiring-resolve 
+                                 'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service)
+                              :IFakeWhoAmIServer
+                              @(requiring-resolve 
+                                 'ctia.test-helpers.fake-whoami-service/fake-whoami-service)))
              app (init/start-ctia!*
                    {:services (vals services-map)
                     :config config})]

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -254,8 +254,16 @@
                        "ctia.http.port" http-port
                        "ctia.http.show.port" http-port]
        (let [config (build-transformed-init-config)
+             services-map (let [services-map (init/default-services-map config)]
+                            (cond-> services-map
+                              (:ThreatgridAuthWhoAmIURLService services-map)
+                              (assoc
+                                :ThreatgridAuthWhoAmIURLService
+                                ;; dynamic require can be removed when #'with-properties is phased out
+                                @(requiring-resolve 
+                                   'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service))))
              app (init/start-ctia!*
-                   {:services (init/default-services config)
+                   {:services (vals services-map)
                     :config config})]
          (try
            ;; both bind app thread-locally and pass as argument.

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -19,7 +19,7 @@
 ;;
 
 (defprotocol IFakeWhoAmIServer
-  (start-server [this])
+  (start-server [this port])
   (stop-server [this])
   (get-url [this])
   (get-port [this])
@@ -123,7 +123,7 @@
      :requests (atom [])
      :token->response (atom {})}))
 
-(s/defservice fake-threatgrid-auth-whoami-url-service
+(tk/defservice fake-threatgrid-auth-whoami-url-service
   threatgrid/ThreatgridAuthWhoAmIURLService
   []
   (start [_ context]

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -126,7 +126,7 @@
                                  (start-server 0))))
   (stop [_ {:keys [server] :as context}]
         (some-> server stop-server)
-        (dissoc :server context))
+        (dissoc context :server))
   (get-whoami-url
     [this]
     (let [{:keys [server]} (service-context this)]
@@ -168,9 +168,7 @@
   ([app
     token :- s/Str
     response :- WhoAmIResponse]
-   (let [{{:keys [get-in-config]} :ConfigService
-          {:keys [get-whoami-url]} :ThreatgridAuthWhoAmIURLService} (app/service-graph app)
-         ;; assuming ThreatgridAuthWhoAmIURLService is fake-threatgrid-auth-whoami-url-service
+   (let [;; assuming ThreatgridAuthWhoAmIURLService is fake-threatgrid-auth-whoami-url-service
          whoami-service (-> (app/get-service app :ThreatgridAuthWhoAmIURLService)
                             service-context
                             :server)

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -166,7 +166,8 @@
   ([app
     token :- s/Str
     response :- WhoAmIResponse]
-   (let [{{:keys [register-token-response]} :IFakeWhoAmIServer} (app/service-graph app)]
+   (let [_ (assert (app/get-service app :IFakeWhoAmIServer))
+         {{:keys [register-token-response]} :IFakeWhoAmIServer} (app/service-graph app)]
      (register-token-response token
                               response))))
 

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer [join-fixtures testing]]
             [ctia.test-helpers
              [core :as helpers]
-             [es :as es-helpers]
-             [fake-whoami-service :as whoami-service]]
+             [es :as es-helpers]]
             [schema.core :as s]))
 
 (def store-fixtures

--- a/test/ctia/test_helpers/store.clj
+++ b/test/ctia/test_helpers/store.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [join-fixtures testing]]
             [ctia.test-helpers
              [core :as helpers]
-             [es :as es-helpers]]
+             [es :as es-helpers]
+             [fake-whoami-service :as whoami-service]]
             [schema.core :as s]))
 
 (def store-fixtures


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

**Epic** https://github.com/threatgrid/iroh/issues/3985

This PR moves the fake WhoAmI service provided by the unit tests to a TK service. This removes the need for `whoami-helpers/fixture-reset-state`, and creates better test isolation since a fake server is now booted for every app that uses `whoami-helpers/fixture-server`.

A new service `ThreatgridAuthWhoAmIURLService` is introduced that exposes an easily stubbable `get-whoami-url` method. This is so we don't need to stub the entire `threatgrid-auth-service` service just to provide our own whoami url. Since we only know the port of the whoami url at app initialization, we can't use ConfigService to provide the URL, so this method provides just enough dynamic configuration to get by.

Unit tests are included for `get-whoami-url`, but relies on existing tests for integration with other services (namely `threatgrid-auth-service`).

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Better isolate fake whoami service
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

