### PR TITLE
Convert entity-routes macro to function

### DIFF
--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -1,0 +1,24 @@
+(ns ctia.http.handler-test
+  (:require [ctia.http.handler :as sut]
+            [clojure.test :refer [deftest is testing]]
+            [compojure.api.api :refer [api]]
+            [compojure.api.core :refer [GET]]
+            [compojure.api.routes :as routes]
+            [compojure.api.swagger :as swagger]))
+
+;; regression test for implementation details of compojure-api
+;; used to implement sut/add-dynamic-tags
+(deftest add-dynamic-tags-test
+  (is (= (routes/get-routes
+           (api
+             (swagger/swagger-routes)
+             (sut/add-dynamic-tags
+               (GET "/" [] nil)
+               ["foo"])))
+
+         [["/swagger.json" :get {:x-no-doc true,
+                                 :x-name :compojure.api.swagger/swagger}]
+          ["/" :get
+           ;; this is the important part. when updating this test,
+           ;; make sure {:tags #{"foo"}} is where it's supposed to be!
+           {:tags #{"foo"}}]])))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close https://github.com/threatgrid/iroh/issues/4343

This is the smallest change I could think of that achieves the goal of convert `entity-routes` to a function. It uses some implementation details of compojure-api, which I've attempted to abstract via `add-dynamic-tags` and unit test.

Reviewers please check the swagger tags are as you'd expect.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Convert entity-routes macro to function
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

