### PR TITLE
fix update description

### DIFF
--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -133,7 +133,7 @@
        (PUT "/:id" []
             :return entity-schema
             :body [entity-update new-schema {:description (format "an updated %s" capitalized)}]
-            :summary (format "Updates an %s" capitalized)
+            :summary (format "Updates an existing %s" capitalized)
             :query-params [{wait_for :- (describe s/Bool "wait for updated entity to be available for search") nil}]
             :path-params [id :- s/Str]
             :capabilities put-capabilities
@@ -223,7 +223,7 @@
                 :identity-map identity-map
                 (GET "/" []
                      :return search-schema
-                     :summary (format "Search for a %s using a Lucene/ES query string and field filters" capitalized)
+                     :summary (format "Search for %s entities using a Lucene/ES query string and field filters" capitalized)
                      :query [params search-q-params]
                      (-> (read-store
                           entity
@@ -250,7 +250,7 @@
                 :identity-map identity-map
                 (GET "/histogram" []
                      :return MetricResult
-                     :summary (format "Histogram for a %s field" capitalized)
+                     :summary (format "Histogram for some %s field" capitalized)
                      :query [params histogram-q-params]
                      (let [aggregate-on (keyword (:aggregate-on params))
                            search-q (search-query aggregate-on
@@ -268,7 +268,7 @@
                            ok)))
                 (GET "/topn" []
                      :return MetricResult
-                     :summary (format "Topn for a %s field" capitalized)
+                     :summary (format "Topn for some %s field" capitalized)
                      :query [params topn-q-params]
                      (let [aggregate-on (:aggregate-on params)
                            search-q (search-query date-field
@@ -286,7 +286,7 @@
                            ok)))
                 (GET "/cardinality" []
                      :return MetricResult
-                     :summary (format "Cardinality for a %s field" capitalized)
+                     :summary (format "Cardinality for some %s field" capitalized)
                      :query [params cardinality-q-params]
                      (let [aggregate-on (:aggregate-on params)
                            search-q (search-query date-field
@@ -304,7 +304,7 @@
                            ok)))))
      (GET "/:id" []
           :return (s/maybe get-schema)
-          :summary (format "Gets a %s by ID" entity-str)
+          :summary (format "Gets one %s by ID" capitalized)
           :path-params [id :- s/Str]
           :query [params get-params]
           :capabilities get-capabilities
@@ -325,7 +325,7 @@
              :no-doc hide-delete?
              :path-params [id :- s/Str]
              :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]
-             :summary (format "Deletes a %s" capitalized)
+             :summary (format "Deletes one %s" capitalized)
              :capabilities delete-capabilities
              :auth-identity identity
              :identity-map identity-map


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

We have a generic description template for route description. The articles `a` and `an` are not always adapted to the entity name. This modify some description to make them fit with any articles.

<a name="qa">[§](#qa)</a> QA
============================

Check that the new routes description in CTIA are proper sentences.

```
intern: Fixed some routes descriptions in CTIA.
```
