### PR TITLE
Es7 store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,8 @@ install:
 before_script:
     - $COMPOSE_BIN -f containers/dev/docker-compose.yml up -d> $COMPOSE_LOG
     # Wait ES
-    - until curl http://127.0.0.1:9200/; do sleep 1; done
+    - until curl http://127.0.0.1:9205/; do sleep 1; done
+    - until curl http://127.0.0.1:9207/; do sleep 1; done
     # Wait Kafka
     - until echo dump | nc 127.0.0.1 2181 | grep brokers; do sleep 1; done
 

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -4,13 +4,22 @@ services:
     image: redis:5.0.5
     ports:
       - "6379:6379"
-  elasticsearch-dev:
+  elasticsearch5:
     image: elasticsearch:5.6.9
     environment:
-      - cluster.name=elasticsearch
+      - cluster.name=elasticsearch5
+      - discovery.type=single-node
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9205:9200"
+      - "9305:9300"
+  elasticsearch7:
+    image: elasticsearch:7.9.2
+    environment:
+      - cluster.name=elasticsearch7
+      - discovery.type=single-node
+    ports:
+      - "9207:9200"
+      - "9307:9300"
   zookeeper:
     image: confluentinc/cp-zookeeper:5.3.2
     hostname: "zookeeper"

--- a/dev/ctia/dev/split_tests.clj
+++ b/dev/ctia/dev/split_tests.clj
@@ -216,12 +216,7 @@
                                     (format "until curl http://127.0.0.1:920%s; do sleep 1; " version)
                                     exit-if-too-long " ; done"))
                         (assert-sh "Error connecting to docker")))]
-      (wait-es 0)
-      ;; uncomment for port 9205
-      #_
       (wait-es 5)
-      ;; uncomment for port 9207
-      #_
       (wait-es 7)
       ; Wait Kafka
       (-> (sh/sh "bash" "-c"

--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
 
                  [threatgrid/ctim "1.0.22"]
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.1.0"]
+                 [threatgrid/ductile "0.2.0"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -60,7 +60,7 @@ ctia.events.log=false
 
 # Use ES for all Stores
 ctia.store.es.default.host=127.0.0.1
-ctia.store.es.default.port=9200
+ctia.store.es.default.port=9205
 #ctia.store.es.default.host=es-storage.int.iroh.site
 #ctia.store.es.default.port=443
 #ctia.store.es.default.protocol=https
@@ -72,6 +72,9 @@ ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
 ctia.store.es.default.rollover.max_docs=10000000
 ctia.store.es.default.aliased=true
+ctia.store.es.default.version=5
+ctia.store.es.default.update-mappings=false
+ctia.store.es.default.update-settings=false
 
 ctia.store.actor=es
 ctia.store.asset=es
@@ -164,7 +167,7 @@ ctia.migration.batch-size=100
 ctia.migration.buffer-size=3
 
 ctia.migration.store.es.default.host=localhost
-ctia.migration.store.es.default.port=9200
+ctia.migration.store.es.default.port=9205
 ctia.migration.store.es.default.protocol=http
 #ctia.migration.store.es.default.replicas=1
 #ctia.migration.store.es.default.refresh_interval=1s
@@ -173,6 +176,7 @@ ctia.migration.store.es.default.shards=1
 #ctia.migration.store.es.default.refresh=false
 #ctia.migration.store.es.default.rollover.max_docs=10000000
 #ctia.migration.store.es.default.aliased=true
+ctia.migration.store.es.default.version=5
 
 ctia.migration.store.es.migration.indexname=ctia_migration
 #ctia.migration.store.es.malware.indexname=v1.2.0_ctia_malware

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -46,7 +46,7 @@
   {:type "object"
    :properties
    {:name  em/token
-    :value em/all_token}})
+    :value em/token}})
 
 (def asset-properties-mapping
   {"asset-properties"

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -64,8 +64,8 @@
      em/sourcable-entity-mapping
      em/stored-entity-mapping
      {:abstraction_level em/token
-      :name em/all_token
-      :description em/all_text
+      :name em/token
+      :description em/text
       :kill_chain_phases em/kill-chain-phase
       :x_mitre_data_sources em/token
       :x_mitre_platforms em/token

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -61,7 +61,7 @@
      em/stored-entity-mapping
      {:valid_time em/valid-time
       :campaign_type em/token
-      :names em/all_token
+      :names em/token
       :intended_effect em/token
       :status em/token
       :confidence em/token

--- a/src/ctia/entity/event/store.clj
+++ b/src/ctia/entity/event/store.clj
@@ -1,9 +1,9 @@
 (ns ctia.entity.event.store
   (:require
    [ctia.entity.event.schemas :refer [PartialEvent]]
-   [ctia.store :refer [IStore IQueryStringSearchableStore]]
+   [ctia.store :refer [IStore IQueryStringSearchableStore IEventStore]]
    [ctia.entity.event.crud :as crud]
-   [ctia.store :refer [IEventStore]]))
+   [ctia.stores.es.store :refer [close-cm!]]))
 
 (defrecord EventStore [state]
   IStore
@@ -23,4 +23,5 @@
      state search-query ident))
   (aggregate [_ search-query agg-query ident]
     (crud/handle-aggregate
-     state search-query agg-query ident)))
+     state search-query agg-query ident))
+  (close [_] (close-cm! state)))

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -57,7 +57,7 @@
     :properties
     (merge em/base-entity-mapping
            em/stored-entity-mapping
-           {:title em/all_text
+           {:title em/text
             :lifetime em/valid-time
             :output em/token
             :secret em/token

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -24,7 +24,7 @@
      em/stored-entity-mapping
      {:entity_id em/token
       :feedback em/integer-type
-      :reason em/sortable-all-text})}})
+      :reason em/sortable-text})}})
 
 (def-es-store FeedbackStore :feedback fs/StoredFeedback fs/PartialStoredFeedback)
 

--- a/src/ctia/entity/identity.clj
+++ b/src/ctia/entity/identity.clj
@@ -2,8 +2,9 @@
   (:require [schema.core :as s]
             [schema-tools.core :as st]
             [ductile.document :refer [create-doc get-doc delete-doc]]
-            [ctia.store :refer [IIdentityStore]]
+            [ctia.store :refer [IIdentityStore IStore]]
             [ctia.stores.es
+             [store :refer [close-cm!]]
              [crud :as crud]
              [mapping :as em]
              [schemas :refer [ESConnState]]]))
@@ -85,6 +86,9 @@
      :groups em/token}}})
 
 (defrecord IdentityStore [state]
+  IStore
+  (close [this]
+    (close-cm! (:state this)))
   IIdentityStore
   (read-identity [_ login]
     (handle-read state login))

--- a/src/ctia/entity/identity.clj
+++ b/src/ctia/entity/identity.clj
@@ -1,8 +1,7 @@
 (ns ctia.entity.identity
   (:require [schema.core :as s]
             [schema-tools.core :as st]
-            [clj-momo.lib.es
-             [document :refer [create-doc get-doc delete-doc]]]
+            [ductile.document :refer [create-doc get-doc delete-doc]]
             [ctia.store :refer [IIdentityStore]]
             [ctia.stores.es
              [crud :as crud]
@@ -37,20 +36,24 @@
   (vec (map name caps)))
 
 (s/defn handle-create :- Identity
-  [{:keys [conn props]} :- ESConnState
+  [{:keys [conn]
+    {:keys [refresh write-index]
+     :or {refresh "false"}} :props} :- ESConnState
    new-identity :- Identity]
   (let [id (:login new-identity)
         realized (assoc new-identity :id id)
-        transformed (update-in realized [:capabilities]
+        transformed (update-in realized
+                               [:capabilities]
                                capabilities-set->capabilities)
-        res (create-doc conn
-                        (:write-index props)
-                        mapping
-                        transformed
-                        (:refresh props "false"))]
-    (-> res
-        (update-in [:capabilities] capabilities->capabilities-set)
-        (dissoc :id))))
+        response (-> transformed
+                     (update-in [:capabilities] capabilities->capabilities-set)
+                     (dissoc :id))]
+    (create-doc conn
+                write-index
+                mapping
+                transformed
+                {:refresh refresh})
+    response))
 
 (s/defn handle-read :- (s/maybe Identity)
   [state :- ESConnState
@@ -69,13 +72,13 @@
                 index
                 mapping
                 login
-                true)))
+                {:refresh "true"})))
 
 (def identity-mapping
   {"identity"
    {:dynamic false
     :properties
-    {:id em/all_token
+    {:id em/token
      :role em/token
      :capabilities em/token
      :login em/token

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -79,7 +79,7 @@
       :negate em/boolean-type
       :indicator_type em/token
       :alternate_ids em/token
-      :tags em/all_token
+      :tags em/token
       :composite_indicator_expression {:type "object"
                                        :properties
                                        {:operator em/token

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -8,6 +8,7 @@
             [ctia.schemas.core :refer [Verdict]]
             [ctia.store :refer [IJudgementStore IQueryStringSearchableStore IStore]]
             [ctia.stores.es
+             [store :refer [close-cm!]]
              [crud :as crud]
              [mapping :as em]
              [query :refer [active-judgements-by-observable-query find-restriction-query-part]]
@@ -126,4 +127,5 @@
   (query-string-count [_ search-query ident]
     (handle-query-string-count state search-query ident))
   (aggregate [_ search-query agg-query ident]
-    (handle-aggregate state search-query agg-query ident)))
+    (handle-aggregate state search-query agg-query ident))
+  (close [_] (close-cm! state)))

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -34,7 +34,7 @@
       :confidence em/token
       :severity em/token
       :valid_time em/valid-time
-      :reason em/sortable-all-text
+      :reason em/sortable-text
       :reason_uri em/token})}})
 
 (def coerce-stored-judgement-list
@@ -44,7 +44,7 @@
 (def handle-create (crud/handle-create :judgement StoredJudgement))
 (def handle-update (crud/handle-update :judgement StoredJudgement))
 (def handle-read (crud/handle-read PartialStoredJudgement))
-(def handle-delete (crud/handle-delete :judgement PartialStoredJudgement))
+(def handle-delete (crud/handle-delete :judgement))
 (def handle-list (crud/handle-find PartialStoredJudgement))
 (def handle-query-string-search (crud/handle-query-string-search PartialStoredJudgement))
 (def handle-query-string-count crud/handle-query-string-count)

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -54,8 +54,8 @@
      em/base-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:name em/all_token
-      :description em/all_text
+     {:name em/token
+      :description em/text
       :labels em/token
       :kill_chain_phases em/kill-chain-phase
       :x_mitre_aliases em/token

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -6,6 +6,7 @@
             [ctia.schemas.core :refer [Observable]]
             [ctia.store :refer [IQueryStringSearchableStore ISightingStore IStore]]
             [ctia.stores.es
+             [store :refer [close-cm!]]
              [crud :as crud]
              [mapping :as em]
              [schemas :refer [ESConnState]]]
@@ -170,4 +171,5 @@
   (query-string-count [_ search-query ident]
     (handle-query-string-count state search-query ident))
   (aggregate [_ search-query agg-query ident]
-    (handle-aggregate state search-query agg-query ident)))
+    (handle-aggregate state search-query agg-query ident))
+  (close [_] (close-cm! state)))

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -120,7 +120,7 @@
     (update-fn state id $ ident params)
     (es-stored-sighting->stored-sighting $)))
 
-(def handle-delete (crud/handle-delete :sighting StoredSighting))
+(def handle-delete (crud/handle-delete :sighting))
 
 (s/defn es-paginated-list->paginated-list
   :- PartialStoredSightingList

--- a/src/ctia/entity/target_record.clj
+++ b/src/ctia/entity/target_record.clj
@@ -38,13 +38,13 @@
 (def ^:private targets
   {:type "object"
    :properties
-   {:type          em/all_token
+   {:type          em/token
     :observables   em/observable
-    :os            em/all_token
+    :os            em/token
     :internal      em/boolean-type
-    :source_uri    em/all_token
+    :source_uri    em/token
     :observed_time em/valid-time
-    :sensor        em/all_token}})
+    :sensor        em/token}})
 
 (def target-record-mapping
   {"target-record"

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -18,8 +18,8 @@
      em/base-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:name em/all_token
-      :description em/all_text
+     {:name em/token
+      :description em/text
       :labels em/token
       :kill_chain_phases em/kill-chain-phase
       :tool_version em/token

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -35,7 +35,10 @@
    (str prefix store ".rollover.max_age") s/Str
    (str prefix store ".aliased")  s/Bool
    (str prefix store ".default_operator") (s/enum "OR" "AND")
-   (str prefix store ".timeout") s/Num})
+   (str prefix store ".timeout") s/Num
+   (str prefix store ".version") s/Num
+   (str prefix store ".update-mappings")  s/Bool
+   (str prefix store ".update-settings")  s/Bool})
 
 (s/defschema StorePropertiesSchema
   "All entity store properties for every implementation"

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -20,8 +20,7 @@
 (defprotocol IIdentityStore
   (read-identity [this login])
   (create-identity [this new-identity])
-  (delete-identity [this org-id role])
-  (close-identity [this]))
+  (delete-identity [this org-id role]))
 
 (defprotocol IEventStore
   (read-event [this id ident params])

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -7,7 +7,8 @@
   (read-record [this id ident params])
   (update-record [this id record ident params])
   (delete-record [this id ident params])
-  (list-records [this filtermap ident params]))
+  (list-records [this filtermap ident params])
+  (close [this]))
 
 (defprotocol IJudgementStore
   (calculate-verdict [this observable ident])
@@ -19,7 +20,8 @@
 (defprotocol IIdentityStore
   (read-identity [this login])
   (create-identity [this new-identity])
-  (delete-identity [this org-id role]))
+  (delete-identity [this org-id role])
+  (close-identity [this]))
 
 (defprotocol IEventStore
   (read-event [this id ident params])

--- a/src/ctia/store_service.clj
+++ b/src/ctia/store_service.clj
@@ -17,6 +17,8 @@
   (start [this context]
          (core/start context
                      get-in-config))
+  (stop [this context]
+        (core/stop context))
 
   (all-stores [this] (core/all-stores (service-context this)))
   (write-store [this store write-fn]

--- a/src/ctia/store_service_core.clj
+++ b/src/ctia/store_service_core.clj
@@ -1,7 +1,7 @@
 (ns ctia.store-service-core
   (:require [clojure.string :as str]
             [ctia.properties :as p]
-            [ctia.store :refer [empty-stores]]
+            [ctia.store :refer [empty-stores close]]
             [ctia.stores.es.init :as es-init]))
 
 (defn init [context]
@@ -45,3 +45,9 @@
 (defn start [{:keys [stores-atom] :as context} get-in-config]
   (init-store-service! stores-atom get-in-config)
   context)
+
+(defn stop
+  [ctx]
+  (doseq [[kw [s]] (all-stores ctx)]
+    (close s))
+  ctx)

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -8,8 +8,6 @@
    [ductile
     [conn :refer [connect]]
     [index]]
-   [clj-momo.lib.es
-    [index :as es-index]]
    [ctia.entity.entities :refer [entities]]
    [schema.core :as s]
    [schema-tools.core :as st]))
@@ -35,23 +33,26 @@
 (s/defn init-store-conn :- ESConnState
   "initiate an ES store connection, returning a map containing a
    connection manager and dedicated store index properties"
-  [{:keys [entity indexname mappings aliased shards replicas refresh_interval]
+  [{:keys [entity indexname mappings aliased shards replicas refresh_interval version]
     :or {aliased false
          shards 1
          replicas 1
-         refresh_interval "1s"}
+         refresh_interval "1s"
+         version 7}
     :as props} :- StoreProperties
    services :- ESConnServices]
   (let [write-index (str indexname
                          (when aliased "-write"))
         settings {:refresh_interval refresh_interval
                   :number_of_shards shards
-                  :number_of_replicas replicas}]
+                  :number_of_replicas replicas}
+        mappings (cond-> (get store-mappings entity mappings)
+                   (> version 5) (some-> first val))]
     {:index indexname
      :props (assoc props :write-index write-index)
      :config (into
               {:settings (into store-settings settings)
-               :mappings (get store-mappings entity mappings)}
+               :mappings mappings}
               (when aliased
                 {:aliases {indexname {}}}))
      :conn (connect props)
@@ -63,35 +64,43 @@
     {:keys [settings]} :config} :- ESConnState]
   (try
     (->> {:index (select-keys settings [:refresh_interval :number_of_replicas])}
-         (es-index/update-settings! conn index))
+         (ductile.index/update-settings! conn index))
     (log/info "updated settings: " index)
     (catch clojure.lang.ExceptionInfo e
       (log/warn "could not update settings on that store"
                 (pr-str (ex-data e))))))
 
-(defn upsert-template!
-  [conn index config]
-  (es-index/create-template! conn index config)
+(s/defn upsert-template!
+  [{:keys [conn index config]} :- ESConnState]
+  (ductile.index/create-template! conn index config)
   (log/infof "updated template: %s" index))
 
 (defn system-exit-error
   []
-  (log/error (str "CTIA tried to start with an invalid configuration: \n"
+  (log/error (str "IGNORE THIS LOG UNTIL MIGRATION"
+                  "CTIA tried to start with an invalid configuration: \n"
                   "- invalid mapping\n"
                   "- ambiguous index names"))
   (System/exit 1))
 
-(defn update-mapping!
-  [conn index config]
-  (try
-    (log/info "updating mapping: " index)
-    (es-index/update-mapping!
-     conn
-     index
-     (:mappings config))
-    (catch clojure.lang.ExceptionInfo e
-      (log/error "cannot update mapping. You probably tried to update the mapping of an existing field. It's only possible to add new field to existing mappings. If you need to modify the type of a field in an existing index, you must perform a migration" (ex-data e))
-      (system-exit-error))))
+(s/defn update-mappings!
+  [{:keys [conn index]
+    {:keys [mappings]} :config} :- ESConnState]
+  (let [[entity-type type-mappings] (when (= (:version conn) 5)
+                                      (first mappings))
+        update-body (or type-mappings mappings)]
+    (try
+      (log/info "updating mapping: " index)
+      (ductile.index/update-mappings! conn
+                                      index
+                                      entity-type
+                                      update-body)
+      (catch clojure.lang.ExceptionInfo e
+        (log/error "cannot update mapping. You probably tried to update the mapping of an existing field. It's only possible to add new field to existing mappings. If you need to modify the type of a field in an existing index, you must perform a migration"
+                   (assoc (ex-data e)
+                          :conn conn
+                          :mappings mappings))
+        (system-exit-error)))))
 
 (defn get-existing-indices
   [conn index]
@@ -110,6 +119,21 @@
           (system-exit-error))
       existing)))
 
+(defn update-index-state
+  [{{update-mappings? :update-mappings
+     update-settings? :update-settings}
+    :props
+    :as conn-state}]
+  (when update-mappings?
+    (update-mappings! conn-state)
+    ;; template update must be after update-mapping
+    ;; if it fails a System/exit is triggered because
+    ;; this means that the mapping in invalid and thus
+    ;; must not be propagated to the template that would accept it
+    (upsert-template! conn-state))
+  (when update-settings?
+    (update-settings! conn-state)))
+
 (s/defn init-es-conn! :- ESConnState
   "initiate an ES Store connection,
    put the index template, return an ESConnState"
@@ -118,10 +142,9 @@
   (let [{:keys [conn index props config] :as conn-state}
         (init-store-conn properties services)
         existing-indices (get-existing-indices conn index)]
-    (when (seq existing-indices)
-      (update-mapping! conn index config)
-      (update-settings! conn-state))
-    (upsert-template! conn index config)
+    (if (seq existing-indices)
+      (update-index-state conn-state)
+      (upsert-template! conn-state))
     (when (and (:aliased props)
                (empty? existing-indices))
       ;;https://github.com/elastic/elasticsearch/pull/34499

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -9,59 +9,44 @@
 ;; even in different entities.
 
 (def float-type
-  {:type "float"
-   :include_in_all false})
+  {:type "float"})
 
 (def long-type
-  {:type "long"
-   :include_in_all false})
+  {:type "long"})
 
 (def boolean-type
-  {:type "boolean"
-   :include_in_all false})
+  {:type "boolean"})
 
 (def integer-type
-  {:type "integer"
-   :include_in_all false})
+  {:type "integer"})
 
 (def ts
   "A mapping for our timestamps, which should all be ISO8601 format"
   {:type "date"
-   :include_in_all false
    :format "date_time"})
 
 (def text
   "A mapping for free text, or markdown, fields.  They will be
   analyzed and treated like prose."
   {:type "text"
-   :include_in_all false
    :analyzer "text_analyzer"
    :search_quote_analyzer "text_analyzer"
    :search_analyzer "search_analyzer"})
