### PR TITLE
Disallow disabled entities in a bundle import #4471

### DIFF
--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -78,7 +78,7 @@
     [(-> plural kw->snake-case-str keyword)
      (-> entity kw->snake-case-str (str "_refs") keyword)]))
 
-(s/defn prep-bundle-schema :- s/Schema
+(s/defn prep-bundle-schema :- s/Any
   [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
   (let [to-remove (->> (entities/all-entities)
                        keys

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -1,24 +1,24 @@
 (ns ctia.bundle.routes
   (:refer-clojure :exclude [identity])
   (:require
+   [clojure.string :as str]
    [compojure.api.core :refer [GET POST context routes]]
-   [ctia.bundle
-    [core :refer [bundle-max-size
-                  bundle-size
-                  import-bundle
-                  export-bundle]]
-    [schemas :refer [BundleImportResult
-                     NewBundleExport
-                     BundleExportIds
-                     BundleExportOptions
-                     BundleExportQuery]]]
+   [ctia.bundle.core :refer [bundle-max-size
+                             bundle-size
+                             import-bundle
+                             export-bundle]]
+   [ctia.bundle.schemas :refer [BundleImportResult
+                                NewBundleExport
+                                BundleExportIds
+                                BundleExportOptions
+                                BundleExportQuery]]
+   [ctia.entity.entities :as entities]
    [ctia.http.routes.common :as common]
    [ctia.schemas.core :refer [APIHandlerServices NewBundle]]
    [ring.swagger.json-schema :refer [describe]]
    [ring.util.http-response :refer [ok bad-request]]
-   [schema.core :as s]
-   [schema-tools.core :as st]))
-
+   [schema-tools.core :as st]
+   [schema.core :as s]))
 
 (def export-capabilities
   #{:list-campaigns
@@ -67,9 +67,28 @@
     :read-casebook
     :list-casebooks})
 
+(defn- keyword->str [key] (str (if (namespace key) "/" "") (name key)))
+
+(defn- entity->bundle-keys
+  "For given entity key returns corresponding keys that may be present in Bundle schema.
+  e.g. :asset => [:assets :asset_refs]"
+  [entity-key]
+  (let [{:keys [entity plural]} (get (entities/all-entities) entity-key)
+        kw->snake-case-str      (fn [kw] (-> kw keyword->str (str/replace #"-" "_")))]
+    [(-> plural kw->snake-case-str keyword)
+     (-> entity kw->snake-case-str (str "_refs") keyword)]))
+
+(s/defn prep-bundle-schema :- s/Schema
+  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  (let [to-remove (->> (entities/all-entities)
+                       keys
+                       (filter (comp not enabled?))
+                       (mapcat entity->bundle-keys))]
+    (apply st/dissoc NewBundle to-remove)))
+
 (s/defn bundle-routes [{{:keys [get-in-config]} :ConfigService
                         :as services} :- APIHandlerServices]
- (routes 
+ (routes
   (context "/bundle" []
            :tags ["Bundle"]
            (let [capabilities export-capabilities]
@@ -127,7 +146,9 @@
                                 :import-bundle}]
              (POST "/import" []
                    :return BundleImportResult
-                   :body [bundle NewBundle {:description "a Bundle to import"}]
+                   :body [bundle
+                          (prep-bundle-schema services)
+                          {:description "a Bundle to import"}]
                    :query-params
                    [{external-key-prefixes
                      :- (describe s/Str "Comma separated list of external key prefixes")

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -16,10 +16,15 @@
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.domain.id :as id]
+            [ctim.examples.asset-properties :refer [asset-properties-maximal]]
+            [ctim.examples.assets :refer [asset-maximal]]
             [ctim.examples.bundles :refer [bundle-maximal]]
+            [ctim.examples.incidents :refer [incident-maximal]]
+            [ctim.examples.target-records :refer [target-record-maximal]]
             [ctim.schemas.common :refer [ctim-schema-version]]
             [ductile.index :as es-index]
-            [puppetlabs.trapperkeeper.app :as app]))
+            [puppetlabs.trapperkeeper.app :as app]
+            [schema.core :as s]))
 
 (defn fixture-properties [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000
@@ -416,35 +421,55 @@
            (es-index/open! (:conn indicator-store-state) indexname)))))))
 
 (deftest bundle-import-should-not-allow-disabled-entities
+  (testing "disabled entities should be removed from Bundle schema"
+    (let [selected-keys    #{:asset :target-record :asset-properties}
+          set-of           (fn [model] (set (repeat 3 model)))
+          fake-bundle      {:id                    "http://ex.tld/ctia/bundle/bundle-5023697b-3857-4652-9b53-ccda297f9c3e"
+                            :source                "source"
+                            :type                  "bundle"
+                            :assets                (set-of asset-maximal)
+                            :asset_refs            #{"http://ex.tld/ctia/asset/asset-5023697b-3857-4652-9b53-ccda297f9c3e"}
+                            :asset_properties      (set-of asset-properties-maximal)
+                            :asset_properties_refs #{"http://ex.tld/ctia/asset-properties/asset-properties-5023697b-3857-4652-9b53-ccda297f9c3e"}
+                            :target_record_refs    #{"http://ex.tld/ctia/target-record/target-record-5023697b-3857-4652-9b53-ccda297f9c3e"}
+                            :target_records        (set-of target-record-maximal)}
+          api-handler-svcs {:FeaturesService {:enabled? #(contains? selected-keys %)}}]
+      (s/set-fn-validation! false)    ;; otherwise it fails for incomplete APIHandlerServices passed into `prep-bundle-schema`
+      (is (map? (s/validate (bundle.routes/prep-bundle-schema api-handler-svcs) fake-bundle)))
+      (is (thrown? Exception
+                   (s/validate
+                    (bundle.routes/prep-bundle-schema api-handler-svcs)
+                    (assoc fake-bundle :incidents (set-of incident-maximal))))
+          "Bundle schema with a key that's not explicitly allowed shouldn't validate")))
   (testing "Attempts to import bundle with disabled entities should fail"
     (let [disable [:asset :asset-properties :actor :sighting]]
-     (helpers/with-config-transformer
-       #(assoc-in
-         % [:ctia :features :disable]
-         (->> disable (map name) (str/join ",")))
-       (test-for-each-store-with-app
-        (fn [app]
-          (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
-          (whoami-helpers/set-whoami-response app
-                                              "45c1f5e3f05d0"
-                                              "foouser"
-                                              "foogroup"
-                                              "user")
-          (let [new-bundle               (deep-dissoc-entity-ids bundle-maximal)
-                resp                     (POST app "ctia/bundle/import"
-                                           :body new-bundle
-                                           :headers {"Authorization" "45c1f5e3f05d0"})
-                disallowed-keys-expected (->> disable
-                                              (mapcat #'bundle.routes/entity->bundle-keys)
-                                              set)
-                disallowed-keys-res      (->> resp
-                                              :body
-                                              edn/read-string
-                                              :errors
-                                              (filter (fn [[_ v]] (= v 'disallowed-key)))
-                                              (map first)
-                                              set)]
-            (is (= disallowed-keys-expected disallowed-keys-res)))))))))
+      (helpers/with-config-transformer
+        #(assoc-in
+          % [:ctia :features :disable]
+          (->> disable (map name) (str/join ",")))
+        (test-for-each-store-with-app
+         (fn [app]
+           (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+           (whoami-helpers/set-whoami-response app
+                                               "45c1f5e3f05d0"
+                                               "foouser"
+                                               "foogroup"
+                                               "user")
+           (let [new-bundle               (deep-dissoc-entity-ids bundle-maximal)
+                 resp                     (POST app "ctia/bundle/import"
+                                            :body new-bundle
+                                            :headers {"Authorization" "45c1f5e3f05d0"})
+                 disallowed-keys-expected (->> disable
+                                               (mapcat #'bundle.routes/entity->bundle-keys)
+                                               set)
+                 disallowed-keys-res      (->> resp
+                                               :body
+                                               edn/read-string
+                                               :errors
+                                               (filter (fn [[_ v]] (= v 'disallowed-key)))
+                                               (map first)
+                                               set)]
+             (is (= disallowed-keys-expected disallowed-keys-res)))))))))
 
 (deftest bundle-import-errors-test
   (test-for-each-store-with-app

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1,23 +1,24 @@
 (ns ctia.bundle.routes-test
-  (:require [ctim.schemas.common :refer [ctim-schema-version]]
-            [ductile.index :as es-index]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure
-             [set :as set]
-             [test :as t :refer [deftest is join-fixtures testing use-fixtures]]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clj-momo.test-helpers.http :refer [encode]]
+            [clojure.edn :as edn]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :as t :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.auth :as auth :refer [IIdentity]]
+            [ctia.auth.capabilities :refer [all-capabilities]]
             [ctia.bulk.core :as bulk]
             [ctia.bundle.core :as core]
+            [ctia.bundle.routes :as bundle.routes]
             [ctia.properties :as p]
-            [ctia.auth.capabilities :refer [all-capabilities]]
-            [ctia.test-helpers
-             [core :as helpers :refer [deep-dissoc-entity-ids GET POST DELETE]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store-with-app]]]
+            [ctia.test-helpers.core :as helpers
+             :refer [deep-dissoc-entity-ids GET POST DELETE]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.domain.id :as id]
-            [ctia.auth :as auth :refer [IIdentity]]
             [ctim.examples.bundles :refer [bundle-maximal]]
+            [ctim.schemas.common :refer [ctim-schema-version]]
+            [ductile.index :as es-index]
             [puppetlabs.trapperkeeper.app :as app]))
 
 (defn fixture-properties [t]


### PR DESCRIPTION
### Won't allow Bundle-imports with disabled entities

> **Epic** #
> Close  https://github.com/threatgrid/iroh/issues/4471
> Related #1020 

<a name="qa">[§](#qa)</a> QA
============================

1. Set property configuration for ctia.features.disabled, e.g. `ctia.features.disable asset,actor,sighting,asset-mapping,asset-properties`
2. Run the app
3. Go to the Swagger console

**Expected:** pre-filled map of `/ctia/bundle/import` path should not contain any keys related to disabled entities, no 'asset', 'asset_refs', 'sighting', etc.

4. Try to submit a bundle that contains key(s) pertaining to disabled entities [anyway]

**Expected:** POST should fail with a message about "disallowed-keys"

<!-- REMOVE UNUSED LINES -->

```
intern: Bundle imports do not allow submitting disabled entities.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

81035bc9 extends tests
325a7ced PR feedback
b901b7aa adds a test
34eec646 fixing ns header
9acd4d7f removing entities in the schema
