### PR TITLE
Minor tooling improvements

### DIFF
--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -3,4 +3,4 @@
 set -ex
 
 # shellcheck disable=SC1010
-lein with-profile -dev do clean, javac, split-test :no-gen
+lein with-profile -dev,+ci do clean, javac, split-test :no-gen

--- a/dev/ctia/dev/split_tests.clj
+++ b/dev/ctia/dev/split_tests.clj
@@ -167,7 +167,11 @@
         example-nses (-> example-timings keys sort vec)]
     (doseq [nsplits (range 1 15)]
       (let [all-splits (for [id (range nsplits)]
-                         (binding [*out* (java.io.PrintWriter. "/dev/null")]
+                         (binding [*out* (java.io.PrintWriter. (proxy [java.io.OutputStream] []
+                                                                 (write
+                                                                   ([a])
+                                                                   ([a b c])
+                                                                   ([a b c d e]))))]
                            (this-split-using-scheduling-with-full-knowledge
                              example-timings
                              [id nsplits]

--- a/dev/ctia/dev/split_tests.clj
+++ b/dev/ctia/dev/split_tests.clj
@@ -167,9 +167,7 @@
         example-nses (-> example-timings keys sort vec)]
     (doseq [nsplits (range 1 15)]
       (let [all-splits (for [id (range nsplits)]
-                         (binding [*out* (java.io.PrintWriter.
-                                           ;; JDK11+
-                                           (java.io.OutputStream/nullOutputStream))]
+                         (binding [*out* (java.io.PrintWriter. "/dev/null")]
                            (this-split-using-scheduling-with-full-knowledge
                              example-timings
                              [id nsplits]

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,14 +1,16 @@
 (ns user
-  (:require [cheshire.core :as json]
-            [clj-http.client :as http]
-            [clj-momo.lib.time :as time]
-            [ctia.init :as init]
-            [ctia.properties :as p]
-            [ctim.schemas.vocabularies :as vocab]
-            [puppetlabs.trapperkeeper.app :as app]
-            [schema.core :as s]))
+  (:require
+   [clojure.tools.namespace.repl :refer [clear refresh refresh-dirs set-refresh-dirs]]
+   [cheshire.core :as json]
+   [clj-http.client :as http]
+   [clj-momo.lib.time :as time]
+   [ctia.init :as init]
+   [ctia.properties :as p]
+   [ctim.schemas.vocabularies :as vocab]
+   [puppetlabs.trapperkeeper.app :as app]
+   [schema.core :as s]))
 
-(set! *warn-on-reflection* true)
+(set-refresh-dirs "src" "dev" "test")
 
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;; Lifecycle management

--- a/project.clj
+++ b/project.clj
@@ -142,7 +142,7 @@
                                   (:out (clojure.java.shell/sh
                                          "git" "symbolic-ref" "--short" "HEAD")))})}]
 
-  :global-vars {*warn-on-reflection* true}
+  
   :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~trapperkeeper-version
                                    :classifier "test"]
                                   [puppetlabs/kitchensink ~trapperkeeper-version
@@ -155,7 +155,6 @@
                                   [org.clojure/math.combinatorics "0.1.6"]
                                   [org.clojure/data.priority-map "1.0.0"]]
                    :pedantic? :warn
-
                    :resource-paths ["test/resources"]
                    :source-paths ["dev"]}
              :jmx {:jvm-opts ["-Dcom.sun.management.jmxremote"
@@ -191,12 +190,14 @@
                                    [com.gfredericks/test.chuck ~test-chuck-version]
                                    [org.clojure/test.check ~test-check-version]
                                    [prismatic/schema-generators ~schema-generators-version]]
-                    :pedantic? :abort
                     :resource-paths ["test/resources"]}
 
-             :dev-test {:pedantic? :warn}
              :prepush {:plugins [[yogsototh/lein-kibit "0.1.6-SNAPSHOT"]
                                  [lein-bikeshed "0.3.0"]]}}
+
+  :ci {:pedantic? :abort
+        :global-vars {*warn-on-reflection* true}}
+  
   :perforate {:environments [{:name :actor
                               :namespaces [ctia.entity.actor-bench]}
                              {:name :campaign
@@ -238,8 +239,7 @@
   #_:git-down #_{threatgrid/ctim {:coordinates frenchy64/ctim}
                  threatgrid/clj-momo {:coordinates frenchy64/clj-momo}
                  threatgrid/ring-jwt-middleware {:coordinates frenchy64/ring-jwt-middleware}}
-  :aliases {"dev-test" ["with-profile" "test,dev-test" "test"]
-            "kibit" ["with-profile" "prepush" "kibit"]
+  :aliases {"kibit" ["with-profile" "prepush" "kibit"]
             "bikeshed" ["with-profile" "prepush" "bikeshed" "-m" "100"]
 
             "prepush" ^{:doc "Check code quality before pushing"}
@@ -248,7 +248,7 @@
             "bench" ^{:doc (str "Launch benchmarks"
                                 "; use `lein bench actor` to only launch"
                                 " actor related benchmarks")}
-            ["with-profile" "test,dev-test" "perforate"]
+            ["with-profile" "test" "perforate"]
 
             "init-properties" ^{:doc (str "create an initial `ctia.properties`"
                                           " using docker machine ip")}
@@ -257,8 +257,8 @@
             ; circleci.test
             ;"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
             "split-test" ["trampoline"
-                          "with-profile" "+test" ;https://github.com/circleci/circleci.test/issues/13
+                          "with-profile" "+test,+ci" ;https://github.com/circleci/circleci.test/issues/13
                           "run" "-m" "ctia.dev.split-tests/dir" :project/test-paths]
-            "tests" ["run" "-m" "circleci.test"]
+            "tests" ["with-profile" "+ci" "run" "-m" "circleci.test"]
             ;"retest" ["run" "-m" "circleci.test.retest"]
             })

--- a/project.clj
+++ b/project.clj
@@ -153,7 +153,8 @@
                                   [prismatic/schema-generators ~schema-generators-version]
                                   [circleci/circleci.test "0.4.3"]
                                   [org.clojure/math.combinatorics "0.1.6"]
-                                  [org.clojure/data.priority-map "1.0.0"]]
+                                  [org.clojure/data.priority-map "1.0.0"]
+                                  [org.clojure/tools.namespace "1.1.0"]]
                    :pedantic? :warn
                    :resource-paths ["test/resources"]
                    :source-paths ["dev"]}
@@ -196,7 +197,7 @@
                                  [lein-bikeshed "0.3.0"]]}}
 
   :ci {:pedantic? :abort
-        :global-vars {*warn-on-reflection* true}}
+       :global-vars {*warn-on-reflection* true}}
   
   :perforate {:environments [{:name :actor
                               :namespaces [ctia.entity.actor-bench]}

--- a/project.clj
+++ b/project.clj
@@ -220,8 +220,8 @@
                                " (start) => start CTIA, if not already started"
                                " (stop)  => stop CTIA, if not already stopped"
                                " (current-app) => get current app, or nil"]))
-                 ;2m
-                 :repl-timeout 120000}
+                 ;10m
+                 :repl-timeout 600000}
   :middleware [lein-git-down.plugin/inject-properties]
   ;; lein-git-down config
   :repositories [["public-github" {:url "git://github.com"}]


### PR DESCRIPTION
Related https://github.com/threatgrid/iroh/issues/3985

* Make a `PrintWriter` cross-JDK
  * I use `8`
* Introduce :ci profile, discard :dev-test profile
  * :dev and :test are standard Lein profiles that can be expected to be in essentially any Lein project, while :dev-test is not.
Requiring developers to opt-in to this profile precludes the possibility of having a unified Lein setup that will work in any project.
* Setup optional tools.namespace setup
  * Doesn't impact non-users (e.g. no code will be loaded if you won't tell it to `(refresh)`)
* Increase :repl-timeout
  * Arbitrary ~/.lein code can require such a high value.
Otherwise setting this in project.clj would override a user-provided value.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Minor tooling improvements
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