-
-(def all_text
-  "The same as the `text` maping, but will be included in the _all field"
-  (assoc text :include_in_all true))
 
 (def token
   "A mapping for fields whose value should be treated like a symbol.
   They will not be analyzed, and they will be lowercased."
   {:type "keyword"
-   :include_in_all false
    :normalizer "lowercase_normalizer"})
 
-(def all_token
-  "The same as the `token` mapping, but will be included in the _all field"
-  (assoc token :include_in_all true))
-
-(def sortable-all-text
-  (assoc all_text
+(def sortable-text
+  (assoc text
          :fields {:whole token}))
 
 (def external-reference
   {:properties
    {:source_name token
-    :description all_text
+    :description text
     :url token
     :hashes token
     :external_id token}})
@@ -78,9 +63,9 @@
    :tlp token})
 
 (def describable-entity-mapping
-  {:title sortable-all-text
-   :short_description all_text
-   :description all_text})
+  {:title sortable-text
+   :short_description text
+   :description text})
 
 (def sourcable-entity-mapping
   {:source token
@@ -142,7 +127,7 @@
   {:type "object"
    :properties
    {:type token
-    :value all_token}})
+    :value token}})
 
 (def identity
   {:dynamic false
@@ -151,23 +136,23 @@
 
 (def assertion
   {:properties
-   {:name all_token
-    :value all_text}})
+   {:name token
+    :value text}})
 
 (def related-identities
   {:properties (assoc related
-                      :identity all_token
+                      :identity token
                       :information_source token)})
 
 (def tg-identity
   {:properties
-   {:description all_text
+   {:description text
     :related_identities related-identities}})
 
 (def activity
   {:properties
    {:date_time ts
-    :description all_text}})
+    :description text}})
 
 (def incident-time
   {:properties
@@ -230,7 +215,6 @@
     :origin_uri token
     :relation token
     :relation_info {:type "object"
-                    :include_in_all false
                     :dynamic true}
     :source observable
     :related observable}})
@@ -262,7 +246,6 @@
 
 (def embedded-data-table
   {:dynamic false
-   :include_in_all false
    :properties
    {:row_count {:type "long"}
     :columns {:enabled false}

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -2,6 +2,7 @@
   (:require [schema.core :as s]
             [schema-tools.core :as st]
             [ductile
+             [conn :as es-conn]
              [index :as es-index]
              [schemas :refer [ESConn]]]
             [ctia.store :refer [IStore IQueryStringSearchableStore]]
@@ -10,6 +11,10 @@
 (defn delete-state-indexes [{:keys [conn index config] :as state}]
   (when conn
     (es-index/delete! conn (str index "*"))))
+
+(s/defn close-cm!
+  [{:keys [conn]}]
+  (es-conn/close conn))
 
 (defmacro def-es-store
   [store-name
@@ -47,7 +52,9 @@
        ~(symbol "state") search-query# ident#))
      (~(symbol "aggregate") [_# search-query# agg-query# ident#]
       (crud/handle-aggregate
-       ~(symbol "state") search-query# agg-query# ident#))))
+       ~(symbol "state") search-query# agg-query# ident#))
+     (~(symbol "close") [_#]
+      (close-cm! ~(symbol "state")))))
 
 (s/defschema StoreMap
   {:conn ESConn

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,14 +1,13 @@
 (ns ctia.stores.es.store
   (:require [schema.core :as s]
             [schema-tools.core :as st]
-            [clj-momo.lib.es
+            [ductile
              [index :as es-index]
-             [conn :as conn]
              [schemas :refer [ESConn]]]
             [ctia.store :refer [IStore IQueryStringSearchableStore]]
             [ctia.stores.es.crud :as crud]))
 
-(defn delete-state-indexes [{:keys [conn index config]}]
+(defn delete-state-indexes [{:keys [conn index config] :as state}]
   (when conn
     (es-index/delete! conn (str index "*"))))
 
@@ -34,7 +33,7 @@
       ((crud/handle-update ~entity ~stored-schema)
        ~(symbol "state") id# actor# ident# params#))
      (~(symbol "delete-record") [_# id# ident# params#]
-      ((crud/handle-delete ~entity ~stored-schema)
+      ((crud/handle-delete ~entity)
        ~(symbol "state") id# ident# params#))
      (~(symbol "list-records") [_# filter-map# ident# params#]
       ((crud/handle-find ~partial-stored-schema)

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -1,8 +1,6 @@
 (ns ctia.task.migration.store
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.lib.clj-time.core :as time]
-            [clj-momo.lib.es.document :as es-doc]
-            [clj-momo.lib.es.index :as es-index]
             [clojure.set :as set]
             [clojure.string :as string]
             [clojure.tools.logging :as log]
@@ -18,10 +16,11 @@
             [ctia.task.migration.migrations :refer [available-migrations]]
             [ctia.task.rollover :refer [rollover-store]]
             [ctim.domain.id :refer [long-id->id]]
-            [ductile.conn :as conn]
-            [ductile.document :as ductile.doc]
-            ductile.index
-            ductile.query
+            [ductile
+             [conn :as conn]
+             [document :as ductile.doc]
+             [index :as ductile.index]
+             [query :as ductile.query]]
             [ductile.schemas :refer [ESConn ESQuery Refresh]]
             [schema-tools.core :as st]
             [schema.core :as s]))
@@ -41,7 +40,8 @@
                 :max_age s/Str})
     :aliased  s/Bool
     :default_operator (s/enum "OR" "AND")
-    :timeout s/Num}))
+    :timeout s/Num
+    :version s/Num}))
 
 (s/defschema MigrationParams
   {:migration-id s/Str
@@ -190,12 +190,12 @@
   (let [prepared (wo-storemaps migration)
         {:keys [indexname entity]} (migration-store-properties services)]
     (retry es-max-retry
-           es-doc/index-doc
+           ductile.doc/index-doc
            conn
            indexname
            (name entity)
            prepared
-           "true"))
+           {:refresh "true"}))
   migration)
 
 (def conn-overrides {:cm (conn/make-connection-manager {:timeout timeout})})
@@ -222,7 +222,8 @@
   (when (seq ids)
     (-> (store-map->es-conn-state store-map services)
         (crud/get-docs-with-indices ids {})
-        (->> (map (fn [{:keys [_id] :as hit}]
+        (->> (map #(assoc % :_type (name mapping))) ;; TODO remove after ES7 migration
+             (map (fn [{:keys [_id] :as hit}]
                     {_id (select-keys hit [:_id :_index :_type])}))
              (into {})))))
 
@@ -244,6 +245,7 @@
   and uses them to set :_index meta for these documents"
   [{:keys [mapping]
     {:keys [aliased write-index]} :props
+    {:keys [version]} :conn
     :as store-map}
    docs
    services :- MigrationStoreServices]
@@ -270,9 +272,10 @@
               mapping
               (count batch))
   (retry es-max-retry
-         es-doc/bulk-create-doc conn
+         ductile.doc/bulk-create-doc
+         conn
          (prepare-docs store-map batch services)
-         "false"
+         {:refresh "false"}
          bulk-max-size))
 
 (s/defn rollover?
@@ -531,7 +534,7 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
     (log/infof "%s - creating index template: %s" entity-type indexname)
     (purge-store entity-type conn indexname)
     (log/infof "%s - creating store: %s" entity-type indexname)
-    (retry es-max-retry es-index/create-template! conn indexname index-config)
+    (retry es-max-retry ductile.index/create-template! conn indexname index-config)
     (retry es-max-retry ductile.index/create! conn (format "<%s-{now/d}-000001>" indexname) index-config)))
 
 (s/defn init-storemap :- StoreMap
@@ -539,7 +542,7 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
    services :- MigrationStoreServices]
   (-> props
       (es.init/init-store-conn (MigrationStoreServices->ESConnServices
-                                 services))
+                                services))
       (es-store/store-state->map conn-overrides)))
 
 (s/defn get-target-store
@@ -637,7 +640,7 @@ when confirm? is true, it stores this state and creates the target indices."
    services :- MigrationStoreServices]
   (let [{:keys [indexname entity]} (migration-store-properties services)
         {:keys [prefix] :as migration-raw} (retry es-max-retry
-                                                  es-doc/get-doc
+                                                  ductile.doc/get-doc
                                                   es-conn
                                                   indexname
                                                   (name entity)
@@ -669,13 +672,13 @@ when confirm? is true, it stores this state and creates the target indices."
    (let [partial-doc {:stores {store-key migrated-doc}}
          {:keys [indexname entity]} (migration-store-properties services)]
      (retry es-max-retry
-            es-doc/update-doc
+            ductile.doc/update-doc
             es-conn
             indexname
             (name entity)
             migration-id
             partial-doc
-            "true"))))
+            {:refresh "true"}))))
 
 (s/defn finalize-migration! :- s/Any
   "reverts optimization settings of target index with configured settings.

--- a/src/ctia/task/update_mapping.clj
+++ b/src/ctia/task/update_mapping.clj
@@ -13,12 +13,12 @@
             [schema.core :as s]))
 
 (defn- update-mapping-state!
-  [{:keys [conn index config] :as state}]
-  (run! #(% conn index config)
+  [conn-state]
+  (run! #(% conn-state)
         ; template update should go first in the (unlikely) case of
         ; a race condition with a simultaneously successful rollover.
         [es-init/upsert-template!
-         es-init/update-mapping!]))
+         es-init/update-mappings!]))
 
 (defn update-mapping-stores!
   "Takes a map the same shape as returned by ctia.store-service/all-stores

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -4,11 +4,16 @@
             [ctia.bundle.core :as sut]
             [ctia.domain.entities :as ent :refer [with-long-id]]
             [ctia.flows.crud :refer [make-id]]
-            [ctia.test-helpers.core :as h]
-            [ctia.test-helpers.http :refer [app->HTTPShowServices]]
+            [clojure.test :as t :refer [deftest use-fixtures are is testing]]
+            [ctia.test-helpers
+             [core :as h]
+             [http :refer [app->HTTPShowServices]]
+             [es :as es-helpers]]
             [schema.core :as s]))
 
-(use-fixtures :each h/fixture-ctia-fast)
+(use-fixtures :each
+  es-helpers/fixture-properties:es-store
+  h/fixture-ctia-fast)
 
 (deftest local-entity?-test
   (are [x y] (= x (sut/local-entity? y (app->HTTPShowServices (h/get-current-app))))

--- a/test/ctia/encryption_test.clj
+++ b/test/ctia/encryption_test.clj
@@ -3,14 +3,15 @@
    [clojure.test
     :refer
     [deftest is join-fixtures testing use-fixtures]]
-   [clj-momo.test-helpers.core :as mth]
+   [schema.test :refer [validate-schemas]]
    [ctia.test-helpers
     [core :as test-helpers]
     [es :as es-helpers]]))
 
-(use-fixtures :once mth/fixture-schema-validation)
-(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
-                                    test-helpers/fixture-ctia-fast]))
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  test-helpers/fixture-ctia-fast)
 
 (deftest test-encryption-fns
   (testing "encryption shortcuts"

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -1,10 +1,10 @@
 (ns ctia.entity.casebook-test
   (:require
    [ctia.domain.entities :refer [schema-version]]
-   [clj-momo.test-helpers.core :as mth]
    [clojure
     [set :refer [subset?]]
-    [test :refer [deftest is join-fixtures testing use-fixtures]]]
+    [test :refer [deftest is testing use-fixtures]]]
+   [schema.test :refer [validate-schemas]]
    [ctia.entity.casebook :as sut]
    [ctia.test-helpers
     [access-control :refer [access-control-test]]
@@ -21,6 +21,10 @@
     :refer
     [new-casebook-maximal new-casebook-minimal]]
    [ctim.schemas.common :refer [ctim-schema-version]]))
+
+(use-fixtures :each
+  validate-schemas
+  whoami-helpers/fixture-server)
 
 (defn partial-operations-tests [app casebook-id casebook]
   ;; observables
@@ -315,10 +319,6 @@
                   final-casebook (:parsed-body response)]
               (is (= 200 (:status response)))
               (is (deep= expected-entity final-casebook)))))))))
-
-(use-fixtures :once
-  (join-fixtures [mth/fixture-schema-validation
-                  whoami-helpers/fixture-server]))
 
 (deftest test-casebook-routes
   (test-for-each-store-with-app

--- a/test/ctia/entity/entities_test.clj
+++ b/test/ctia/entity/entities_test.clj
@@ -2,9 +2,11 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [ctia.entity.entities :as sut]
             [ctia.schemas.core :refer [lift-realize-fn-with-context]]
-            [ctia.test-helpers.core :as test-helpers]
+            [ctia.test-helpers
+             [core :as test-helpers]
+             [es :as es-helpers]]
             [ctia.lib.utils :refer [service-subgraph]]
-            [clojure.test :as t :refer [deftest is use-fixtures join-fixtures]]
+            [clojure.test :as t :refer [deftest is use-fixtures]]
             [clojure.spec.alpha :refer [gen]]
             [clojure.spec.gen.alpha :refer [generate]]
             [puppetlabs.trapperkeeper.app :as app]
@@ -15,7 +17,9 @@
 #_
 (use-fixtures :once mth/fixture-schema-validation)
 
-(use-fixtures :each test-helpers/fixture-ctia-fast)
+(use-fixtures :each
+  es-helpers/fixture-properties:es-store
+  test-helpers/fixture-ctia-fast)
 
 (defn gen-sample-entity
   [{:keys [new-spec]}]

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -6,9 +6,8 @@
     [string :as str]
     [test :refer [is testing]]]
    [clj-momo.lib.time :as time]
-   [clj-momo.test-helpers.core :as mth]
    [clj-momo.lib.clj-time.core :as t]
-   [clojure.test :refer [deftest join-fixtures use-fixtures]]
+   [clojure.test :refer [deftest use-fixtures]]
    [ctim.domain.id :as id]
    [ctia.entity.event :as ev]
    [ctia.test-helpers
@@ -23,11 +22,12 @@
    [ctim.domain.id :as id]
    [cemerick.uri :as uri]
    [ctia.test-helpers.es :as es-helpers]
-   [puppetlabs.trapperkeeper.app :as app]))
+   [puppetlabs.trapperkeeper.app :as app]
+   [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once
-  (join-fixtures [mth/fixture-schema-validation
-                  whoami-helpers/fixture-server]))
+(use-fixtures :each
+  validate-schemas
+  whoami-helpers/fixture-server)
 
 (deftest test-event-routes
   (test-for-each-store-with-app

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -7,7 +7,7 @@
             [clj-momo.test-helpers.core :as mth]
             [clj-time.core :as t]
             [clojure.data.json :as json]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
             [clojure.tools.logging.test :as tlog]
             [ctia.domain.entities :refer [schema-version]]
             [ctia.test-helpers
@@ -18,12 +18,13 @@
              [store :refer [test-for-each-store-with-app]]]
             [ctim.domain.id :as id]
             [ring.adapter.jetty :as jetty]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once mth/fixture-schema-validation)
-
-(use-fixtures :each (join-fixtures [helpers/fixture-properties:cors
-                                    whoami-helpers/fixture-server]))
+(use-fixtures :each
+  validate-schemas
+  helpers/fixture-properties:cors
+  whoami-helpers/fixture-server)
 
 (def new-judgement-1
   {:observable {:value "1.2.3.4"

--- a/test/ctia/events_test.clj
+++ b/test/ctia/events_test.clj
@@ -11,12 +11,12 @@
    [ctia.test-helpers
     [core :as helpers]
     [es :as es-helpers]]
-   [schema.test :as st]))
+   [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once st/validate-schemas)
-
-(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
-                                    helpers/fixture-ctia-fast]))
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  helpers/fixture-ctia-fast)
 
 (deftest test-send-event
   "Tests the basic action of sending an event"

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -1,6 +1,10 @@
 (ns ctia.features-service-test
-  (:require  [clojure.test :refer [deftest are is join-fixtures testing use-fixtures]]
-             [ctia.test-helpers.core :as th]))
+  (:require  [clojure.test :refer [deftest are is testing use-fixtures]]
+             [ctia.test-helpers
+              [core :as th]
+              [es :as es-helpers]]))
+
+(use-fixtures :each es-helpers/fixture-properties:es-store)
 
 (deftest features-service-test
   (testing "FeaturesService methods for entity marked as disabled in config"

--- a/test/ctia/flows/hooks_test.clj
+++ b/test/ctia/flows/hooks_test.clj
@@ -1,15 +1,16 @@
 (ns ctia.flows.hooks-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [ctia.flows.hooks-service :as hooks-svc]
+  (:require [ctia.flows.hooks-service :as hooks-svc]
             [ctia.flows.hook-protocol :refer [Hook]]
             [ctia.test-helpers
              [core :as helpers]
              [es :as es-helpers]]
-            [clojure.test :as t]))
+            [clojure.test :as t]
+            [schema.test :refer [validate-schemas]]))
 
-(t/use-fixtures :each (t/join-fixtures [mth/fixture-schema-validation
-                                        es-helpers/fixture-properties:es-store
-                                        helpers/fixture-ctia-fast]))
+(t/use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  helpers/fixture-ctia-fast)
 
 (def obj {:x "x" :y 0 :z {:foo "bar"}})
 

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -4,14 +4,15 @@
             [ctia.test-helpers
              [core :as helpers :refer [POST GET]]
              [es :as es-helpers]]
-            [clojure.test :refer [deftest is testing use-fixtures join-fixtures]]
-            [ctim.domain.id :as id]))
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [ctim.domain.id :as id]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once mth/fixture-schema-validation)
-
-(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
-                                    helpers/fixture-allow-all-auth
-                                    helpers/fixture-ctia]))
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  helpers/fixture-allow-all-auth
+  helpers/fixture-ctia)
 
 (deftest allow-all-auth-judgement-routes-test
   (testing "POST /ctia/judgement"

--- a/test/ctia/http/handler/static_auth_anonymous_test.clj
+++ b/test/ctia/http/handler/static_auth_anonymous_test.clj
@@ -5,7 +5,8 @@
              [core :as helpers :refer [GET with-properties]]
              [es :as es-helpers]]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [ctim.domain.id :as id]))
+            [ctim.domain.id :as id]
+            [schema.test :refer [validate-schemas]]))
 
 (defn fixture-anonymous-readonly-access
   [t]
@@ -13,9 +14,8 @@
     ["ctia.auth.static.readonly-for-anonymous" true]
     (t)))
 
-(use-fixtures :once mth/fixture-schema-validation)
-
 (use-fixtures :each
+  validate-schemas
   es-helpers/fixture-properties:es-store
   (helpers/fixture-properties:static-auth "kitara" "tearbending")
   fixture-anonymous-readonly-access

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -5,11 +5,11 @@
              [core :as helpers :refer [POST GET]]
              [es :as es-helpers]]
             [clojure.test :refer [deftest is testing use-fixtures]]
-            [ctim.domain.id :as id]))
-
-(use-fixtures :once mth/fixture-schema-validation)
+            [ctim.domain.id :as id]
+            [schema.test :refer [validate-schemas]]))
 
 (use-fixtures :each
+  validate-schemas
   es-helpers/fixture-properties:es-store
   (helpers/fixture-properties:static-auth "kitara" "tearbending")
   helpers/fixture-ctia)

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -1,18 +1,18 @@
 (ns ctia.http.middleware.cache-control-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers :refer [GET POST]]
              [es :as es-helpers]
              [fake-whoami-service :as whoami-helpers]]
