### PR TITLE
Fix event history route

### DIFF
--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -68,8 +68,6 @@
 
 (def EventGetParams EventFieldsParam)
 
-(def EventTimelineParams PagingParams)
-
 (s/defn same-bucket? :- s/Bool
   [bucket :- EventBucket
    event :- Event
@@ -134,7 +132,6 @@
     (let [capabilities :search-event]
       (GET "/history/:entity_id" []
            :return [EventBucket]
-           :query [q EventTimelineParams]
            :path-params [entity_id :- s/Str]
            :summary "Timeline history of an entity"
            :description (routes.common/capabilities->description capabilities)
@@ -143,7 +140,7 @@
            :identity-map identity-map
            (let [res (fetch-related-events entity_id
                                            identity-map
-                                           (into q {:sort_by :timestamp :sort_order :desc})
+                                           {:sort_by :timestamp :sort_order :desc}
                                            services)
                  timeline (bucketize-events res get-in-config)]
              (ok timeline))))))

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -22,8 +22,8 @@
   (s/enum :histogram :topn :cardinality))
 
 (s/defschema AggCommonParams
-  (st/merge
-   {:aggregate-on s/Str}))
+  {:aggregate-on s/Str
+   (s/optional-key :agg-key) s/Keyword})
 
 (s/defschema Timezone
   (let [positives (map #(format "+%02d:00" %) (range 12))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -81,5 +81,6 @@
                 identity-map
                 query-params))]
       (if-let [next-params (:next paging)]
-        (recur next-params (into results data))
+        (recur (into query-params next-params)
+               (into results data))
         (into results data)))))

--- a/src/ctia/store_service.clj
+++ b/src/ctia/store_service.clj
@@ -17,7 +17,8 @@
   "A service to manage the central storage area for all stores."
   StoreService
   [[:ConfigService get-in-config]]