-            [ctim.domain.id :as id]))
+            [ctim.domain.id :as id]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    es-helpers/fixture-properties:es-store
-                                    whoami-helpers/fixture-server]))
-
-(use-fixtures :each helpers/fixture-ctia)
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  whoami-helpers/fixture-server
+  helpers/fixture-ctia)
 
 (defn get-actor [app actor-id headers]
   (select-keys (GET app

--- a/test/ctia/http/routes/swagger_json_test.clj
+++ b/test/ctia/http/routes/swagger_json_test.clj
@@ -1,10 +1,14 @@
 (ns ctia.http.routes.swagger-json-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
-            [ctia.test-helpers.core :as helpers]))
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ctia.test-helpers
+             [core :as helpers]
+             [es :as es-helpers]]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    helpers/fixture-ctia]))
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  helpers/fixture-ctia)
 
 (deftest test-swagger-json
   (let [app (helpers/get-current-app)]

--- a/test/ctia/http/server_test.clj
+++ b/test/ctia/http/server_test.clj
@@ -1,12 +1,14 @@
 (ns ctia.http.server-test
-  (:require [clj-momo.test-helpers.core :as mth]
+  (:require [schema.test :refer [validate-schemas]]
             [ctia.http.server :as sut]
             [ctia.test-helpers
              [core :as helpers :refer [GET with-properties]]
              [es :as es-helpers]]
             [clojure.test :refer [deftest is testing use-fixtures]]))
 
-(use-fixtures :once mth/fixture-schema-validation)
+(use-fixtures :each
+  es-helpers/fixture-properties:es-store
+  validate-schemas)
 
 (deftest parse-external-endpoints-test
   (is (nil? (sut/parse-external-endpoints nil)))

--- a/test/ctia/lib/redis_test.clj
+++ b/test/ctia/lib/redis_test.clj
@@ -9,9 +9,9 @@
              [es :as es-helpers]])
   (:import [java.util.concurrent CountDownLatch TimeUnit]))
 
-(use-fixtures :each (join-fixtures
-                     [es-helpers/fixture-properties:es-store
-                      test-helpers/fixture-ctia-fast]))
+(use-fixtures :each
+  es-helpers/fixture-properties:es-store
+  test-helpers/fixture-ctia-fast)
 
 (deftest redis-conf->conn-spec-test
   (is (= {:port 6379

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -3,20 +3,20 @@
              [core :as test-helpers]
              [es :as es-helpers]]
             [ctia.entity.event.obj-to-event :as o2e]
-            [clojure.test :as t :refer :all]
+            [clojure.test :refer [deftest is use-fixtures]]
             [schema.test :as st]
             [clojure.tools.logging :as log]
             [clojure.string :as str]))
 
-(use-fixtures :once st/validate-schemas)
-(use-fixtures :each (join-fixtures [es-helpers/fixture-properties:es-store
-                                    test-helpers/fixture-properties:events-logging
-                                    test-helpers/fixture-ctia-fast]))
+(use-fixtures :each
+  es-helpers/fixture-properties:es-store
+  test-helpers/fixture-properties:events-logging
+  test-helpers/fixture-ctia-fast
+  st/validate-schemas)
 
 (deftest test-logged
   (let [app (test-helpers/get-current-app)
         {:keys [send-event]} (test-helpers/get-service-map app :EventsService)
-        
         sb (StringBuilder.)
         patched-log (fn [logger
                          level

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -19,6 +19,9 @@
             "ctia.store.es.malware.rollover.max_age" s/Str
             "ctia.store.es.malware.aliased"  s/Bool
             "ctia.store.es.malware.default_operator" (s/enum "OR" "AND")
+            "ctia.store.es.malware.version" s/Num
+            "ctia.store.es.malware.update-mappings" s/Bool
+            "ctia.store.es.malware.update-settings" s/Bool
             "ctia.store.es.malware.timeout" s/Num}
            (sut/es-store-impl-properties "ctia.store.es." "malware")))
 
@@ -35,5 +38,8 @@
             "prefix.sighting.rollover.max_age" s/Str
             "prefix.sighting.aliased"  s/Bool
             "prefix.sighting.default_operator" (s/enum "OR" "AND")
+            "prefix.sighting.version" s/Num
+            "prefix.sighting.update-mappings" s/Bool
+            "prefix.sighting.update-settings" s/Bool
             "prefix.sighting.timeout" s/Num}
            (sut/es-store-impl-properties "prefix." "sighting")))))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -87,7 +87,7 @@
 (def create-fn (sut/handle-create :sighting s/Any))
 (def update-fn (sut/handle-update :sighting s/Any))
 (def read-fn (sut/handle-read s/Any))
-(def delete-fn (sut/handle-delete :sighting s/Any))
+(def delete-fn (sut/handle-delete :sighting))
 (def search-fn (sut/handle-query-string-search s/Any))
 (def count-fn sut/handle-query-string-count)
 (def aggregate-fn sut/handle-aggregate)
@@ -100,16 +100,18 @@
 (def props-aliased {:entity :sighting
                     :indexname "ctia_sighting"
                     :host "localhost"
-                    :port 9200
+                    :port 9205
                     :aliased true
                     :rollover {:max_docs 3}
-                    :refresh "true"})
+                    :refresh "true"
+                    :version 5})
 
 (def props-not-aliased {:entity :sighting
                         :indexname "ctia_sighting"
                         :host "localhost"
-                        :port 9200
-                        :refresh "true"})
+                        :port 9205
+                        :refresh "true"
+                        :version 5})
 
 (deftest crud-aliased-test
   (let [app (helpers/get-current-app)

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -1,7 +1,7 @@
 (ns ctia.stores.es.init-test
   (:require [ctia.stores.es.init :as sut]
             [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.es :refer [->ESConnServices]]
+            [ctia.test-helpers.es :refer [->ESConnServices for-each-es-version]]
             [clj-http.client :as http]
             [ctia.stores.es.mapping :as m]
             [ductile
@@ -9,8 +9,6 @@
              [conn :as conn]]
             [clojure.test :refer [deftest testing is are]]))
 
-(def es-conn (conn/connect {:host "localhost"
-                            :port "9200"}))
 (def indexname "ctia_init_test_sighting")
 (def write-alias (str indexname "-write"))
 (def props-aliased {:entity :sighting
@@ -20,8 +18,11 @@
                     :replicas 1
                     :mappings {:a 1 :b 2}
                     :host "localhost"
-                    :port 9200
-                    :aliased true})
+                    :port 9207
+                    :aliased true
+                    :update-mappings true
+                    :update-settings true
+                    :version 7})
 
 (def props-not-aliased {:entity :sighting
                         :indexname indexname
@@ -29,8 +30,11 @@
                         :replicas 1
                         :mappings {:a 1 :b 2}
                         :host "localhost"
-                        :port 9200
-                        :aliased false})
+                        :port 9207
+                        :aliased false
+                        :update-mappings true
+                        :update-settings true
+                        :version 7})
 
 (deftest init-store-conn-test
  (let [services (->ESConnServices)]
@@ -39,7 +43,7 @@
            (sut/init-store-conn props-not-aliased services)]
        (is (= index indexname))
        (is (= (:write-index props) indexname))
-       (is (= "http://localhost:9200" (:uri conn)))
+       (is (= "http://localhost:9207" (:uri conn)))
        (is (nil? (:aliases config)))
        (is (= "1s" (get-in config [:settings :refresh_interval])))
        (is (= 1 (get-in config [:settings :number_of_replicas])))
@@ -51,7 +55,7 @@
            (sut/init-store-conn props-aliased services)]
        (is (= index indexname))
        (is (= (:write-index props) write-alias))
-       (is (= "http://localhost:9200" (:uri conn)))
+       (is (= "http://localhost:9207" (:uri conn)))
        (is (= indexname
               (-> config :aliases keys first)))
        (is (= "2s" (get-in config [:settings :refresh_interval])))
@@ -69,12 +73,12 @@
 
        "default protocol is http"
        props-aliased
-       "http://localhost:9200"
+       "http://localhost:9207"
 
        "uri should respect given protocol"
        (assoc props-aliased
               :protocol :https)