-  (init [this context] (core/init context))
+  (init [this context]
+        (core/init context))
   (start [this context]
          (core/start context
                      get-in-config))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -408,14 +408,18 @@ It returns the documents with full hits meta data including the real index in wh
                  :precision_threshold 10000}})
 
 (s/defn make-aggregation
-  [{:keys [agg-type] :as agg-query} :- AggQuery]
-  (let [agg-fn
+  [{:keys [agg-type agg-key aggs]
+    :or {agg-key :metric}
+    :as agg-query} :- AggQuery]
+  (let [root-agg (dissoc agg-query :aggs)
+        agg-fn
         (case agg-type
           :topn make-topn
           :cardinality make-cardinality
           :histogram make-histogram
           (throw (ex-info "invalid aggregation type" agg-type)))]
-    {:metric (agg-fn agg-query)}))
+    (cond-> {agg-key (agg-fn root-agg)}
+      (seq aggs) (assoc :aggs (make-aggregation aggs)))))
 
 (defn format-agg-result
   [agg-type
@@ -436,7 +440,7 @@ It returns the documents with full hits meta data including the real index in wh
    {:keys [agg-type] :as agg-query} :- AggQuery
    ident]
   (let [query (make-search-query es-conn-state search-query ident)
-        agg (make-aggregation agg-query)
+        agg (make-aggregation (assoc agg-query :agg-key :metric))
         es-res (ductile.doc/query conn
                                   index
                                   query

--- a/src/ctia/task/stats.clj
+++ b/src/ctia/task/stats.clj
@@ -1,0 +1,22 @@
+(ns ctia.task.stats
+  (:require [ctia.stores.es.crud :refer [make-aggregation]]))
+
+(defn topn-orgs
+  [n]
+  {:agg-key :top-orgs
+   :agg-type :topn
+   :aggregate-on :groups
+   :limit n})
+
+(defn topn-sources
+  [n]
+  {:agg-key :top-sources
+   :agg-type :topn
+   :aggregate-on :groups
+   :limit n})
+
+(defn topn-source-top-orgs
+  [n-sources n-orgs]
+  (assoc (topn-sources n-sources)
+         :aggs
+         (topn-orgs n-orgs)))

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -7,19 +7,19 @@
             [clojure.test :refer [deftest testing is]]))
 
 (def admin-ident {:login "johndoe"
-            :groups ["Administators"]})
+                  :groups ["Administators"]})
 
 (deftest list-all-pages-test
   (testing "list all pages shall properly list all results for given entity and parameters. "
     (helpers/fixture-ctia-with-app
      (fn [app]
-       (let [{:keys [StoreService] :as services} (app->APIHandlerServices app)
+       (let [services (app->APIHandlerServices app)
              incidents-1 (fixt/n-doc incident-minimal 10)
              incidents-2 (->> (fixt/n-doc incident-minimal 10)
                               (map #(assoc % :source "incident-2-source")))
              incidents (concat incidents-1 incidents-2)
              bulk-result (helpers/POST-bulk app {:incidents incidents})]
-         (Thread/sleep 1000) ;; ensure index refresh
+         (Thread/sleep 1500) ;; ensure index refresh
          (is
           (= (count incidents)
              (count (sut/list-all-pages :incident

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -7,7 +7,7 @@
             [ctia.store-service :as store-svc]
             [clojure.test :refer [deftest testing is]]))
 
-(def ident {:login "johndoe"
+(def admin-ident {:login "johndoe"
             :groups ["Administators"]})
 
 (deftest list-all-pages-test
@@ -26,19 +26,19 @@
              (count (sut/list-all-pages :incident
                                         sut/list-fn
                                         {:query "*"}
-                                        ident
+                                        admin-ident
                                         {}
                                         services))
              (count (sut/list-all-pages :incident
                                         sut/list-fn
                                         {:query "*"}
-                                        ident
+                                        admin-ident
                                         {:limit 2}
                                         services))
              (count (sut/list-all-pages :incident
                                         sut/list-fn
                                         {:query "*"}
-                                        ident
+                                        admin-ident
                                         {:limit 3}
                                         services)))
           "paging parameters shall not alter the number of retrieved entities.")
@@ -47,13 +47,13 @@
              (count (sut/list-all-pages :incident
                                         sut/list-fn
                                         {:query "*"}
-                                        ident
+                                        admin-ident
                                         {}
                                         services))
              (count (sut/list-all-pages :event
                                         sut/list-events
                                         {:query "*"}
-                                        ident
+                                        admin-ident
                                         {}
                                         services)))
           "all store shall be properly listed.")
@@ -61,7 +61,7 @@
                 (count (sut/list-all-pages :incident
                                            sut/list-fn
                                            {:one-of {:source "incident-2-source"}}
-                                           ident
+                                           admin-ident
                                            {}
                                            services)))
              "entities shall be properly filtered."))))))

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -1,0 +1,67 @@
+(ns ctia.store-test
+  (:require [ctia.store :as sut]
+            [ctia.test-helpers.http :refer [app->APIHandlerServices]]
+            [ctia.test-helpers.fixtures :as fixt]
+            [ctia.test-helpers.core :as helpers :refer [GET POST PATCH]]
+            [ctim.examples.incidents :refer [incident-minimal]]
+            [ctia.store-service :as store-svc]
+            [clojure.test :refer [deftest testing is]]))
+
+(def ident {:login "johndoe"
+            :groups ["Administators"]})
+
+(deftest list-all-pages-test
+  (testing "list all pages shall properly list all results for given entity and parameters. "
+    (helpers/fixture-ctia-with-app
+     (fn [app]
+       (let [{:keys [StoreService] :as services} (app->APIHandlerServices app)
+             incidents-1 (fixt/n-doc incident-minimal 10)
+             incidents-2 (->> (fixt/n-doc incident-minimal 10)
+                              (map #(assoc % :source "incident-2-source")))
+             incidents (concat incidents-1 incidents-2)
+             bulk-result (helpers/POST-bulk app {:incidents incidents})]
+         (Thread/sleep 1000) ;; ensure index refresh
+         (is
+          (= (count incidents)
+             (count (sut/list-all-pages :incident
+                                        sut/list-fn
+                                        {:query "*"}
+                                        ident
+                                        {}
+                                        services))
+             (count (sut/list-all-pages :incident
+                                        sut/list-fn
+                                        {:query "*"}
+                                        ident
+                                        {:limit 2}
+                                        services))
+             (count (sut/list-all-pages :incident
+                                        sut/list-fn
+                                        {:query "*"}
+                                        ident
+                                        {:limit 3}
+                                        services)))
+          "paging parameters shall not alter the number of retrieved entities.")
+         (is
+          (= (count incidents)
+             (count (sut/list-all-pages :incident
+                                        sut/list-fn
+                                        {:query "*"}
+                                        ident
+                                        {}
+                                        services))
+             (count (sut/list-all-pages :event
+                                        sut/list-events
+                                        {:query "*"}
+                                        ident
+                                        {}
+                                        services)))
+          "all store shall be properly listed.")
+         (is (= (count incidents-2)
+                (count (sut/list-all-pages :incident
+                                           sut/list-fn
+                                           {:one-of {:source "incident-2-source"}}
+                                           ident
+                                           {}
+                                           services)))
+             "entities shall be properly filtered."))))))

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -2,9 +2,8 @@
   (:require [ctia.store :as sut]
             [ctia.test-helpers.http :refer [app->APIHandlerServices]]
             [ctia.test-helpers.fixtures :as fixt]
-            [ctia.test-helpers.core :as helpers :refer [GET POST PATCH]]
+            [ctia.test-helpers.core :as helpers]
             [ctim.examples.incidents :refer [incident-minimal]]
-            [ctia.store-service :as store-svc]
             [clojure.test :refer [deftest testing is]]))
 
 (def admin-ident {:login "johndoe"

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -305,7 +305,40 @@
            {:field "observable.value"
             :precision_threshold 10000}}}
          (sut/make-aggregation {:agg-type :cardinality
-                                :aggregate-on "observable.value"}))))
+                                :aggregate-on "observable.value"})))
+  (is (= {:custom
+          {:cardinality
+           {:field "observable.value"
+            :precision_threshold 10000}}}
+         (sut/make-aggregation {:agg-type :cardinality
+                                :agg-key :custom
+                                :aggregate-on "observable.value"})))
+  (is (= {:top-sources
+          {:terms
+           {:field "sources"
+            :size 20
+            :order {:_count :desc}}}
+          :aggs {:by-month
+                 {:date_histogram
+                  {:field "created"
+                   :interval :month
+                   :time_zone "+00:00"}}
+                 :aggs {:nb-orgs
+                        {:cardinality
+                         {:field "groups"
+                          :precision_threshold 10000}}}}}
+         (sut/make-aggregation {:agg-type :topn
+                                :agg-key :top-sources
+                                :aggregate-on "sources"
+                                :limit 20
+                                :sort_order :desc
+                                :aggs {:agg-type :histogram
+                                       :agg-key :by-month
+                                       :aggregate-on "created"
+                                       :granularity :month
+                                       :aggs {:agg-type :cardinality
+                                              :agg-key :nb-orgs
+                                              :aggregate-on "groups"}}}))))
 
 (defn generate-sightings
   [nb confidence title timestamp]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/threatgrid/iroh/issues/4506

This PR fixes the event history which bug have been revealed by the fix of the default sort in ES CRUD.

<a name="qa">[§](#qa)</a> QA
============================

Check that the event history route works [as expected](https://github.com/threatgrid/ctia/pull/781).