-       "https://localhost:9200"
+       "https://localhost:9207"
 
        "uri should respect given protocol, host and port"
        (assoc props-aliased
@@ -84,182 +88,214 @@
        "https://cisco.com:9201"))))
 
 (deftest update-settings!-test
-  (let [services (->ESConnServices)
-        indexname "ctia_malware"
-        initial-props {:entity :malware
-                       :indexname indexname
-                       :host "localhost"
-                       :aliased true
-                       :port 9200
-                       :shards 5
-                       :replicas 2
-                       :refresh_interval "1s"}
-        ;; create index
-        {:keys [conn]} (sut/init-es-conn! initial-props services)
-        new-props (assoc initial-props
-                         :shards 4
-                         :replicas 1
-                         :refresh_interval "2s")
-        _ (sut/update-settings! (sut/init-store-conn new-props services))
-        {:keys [refresh_interval
-                number_of_shards
-                number_of_replicas]} (-> (index/get conn indexname)
-                                         first
-                                         val
-                                         :settings
-                                         :index)]
-    (is (= "5" number_of_shards)
-        "the number of shards is a static parameter")
-    (testing "dynamic parameters should be updated"
-      (is (= "1" number_of_replicas))
-      (is (= "2s" refresh_interval)))
-    (index/delete! conn (str indexname "*"))))
+  (doseq [version [5 7]]
+    (let [services (->ESConnServices)
+          indexname "ctia_malware"
+          initial-props {:entity :malware
+                         :indexname indexname
+                         :host "localhost"
+                         :aliased true
+                         :port (+ 9200 version)
+                         :shards 5
+                         :replicas 2
+                         :refresh_interval "1s"
+                         :version version}
+          ;; create index
+          {:keys [conn]} (sut/init-es-conn! initial-props services)
+          new-props (assoc initial-props
+                           :shards 4
+                           :replicas 1
+                           :refresh_interval "2s")
+          _ (sut/update-settings! (sut/init-store-conn new-props services))
+          {:keys [refresh_interval
+                  number_of_shards
+                  number_of_replicas]} (-> (index/get conn indexname)
+                                           first
+                                           val
+                                           :settings
+                                           :index)]
+      (is (= "5" number_of_shards)
+          "the number of shards is a static parameter")
+      (testing "dynamic parameters should be updated"
+        (is (= "1" number_of_replicas))
+        (is (= "2s" refresh_interval)))
+      (index/delete! conn (str indexname "*")))))
 
 (deftest get-existing-indices-test
-  (index/delete! es-conn (str indexname "*"))
-  (let [successful? (atom true)
-        fake-exit (fn [] (reset! successful? false))]
-    (let [test-fn (fn [msg
-                       input-indexname
-                       expected-successful?
-                       expected-output]
-                    (assert (boolean? expected-successful?))
-                    (reset! successful? true)
-                    (testing msg
-                      (let [ouput (with-redefs [sut/system-exit-error fake-exit]
-                                    (sut/get-existing-indices es-conn input-indexname))]
-                        ;; sut/system-exit-error is redefined to check if
-                        ;; it was called but avoid to actually System/exit
-                        ;; thus testing the output makes sense only on success
-                        (when expected-successful?
-                          (is (= expected-output ouput)))
-                        (is (= expected-successful? @successful?)))))
+  (for-each-es-version
+   "get-existing-indices should retrieve existing indices if any."
+   [5 7]
+   #(index/delete! % (str indexname "*"))
+   (let [successful? (atom true)
+         fake-exit (fn [] (reset! successful? false))]
+     (let [test-fn (fn [msg
+                        input-indexname
+                        expected-successful?
+                        expected-output]
+                     (assert (boolean? expected-successful?))
+                     (reset! successful? true)
+                     (testing msg
+                       (let [ouput (with-redefs [sut/system-exit-error fake-exit]
+                                     (sut/get-existing-indices conn input-indexname))]
+                         ;; sut/system-exit-error is redefined to check if
+                         ;; it was called but avoid to actually System/exit
+                         ;; thus testing the output makes sense only on success
+                         (when expected-successful?
+                           (is (= expected-output ouput)))
+                         (is (= expected-successful? @successful?)))))
 
-          _ (test-fn "0 existing index"
-                     indexname
-                     true
-                     #{})
+           _ (test-fn "0 existing index"
+                      indexname
+                      true
+                      #{})
 
-          _ (index/create! es-conn indexname {})
-          _ (test-fn "1 existing index with the exact name"
-                     indexname
-                     true
-                     #{(keyword indexname)})
+           _ (index/create! conn indexname {})
+           _ (test-fn "1 existing index with the exact name"
+                      indexname
+                      true
+                      #{(keyword indexname)})
 
-          indexname-with-date (str indexname "-2020.07.31")
-          _ (index/create! es-conn indexname-with-date {})
-          _ (test-fn "2 existing indices, 1 with exact name, 1 suffixed with date"
-                     indexname
-                     true
-                     #{(keyword indexname-with-date)
-                       (keyword indexname)})
+           indexname-with-date (str indexname "-2020.07.31")
+           _ (index/create! conn indexname-with-date {})
+           _ (test-fn "2 existing indices, 1 with exact name, 1 suffixed with date"
+                      indexname
+                      true
+                      #{(keyword indexname-with-date)
+                        (keyword indexname)})
 
-          ;; generate an indexname which is a prefix of indexname
-          ambiguous-indexname (->> (count indexname)
-                                   dec
-                                   (subs indexname 0))]
-      (test-fn "CTIA must fail to start with configuration having ambiguous index names between stores"
-               ambiguous-indexname
-               false
-               nil)
-      ;; clean
-      (index/delete! es-conn (str indexname "*")))))
+           ;; generate an indexname which is a prefix of indexname
+           ambiguous-indexname (->> (count indexname)
+                                    dec
+                                    (subs indexname 0))]
+       (test-fn "CTIA must fail to start with configuration having ambiguous index names between stores"
+                ambiguous-indexname
+                false
+                nil)))))
 
 (deftest init-es-conn!-test
-  (index/delete! es-conn (str indexname "*"))
-  (testing "init-es-conn! should return a proper conn state with unaliased conf, but not create any index"
-    (let [services (->ESConnServices)
-          {:keys [index props config conn]}
-          (sut/init-es-conn! props-not-aliased services)
-          existing-index (index/get es-conn (str indexname "*"))]
-      (is (empty? existing-index))
-      (is (= index indexname))
-      (is (= (:write-index props) indexname))
-      (is (= "http://localhost:9200" (:uri conn)))
-      (is (nil? (:aliases config)))
-      (is (= "1s" (get-in config [:settings :refresh_interval])))
-      (is (= 1 (get-in config [:settings :number_of_replicas])))
-      (is (= 2 (get-in config [:settings :number_of_shards])))
-      (is (= {} (select-keys (:mappings config) [:a :b])))))
+  (let [clean-template (fn [{:keys [uri] :as c}]
+                         (http/delete (format "%s/_template/%s*" uri indexname)))
+        clean-index #(index/delete! % (str indexname "*"))
+        clean-all #(do (clean-index %) (clean-template %))
+        prepare-props (fn [props version]
+                        (assoc props
+                               :version version
+                               :port (+ 9200 version)))]
+    (for-each-es-version
+     "get-existing-indices should retrieve existing indices if any."
+     [5 7]
+     clean-index
+     (testing "init-es-conn! should return a proper conn state with unaliased conf, but not create any index"
+       (let [services (->ESConnServices)
+             props (prepare-props props-not-aliased version)
+             {:keys [index props config conn]}
+             (sut/init-es-conn! props services)
+             existing-index (index/get conn (str indexname "*"))]
+         (is (empty? existing-index))
+         (is (= index indexname))
+         (is (= (:write-index props) indexname))
+         (is (= (str "http://localhost:920" version) (:uri conn)))
+         (is (nil? (:aliases config)))
+         (is (= "1s" (get-in config [:settings :refresh_interval])))
+         (is (= 1 (get-in config [:settings :number_of_replicas])))
+         (is (= 2 (get-in config [:settings :number_of_shards])))
+         (is (= {} (select-keys (:mappings config) [:a :b])))
+         (clean-all conn)))
 
-  (testing "update mapping should allow adding fields or identical mapping"
-    (let [services (->ESConnServices)
-          sucessful? (atom true)
-          fake-exit (fn [] (reset! sucessful? false))
-          test-fn (fn [msg expected-successful? field field-mapping]
-                    ;; init and create aliased indices
-                    (sut/init-es-conn! props-aliased services)
-                    (with-redefs [sut/system-exit-error fake-exit
-                                  ;; redef mappings
-                                  sut/store-mappings
-                                  (cond-> sut/store-mappings
-                                    field (assoc-in [:sighting "sighting" :properties field]
-                                                    field-mapping))]
-                      (testing msg
-                        ;; init again to trigger mapping update
-                        (sut/init-es-conn! props-aliased services)
-                        ;; check state
-                        (is (= expected-successful? @sucessful?)))
-                      ;; reset state
-                      (index/delete! es-conn (str indexname "*"))
-                      (http/delete (str "http://localhost:9200/_template/" indexname "*"))
-                      (reset! sucessful? true)))]
-      (test-fn "update mapping should not fail on unchanged mapping"
-               true nil nil)
-      (test-fn "update mapping should not fail on field addition"
-               true :new-field m/token)
-      (test-fn "Update mapping fails when modifying existing field mapping and CTIA must not start in that case."
-               false :id m/text)))
+     (testing "update mapping should allow adding fields or identical mapping"
+       (let [services (->ESConnServices)
+             sucessful? (atom true)
+             fake-exit (fn [] (reset! sucessful? false))
+             props (prepare-props props-aliased version)
+             test-fn (fn [msg expected-successful? field field-mapping]
+                       ;; init and create aliased indices
+                       (sut/init-es-conn! props services)
+                       (with-redefs [sut/system-exit-error fake-exit
+                                     ;; redef mappings
+                                     sut/store-mappings
+                                     (cond-> sut/store-mappings
+                                       field (assoc-in [:sighting "sighting" :properties field]
+                                                       field-mapping))]
+                         (testing msg
+                           ;; init again to trigger mapping update
+                           (sut/init-es-conn! props services)
+                           ;; check state
+                           (is (= expected-successful? @sucessful?)))
+                         ;; reset state
+                         (clean-all conn)
+                         (reset! sucessful? true)))]
+       (test-fn "update mapping should not fail on unchanged mapping"
+                true nil nil)
+       (test-fn "update mapping should not fail on field addition"
+                true :new-field m/token)
+       (test-fn "Update mapping fails when modifying existing field mapping and CTIA must not start in that case."
+                false :id m/text)))
 
-  (testing "init-es-conn! should return a proper conn state with aliased conf, and create an initial aliased index"
-    (index/delete! es-conn (str indexname "*"))
-    (let [services (->ESConnServices)
-          {:keys [index props config conn]}
-          (sut/init-es-conn! props-aliased services)
-          existing-index (index/get es-conn (str indexname "*"))
-          created-aliases (->> existing-index
-                               vals
-                               first
-                               :aliases
-                               keys
-                               set)]
-      (is (= #{(keyword indexname) (keyword write-alias)}
-             created-aliases))
-      (is (= index indexname))
-      (is (= (:write-index props) write-alias))
-      (is (= "http://localhost:9200" (:uri conn)))
-      (is (= indexname
-             (-> config :aliases keys first)))
-      (is (= "2s" (get-in config [:settings :refresh_interval])))
-      (is (= 1 (get-in config [:settings :number_of_replicas])))
-      (is (= 2 (get-in config [:settings :number_of_shards])))
-      (is (= {} (select-keys (:mappings config) [:a :b])))))
+     (testing "init-es-conn! should return a proper conn state with aliased conf, and create an initial aliased index"
+       (let [services (->ESConnServices)
+             {:keys [index props config conn]}
+             (-> (prepare-props props-aliased version)
+                 (sut/init-es-conn! services))
+             existing-index (index/get conn (str indexname "*"))
+             created-aliases (->> existing-index
+                                  vals
+                                  first
+                                  :aliases
+                                  keys
+                                  set)]
+         (is (= #{(keyword indexname) (keyword write-alias)}
+                created-aliases))
+         (is (= index indexname))
+         (is (= (:write-index props) write-alias))
+         (is (= (str "http://localhost:920" version) (:uri conn)))
+         (is (= indexname
+                (-> config :aliases keys first)))
+         (is (= "2s" (get-in config [:settings :refresh_interval])))
+         (is (= 1 (get-in config [:settings :number_of_replicas])))
+         (is (= 2 (get-in config [:settings :number_of_shards])))
+         (is (= {} (select-keys (:mappings config) [:a :b])))
+         (clean-all conn)))
 
-  (testing "init-es-conn! should return a conn state that ignore aliased conf setting when an unaliased index already exists"
-    (index/delete! es-conn (str indexname "*"))
-    (http/delete (str "http://localhost:9200/_template/" indexname "*"))
-    (index/create! es-conn
-                   indexname
-                   {:settings m/store-settings})
-    (let [services (->ESConnServices)
-          {:keys [index props config conn]}
-          (sut/init-es-conn! props-aliased services)
-          existing-index (index/get es-conn (str indexname "*"))
-          created-aliases (->> existing-index
-                               vals
-                               first
-                               :aliases
-                               keys
-                               set)]
-      (is (= #{} created-aliases))
-      (is (= index indexname))
-      (is (= (:write-index props) indexname))
-      (is (= "http://localhost:9200" (:uri conn)))
-      (is (= indexname
-             (-> config :aliases keys first)))
-      (is (= 1 (get-in config [:settings :number_of_replicas])))
-      (is (= 2 (get-in config [:settings :number_of_shards])))
-      (is (= {} (select-keys (:mappings config) [:a :b])))))
-  ;; clean
-  (http/delete (str "http://localhost:9200/_template/" indexname "*"))
-  (index/delete! es-conn (str indexname "*")))
+     (testing "init-es-conn! should return a conn state that ignore aliased conf setting when an unaliased index already exists"
+       (index/create! conn
+                      indexname
+                      {:settings m/store-settings})
+       (let [services (->ESConnServices)
+             {:keys [index props config conn]}
+             (-> (prepare-props props-aliased version)
+                 (sut/init-es-conn! services))
+             existing-index (index/get conn (str indexname "*"))
+             created-aliases (->> existing-index
+                                  vals
+                                  first
+                                  :aliases
+                                  keys
+                                  set)]
+         (is (= #{} created-aliases))
+         (is (= index indexname))
+         (is (= (:write-index props) indexname))
+         (is (= (str "http://localhost:920" version) (:uri conn)))
+         (is (= indexname
+                (-> config :aliases keys first)))
+         (is (= 1 (get-in config [:settings :number_of_replicas])))
+         (is (= 2 (get-in config [:settings :number_of_shards])))
+         (is (= {} (select-keys (:mappings config) [:a :b]))))))))
+
+(deftest update-index-state-test
+  (let [test-fn (fn [{:keys [update-mappings update-settings]
+                      :as props}]
+                  (let [updated-mappings (atom false)
+                        updated-template (atom false)
+                        updated-settings (atom false)]
+                    (with-redefs [sut/update-mappings! (fn [c] (reset! updated-mappings true))
+                                  sut/update-settings! (fn [c] (reset! updated-settings true))
+                                  sut/upsert-template! (fn [c] (reset! updated-template true))]
+                      (sut/update-index-state {:props props})
+                      (is (= @updated-mappings (boolean update-mappings)))
+                      (is (= @updated-template (boolean update-mappings)))
+                      (is (= @updated-settings (boolean update-settings))))))]
+    (doseq [update-mappings? [true false nil]
+            update-settings? [true false nil]]
+      (test-fn (assoc props-aliased
+                      :update-mappings update-mappings?
+                      :update-settings update-settings?)))))

--- a/test/ctia/stores/es/mapping_test.clj
+++ b/test/ctia/stores/es/mapping_test.clj
@@ -4,229 +4,189 @@
              [document :as doc]
              [conn :as conn]
              [index :as index]]
-            [clj-momo.lib.es.document :refer [bulk-create-doc]]
+            [ctia.test-helpers.es :as es-helpers]
             [clojure.test :refer [deftest testing is]]))
 
 (deftest mapping-test
-  (let [indexname "test_mapping"
-        doc-type "test_docs"
-        mapping {:id sut/all_token
-                 :boolean sut/boolean-type
-                 :float sut/float-type
-                 :long sut/long-type
-                 :integer sut/integer-type
-                 :table sut/embedded-data-table
-                 :timestamp sut/ts
-                 :source sut/token
-                 :token1 sut/token
-                 :token2 sut/token
-                 :all-token sut/all_token
-                 :text sut/text
-                 :all-text sut/all_token
-                 :sortable-all-text sut/sortable-all-text}
-        settings {:mappings {doc-type {:properties mapping}}
-                  :settings sut/store-settings}
-        es-conn (conn/connect {:host "localhost"
-                               :port 9200})
-        docs (map #(assoc {:id (str "doc" %)
-                           :boolean (even? %)
-                           :float (+ 100 %)
-                           :long (+ 200 %)
-                           :integer (+ 300 %)
-                           :table {:row_count %}
-                           :timestamp (format "2019-07-15T0%s:00:00.000-00:00" %)
-                           :source "cisco"
-                           :token1 "a lower token"
-                           :token2 "an upper TOKEN"
-                           :all-token "token in _all"
-                           :text "this is a simpletext"
-                           :all-text "this is an AllText"
-                           :sortable-all-text (str "sortable" %)}
-                          :_id (str "doc" %)
-                          :_index indexname
-                          :_type doc-type)
-                  (range 3))
-        [doc0 doc1 doc2] docs
-        test-not-all (fn [field search-value found-doc-id]
-                       (is (= found-doc-id
-                              (-> (doc/search-docs es-conn
-                                                   indexname
-                                                   {"term" {field search-value}}
-                                                   nil
-                                                   {})
-                                  :data
-                                  first
-                                  :id)))
-                       (is (nil? (-> (doc/search-docs es-conn
-                                                      indexname
-                                                      {"query_string" {"query" (str search-value)}}
-                                                      nil
-                                                      {})
-                                     :data
-                                     seq))))
-        test-sort (fn [field expected-asc]
-                    (is (= expected-asc
-                           (->> (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 nil
-                                                 {:sort_by field
-                                                  :sort_order "asc"})
-                                :data
-                                (map :id))))
-                    (is (= (reverse expected-asc)
-                           (->> (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 nil
-                                                 {:sort_by field
-                                                  :sort_order "desc"})
-                                :data
-                                (map :id)))))]
-    (index/delete! es-conn indexname)
-    (index/create! es-conn indexname settings)
-    (bulk-create-doc es-conn docs "true")
-    (index/refresh! es-conn indexname)
-    (testing "token should be matched with exact values, and can be directly used for aggregating and sorting on without fielddata"
-      (let [search-res-doc0 (doc/search-docs es-conn
-                                             indexname
-                                             nil
-                                             {:id "doc0"}
-                                             nil)
-            search-res-token1-1 (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 {:token1 "a lower token"}
-                                                 nil)
-            search-res-token1-2 (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 {:token1 "a lower TOKEN"}
-                                                 nil)
-            search-res-token1-3 (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 {:token1 "token"}
-                                                 nil)
+  (es-helpers/for-each-es-version
+   "mappings of different type should apply proper analyzers and tokenizers"
+   [5 7]
+   #(index/delete! % "ctia_*")
+   (let [indexname "ctia_test_mapping"
+         doc-type "test_docs"
+         mapping {:id sut/token
+                  :boolean sut/boolean-type
+                  :float sut/float-type
+                  :long sut/long-type
+                  :integer sut/integer-type
+                  :table sut/embedded-data-table
+                  :timestamp sut/ts
+                  :source sut/token
+                  :token1 sut/token
+                  :token2 sut/token
+                  :text1 sut/text
+                  :text2 sut/text
+                  :sortable-text sut/sortable-text}
+         settings {:mappings (cond-> {:properties mapping}
+                               (= version 5) (as-> m
+                                               ;; _all is enabled by default in ES5
+                                               ;; this field was removed by default in ES7
+                                               ;; we need to disable it to have a close behavior
+                                               (assoc m :_all {:enabled false}) 
+                                               {doc-type m}))
+                   :settings sut/store-settings}
+         docs (map #(assoc {:id (str "doc" %)
+                            :boolean (even? %)
+                            :float (+ 100 %)
+                            :long (+ 200 %)
+                            :integer (+ 300 %)
+                            :table {:row_count %}
+                            :timestamp (format "2019-07-15T0%s:00:00.000-00:00" %)
+                            :source "cisco"
+                            :token1 "a lower token"
+                            :token2 "an upper TOKEN"
+                            :text1 "this is a first text"
+                            :text2 "this is a second text"
+                            :sortable-text (str "sortable" %)}
+                           :_id (str "doc" %)
+                           :_index indexname
+                           :_type doc-type)
+                   (range 3))
+         [doc0 doc1 doc2] docs
+         test-sort (fn [field expected-asc]
+                     (is (= expected-asc
+                            (->> (doc/search-docs conn
+                                                  indexname
+                                                  nil
+                                                  nil
+                                                  {:sort_by field
+                                                   :sort_order "asc"})
+                                 :data
+                                 (map :id))))
+                     (is (= (reverse expected-asc)
+                            (->> (doc/search-docs conn
+                                                  indexname
+                                                  nil
+                                                  nil
+                                                  {:sort_by field
+                                                   :sort_order "desc"})
+                                 :data
+                                 (map :id)))))
+         search (fn [query filters opts]
+                  (:data
+                   (doc/search-docs conn
+                                    indexname
+                                    query
+                                    filters
+                                    opts)))]
+     (index/create! conn indexname settings)
+     (doc/bulk-create-doc conn docs {:refresh "true"})
+     (index/refresh! conn indexname)
+     (testing "token should be matched with exact values, and can be directly used for aggregating and sorting on without fielddata"
+       (let [res-doc0 (search nil
+                              {:id "doc0"}
+                              nil)
+             res-token1-1 (search nil
+                                  {:token1 "a lower token"}
+                                  nil)
+             res-token1-2 (search nil
+                                  {:token1 "a lower TOKEN"}
+                                  nil)
+             res-token1-3 (search nil
+                                  {:token1 "token"}
+                                  nil)
 
-            search-res-token2-1 (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 {:token2 "an upper token"}
-                                                 nil)
-            search-res-token2-2 (doc/search-docs es-conn
-                                                 indexname
-                                                 nil
-                                                 {:token2 "an upper TOKEN"}
-                                                 nil)
+             res-token2-1 (search nil
+                                  {:token2 "an upper token"}
+                                  nil)
+             res-token2-2 (search nil
+                                  {:token2 "an upper TOKEN"}
+                                  nil)
 
-            search-res-all-token-1 (doc/search-docs es-conn
-                                                    indexname
-                                                    {:query_string {:query "\"token in _all\""}}
-                                                    nil
-                                                    nil)
-            search-res-all-token-2 (doc/search-docs es-conn
-                                                    indexname
-                                                    {:query_string {:query "_all"}}
-                                                    nil
-                                                    nil)
-            search-res-all-token-3 (doc/search-docs es-conn
-                                                    indexname
-                                                    {:query_string {:query "upper"}}
-                                                    nil
-                                                    nil)]
-        (test-sort "id" '("doc0" "doc1" "doc2"))
+             res-all-token-1 (search {:query_string {:query "\"a lower token\""}}
+                                     nil
+                                     nil)
+             res-all-token-2 (search {:query_string {:query "\"A LOWER TOKEN\""}}
+                                     nil
+                                     nil)
+             res-all-token-3 (search {:query_string {:query "token"}}
+                                     nil
+                                     nil)]
+         (test-sort "id" '("doc0" "doc1" "doc2"))
 
-        (is (= "doc0" (-> search-res-doc0 :data first :id)))
-        (is (= 1 (-> search-res-doc0 :data count)))
+         (is (= ["doc0"] (map :id res-doc0)))
 
-        (is (= 3
-               (-> search-res-token1-1 :data count)
-               (-> search-res-token1-2 :data count)))
-        (is (= search-res-token1-1 search-res-token1-2))
-        (is (nil? (-> search-res-token1-3 :data seq)))
+         (is (= 3
+                (count res-token1-1)
+                (count res-token1-2)))
+         (is (= res-token1-1 res-token1-2))
+         (is (nil? (seq res-token1-3)))
 
-        (is (= 3
-               (-> search-res-token2-1 :data count)
-               (-> search-res-token2-2 :data count)))
-        (is (= search-res-token2-1 search-res-token2-2))
+         (is (= 3
+                (count res-token2-1)
+                (count res-token2-2)))
+         (is (= res-token2-1 res-token2-2))
 
-        (is (= 3
-               (-> search-res-all-token-1 :data count)
-               (-> search-res-all-token-2 :data count)))
-        (is (= search-res-all-token-1 search-res-all-token-2))
-        (is (nil? (-> search-res-all-token-3 :data seq)))))
+         (is (= 3
+                (count res-all-token-1)
+                (count res-all-token-2)))
+         (is (= res-all-token-1 res-all-token-2))
+         (is (nil? (seq res-all-token-3)))))
 
-    (testing "text should be matched with analyzed values, and cannot be used for aggregating and sorting without a fielddata field"
-      (let [search-res-text-1 (doc/search-docs es-conn
-                                               indexname
-                                               nil
-                                               {:text "simpletext"}
-                                               nil)
-            search-res-text-2 (doc/search-docs es-conn
-                                               indexname
-                                               {:query_string {:query "text:simpletext"}}
-                                               nil
-                                               nil)
-            search-res-text-3 (doc/search-docs es-conn
-                                               indexname
-                                               {:query_string {:query "simpletext"}}
-                                               nil
-                                               nil)
-            search-res-all-text (doc/search-docs es-conn
-                                                 indexname
-                                                 {:query_string {:query "alltext"}}
-                                                 nil
-                                                 nil)
-]
-        (is (= 3
-               (-> search-res-text-1 :data count)
-               (-> search-res-text-2 :data count)
-               (-> search-res-all-text :data count)))
-        (is (= search-res-text-1
-               search-res-text-2
-               search-res-all-text))
-        (is (nil? (-> search-res-text-3 :data seq)))
+     (testing "text should be matched with analyzed values, and cannot be used for aggregating and sorting without a fielddata field"
+       (let [res-text-1 (search nil
+                                {:text1 "text"}
+                                nil)
+             res-text-2 (search {:query_string {:query "text1:\"text\""}}
+                                nil
+                                nil)
+             res-text-3 (search {:query_string {:query "first text"}}
+                                nil
+                                nil)
+             res-cross-field-text (search {:query_string {:query "first second"}}
+                                          nil
+                                          nil)
 
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (doc/search-docs es-conn
-                                      indexname
-                                      {:query_string {:query "alltext"}}
+             res-missing-text (search {:query_string {:query "missing AND text"}}
                                       nil
-                                      {:sort_by "sortable-all-text"
-                                       :sort_order "asc"})))
-        (test-sort "sortable-all-text.whole" '("doc0" "doc1" "doc2"))))
-    (testing "ts mapping should be a date type, not in _all field and sortable"
-      (let [search-res-all (doc/search-docs es-conn
-                                            indexname
-                                            {:query_string {:query "2019"}}
-                                            nil
-                                            {})
-            search-res-range (doc/search-docs es-conn
-                                              indexname
-                                              {:range {:timestamp
-                                                       {"gte" "2019-07-15T01:00:00.000-00:00"}}}
-                                              nil
-                                              {})]
-        (test-sort "timestamp" '("doc0" "doc1" "doc2"))
-        (is (nil? (-> search-res-all :data seq)))
-        (is (= #{"doc1" "doc2"}
-               (->> search-res-range
-                    :data
-                    (map :id)
-                    set)))))
-    (testing "float-type should not be included in _all"
-      (test-sort "float" '("doc0" "doc1" "doc2"))
-      (test-not-all "float" 100 "doc0"))
-    (testing "long-type should not be included in _all and we can be sorted on"
-      (test-sort "long" '("doc0" "doc1" "doc2"))
-      (test-not-all "long" 200 "doc0"))
-    (testing "integer-type should not be included in _all"
-      (test-sort "integer" '("doc0" "doc1" "doc2"))
-      (test-not-all "integer" 300 "doc0"))
-    (testing "boolean-type should not be included in _all"
-      (test-sort "boolean,id" '("doc1" "doc0" "doc2"))
-      (test-not-all "boolean" false "doc1"))
-    (testing "embedded data table should not be included in _all"
-      (test-not-all "table.row_count" 0 "doc0"))
-    (index/delete! es-conn indexname)))
+                                      nil)
+             ]
+         (is (= 3
+                (count res-text-1)
+                (count res-text-2)
+                (count res-cross-field-text)))
+         (is (= res-text-1
+                res-text-2
+                res-cross-field-text))
+         (is (nil? (seq res-missing-text)))
+
+         (is (thrown? clojure.lang.ExceptionInfo
+                      (search {:query_string {:query "simpletext"}}
+                              nil
+                              {:sort_by "sortable-text"
+                               :sort_order "asc"})))
+         (test-sort "sortable-text.whole" '("doc0" "doc1" "doc2"))))
+     (testing "ts mapping should be a date type, not in _all field and sortable"
+       (let [res-all (search {:query_string {:query "2019"}}
+                             nil
+                             {})
+             res-range (search {:range {:timestamp
+                                        {"gte" "2019-07-15T01:00:00.000-00:00"}}}
+                               nil
+                               {})]
+         (test-sort "timestamp" '("doc0" "doc1" "doc2"))
+         (is (nil? (seq res-all)))
+         (is (= #{"doc1" "doc2"}
+                (->> res-range
+                     (map :id)
+                     set)))))
+     (testing "scalar type should be properly sorted"
+       (doseq [[s r] (concat
+                      (map vector
+                           ["float"
+                            "long"
+                            "integer"
+                            "table.row_count"]
+                           (repeat '("doc0" "doc1" "doc2")))
+                      [["boolean,id" '("doc1" "doc0" "doc2")]])]
+         (test-sort s r))))))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -1,6 +1,5 @@
 (ns ctia.task.migration.migrate-es-stores-test
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
-            [clj-momo.lib.es.document :as es-doc]
             [clj-momo.test-helpers.core :as mth]
             [clojure.data :refer [diff]]
             [clojure.java.io :as io]
@@ -206,7 +205,7 @@
     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           {:keys [all-stores]} (helpers/get-service-map app :StoreService)
           services (app->MigrationStoreServices app)
-
+          conn (es-conn get-in-config)
           store-types [:malware :tool :incident]]
       (helpers/set-capabilities! app
                                  "foouser"
@@ -221,7 +220,7 @@
       (rollover-post-bulk app all-stores)
       ;; insert malformed documents
       (doseq [store-type store-types]
-        (es-index/get (es-conn get-in-config)
+        (es-index/get conn
                       (str (get-in (es-props get-in-config) [store-type :indexname]) "*")))
       (sut/migrate-store-indexes {:migration-id "test-3"
                                   :prefix       "0.0.0"
@@ -232,17 +231,17 @@
                                   :confirm?     true
                                   :restart?     false}
                                  services)
-      (let [migration-state (es-doc/get-doc (es-conn get-in-config)
-                                            (migration-index get-in-config)
-                                            "migration"
-                                            "test-3"
-                                            {})]
+      (let [migration-state (ductile.doc/get-doc conn
+                                                 (migration-index get-in-config)
+                                                 "migration"
+                                                 "test-3"
+                                                 {})]
           (doseq [store-type store-types]
-            (is (= (count (es-index/get (es-conn get-in-config)
+            (is (= (count (es-index/get conn
                                         (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*")))
                    3)
                 "target indice should be rolledover during migration")
-            (es-index/get (es-conn get-in-config)
+            (es-index/get conn
                           (str "v0.0.0_" (get-in (es-props get-in-config) [store-type :indexname]) "*"))
             (let [migrated-store (get-in migration-state [:stores store-type])
                   {:keys [source target]} migrated-store]
@@ -256,8 +255,8 @@
   (with-each-fixtures identity app
     (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
       (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-
-            storemap {:conn (es-conn get-in-config)
+            conn (es-conn get-in-config)
+            storemap {:conn conn
                       :indexname "ctia_relationship"
                       :mapping "relationship"
                       :props {:write-index "ctia_relationship"}
@@ -266,7 +265,7 @@
                       :config {}}
             docs (map es-helpers/prepare-bulk-ops
                       (line-seq rdr))
-            _ (es-helpers/load-bulk (es-conn get-in-config) docs)
+            _ (es-helpers/load-bulk conn docs)
             no-meta-docs (map #(dissoc % :_index :_type :_id)
                               docs)
             docs-no-modified (filter #(nil? (:modified %))
@@ -351,7 +350,8 @@
 
             prefix "0.0.1"
             indexname "v0.0.1_ctia_relationship"
-            storemap {:conn (es-conn get-in-config)
+            conn (es-conn get-in-config)
+            storemap {:conn conn
                       :indexname indexname
                       :mapping "relationship"
                       :props {:write-index indexname}
@@ -368,7 +368,7 @@
                          :migration-id migration-id
                          :migrations (sut/compose-migrations [:__test])
                          :batch-size 1000
-                         :migration-es-conn (es-conn get-in-config)
+                         :migration-es-conn conn
                          :confirm? true}
             test-fn (fn [total
                          migrated-count
@@ -395,12 +395,12 @@
                                                           services)
                             {target-state :target
                              source-state :source} (-> (get-migration migration-id
-                                                                      (es-conn get-in-config)
+                                                                      conn
                                                                       services)
                                                        :stores
                                                        :relationship)
-                            _ (es-index/refresh! (es-conn get-in-config))
-                            migrated-docs (:data (ductile.doc/query (es-conn get-in-config)
+                            _ (es-index/refresh! conn)
+                            migrated-docs (:data (ductile.doc/query conn
                                                                     indexname
                                                                     {:match_all {}}
                                                                     {:limit total}))]
@@ -447,7 +447,7 @@
     (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
       (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
             services (app->MigrationStoreServices app)
-
+            conn (es-conn get-in-config)
             {wo-modified true
              w-modified false} (->> (line-seq rdr)
                                     (map es-helpers/prepare-bulk-ops)
@@ -456,7 +456,7 @@
             bulk-1 (concat wo-modified (take 500 sorted-w-modified))
             bulk-2 (drop 500 sorted-w-modified)
             logger-1 (atom [])
-            _ (es-helpers/load-bulk (es-conn get-in-config) bulk-1)
+            _ (es-helpers/load-bulk conn bulk-1)
             _ (with-atom-logger logger-1
                 (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                             :prefix       "0.0.0"
@@ -467,15 +467,15 @@
                                             :confirm?     true
                                             :restart?     false}
                                            services))
-            migration-state-1 (es-doc/get-doc (es-conn get-in-config)
-                                              (migration-index get-in-config)
-                                              "migration"
-                                              "migration-test-4"
-                                              {})
-            target-count-1 (ductile.doc/count-docs (es-conn get-in-config)
+            migration-state-1 (ductile.doc/get-doc conn
+                                                   (migration-index get-in-config)
+                                                   "migration"
+                                                   "migration-test-4"
+                                                   {})
+            target-count-1 (ductile.doc/count-docs conn
                                                    "v0.0.0_ctia_relationship"
                                                    nil)
-            _ (es-helpers/load-bulk (es-conn get-in-config) bulk-2)
+            _ (es-helpers/load-bulk conn bulk-2)
             _ (with-atom-logger logger-1
                 (sut/migrate-store-indexes {:migration-id "migration-test-4"
                                             :prefix       "0.0.0"
@@ -486,14 +486,14 @@
                                             :confirm?     true
                                             :restart?     true}
                                            services))
-            target-count-2 (ductile.doc/count-docs (es-conn get-in-config)
+            target-count-2 (ductile.doc/count-docs conn
                                                    "v0.0.0_ctia_relationship"
                                                    nil)
-            migration-state-2 (es-doc/get-doc (es-conn get-in-config)
-                                              (migration-index get-in-config)
-                                              "migration"
-                                              "migration-test-4"
-                                              {})]
+            migration-state-2 (ductile.doc/get-doc conn
+                                                   (migration-index get-in-config)
+                                                   "migration"
+                                                   "migration-test-4"
+                                                   {})]
         (is (= (+ 500 (count wo-modified))
                target-count-1
                (get-in migration-state-1 [:stores :relationship :target :migrated])
@@ -511,7 +511,7 @@
     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           {:keys [all-stores]} (helpers/get-service-map app :StoreService)
           services (app->MigrationStoreServices app)
-
+          conn (es-conn get-in-config)
           store-types [:malware :tool :incident]
           logger (atom [])
           bad-doc {:id 1
@@ -532,11 +532,11 @@
         (rollover-post-bulk app all-stores)
         ;; insert malformed documents
         (doseq [store-type store-types]
-          (es-doc/create-doc (es-conn get-in-config)
-                             (str (get-in (es-props get-in-config) [store-type :indexname]) "-write")
-                             (name store-type)
-                             bad-doc
-                             "true"))
+          (ductile.doc/create-doc conn
+                                  (str (get-in (es-props get-in-config) [store-type :indexname]) "-write")
+                                  (name store-type)
+                                  bad-doc
+                                  {:refresh "true"}))
         (with-atom-logger logger
           (sut/migrate-store-indexes {:migration-id "test-3"
                                       :prefix       "0.0.0"
@@ -548,11 +548,11 @@
                                       :restart?     false}
                                      services))
         (let [messages (set @logger)
-              migration-state (es-doc/get-doc (es-conn get-in-config)
-                                              (migration-index get-in-config)
-                                              "migration"
-                                              "test-3"
-                                              {})]
+              migration-state (ductile.doc/get-doc conn
+                                                   (migration-index get-in-config)
+                                                   "migration"
+                                                   "test-3"
+                                                   {})]
           (doseq [store-type store-types]
             (let [migrated-store (get-in migration-state [:stores store-type])
                   {:keys [source target]} migrated-store]
@@ -569,7 +569,8 @@
   ;; TODO clean data
   (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
         {:keys [all-stores]} (helpers/get-service-map app :StoreService)
-        services (app->MigrationStoreServices app)]
+        services (app->MigrationStoreServices app)
+        conn (es-conn get-in-config)]
     (helpers/set-capabilities! app
                                "foouser"
                                ["foogroup"]
@@ -596,32 +597,33 @@
 
         (doseq [store (vals (all-stores))]
           (is (not (index-exists? store "0.0.0"))))
-        (is (nil? (seq (es-doc/get-doc (es-conn get-in-config)
-                                       (migration-index get-in-config)
-                                       "migration"
-                                       "test-1"
-                                       {})))))))
-  (testing "migrate es indexes"
-    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          {:keys [all-stores]} (helpers/get-service-map app :StoreService)
-          services (app->MigrationStoreServices app)
-          logger (atom [])]
-        (with-atom-logger logger
-          (sut/migrate-store-indexes {:migration-id "test-2"
-                                      :prefix       "0.0.0"
-                                      :migrations   [:__test]
-                                      :store-keys   (keys (all-stores))
-                                      :batch-size   10
-                                      :buffer-size  3
-                                      :confirm?     true
-                                      :restart?     false}
-                                     services))
-        (testing "shall generate a proper migration state"
-          (let [migration-state (es-doc/get-doc (es-conn get-in-config)
-                                                (migration-index get-in-config)
-                                                "migration"
-                                                "test-2"
-                                                {})]
+        (is (nil? (seq (ductile.doc/get-doc conn
+                                            (migration-index get-in-config)
+                                            "migration"
+                                            "test-1"
+                                            {})))))))
+   (testing "migrate es indexes"
+     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+           {:keys [all-stores]} (helpers/get-service-map app :StoreService)
+           services (app->MigrationStoreServices app)
+           conn (es-conn get-in-config)
+           logger (atom [])]
+       (with-atom-logger logger
+         (sut/migrate-store-indexes {:migration-id "test-2"
+                                     :prefix       "0.0.0"
+                                     :migrations   [:__test]
+                                     :store-keys   (keys (all-stores))
+                                     :batch-size   10
+                                     :buffer-size  3
+                                     :confirm?     true
+                                     :restart?     false}
+                                    services))
+       (testing "shall generate a proper migration state"
+          (let [migration-state (ductile.doc/get-doc conn
+                                                     (migration-index get-in-config)
+                                                     "migration"
+                                                     "test-2"
+                                                     {})]
             (is (= (set (keys (all-stores)))
                    (set (keys (:stores migration-state)))))
             (doseq [[entity-type migrated-store] (:stores migration-state)]
@@ -720,9 +722,8 @@
                              (format  "v0.0.0_%s-%s-000003" (:indexname k) index-date) 0}))
                      (into expected-event-indices)
                      keywordize-keys)
-                _ (es-index/refresh! (es-conn get-in-config))
-                formatted-cat-indices (es-helpers/get-cat-indices (:host default)
-                                                                  (:port default))
+                _ (es-index/refresh! conn)
+                formatted-cat-indices (es-helpers/get-cat-indices conn)
                 result-indices (select-keys formatted-cat-indices
                                             (keys expected-indices))]
             (is (= expected-indices result-indices)
@@ -733,7 +734,7 @@
                           only-result)))
             (doseq [[index _]
                     expected-indices]
-              (let [docs (->> (ductile.doc/search-docs (es-conn get-in-config) (name index) nil nil {})
+              (let [docs (->> (ductile.doc/search-docs conn (name index) nil nil {})
                               :data
                               (map :groups))]
                 (is (every? #(= ["migration-test"] %)
@@ -742,7 +743,7 @@
           (let [;; retrieve the first 2 source indices for sighting store
                 {:keys [host port]} (get-in-config [:ctia :store :es :default])
                 [sighting-index-1 sighting-index-2]
-                (->> (es-helpers/get-cat-indices host port)
+                (->> (es-helpers/get-cat-indices conn)
                      keys
                      (map name)
                      (filter #(.contains ^String % "sighting"))
@@ -750,7 +751,7 @@
                      (take 2))
 
                 ;; retrieve source entity to update, in first position of first index
-                es-sighting0 (-> (ductile.doc/query (es-conn get-in-config)
+                es-sighting0 (-> (ductile.doc/query conn
                                                     sighting-index-1
                                                     {:match_all {}}
                                                     {:sort_by "timestamp:asc"
@@ -758,7 +759,7 @@
                                  :data
                                  first)
                 ;; retrieve source entity to update, in first position of second index
-                es-sighting1 (-> (ductile.doc/query (es-conn get-in-config)
+                es-sighting1 (-> (ductile.doc/query conn
                                                     sighting-index-2
                                                     {:match_all {}}
                                                     {:sort_by "timestamp:asc"
@@ -772,14 +773,14 @@
                                   (hash-map :malwares))
 
                 ;; retrieve 5 source entities to delete, in last positions of first index
-                es-sightings-1 (-> (ductile.doc/query (es-conn get-in-config)
+                es-sightings-1 (-> (ductile.doc/query conn
                                                       sighting-index-1
                                                       {:match_all {}}
                                                       {:sort_by "timestamp:desc"
                                                        :limit 5})
                                    :data)
                 ;; retrieve 5 source entities to delete, in last positions of second index
-                es-sightings-2 (-> (ductile.doc/query (es-conn get-in-config)
+                es-sightings-2 (-> (ductile.doc/query conn
                                                       sighting-index-2
                                                       {:match_all {}}
                                                       {:sort_by "timestamp:desc"
@@ -819,7 +820,7 @@
                                         :confirm?     true
                                         :restart?     true}
                                        services)
-            (let [migration-state (get-migration "test-2" (es-conn get-in-config) services)
+            (let [migration-state (get-migration "test-2" conn services)
                   malware-migration (get-in migration-state [:stores :malware])
                   sighting-migration (get-in migration-state [:stores :sighting])
                   malware-target-store (get-in malware-migration [:target :store])
@@ -851,7 +852,7 @@
   (doseq [batch-size [1000 3000 6000 10000]]
     (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
           services (app->MigrationStoreServices app)
-
+          conn (es-conn get-in-config)
           total-docs (* (count @example-types) 20000)
           _ (println (format "===== migrating %s documents with batch size %s"
                              total-docs
@@ -871,19 +872,19 @@
           end (System/currentTimeMillis)
           total (/ (- end start) 1000)
           doc-per-sec (/ total-docs total)
-          migration-state (es-doc/get-doc (es-conn get-in-config)
-                                          (migration-index get-in-config)
-                                          "migration"
-                                          migration-id
-                                          {})]
+          migration-state (ductile.doc/get-doc conn
+                                               (migration-index get-in-config)
+                                               "migration"
+                                               migration-id
+                                               {})]
       (println "total: " (float total))
       (println "documents per seconds: " (float doc-per-sec))
       (doseq [[_ state] (:stores migration-state)]
         (is (= 20000
                (get-in state [:source :total])
                (get-in state [:target :migrated]))))
-      (es-index/delete! (es-conn get-in-config) (format "v%s*" prefix))
-      (es-doc/delete-doc (es-conn get-in-config) "migration" migration-id "true")))
+      (es-index/delete! conn (format "v%s*" prefix))
+      (ductile.doc/delete-doc conn "migration" migration-id {:refresh "true"})))
   (es-index/delete! (es-conn (helpers/current-get-in-config-fn app)) "ctia_*"))
 
 ;;(deftest ^:integration minimal-load-test

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -3,12 +3,11 @@
             [clj-momo.lib.clj-time.core :as time]
             [ductile
              [conn :refer [connect]]
-             [index :as ductile.index]]
-            [clj-momo.lib.es.document :as es-doc]
-            [clj-momo.test-helpers.core :as mth]
+             [index :as ductile.index]
+             [document :as es-doc]]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [ctia.stores.es.mapping :as em]
             [ctia.task.migration.store :as sut]
             [ctia.task.rollover :refer [rollover-stores]]
@@ -180,21 +179,21 @@
         "format-range-buckets should properly format raw buckets per month")))
 
 (deftest wo-storemaps-test
-  (let [app (helpers/get-current-app)
-        services (app->MigrationStoreServices app)
-
-        fake-migration (sut/init-migration {:migration-id "migration-id-1"
-                                            :prefix "0.0.0"
-                                            :store-keys [:tool :sighting :malware]
-                                            :confirm? false
-                                            :migrations [:identity]
-                                            :batch-size 1000
-                                            :buffer-size 3
-                                            :restart? false}
-                                           services)
-        wo-stores (sut/wo-storemaps fake-migration)]
-    (is (nil? (get-in wo-stores [:source :store])))
-    (is (nil? (get-in wo-stores [:target :store])))))
+  (helpers/fixture-ctia-with-app
+   (fn [app]
+     (let [services (app->MigrationStoreServices app)
+           fake-migration (sut/init-migration {:migration-id "migration-id-1"
+                                               :prefix "0.0.0"
+                                               :store-keys [:tool :sighting :malware]
+                                               :confirm? false
+                                               :migrations [:identity]
+                                               :batch-size 1000
+                                               :buffer-size 3
+                                               :restart? false}
+                                              services)
+           wo-stores (sut/wo-storemaps fake-migration)]
+       (is (nil? (get-in wo-stores [:source :store])))
+       (is (nil? (get-in wo-stores [:target :store])))))))
 
 (deftest rollover?-test
   (is (false? (sut/rollover? false 10 10 10))
@@ -231,451 +230,446 @@
                                       :modified "04-29-2019"}))))
 
 (deftest get-target-stores-test
-  (let [app (helpers/get-current-app)
-        services (app->MigrationStoreServices app)
-
-        {:keys [tool malware]}
-        (sut/get-target-stores "0.0.0" [:tool :malware] services)]
-    (is (= "v0.0.0_ctia_malware" (:indexname malware)))
-    (is (= "v0.0.0_ctia_tool" (:indexname tool)))
-    (is (= "v0.0.0_ctia_malware-write" (get-in malware [:props :write-index])))
-    (is (= "v0.0.0_ctia_tool-write" (get-in tool [:props :write-index])))))
+  (helpers/fixture-ctia-with-app
+   (fn [app]
+     (let [services (app->MigrationStoreServices app)
+           {:keys [tool malware]}
+           (sut/get-target-stores "0.0.0" [:tool :malware] services)]
+       (is (= "v0.0.0_ctia_malware" (:indexname malware)))
+       (is (= "v0.0.0_ctia_tool" (:indexname tool)))
+       (is (= "v0.0.0_ctia_malware-write" (get-in malware [:props :write-index])))
+       (is (= "v0.0.0_ctia_tool-write" (get-in tool [:props :write-index])))))))
 
 
 (use-fixtures :once
-  (join-fixtures [mth/fixture-schema-validation
-                  es-helpers/fixture-properties:es-store
-                  validate-schemas]))
-
-(defn es-props [get-in-config]
-  (get-in-config [:ctia :store :es]))
-
-(defn es-conn [get-in-config]
-  (connect (:default (es-props get-in-config))))
-
-(defn migration-index [get-in-config]
-  (get-in (es-props get-in-config) [:migration :indexname]))
-
-(defn fixture-clean-migration [t]
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
-    (try
-      (t)
-      (finally
-        (doto (es-conn get-in-config)
-          (ductile.index/delete! "v0.0.0*")
-          (ductile.index/delete! (str (migration-index get-in-config) "*")))))))
-
-(use-fixtures :each
-  (join-fixtures [helpers/fixture-ctia
-                  es-helpers/fixture-delete-store-indexes
-                  fixture-clean-migration]))
+  es-helpers/fixture-properties:es-store
+  validate-schemas)
 
 (def fixtures-nb 100)
 (def examples (fixt/bundle fixtures-nb false))
 
 (deftest rollover-test
-  (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (let [app (helpers/get-current-app)
-          {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
-
-          storename "ctia_relationship"
-          write-alias (str storename "-write")
-          max-docs 40
-          batch-size 4
-          storemap {:conn (es-conn get-in-config)
-                    :indexname storename
-                    :mapping "relationship"
-                    :props {:aliased true
-                            :write-index write-alias
-                            :rollover {:max_docs max-docs}}
-                    :type "relationship"
-                    :settings {}
-                    :config {}}
-          docs-all (->> (line-seq rdr)
-                        (map es-helpers/prepare-bulk-ops)
-                        (map #(assoc % :_index write-alias)))
-          batch-sizes (repeatedly 300 #(inc (rand-int batch-size)))
-          test-fn (fn [{:keys [source-docs
-                               migrated-count
-                               current-index-size]
-                        :as state}
-                       nb]
-                    (let [rollover? (<= max-docs (+ current-index-size nb))
-                          cat-before (es-helpers/get-cat-indices
-                                      "localhost"
-                                      9200)
-                          indices-before (set (keys cat-before))
-                          _ (es-helpers/load-bulk (es-conn get-in-config)
-                                                  (take nb source-docs)
-                                                  "false")
-                          res (when rollover?
-                                (sut/rollover storemap
-                                              batch-size
-                                              (+ nb migrated-count)
-                                              services))
-                          cat-after (es-helpers/get-cat-indices
-                                     "localhost"
-                                     9200)
-                          indices-after (set (keys cat-after))
-                          total-after (reduce + (vals cat-after))]
-                      (when rollover?
-                        (is (true? (:rolled_over res)))
-                        (is (< (count indices-before)
-                               (count indices-after)))
-                        (is (= (+ nb migrated-count)
-                               total-after)))
-                      (when-not rollover?
-                        (is (= indices-before indices-after)))
-
-                      (cond-> (update state :migrated-count + nb)
-                        true (assoc :source-docs (drop nb source-docs))
-                        rollover? (assoc :current-index-size 0)
-                        (not rollover?) (update :current-index-size + nb))))]
-      (ductile.index/delete! (es-conn get-in-config) (str "*" storename "*"))
-      (ductile.index/create! (es-conn get-in-config)
-                        (format "<%s-000001>" storename)
-                        {:settings {:refresh_interval -1}
-                         :aliases {write-alias {}}})
-      (testing "rollover should refresh write index and trigger rollover when index size is strictly bigger than max-docs"
-        (reduce test-fn
-                {:source-docs docs-all
-                 :migrated-count 0
-                 :current-index-size 0}
-                batch-sizes)
-
-        (is (every? #(<= % (+ max-docs batch-size))
-                    (->> (es-helpers/get-cat-indices
-                          "localhost"
-                          9200)
-                         (keep (fn [[k v]]
-                                 (when (str/starts-with? (name k) storename)
-                                   v)))))
-            "All the indices should be smaller than max-docs + batch-size")))))
-
-(deftest sliced-queries-test
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-
-        storemap {:conn (es-conn get-in-config)
-                  :indexname "ctia_relationship"
-                  :mapping "relationship"
-                  :props {:write-index "ctia_relationship"}
-                  :type "relationship"
-                  :settings {}
-                  :config {}}
-        _ (es-helpers/load-file-bulk (es-conn get-in-config) "./test/data/indices/sample-relationships-1000.json")
-        expected-queries [missing-modified-query
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-02-26T00:00:00.000Z",
-                               :lt "2018-02-26T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-03-05T00:00:00.000Z",
-                               :lt "2018-03-05T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-03-12T00:00:00.000Z",
-                               :lt "2018-03-12T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-03-19T00:00:00.000Z",
-                               :lt "2018-03-19T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-04-09T00:00:00.000Z",
-                               :lt "2018-04-09T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-04-16T00:00:00.000Z",
-                               :lt "2018-04-16T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-04-23T00:00:00.000Z",
-                               :lt "2018-04-23T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-04-30T00:00:00.000Z",
-                               :lt "2018-04-30T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-05-07T00:00:00.000Z",
-                               :lt "2018-05-07T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-05-14T00:00:00.000Z",
-                               :lt "2018-05-14T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-05-21T00:00:00.000Z",
-                               :lt "2018-05-21T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-06-18T00:00:00.000Z",
-                               :lt "2018-06-18T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-06-25T00:00:00.000Z",
-                               :lt "2018-06-25T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-07-02T00:00:00.000Z",
-                               :lt "2018-07-02T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-07-09T00:00:00.000Z",
-                               :lt "2018-07-09T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-07-16T00:00:00.000Z",
-                               :lt "2018-07-16T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-07-23T00:00:00.000Z",
-                               :lt "2018-07-23T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter
-                            {:range
-                             {:modified
-                              {:gte "2018-07-30T00:00:00.000Z",
-                               :lt "2018-07-30T00:00:00.000Z||+1w"}}}}}
-                          {:bool
-                           {:filter {:range {:modified {:gte "2018-08-06T00:00:00.000Z"}}}}}]]
-    (is (= expected-queries
-           (sut/sliced-queries storemap nil "week")))
-    (is (= [missing-modified-query
-            {:bool
-             {:filter
-              {:range
-               {:modified
-                {:gte "2018-07-16T00:00:00.000Z",
-                 :lt "2018-07-16T00:00:00.000Z||+1w"}}}}}
-            {:bool
-             {:filter
-              {:range
-               {:modified
-                {:gte "2018-07-23T00:00:00.000Z",
-                 :lt "2018-07-23T00:00:00.000Z||+1w"}}}}}
-            {:bool
-             {:filter
-              {:range
-               {:modified
-                {:gte "2018-07-30T00:00:00.000Z",
-                 :lt "2018-07-30T00:00:00.000Z||+1w"}}}}}
-            {:bool
-             {:filter {:range {:modified {:gte "2018-08-06T00:00:00.000Z"}}}}}]
-           (sut/sliced-queries storemap
-                               [(time-coerce/to-long "2018-07-16T00:00:00.000Z")
-                                "whatever"]
-                               "week"))
-        "slice-queries should take into account search_after param")))
-
-(deftest bulk-metas-test
-  ;; insert elements in different indices and check that we retrieve the right one
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-        {:keys [all-stores]} (helpers/get-service-map app :StoreService)
-        services (app->MigrationStoreServices app)
-
-        sighting-store-map {:conn (es-conn get-in-config)
-                            :indexname "ctia_sighting"
-                            :props {:write-index "ctia_sighting"}
-                            :mapping "sighting"
-                            :type "sighting"
+  (es-helpers/for-each-es-version
+   "rollover should refresh write index and trigger rollover when index size is strictly bigger than max-docs"
+   [5 7]
+   #(ductile.index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     (fn []
+       (helpers/fixture-ctia-with-app
+        (fn [app]
+          (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
+            (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+                  services (app->MigrationStoreServices app)
+                  storename "ctia_relationship"
+                  write-alias (str storename "-write")
+                  max-docs 40
+                  batch-size 4
+                  storemap {:conn conn
+                            :indexname storename
+                            :mapping "relationship"
+                            :props {:aliased true
+                                    :write-index write-alias
+                                    :rollover {:max_docs max-docs}}
+                            :type "relationship"
                             :settings {}
                             :config {}}
-        post-bulk-res-1 (POST-bulk app examples)
-        {:keys [nb-errors]} (rollover-stores (all-stores))
-        _ (is (= 0 nb-errors))
-        post-bulk-res-2 (POST-bulk app examples)
-        malware-ids (->> (:malwares post-bulk-res-1)
-                         (map #(-> % long-id->id :short-id))
-                         (take 10))
-        sighting-ids-1 (->> (:sightings post-bulk-res-1)
-                            (map #(-> % long-id->id :short-id))
-                            (take 10))
-        sighting-ids-2 (->> (:sightings post-bulk-res-2)
-                            (map #(-> % long-id->id :short-id))
-                            (take 10))
-        _ (ductile.index/refresh! (es-conn get-in-config))
-        [malware-index-1 _] (->> (ductile.index/get (es-conn get-in-config) "ctia_malware*")
-                                 keys
-                                 sort
-                                 (map name))
-        [sighting-index-1 sighting-index-2] (->> (ductile.index/get (es-conn get-in-config) "ctia_sighting*")
-                                                 keys
-                                                 sort
-                                                 (map name))
-        bulk-metas-malware-res (sut/bulk-metas sighting-store-map malware-ids services)
-        bulk-metas-sighting-res-1 (sut/bulk-metas sighting-store-map sighting-ids-1 services)
-        bulk-metas-sighting-res-2 (sut/bulk-metas sighting-store-map sighting-ids-2 services)]
-    (testing "bulk-metas should property return _id, _type, _index from a document id"
-      (doseq [[_id metas] bulk-metas-malware-res]
-        (is (= _id (:_id metas)))
-        (is (= "malware" (:_type metas)))
-        (is (= malware-index-1 (:_index metas))))
-      (doseq [[_id metas] bulk-metas-sighting-res-1]
-        (is (= _id (:_id metas)))
-        (is (= "sighting" (:_type metas)))
-        (is (= sighting-index-1 (:_index metas))))
-      (doseq [[_id metas] bulk-metas-sighting-res-2]
-        (is (= _id (:_id metas)))
-        (is (= "sighting" (:_type metas)))
-        (is (= sighting-index-2 (:_index metas)))))))
+                  docs-all (->> (line-seq rdr)
+                                 (map es-helpers/prepare-bulk-ops)
+                                 (map #(assoc % :_index write-alias)))
+                  batch-sizes (repeatedly 300 #(inc (rand-int batch-size)))
+                  test-fn (fn [{:keys [source-docs
+                                       migrated-count
+                                       current-index-size]
+                                :as state}
+                               nb]
+                            (let [rollover? (<= max-docs (+ current-index-size nb))
+                                  cat-before (es-helpers/get-cat-indices conn)
+                                  indices-before (set (keys cat-before))
+                                  _ (es-helpers/load-bulk conn
+                                                          (take nb source-docs)
+                                                          "false")
+                                  res (when rollover?
+                                        (sut/rollover storemap
+                                                      batch-size
+                                                      (+ nb migrated-count)
+                                                      services))
+                                  cat-after (es-helpers/get-cat-indices conn)
+                                  indices-after (set (keys cat-after))
+                                  total-after (reduce + (vals cat-after))]
+                              (when rollover?
+                                (is (true? (:rolled_over res)))
+                                (is (< (count indices-before)
+                                       (count indices-after)))
+                                (is (= (+ nb migrated-count)
+                                       total-after)))
+                              (when-not rollover?
+                                (is (= indices-before indices-after)))
+
+                              (cond-> (update state :migrated-count + nb)
+                                true (assoc :source-docs (drop nb source-docs))
+                                rollover? (assoc :current-index-size 0)
+                                (not rollover?) (update :current-index-size + nb))))]
+              (reduce test-fn
+                      {:source-docs docs-all
+                       :migrated-count 0
+                       :current-index-size 0}
+                      batch-sizes)
+
+              (is (every? #(<= % (+ max-docs batch-size))
+                          (->> (es-helpers/get-cat-indices conn)
+                               (keep (fn [[k v]]
+                                       (when (str/starts-with? (name k) storename)
+                                         v)))))
+                  "All the indices should be smaller than max-docs + batch-size")))))))))
+
+(deftest sliced-queries-test
+  (es-helpers/for-each-es-version
+   "Sliced-queries should properly decompose a store into time window queries for given time interval"
+   [5 7]
+   #(ductile.index/delete! % "*ctia_relationship*")
+   (helpers/with-properties* ;; simple way to have a proper store initialization
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [storemap {:conn conn
+                         :indexname "ctia_relationship"
+                         :mapping "relationship"
+                         :props {:write-index "ctia_relationship"}
+                         :type "relationship"
+                         :settings {}
+                         :config {}}
+               _ (es-helpers/load-file-bulk conn "./test/data/indices/sample-relationships-1000.json")
+               expected-queries [missing-modified-query
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-02-26T00:00:00.000Z",
+                                      :lt "2018-02-26T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-03-05T00:00:00.000Z",
+                                      :lt "2018-03-05T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-03-12T00:00:00.000Z",
+                                      :lt "2018-03-12T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-03-19T00:00:00.000Z",
+                                      :lt "2018-03-19T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-04-09T00:00:00.000Z",
+                                      :lt "2018-04-09T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-04-16T00:00:00.000Z",
+                                      :lt "2018-04-16T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-04-23T00:00:00.000Z",
+                                      :lt "2018-04-23T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-04-30T00:00:00.000Z",
+                                      :lt "2018-04-30T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-05-07T00:00:00.000Z",
+                                      :lt "2018-05-07T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-05-14T00:00:00.000Z",
+                                      :lt "2018-05-14T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-05-21T00:00:00.000Z",
+                                      :lt "2018-05-21T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-06-18T00:00:00.000Z",
+                                      :lt "2018-06-18T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-06-25T00:00:00.000Z",
+                                      :lt "2018-06-25T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-07-02T00:00:00.000Z",
+                                      :lt "2018-07-02T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-07-09T00:00:00.000Z",
+                                      :lt "2018-07-09T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-07-16T00:00:00.000Z",
+                                      :lt "2018-07-16T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-07-23T00:00:00.000Z",
+                                      :lt "2018-07-23T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter
+                                   {:range
+                                    {:modified
+                                     {:gte "2018-07-30T00:00:00.000Z",
+                                      :lt "2018-07-30T00:00:00.000Z||+1w"}}}}}
+                                 {:bool
+                                  {:filter {:range {:modified {:gte "2018-08-06T00:00:00.000Z"}}}}}]]
+           (is (= expected-queries
+                  (sut/sliced-queries storemap nil "week")))
+           (is (= [missing-modified-query
+                   {:bool
+                    {:filter
+                     {:range
+                      {:modified
+                       {:gte "2018-07-16T00:00:00.000Z",
+                        :lt "2018-07-16T00:00:00.000Z||+1w"}}}}}
+                   {:bool
+                    {:filter
+                     {:range
+                      {:modified
+                       {:gte "2018-07-23T00:00:00.000Z",
+                        :lt "2018-07-23T00:00:00.000Z||+1w"}}}}}
+                   {:bool
+                    {:filter
+                     {:range
+                      {:modified
+                       {:gte "2018-07-30T00:00:00.000Z",
+                        :lt "2018-07-30T00:00:00.000Z||+1w"}}}}}
+                   {:bool
+                    {:filter {:range {:modified {:gte "2018-08-06T00:00:00.000Z"}}}}}]
+                  (sut/sliced-queries storemap
+                                      [(time-coerce/to-long "2018-07-16T00:00:00.000Z")
+                                       "whatever"]
+                                      "week"))
+               "slice-queries should take into account search_after param")))))))
+
+
+(def short-id (fn [s] (-> s long-id->id :short-id)))
+
+(deftest bulk-metas-test
+  (es-helpers/for-each-es-version
+   "bulk-metas prepares ES bulk data for given document ids"
+   [5 7]
+   #(ductile.index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [{:keys [all-stores]} (helpers/get-service-map app :StoreService)
+               services (app->MigrationStoreServices app)
+               ;; insert elements in different indices and check that we retrieve the right one
+               sighting-store-map {:conn conn
+                                   :indexname "ctia_sighting"
+                                   :props {:write-index "ctia_sighting"}
+                                   :mapping "sighting"
+                                   :type "sighting"
+                                   :settings {}
+                                   :config {}}
+               malware-store-map {:conn conn
+                                  :indexname "ctia_malware"
+                                  :props {:write-index "ctia_malware"}
+                                  :mapping "malware"
+                                  :type "malware"
+                                  :settings {}
+                                  :config {}}
+               post-bulk-res-1 (POST-bulk app examples)
+               {:keys [nb-errors]} (rollover-stores (all-stores))
+               _ (assert (= 0 nb-errors) "could not properly trigger _rollover")
+               post-bulk-res-2 (POST-bulk app examples)
+               malware-ids (->> (:malwares post-bulk-res-1)
+                                (map short-id)
+                                (take 10))
+               sighting-ids-1 (->> (:sightings post-bulk-res-1)
+                                   (map short-id)
+                                   (take 10))
+               sighting-ids-2 (->> (:sightings post-bulk-res-2)
+                                   (map short-id)
+                                   (take 10))
+               _ (ductile.index/refresh! conn)
+               [malware-index-1 _] (->> (ductile.index/get conn "ctia_malware*")
+                                        keys
+                                        sort
+                                        (map name))
+               [sighting-index-1 sighting-index-2] (->> (ductile.index/get conn "ctia_sighting*")
+                                                        keys
+                                                        sort
+                                                        (map name))
+               bulk-metas-malware-res (sut/bulk-metas malware-store-map malware-ids services)
+               bulk-metas-sighting-res-1 (sut/bulk-metas sighting-store-map sighting-ids-1 services)
+               bulk-metas-sighting-res-2 (sut/bulk-metas sighting-store-map sighting-ids-2 services)]
+           (testing "bulk-metas should property return _id, _type, _index from a document id"
+             (doseq [[_id metas] bulk-metas-malware-res]
+               (is (= _id (:_id metas)))
+               (is (= "malware" (:_type metas)))
+               (is (= malware-index-1 (:_index metas))))
+             (doseq [[_id metas] bulk-metas-sighting-res-1]
+               (is (= _id (:_id metas)))
+               (is (= "sighting" (:_type metas)))
+               (is (= sighting-index-1 (:_index metas))))
+             (doseq [[_id metas] bulk-metas-sighting-res-2]
+               (is (= _id (:_id metas)))
+               (is (= "sighting" (:_type metas)))
+               (is (= sighting-index-2 (:_index metas)))))))))))
 
 (deftest prepare-docs-test
   ;; insert elements in different indices, modify some and check that we retrieve the right one
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-        {:keys [all-stores]} (helpers/get-service-map app :StoreService)
-        services (app->MigrationStoreServices app)
+  (es-helpers/for-each-es-version
+   "prepare-docs properly generates meta data for bulk ops for new and modified documents"
+   [5 7]
+   #(ductile.index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [{:keys [all-stores]} (helpers/get-service-map app :StoreService)
+               services (app->MigrationStoreServices app)
 
-        sighting-store-map {:conn (es-conn get-in-config)
-                            :indexname "ctia_sighting"
-                            :props {:write-index "ctia_sighting-write"
-                                    :aliased true}
-                            :mapping "sighting"
-                            :type "sighting"
-                            :settings {}
-                            :config {}}
-        post-bulk-res-1 (POST-bulk app examples)
-        {:keys [nb-errors]} (rollover-stores (all-stores))
-        _ (is (= 0 nb-errors))
-        post-bulk-res-2 (POST-bulk app examples)
-        _ (ductile.index/refresh! (es-conn get-in-config))
-
-        sighting-ids-1 (->> (:sightings post-bulk-res-1)
-                            (map #(-> % long-id->id :short-id))
-                            (take 3))
-        sighting-ids-2 (->> (:sightings post-bulk-res-2)
-                            (map #(-> % long-id->id :short-id))
-                            (take 3))
-        sighting-id-1 (first sighting-ids-1)
-        sighting-id-2 (first sighting-ids-2)
-        _  (PUT app
-                (format "ctia/sighting/%s" sighting-id-1)
-                :body (-> (GET app
-                               (format "ctia/sighting/%s" sighting-id-1)
-                               :headers {"Authorization" "45c1f5e3f05d0"})
-                          :parsed-body
-                          (assoc :description "UPDATED"))
-                :headers {"Authorization" "45c1f5e3f05d0"})
-        _  (PUT app
-                (format "ctia/sighting/%s" sighting-id-2)
-                :body (-> (GET app
-                               (format "ctia/sighting/%s" sighting-id-1)
-                               :headers {"Authorization" "45c1f5e3f05d0"})
-                          :parsed-body
-                          (assoc :description "UPDATED"))
-                :headers {"Authorization" "45c1f5e3f05d0"})
-
-        _ (ductile.index/refresh! (es-conn get-in-config))
-        [sighting-index-1 sighting-index-2] (->> (ductile.index/get (es-conn get-in-config) "ctia_sighting*")
-                                                 keys
-                                                 sort
-                                                 (map name))
-
-        sighting-docs-1 (map #(es-doc/get-doc (es-conn get-in-config)
-                                              sighting-index-1
+               sighting-store-map {:conn conn
+                                   :indexname "ctia_sighting"
+                                   :props {:write-index "ctia_sighting-write"
+                                           :aliased true}
+                                   :mapping "sighting"
+                                   :type "sighting"
+                                   :settings {}
+                                   :config {}}
+               post-bulk-res-1 (POST-bulk app examples)
+               {:keys [nb-errors]} (rollover-stores (all-stores))
+               _ (is (= 0 nb-errors))
+               post-bulk-res-2 (POST-bulk app examples)
+               _ (ductile.index/refresh! conn)
+               sighting-ids-1 (->> (:sightings post-bulk-res-1)
+                                   (map short-id)
+                                   (take 3))
+               sighting-ids-2 (->> (:sightings post-bulk-res-2)
+                                   (map short-id)
+                                   (take 3))
+               sighting-id-1 (first sighting-ids-1)
+               sighting-id-2 (first sighting-ids-2)
+               update-sighting (fn [sighting-id]
+                                 (PUT app
+                                      (format "ctia/sighting/%s" sighting-id)
+                                      :body (-> (GET app
+                                                     (format "ctia/sighting/%s" sighting-id))
+                                                :parsed-body
+                                                (assoc :description "UPDATED"))))
+               _  (update-sighting sighting-id-1)
+               _  (update-sighting sighting-id-2)
+               _ (ductile.index/refresh! conn)
+               [sighting-index-1 sighting-index-2] (->> (ductile.index/get conn "ctia_sighting*")
+                                                        keys
+                                                        sort
+                                                        (map name))
+               get-sighting (fn [index doc-id]
+                              (es-doc/get-doc conn
+                                              index
                                               "sighting"
-                                              %
-                                              {})
-                             sighting-ids-1)
-        sighting-docs-2 (map #(es-doc/get-doc (es-conn get-in-config)
-                                              sighting-index-2
-                                              "sighting"
-                                              %
-                                              {})
-                             sighting-ids-2)
-        sighting-docs (concat sighting-docs-1 sighting-docs-2)
-        prepared-docs (sut/prepare-docs sighting-store-map sighting-docs services)]
-    (testing "prepare-docs should set proper _id, _type, _index for modified and unmodified documents"
-      (is (= (sort (concat [sighting-index-1 sighting-index-2]
-                           (repeat 4 "ctia_sighting-write")))
-             (sort (map :_index prepared-docs))))
-      (is (= (repeat 6 "sighting")
-             (sort (map :_type prepared-docs))))
-      (is (= (set (concat sighting-ids-1 sighting-ids-2))
-             (set (map :_id prepared-docs)))))))
-
+                                              doc-id
+                                              {}))
+               sighting-docs-1 (map (partial get-sighting sighting-index-1)
+                                    sighting-ids-1)
+               sighting-docs-2 (map (partial get-sighting sighting-index-2)
+                                    sighting-ids-2)
+               sighting-docs (concat sighting-docs-1 sighting-docs-2)
+               prepared-docs (sut/prepare-docs sighting-store-map sighting-docs services)]
+           (testing "prepare-docs should set proper _id, _type, _index for modified and unmodified documents"
+             (is (= (sort (concat [sighting-index-1 sighting-index-2]
+                                  (repeat 4 "ctia_sighting-write")))
+                    (sort (map :_index prepared-docs))))
+             (is (= (repeat 6 "sighting")
+                    (sort (map :_type prepared-docs))))
+             (is (= (set (concat sighting-ids-1 sighting-ids-2))
+                    (set (map :_id prepared-docs)))))))))))
 
 (deftest store-batch-store-size-test
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-        services (app->MigrationStoreServices app)
+  (es-helpers/for-each-es-version
+   "store-batch should properly write data in given store"
+   [5 7]
+   #(do (ductile.index/delete! % "test_index*")
+        (ductile.index/delete! % "ctia_*"))
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [services (app->MigrationStoreServices app)
+               indexname "test_index"
+               store {:conn conn
+                      :indexname indexname
+                      :props {:write-index indexname}
+                      :mapping "test_mapping"}
+               nb-docs-1 10
+               nb-docs-2 20
+               make-sample-doc (fn [nb v]
+                                 {:id (str (UUID/randomUUID))
+                                  :batch nb
+                                  :value v})
+               sample-docs-1 (map (partial make-sample-doc 1)
+                                  (range nb-docs-1))
+               sample-docs-2 (map (partial make-sample-doc 2)
+                                  (range nb-docs-2))]
+           (testing "store-batch and store-size"
+             (sut/store-batch store sample-docs-1 services)
+             (is (= 0 (sut/store-size store))
+                 "store-batch shall not refresh the index")
+             (ductile.index/refresh! conn indexname)
+             (sut/store-batch store sample-docs-2 services)
+             (is (= nb-docs-1 (sut/store-size store))
+                 "store-size shall return the number of first batch docs")
+             (ductile.index/refresh! conn indexname)
+             (is (= (+ nb-docs-1 nb-docs-2) (sut/store-size store))
+                 "store size shall return the proper number of documents after second refresh")
+             (ductile.index/delete! conn indexname))))))))
 
-        indexname "test_index"
-        store {:conn (es-conn get-in-config)
-               :indexname indexname
-               :props {:write-index indexname}
-               :mapping "test_mapping"}
-        nb-docs-1 10
-        nb-docs-2 20
-        sample-docs-1 (map #(hash-map :id (str (UUID/randomUUID))
-                                      :batch 1
-                                      :value %)
-                           (range nb-docs-1))
-        sample-docs-2 (map #(hash-map :id (str (UUID/randomUUID))
-                                      :batch 2
-                                      :value %)
-                           (range nb-docs-2))]
-    (testing "store-batch and store-size"
-      (sut/store-batch store sample-docs-1 services)
-      (is (= 0 (sut/store-size store))
-          "store-batch shall not refresh the index")
-      (ductile.index/refresh! (es-conn get-in-config) indexname)
-      (sut/store-batch store sample-docs-2 services)
-      (is (= nb-docs-1 (sut/store-size store))
-          "store-size shall return the number of first batch docs")
-      (ductile.index/refresh! (es-conn get-in-config) indexname)
-      (is (= (+ nb-docs-1 nb-docs-2) (sut/store-size store))
-          "store size shall return the proper number of documents after second refresh")
-      (ductile.index/delete! (es-conn get-in-config) indexname))))
-
-(deftest query-fetch-batch-test
+(defn test-query-fetch-batch-events
+  [{:keys [version] :as conn} services]
   (testing "query-fetch-batch should property fetch and sort events on timestamp"
-    (let [app (helpers/get-current-app)
-          {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
-
-          indexname "test_event"
-          event-store {:conn (es-conn get-in-config)
+    (let [indexname "event_index"
+          event-store {:conn conn
                        :indexname indexname
                        :props {:write-index indexname}
                        :mapping "event"
@@ -692,16 +686,18 @@
                                         :timestamp %
                                         :modified (rand-int 50))
                              (range 50 90))]
-      (ductile.index/create! (es-conn get-in-config)
-                        indexname
-                        {:settings {:refresh_interval -1}
-                         :mappings {:event {:properties {:id {:type "keyword"}
-                                                         :batch em/integer-type
-                                                         :timestamp em/integer-type
-                                                         :modified em/integer-type}}}})
+      (ductile.index/create! conn
+                             indexname
+                             {:settings {:refresh_interval -1}
+                              :mappings (es-helpers/build-mappings {:id {:type "keyword"}
+                                                                    :batch em/integer-type
+                                                                    :timestamp em/integer-type
+                                                                    :modified em/integer-type}
+                                                                   :event
+                                                                   version)})
       (sut/store-batch event-store event-batch-1 services)
       (sut/store-batch event-store event-batch-2 services)
-      (ductile.index/refresh! (es-conn get-in-config) indexname)
+      (ductile.index/refresh! conn indexname)
       (let [{fetched-no-query :data} (sut/fetch-batch event-store 80 0 nil nil)
             {fetched-batch-1 :data} (sut/query-fetch-batch {:term {:batch 1}}
                                                            event-store
@@ -746,16 +742,14 @@
                                              fetched-events-3)))
             "offset and asc orders should be properly applied, events must be sorted on timestamp")
         (is (apply > (map :timestamp fetched-events-4))
-            "desc sort was not properly applied"))))
+            "desc sort was not properly applied")))))
 
+(defn test-query-fetch-batch-entities
+  [{:keys [version] :as conn} services]
   (testing "query-fetch-batch should properly sort entities on modified field"
-    (let [app (helpers/get-current-app)
-          {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
-
-          tool-indexname "tool_index"
+    (let [tool-indexname "tool_index"
           malware-indexname "malware_index"
-          tool-store {:conn (es-conn get-in-config)
+          tool-store {:conn conn
                       :indexname tool-indexname
                       :props {:write-index tool-indexname}
                       :mapping "tool"
@@ -767,7 +761,7 @@
                                      :modified %
                                      :created %)
                           (range 100))
-          malware-store {:conn (es-conn get-in-config)
+          malware-store {:conn conn
                          :indexname malware-indexname
                          :mapping "malware"
                          :props {:write-index malware-indexname}
@@ -783,17 +777,21 @@
                     :timestamp em/integer-type
                     :created em/integer-type
                     :modified em/integer-type}]
-      (ductile.index/create! (es-conn get-in-config)
-                        tool-indexname
-                        {:settings {:refresh_interval -1}
-                         :mappings {:tool {:properties mappings}}})
-      (ductile.index/create! (es-conn get-in-config)
-                        malware-indexname
-                        {:settings {:refresh_interval -1}
-                         :mappings {:malware {:properties mappings}}})
+      (ductile.index/create! conn
+                             tool-indexname
+                             {:settings {:refresh_interval -1}
+                              :mappings (es-helpers/build-mappings mappings
+                                                                   :tool
+                                                                   version)})
+      (ductile.index/create! conn
+                             malware-indexname
+                             {:settings {:refresh_interval -1}
+                              :mappings (es-helpers/build-mappings mappings
+                                                                   :malware
+                                                                   version)})
       (sut/store-batch tool-store tool-batch services)
       (sut/store-batch malware-store malware-batch services)
-      (ductile.index/refresh! (es-conn get-in-config) "*")
+      (ductile.index/refresh! conn "*")
       (let [{fetched-tool-asc :data} (sut/fetch-batch tool-store 80 0 "asc" nil)
             {fetched-tool-desc :data} (sut/fetch-batch tool-store 80 0 "desc" nil)
             {fetched-malware-asc :data} (sut/fetch-batch malware-store 80 0 "asc" nil)
@@ -801,164 +799,192 @@
         (is (apply < (map :modified (concat fetched-tool-asc))))
         (is (apply > (map :modified (concat fetched-tool-desc))))
         (is (apply < (map :modified (concat fetched-malware-asc))))
-        (is (apply > (map :modified (concat fetched-malware-desc)))))))
+        (is (apply > (map :modified (concat fetched-malware-desc))))))))
 
-  (ductile.index/delete! (es-conn (helpers/current-get-in-config-fn)) "tool_index")
-  (ductile.index/delete! (es-conn (helpers/current-get-in-config-fn)) "malware_index"))
+(deftest query-fetch-batch-test
+  (es-helpers/for-each-es-version
+   "query-fetch should properly fetch and sort data"
+   [5 7]
+   (fn [conn]
+     (ductile.index/delete! conn "ctia_*")
+     (ductile.index/delete! conn "event_index*")
+     (ductile.index/delete! conn "tool_index*")
+     (ductile.index/delete! conn "malware_index*"))
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [services (app->MigrationStoreServices app)]
+           (test-query-fetch-batch-events conn services)
+           (test-query-fetch-batch-entities conn services)))))))
 
 (deftest fetch-deletes-test
-  (let [app (helpers/get-current-app)
-        {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-        services (app->MigrationStoreServices app)
+  (es-helpers/for-each-es-version
+   "fetch-deletes should be properly configured to fetch deletes in source store"
+   [5 7]
+   #(ductile.index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+               services (app->MigrationStoreServices app)
 
-        _ (POST-bulk app examples)
-        _ (ductile.index/refresh! (es-conn get-in-config)) ;; ensure indices refresh
-        [sighting1 sighting2] (:parsed-body (GET app
-                                                 "ctia/sighting/search"
-                                                 :query-params {:limit 2 :query "*"}
-                                                 :headers {"Authorization" "45c1f5e3f05d0"}))
-        [tool1 tool2 tool3] (:parsed-body (GET app
-                                               "ctia/tool/search"
-                                               :query-params {:limit 3 :query "*"}
-                                               :headers {"Authorization" "45c1f5e3f05d0"}))
-        [malware1] (:parsed-body (GET app
-                                      "ctia/malware/search"
-                                      :query-params {:limit 1 :query "*"}
-                                      :headers {"Authorization" "45c1f5e3f05d0"}))
-        sighting1-id (-> sighting1 :id long-id->id :short-id)
-        sighting2-id (-> sighting2 :id long-id->id :short-id)
-        tool1-id (-> tool1 :id long-id->id :short-id)
-        tool2-id (-> tool2 :id long-id->id :short-id)
-        tool3-id (-> tool3 :id long-id->id :short-id)
-        malware1-id (-> malware1 :id long-id->id :short-id)
-        _ (DELETE app
-                  (format "ctia/sighting/%s" sighting1-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (ductile.index/refresh! (es-conn get-in-config))
-        since (time/internal-now)
-        _ (DELETE app
-                  (format "ctia/sighting/%s" sighting2-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (DELETE app
-                  (format "ctia/tool/%s" tool1-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (DELETE app
-                  (format "ctia/tool/%s" tool2-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (DELETE app
-                  (format "ctia/tool/%s" tool3-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        _ (DELETE app
-                  (format "ctia/tool/%s" malware1-id)
-                  :headers {"Authorization" "45c1f5e3f05d0"})
-        event-store (sut/get-source-store :event services)
-        {data1 :data paging1 :paging} (sut/fetch-deletes event-store
-                                                         [:sighting :tool]
-                                                         since
-                                                         3
-                                                         nil)
-        {data2 :data paging2 :paging} (sut/fetch-deletes event-store
-                                                         [:sighting :tool]
-                                                         since
-                                                         2
-                                                         (:sort paging1))]
-    (is (nil? (:next paging2)))
-    (is (= #{(:id tool1) (:id tool2)} (->> (:tool data1)
-                                           (map :id)
-                                           set))
-        "fetch-deletes first batch shall return tool1 and tool2 that were deleted after since")
-    (is (= #{(:id sighting2)} (->> (:sighting data1)
-                                   (map :id)
-                                   set))
-        "fetch-deletes shall return only the sighting that was deleted after since parameter")
-    (is (= #{(:id tool3)} (->> (:tool data2)
-                               (map :id)
-                               set))
-        "fetch-deletes second batch shall return tool3 that was deleted after since")
-    (is (nil? (:sighting data2))
-        "fetch-deletes shall not return any more sightings in the second batch")
-    (is (nil? (:malware data1)) "fetch-deletes shall only retrieve entity types given as parameter")
-    (is (nil? (:malware data2)) "fetch-deletes shall only retrieve entity types given as parameter")))
+               _ (POST-bulk app examples true)
+               _ (ductile.index/refresh! conn) ;; ensure indices refresh
+               [sighting1 sighting2] (:parsed-body (GET app
+                                                        "ctia/sighting/search"
+                                                        :query-params {:limit 2 :query "*"}))
+
+               [tool1 tool2 tool3] (:parsed-body (GET app
+                                                      "ctia/tool/search"
+                                                      :query-params {:limit 3 :query "*"}))
+               [malware1] (:parsed-body (GET app
+                                             "ctia/malware/search"
+                                             :query-params {:limit 1 :query "*"}))
+
+               sighting1-id (-> sighting1 :id short-id)
+               sighting2-id (-> sighting2 :id short-id)
+               tool1-id (-> tool1 :id short-id)
+               tool2-id (-> tool2 :id short-id)
+               tool3-id (-> tool3 :id short-id)
+               malware1-id (-> malware1 :id short-id)
+               _ (DELETE app
+                         (format "ctia/sighting/%s" sighting1-id))
+               _ (ductile.index/refresh! conn)
+               since (time/internal-now)
+               _ (DELETE app
+                         (format "ctia/sighting/%s" sighting2-id))
+               _ (DELETE app
+                         (format "ctia/tool/%s" tool1-id))
+               _ (DELETE app
+                         (format "ctia/tool/%s" tool2-id))
+               _ (DELETE app
+                         (format "ctia/tool/%s" tool3-id))
+               _ (DELETE app
+                         (format "ctia/tool/%s" malware1-id))
+               event-store (sut/get-source-store :event services)
+               {data1 :data paging1 :paging} (sut/fetch-deletes event-store
+                                                                [:sighting :tool]
+                                                                since
+                                                                3
+                                                                nil)
+               {data2 :data paging2 :paging} (sut/fetch-deletes event-store
+                                                                [:sighting :tool]
+                                                                since
+                                                                2
+                                                                (:sort paging1))]
+
+           (is (nil? (:next paging2)))
+           (is (= #{(:id tool1) (:id tool2)} (->> (:tool data1)
+                                                  (map :id)
+                                                  set))
+               "fetch-deletes first batch shall return tool1 and tool2 that were deleted after since")
+           (is (= #{(:id sighting2)} (->> (:sighting data1)
+                                          (map :id)
+                                          set))
+               "fetch-deletes shall return only the sighting that was deleted after since parameter")
+           (is (= #{(:id tool3)} (->> (:tool data2)
+                                      (map :id)
+                                      set))
+               "fetch-deletes second batch shall return tool3 that was deleted after since")
+           (is (nil? (:sighting data2))
+               "fetch-deletes shall not return any more sightings in the second batch")
+           (is (nil? (:malware data1)) "fetch-deletes shall only retrieve entity types given as parameter")
+           (is (nil? (:malware data2)) "fetch-deletes shall only retrieve entity types given as parameter")))))))
 
 (deftest init-get-migration-test
-  (testing "init-migration should properly create new migration state from selected types."
-    (let [app (helpers/get-current-app)
-          {:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-          services (app->MigrationStoreServices app)
-
-          _ (POST-bulk app examples)
-          _ (ductile.index/refresh! (es-conn get-in-config)) ; ensure indices refresh
-          prefix "0.0.0"
-          entity-types [:tool :malware :relationship]
-          migration-id-1 "migration-1"
-          migration-id-2 "migration-2"
-          base-migration-params {:prefix prefix
-                                 :migrations [:identity]
-                                 :store-keys entity-types
-                                 :batch-size 1000
-                                 :buffer-size 3
-                                 :restart? false}
-          fake-migration (sut/init-migration (assoc base-migration-params
-                                                    :migration-id migration-id-1
-                                                    :confirm? false)
-                                             services)
-          real-migration-from-init (sut/init-migration (assoc base-migration-params
-                                                              :migration-id migration-id-2
-                                                              :confirm? true)
-                                                       services)
-          check-state (fn [{:keys [id stores]} migration-id message]
-                        (testing message
-                          (is (= id migration-id))
-                          (is (= (set (keys stores))
-                                 (set entity-types)))
-                          (doseq [entity-type entity-types]
-                            (let [{:keys [source target started completed]} (get stores entity-type)
-                                  created-indices (ductile.index/get (es-conn get-in-config) (str (:index target) "*"))]
-                              (is (= "-1"  (-> (vals created-indices)
-                                               first
-                                               :settings
-                                               :index
-                                               :refresh_interval)))
-                              (is (= "0"  (-> (vals created-indices)
-                                              first
-                                              :settings
-                                              :index
-                                              :number_of_replicas)))
-                              (is (nil? started))
-                              (is (nil? completed))
-                              (is (= 0 (:migrated target)))
-                              (is (= fixtures-nb (:total source)))
-                              (is (nil? (:started source)))
-                              (is (nil? (:completed target)))
-                              (is (= entity-type
-                                     (keyword (get-in source [:store :type]))))
-                              (is (= entity-type
-                                     (keyword (get-in target [:store :type]))))
-                              (is (= (:index source)
-                                     (get-in source [:store :indexname])))
-                              (is (= (:index target)
-                                     (get-in target [:store :indexname])))))))]
-      (check-state fake-migration
-                   migration-id-1
-                   "init-migration without confirmation shall return a proper migration state")
-      (check-state real-migration-from-init
-                   migration-id-2
-                   "init-migration with confirmation shall return a propr migration state")
-      (check-state (sut/get-migration migration-id-2 (es-conn get-in-config) services)
-                   migration-id-2
-                   "init-migration shall store confirmed migration, and get-migration should be properly retrieved from store")
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (sut/get-migration migration-id-1 (es-conn get-in-config) services))
-          "migration-id-1 was not confirmed it should not exist and thus get-migration must raise a proper exception")
-      (testing "stored document shall not contains object stores in source and target"
-        (let [{:keys [stores]} (es-doc/get-doc (es-conn get-in-config)
-                                               "ctia_migration"
-                                               "migration"
-                                               migration-id-2
-                                               {})]
-          (doseq [store stores]
-            (is (nil? (get-in store [:source :store])))
-            (is (nil? (get-in store [:target :store])))))))))
+  (es-helpers/for-each-es-version
+   "init-migration should properly create new migration state from selected types."
+   [5 7]
+   (fn [c]
+     (ductile.index/delete! c "ctia_*")
+     (ductile.index/delete! c "v0.0.0*"))
+   (helpers/with-properties*
+     ["ctia.migration.store.es.default.port" es-port
+      "ctia.migration.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
+               services (app->MigrationStoreServices app)
+               _ (POST-bulk app examples)
+               _ (ductile.index/refresh! conn) ; ensure indices refresh
+               prefix "0.0.0"
+               entity-types [:tool :malware :relationship]
+               migration-id-1 "migration-1"
+               migration-id-2 "migration-2"
+               base-migration-params {:prefix prefix
+                                      :migrations [:identity]
+                                      :store-keys entity-types
+                                      :batch-size 1000
+                                      :buffer-size 3
+                                      :restart? false}
+               fake-migration (sut/init-migration (assoc base-migration-params
+                                                         :migration-id migration-id-1
+                                                         :confirm? false)
+                                                  services)
+               real-migration-from-init (sut/init-migration (assoc base-migration-params
+                                                                   :migration-id migration-id-2
+                                                                   :confirm? true)
+                                                            services)
+               check-state (fn [{:keys [id stores]} migration-id message]
+                             (testing message
+                               (is (= id migration-id))
+                               (is (= (set (keys stores))
+                                      (set entity-types)))
+                               (doseq [entity-type entity-types]
+                                 (let [{:keys [source target started completed]} (get stores entity-type)
+                                       created-indices (ductile.index/get conn (str (:index target) "*"))]
+                                   (is (= "-1"  (-> (vals created-indices)
+                                                    first
+                                                    :settings
+                                                    :index
+                                                    :refresh_interval)))
+                                   (is (= "0"  (-> (vals created-indices)
+                                                   first
+                                                   :settings
+                                                   :index
+                                                   :number_of_replicas)))
+                                   (is (nil? started))
+                                   (is (nil? completed))
+                                   (is (= 0 (:migrated target)))
+                                   (is (= fixtures-nb (:total source)))
+                                   (is (nil? (:started source)))
+                                   (is (nil? (:completed target)))
+                                   (is (= entity-type
+                                          (keyword (get-in source [:store :type]))))
+                                   (is (= entity-type
+                                          (keyword (get-in target [:store :type]))))
+                                   (is (= (:index source)
+                                          (get-in source [:store :indexname])))
+                                   (is (= (:index target)
+                                          (get-in target [:store :indexname])))))))]
+           (check-state fake-migration
+                        migration-id-1
+                        "init-migration without confirmation shall return a proper migration state")
+           (check-state real-migration-from-init
+                        migration-id-2
+                        "init-migration with confirmation shall return a propr migration state")
+           (check-state (sut/get-migration migration-id-2 conn services)
+                        migration-id-2
+                        "init-migration shall store confirmed migration, and get-migration should be properly retrieved from store")
+           (is (thrown? clojure.lang.ExceptionInfo
+                        (sut/get-migration migration-id-1 conn services))
+               "migration-id-1 was not confirmed it should not exist and thus get-migration must raise a proper exception")
+           (testing "stored document shall not contains object stores in source and target"
+             (let [{:keys [stores]} (es-doc/get-doc conn
+                                                    "ctia_migration"
+                                                    "migration"
+                                                    migration-id-2
+                                                    {})]
+               (doseq [store stores]
+                 (is (nil? (get-in store [:source :store])))
+                 (is (nil? (get-in store [:target :store]))))))))))))
 
 (deftest target-store-properties-test
   (let [default-es-props {:host "localhost"

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -1,62 +1,67 @@
 (ns ctia.task.rollover-test
   (:require [ductile.index :as es-index]
             [clojure.string :as string]
-            [clojure.test :refer [deftest is join-fixtures use-fixtures]]
+            [clojure.test :refer [deftest testing is]]
             [ctia.stores.es.init :as init]
             [ctia.task.rollover :as sut]
-            [ctia.test-helpers.core :as helpers :refer [POST-bulk]]
+            [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.es :as es-helpers]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.fixtures :as fixt]))
 
-(use-fixtures :once
-  (join-fixtures [whoami-helpers/fixture-server
-                  es-helpers/fixture-properties:es-store]))
-
-(use-fixtures :each
-  (join-fixtures [#(helpers/with-properties
-                     ["ctia.auth.type" "allow-all"]
-                     (helpers/fixture-ctia %))
-                  es-helpers/fixture-delete-store-indexes]))
-
-(def examples (fixt/bundle 100 false))
-
 (deftest rollover-aliased-test
-  (let [app (helpers/get-current-app)
-        services (es-helpers/app->ESConnServices app)
-
-        props-not-aliased {:entity :malware
-                           :indexname "ctia_malware"
-                           :host "localhost"
-                           :port 9200}
-        state-not-aliased (init/init-es-conn! props-not-aliased services)
-        rollover-not-aliased (sut/rollover-store state-not-aliased)
-        props-aliased {:entity :sighting
-                       :indexname "ctia_sighting"
-                       :host "localhost"
-                       :port 9200
-                       :aliased true
-                       :rollover {:max_docs 3}
-                       :refresh "true"}
-        state-aliased (init/init-es-conn! props-aliased services)
-        rollover-aliased (sut/rollover-store state-aliased)
-
-        count-index #(count (es-index/get (:conn state-aliased)
-                                          (str (:index state-aliased) "*")))]
-    (is (nil? rollover-not-aliased))
-    (is (seq rollover-aliased))
-    (is (false? (:rolled_over rollover-aliased)))
-    (is (= 1 (count-index)))
-    (POST-bulk app examples)
-    (es-index/refresh! (:conn state-aliased))
-    (is (nil? (sut/rollover-store state-not-aliased)))
-    (is (= 1 (count-index)))
-    (is (true? (:rolled_over (sut/rollover-store state-aliased))))
-    (is (= 2 (count-index)))
-    (POST-bulk app examples)
-    (es-index/refresh! (:conn state-aliased))
-    (is (true? (:rolled_over (sut/rollover-store state-aliased))))
-    (is (= 3 (count-index)))))
+  (es-helpers/for-each-es-version
+   "rollover should properly trigger _rollover"
+   [5 7]
+   #(es-index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version
+      "ctia.auth.type" "allow-all"]
+     #(helpers/fixture-ctia-with-app
+       (fn [app]
+         (let [{{:keys [get-in-config]} :ConfigService :as services} (es-helpers/app->ESConnServices app)
+               _ (assert (and (= es-port (get-in-config [:ctia :store :es :default :port]))
+                              (= version (get-in-config [:ctia :store :es :default :version])))
+                         (format "CTIA is not properly configured for testing ES version %s."
+                                 version))
+               props-not-aliased {:entity :malware
+                                  :indexname "ctia_malware"
+                                  :host "localhost"
+                                  :port es-port
+                                  :version version}
+               state-not-aliased (init/init-es-conn! props-not-aliased services)
+               rollover-not-aliased (sut/rollover-store state-not-aliased)
+               props-aliased {:entity :sighting
+                              :indexname "ctia_sighting"
+                              :host "localhost"
+                              :port es-port
+                              :aliased true
+                              :rollover {:max_docs 3}
+                              :refresh "true"
+                              :version version}
+               state-aliased (init/init-es-conn! props-aliased services)
+               rollover-aliased (sut/rollover-store state-aliased)
+               count-indices (fn []
+                               (->> (str (:index state-aliased) "*")
+                                    (es-index/get (:conn state-aliased))
+                                    count))
+               post-bulk-fn (fn []
+                              (let [examples (fixt/bundle 100 false)
+                                    {:keys [error message]} (helpers/POST-bulk app examples true)]
+                                (es-index/refresh! (:conn state-aliased))))]
+           (is (nil? rollover-not-aliased))
+           (is (seq rollover-aliased))
+           (is (false? (:rolled_over rollover-aliased)))
+           (is (= 1 (count-indices)))
+           (post-bulk-fn)
+           (is (nil? (sut/rollover-store state-not-aliased)))
+           (is (= 1 (count-indices)))
+           (is (true? (:rolled_over (sut/rollover-store state-aliased))))
+           (is (= 2 (count-indices)))
+           (post-bulk-fn)
+           (is (true? (:rolled_over (sut/rollover-store state-aliased))))
+           (is (= 3 (count-indices)))))))))
 
 (deftest rollover-stores-error-test
   (with-redefs [es-index/rollover! (fn [_ alias _]
@@ -64,31 +69,36 @@
                                        {:rolled_over (rand-nth [true false])}
                                        (throw (ex-info "that's baaaaaaaddd"
                                                        {:code :unhappy}))))]
-    (let [app (helpers/get-current-app)
-          services (es-helpers/app->ESConnServices app)
-
-          ok-state (init/init-store-conn {:entity "sighting"
-                                          :indexname "ok_index"
-                                          :rollover {:max_docs 3}
-                                          :aliased true}
-                                         services)
-          ko-state (init/init-store-conn {:entity "sighting"
-                                          :indexname "bbaaaaadddd_index"
-                                          :rollover {:max_docs 2}
-                                          :aliased true}
-                                         services)
-          stores {:ok-type-1 [{:state ok-state}]
-                  :ok-type-2 [{:state ok-state}]
-                  :ok-type-3 [{:state ok-state}]
-                  :ko-type-1 [{:state ko-state}]
-                  :ko-type-2 [{:state ko-state}]}
-          {:keys [nb-errors
-                  ok-type-1
-                  ok-type-2
-                  ok-type-3
-                  ko-type-1
-                  ko-type-2]} (sut/rollover-stores stores)]
-      (is (= 2 nb-errors))
-      (is (every? nil? [ko-type-1 ko-type-2]))
-      (is (every? #(some? (:rolled_over %))
-                  [ok-type-1 ok-type-2 ok-type-3])))))
+    ;; this test does not depends on ES version
+    (helpers/with-properties*
+      ["ctia.auth.type" "allow-all"
+       "ctia.store.es.default.port" 9207
+       "ctia.store.es.default.version" 7]
+      #(helpers/fixture-ctia-with-app
+        (fn [app]
+          (let [services (es-helpers/app->ESConnServices app)
+                ok-state (init/init-store-conn {:entity "sighting"
+                                                :indexname "ok_index"
+                                                :rollover {:max_docs 3}
+                                                :aliased true}
+                                               services)
+                ko-state (init/init-store-conn {:entity "sighting"
+                                                :indexname "bbaaaaadddd_index"
+                                                :rollover {:max_docs 2}
+                                                :aliased true}
+                                               services)
+                stores {:ok-type-1 [{:state ok-state}]
+                        :ok-type-2 [{:state ok-state}]
+                        :ok-type-3 [{:state ok-state}]
+                        :ko-type-1 [{:state ko-state}]
+                        :ko-type-2 [{:state ko-state}]}
+                {:keys [nb-errors
+                        ok-type-1
+                        ok-type-2
+                        ok-type-3
+                        ko-type-1
+                        ko-type-2]} (sut/rollover-stores stores)]
+            (is (= 2 nb-errors))
+            (is (every? nil? [ko-type-1 ko-type-2]))
+            (is (every? (fn [k] (some? (:rolled_over k)))
+                        [ok-type-1 ok-type-2 ok-type-3]))))))))

--- a/test/ctia/task/update_mapping_test.clj
+++ b/test/ctia/task/update_mapping_test.clj
@@ -3,7 +3,7 @@
              [index :as es-index]
              [conn :as conn]]
             [clojure.string :as string]
-            [clojure.test :refer [deftest is join-fixtures use-fixtures testing]]
+            [clojure.test :refer [deftest is use-fixtures testing]]
             [ctia.task.rollover :as rollover]
             [ctia.entity.incident :as incident]
             [ctia.store :as store]
@@ -11,18 +11,14 @@
             [ctia.properties :as props]
             [ctia.stores.es.mapping :as es-mapping]
             [ctia.task.update-mapping :as task]
-            [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.es :as es-helpers]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-            [ctia.test-helpers.fixtures :as fixt]))
+            [ctia.test-helpers
+             [core :as helpers]
+             [es :as es-helpers]
+             [fake-whoami-service :as whoami-helpers]
+             [fixtures :as fixt]]))
 
 (use-fixtures :once
-  (join-fixtures [whoami-helpers/fixture-server
-                  es-helpers/fixture-properties:es-store]))
-
-(use-fixtures :each
-  (join-fixtures [helpers/fixture-ctia
-                  es-helpers/fixture-delete-store-indexes]))
+  es-helpers/fixture-properties:es-store)
 
 ; TestingStep = {:present {Kw Mapping}
 ;                :absent [Kw]
@@ -54,75 +50,84 @@
   This function builds up a `reduce` to functionally step through a sequence of
   of stores, rollovers, and update-mapping-stores! calls, and test intermediate states.
   "
-  [aliased? app]
+  [aliased?]
   {:pre [(boolean? aliased?)]}
-  (let [services (es-helpers/app->ESConnServices app)
-        ; set up connection
-        store-properties (cond-> {:entity :incident
-                                  :indexname "ctia_incident"
-                                  :host "localhost"
-                                  :port 9200
-                                  :aliased aliased?}
-                           ; cheap trick to rollover store without adding docs
-                           aliased? (assoc :rollover {:max_docs 0}))
+  (es-helpers/for-each-es-version
+   "update-mapping store should apply valid updates (field addition). for aliased stores, all indices must be updated"
+   [5] ;; TODO compatbility with ES7
+   #(ductile.index/delete! % "ctia_*")
+   (helpers/with-properties*
+     ["ctia.store.es.default.port" es-port
+      "ctia.store.es.default.version" version]
+     (fn []
+       (helpers/fixture-ctia-with-app
+        (fn [app]
+          (let [services (es-helpers/app->ESConnServices app)
+                ;; set up connection
+                store-properties (cond-> {:entity :incident
+                                          :indexname "ctia_incident"
+                                          :host "localhost"
+                                          :port es-port
+                                          :aliased aliased?
+                                          :version version}
+                                   ;; cheap trick to rollover store without adding docs
+                                   aliased? (assoc :rollover {:max_docs 0}))
 
-        index-names (cond-> ["ctia_incident"]
-                      aliased? (conj "ctia_incident-write"))
+                index-names (cond-> ["ctia_incident"]
+                              aliased? (conj "ctia_incident-write"))
 
-        ; minimal store (same shape as `(all-stores)`)
-        [conn stores] (let [{:keys [conn] :as state} (init/init-es-conn! store-properties
-                                                                         services)]
-                        [conn {:incident [((:es-store incident/incident-entity)
-                                           state)]}])
+                                        ; minimal store (same shape as `(all-stores)`)
+                stores (let [state (init/init-es-conn! store-properties
+                                                       services)]
+                         {:incident [((:es-store incident/incident-entity)
+                                      state)]})
 
-        testing-plan (gen-testing-plan 10)
+                testing-plan (gen-testing-plan 10)
 
-        ; update-mapping-stores! and rollover-stores should be able to run in
-        ; any order. the order is chosen below
-        fs (cond-> {:update-mapping-stores! task/update-mapping-stores!}
-             aliased?
-             (assoc
-               :rollover-stores
-               #(let [{:keys [nb-errors] :as responses} (rollover/rollover-stores %)]
-                  (testing "Rollover completed without errors"
-                    (is (= 0 nb-errors)
-                        (pr-str responses)))
-                  (testing ":incident store successfully rolled over"
-                    (is (get-in responses [:incident :rolled_over])
-                        (pr-str responses))))))
+                                        ; update-mapping-stores! and rollover-stores should be able to run in
+                                        ; any order. the order is chosen below
+                fs (cond-> {:update-mapping-stores! task/update-mapping-stores!}
+                     aliased?
+                     (assoc
+                      :rollover-stores
+                      #(let [{:keys [nb-errors] :as responses} (rollover/rollover-stores %)]
+                         (testing "Rollover completed without errors"
+                           (is (= 0 nb-errors)
+                               (pr-str responses)))
+                         (testing ":incident store successfully rolled over"
+                           (is (get-in responses [:incident :rolled_over])
+                               (pr-str responses))))))
 
-        ; Store TestingStep -> Store
-        testing-fn (fn [stores {:keys [present absent add-field] :as _step_}]
-                     (let [chosen-order (shuffle (keys fs))
-                           stores (cond-> stores
-                                    add-field (assoc-in
-                                                [:incident 0 :state :config :mappings
-                                                 "incident" :properties (nth add-field 0)]
-                                                (nth add-field 1)))]
-                       (testing (str "Incides should correctly update with ordering " (vec chosen-order))
-                         (testing "Store should update without error"
-                           (run! (comp #(% stores) fs) chosen-order))
-                         (let [index-map (into {}
-                                               (map (juxt identity (partial es-index/get conn)))
-                                               index-names)]
-                           (testing "Each query yields at least one index"
-                             (is (every? (comp seq index-map) index-names)))
-                           (doseq [[index-name idxs] index-map
-                                   [_index-kw_ {:keys [mappings] :as _index_}] idxs]
-                             (run! #(testing (str "Index " index-name " should not map field " %)
-                                      (is (nil? (get-in mappings [:incident :properties %]))))
-                                   absent)
-                             (doseq [[field expected-mapping] present]
-                               (testing (str "Index " index-name " should map field " field)
-                                 (is (= expected-mapping
-                                        (get-in mappings [:incident :properties field]))))))))
-                       stores))
+                                        ; Store TestingStep -> Store
+                testing-fn (fn [stores {:keys [present absent add-field] :as _step_}]
+                             (let [chosen-order (shuffle (keys fs))
+                                   stores (cond-> stores
+                                            add-field (assoc-in
+                                                       [:incident 0 :state :config :mappings
+                                                        "incident" :properties (nth add-field 0)]
+                                                       (nth add-field 1)))]
+                               (testing (str "Incides should correctly update with ordering " (vec chosen-order))
+                                 (testing "Store should update without error"
+                                   (run! (comp #(% stores) fs) chosen-order))
+                                 (let [index-map (into {}
+                                                       (map (juxt identity (partial es-index/get conn)))
+                                                       index-names)]
+                                   (testing "Each query yields at least one index"
+                                     (is (every? (comp seq index-map) index-names)))
+                                   (doseq [[index-name idxs] index-map
+                                           [_index-kw_ {:keys [mappings] :as _index_}] idxs]
+                                     (run! #(testing (str "Index " index-name " should not map field " %)
+                                              (is (nil? (get-in mappings [:incident :properties %]))))
+                                           absent)
+                                     (doseq [[field expected-mapping] present]
+                                       (testing (str "Index " index-name " should map field " field)
+                                         (is (= expected-mapping
+                                                (get-in mappings [:incident :properties field]))))))))
+                               stores))
 
-        ; the actual testing
-        _ (reduce testing-fn stores testing-plan)]))
+                                        ; the actual testing
+                _ (reduce testing-fn stores testing-plan)])))))))
 
 ; separated to take advantage of fixtures
-(deftest update-mapping-stores!-aliased-test   (update-mapping-stores!-test-helper true
-                                                                                   (helpers/get-current-app)))
-(deftest update-mapping-stores!-unaliased-test (update-mapping-stores!-test-helper false
-                                                                                   (helpers/get-current-app)))
+(deftest update-mapping-stores!-aliased-test   (update-mapping-stores!-test-helper true))
+(deftest update-mapping-stores!-unaliased-test (update-mapping-stores!-test-helper false))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -251,10 +251,10 @@
                             ;; dynamic requires can be removed when #'with-properties is phased out or moved
                             (assoc
                               :ThreatgridAuthWhoAmIURLService
-                              @(requiring-resolve 
+                              @(requiring-resolve
                                  'ctia.test-helpers.fake-whoami-service/fake-threatgrid-auth-whoami-url-service)
                               :IFakeWhoAmIServer
-                              @(requiring-resolve 
+                              @(requiring-resolve
                                  'ctia.test-helpers.fake-whoami-service/fake-whoami-service)))
              app (init/start-ctia!*
                    {:services (vals services-map)
@@ -335,14 +335,19 @@
          path
          kw-options))
 
-(defn POST-bulk [app examples]
-  (let [{bulk-res :parsed-body}
-        (POST app
-              "ctia/bulk"
-              :body examples
-              :socket-timeout (* 5 60000)
-              :headers {"Authorization" "45c1f5e3f05d0"})]
-    bulk-res))
+(defn POST-bulk
+  ([app examples] (POST-bulk app examples true))
+  ([app examples check?]
+   (let [{{:keys [error message] :as bulk-res} :parsed-body}
+         (POST app
+               "ctia/bulk"
+               :body examples
+               :socket-timeout (* 5 60000)
+               :headers {"Authorization" "45c1f5e3f05d0"})]
+     (when check?
+       (assert (nil? error)
+               (format "POST-bulk error: %s, message: \"%s\"" error message)))
+     bulk-res)))
 
 (defn POST-entity-bulk [app example plural x headers]
   (let [new-records

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -96,8 +96,8 @@
                                        (boolean? wait_for) (str "?wait_for=" wait_for))
                                 updates (cond->> {update-field "modified"}
                                           (= :PUT method-kw) (into new-record))
-                                es-index-uri-pattern (re-pattern (str ".*9200.*" entity-id ".*"))]
-                            (with-global-fake-routes {es-index-uri-pattern {:put simple-handler}}
+                                es-index-uri-pattern (re-pattern (str ".*920.*" entity-id ".*"))]
+                            (with-global-fake-routes {es-index-uri-pattern {:post simple-handler}}
                               (method app
                                       path
                                       :body updates

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -127,7 +127,7 @@
     (testing "testing wait_for values on entity deletion"
       (let [test-delete (fn [wait_for msg]
                           (let [entity-id (new-entity-short-id)
-                                es-index-uri-pattern (re-pattern (str ".*9200.*" entity-id ".*"))
+                                es-index-uri-pattern (re-pattern (str ".*920.*" entity-id ".*"))
                                 path (cond-> (format "ctia/%s/%s" entity entity-id)
                                        (boolean? wait_for) (str "?wait_for=" wait_for))]
                             (with-global-fake-routes {es-index-uri-pattern {:delete simple-handler}}
@@ -148,10 +148,10 @@
       (testing "testing wait_for values on entity revocation"
         (let [test-revoke (fn [wait_for msg]
                             (let [entity-id (new-entity-short-id)
-                                  es-index-uri-pattern (re-pattern (str ".*9200.*" entity-id ".*"))
+                                  es-index-uri-pattern (re-pattern (str ".*920.*" entity-id ".*"))
                                   path (cond-> (format "ctia/%s/%s/expire" entity entity-id)
                                          (boolean? wait_for) (str "?wait_for=" wait_for))]
-                              (with-global-fake-routes {es-index-uri-pattern {:put simple-handler}}
+                              (with-global-fake-routes {es-index-uri-pattern {:post simple-handler}}
                                 (apply POST
                                        app
                                        path


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close https://github.com/threatgrid/iroh/issues/4427

> Related #https://github.com/threatgrid/ctia/pull/1013

This PR pushes again the ES7 store that we reverted due to SocketException thrown during `lein test` https://github.com/threatgrid/iroh/issues/4427.
Indeed the problem was not directly related to the ES7 store but was emphasized by it. The ES connection managers were never shut down while being more numerous in this PR. 
There is 2 commits:
* the [first one](https://github.com/threatgrid/ctia/pull/1039/commits/ec84f1a43bab4bc892d0f6b2aae065467234bc21) with contains the changes of previous PR implementing es7 store.
* the [second one](https://github.com/threatgrid/ctia/pull/1039/commits/f17c5399d9603e306efb097005f737b6929f0894) implements the `stop` funciton in the StoreService

For those who already reviewed the previous PR, you can directly jump to the [second commit](https://github.com/threatgrid/ctia/pull/1039/commits/ec84f1a43bab4bc892d0f6b2aae065467234bc21).


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.


