### PR TITLE
Isolate compojure.api.core usage to guarantee ns loading order

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -2,9 +2,9 @@
   {:unresolved-symbol
    {:exclude [(puppetlabs.trapperkeeper.testutils.bootstrap/with-app-with-config [app])]}}
  :lint-as {puppetlabs.trapperkeeper.core/defservice clj-kondo.lint-as/def-catch-all
-           compojure.api.core/GET clj-kondo.lint-as/def-catch-all
-           compojure.api.core/PATCH clj-kondo.lint-as/def-catch-all
-           compojure.api.core/POST clj-kondo.lint-as/def-catch-all
-           compojure.api.core/PUT clj-kondo.lint-as/def-catch-all
-           compojure.api.core/DELETE clj-kondo.lint-as/def-catch-all
-           compojure.api.core/context clj-kondo.lint-as/def-catch-all}}
+           ctia.lib.compojure.api.core/GET clj-kondo.lint-as/def-catch-all
+           ctia.lib.compojure.api.core/PATCH clj-kondo.lint-as/def-catch-all
+           ctia.lib.compojure.api.core/POST clj-kondo.lint-as/def-catch-all
+           ctia.lib.compojure.api.core/PUT clj-kondo.lint-as/def-catch-all
+           ctia.lib.compojure.api.core/DELETE clj-kondo.lint-as/def-catch-all
+           ctia.lib.compojure.api.core/context clj-kondo.lint-as/def-catch-all}}

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.bulk.routes
   (:require
-   [compojure.api.core :refer [GET POST routes]]
+   [ctia.lib.compojure.api.core :refer [GET POST routes]]
    [ctia.bulk
     [core :refer [bulk-size create-bulk fetch-bulk get-bulk-max-size]]
     [schemas :refer [Bulk BulkRefs NewBulk]]]

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [identity])
   (:require
    [clojure.string :as str]
-   [compojure.api.core :refer [GET POST context routes]]
+   [ctia.lib.compojure.api.core :refer [GET POST context routes]]
    [ctia.bundle.core :refer [bundle-max-size
                              bundle-size
                              import-bundle

--- a/src/ctia/documentation/routes.clj
+++ b/src/ctia/documentation/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.documentation.routes
   (:require
-   [compojure.api.core :refer [context GET]]
+   [ctia.lib.compojure.api.core :refer [context GET]]
    [clojure.core.memoize :as memo]
    [clojure.java.io :as io]
    [hiccup.page :as page]

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.asset-properties
   (:require [clj-momo.lib.clj-time.core :as time]
-            [compojure.api.sweet :refer [POST routes]]
+            [ctia.lib.compojure.api.core :refer [POST routes]]
             [ctia.domain.entities :refer [default-realize-fn]]
             [ctia.flows.crud :as flows]
             [ctia.http.routes.common :as routes.common]

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -1,5 +1,5 @@
 (ns ctia.entity.casebook
-  (:require [compojure.api.sweet :refer [context POST PATCH routes]]
+  (:require [ctia.lib.compojure.api.core :refer [context POST PATCH routes]]
             [ctia.domain.entities :refer [default-realize-fn un-store with-long-id]]
             [ctia.flows.crud :as flows]
             [ctia.http.routes

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -2,7 +2,7 @@
   (:require
    [ctia.entity.event.store
     :refer [->EventStore]]
-   [compojure.api.core :refer [GET routes]]
+   [ctia.lib.compojure.api.core :refer [GET routes]]
    [ring.util.http-response :refer [ok]]
    [schema-tools.core :as st]
    [schema.core :as s]

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -3,7 +3,7 @@
    [clojure.string :as string]
    [ctia.http.routes.crud :as crud]
    [ctia.schemas.core :refer [APIHandlerServices]]
-   [compojure.api.core :refer [DELETE GET POST PUT routes]]
+   [ctia.lib.compojure.api.core :refer [DELETE GET POST PUT routes]]
    [ctia.domain.entities
     :refer
     [page-with-long-id un-store un-store-page with-long-id]]

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -1,5 +1,5 @@
 (ns ctia.entity.feedback
-  (:require [compojure.api.core :refer [GET routes]]
+  (:require [ctia.lib.compojure.api.core :refer [GET routes]]
             [ctia.domain.entities :refer [page-with-long-id un-store-page]]
             [ctia.entity.feedback.schemas :as fs]
             [ctia.http.routes

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.incident
   (:require [clj-momo.lib.clj-time.core :as time]
-            [compojure.api.sweet :refer [POST routes]]
+            [ctia.lib.compojure.api.core :refer [POST routes]]
             [ctia.domain.entities
              :refer [default-realize-fn un-store with-long-id]]
             [ctia.entity.feedback.graphql-schemas :as feedback]

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.judgement
   (:require [clj-momo.lib.clj-time.core :as time]
-            [compojure.api.core :refer [context POST routes]]
+            [ctia.lib.compojure.api.core :refer [context POST routes]]
             [compojure.api.resource :refer [resource]]
             [ctia.domain.entities :refer [un-store with-long-id]]
             [ctia.entity.feedback.graphql-schemas :as feedback]
@@ -9,8 +9,6 @@
              [schemas :as js]]
             [ctia.entity.relationship.graphql-schemas :as relationship]
             [ctia.flows.crud :as flows]
-            ;; do not delete, defmethod side effects
-            [ctia.http.middleware.auth]
             [ctia.http.routes
              [common :refer [BaseEntityFilterParams
                              PagingParams

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.relationship
   (:require [clojure.string :as str]
-            [compojure.api.core :refer [POST]]
+            [ctia.lib.compojure.api.core :refer [POST]]
             [ctia.store :refer [create-record
                                 read-record]]
             [ctia.domain.entities :refer [long-id->id short-id->long-id un-store with-long-id]]

--- a/src/ctia/graphql/routes.clj
+++ b/src/ctia/graphql/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.graphql.routes
   (:require [clojure.tools.logging :as log]
-            [compojure.api.core :as c :refer [POST routes]]
+            [ctia.lib.compojure.api.core :as c :refer [POST routes]]
             [ctia.http.routes.common :as common]
             [ctia.graphql.schemas :as gql]
             [ctia.schemas.core :refer [APIHandlerServices]]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -5,10 +5,9 @@
             [ctia.entity.feed :refer [feed-view-routes]]
             [ctia.entity.relationship :refer [incident-link-route]]
             [ctia.schemas.core :refer [APIHandlerServices Entity]]
-            [compojure.api
-             [core :refer [middleware]]
-             [routes :as api-routes]
-             [sweet :refer  [routes api context undocumented]]]
+            [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
+            [compojure.api.api :refer [api]]
+            [compojure.api.routes :as api-routes]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -3,7 +3,7 @@
    [clj-momo.lib.clj-time.core :as time]
    [clojure.string :as str]
    [ctia.http.middleware.auth]
-   [compojure.api.core :refer [context DELETE GET POST PUT PATCH routes]]
+   [ctia.lib.compojure.api.core :refer [context DELETE GET POST PUT PATCH routes]]
    [ctia.domain.entities
     :refer
     [page-with-long-id

--- a/src/ctia/lib/compojure/api/core.clj
+++ b/src/ctia/lib/compojure/api/core.clj
@@ -1,0 +1,60 @@
+(ns ctia.lib.compojure.api.core
+  "Exposes the API of compojure.api.core v1.1.13
+  
+  Always use this namespace over compojure.api.{core,sweet}
+  as it also loads the CTIA routing extensions."
+  (:require [ctia.http.middleware.auth :as magic]))
+
+;; banned
+(require '[compojure.api.core :as core])
+
+(assert magic/add-id-to-request
+        (str "Never delete the :require of ctia.http.middleware.auth! "
+             "It has magic defmethod calls that are crucial to the "
+             "reliability of CTIA's startup. "
+             "See also: https://github.com/threatgrid/iroh/issues/4458"))
+
+(defn routes
+  "Create a Ring handler by combining several handlers into one."
+  [& handlers]
+  (apply core/routes handlers))
+
+(defmacro defroutes
+  "Define a Ring handler function from a sequence of routes.
+  The name may optionally be followed by a doc-string and meadata map."
+  {:style/indent 1}
+  [name & routes]
+  `(core/defroutes ~name ~@routes))
+
+(defmacro let-routes
+  "Takes a vector of bindings and a body of routes.
+  Equivalent to: `(let [...] (routes ...))`"
+  {:style/indent 1}
+  [bindings & body]
+  `(core/let-routes ~bindings ~@body))
+
+(defn undocumented
+  "Routes without route-documentation. Can be used to wrap routes,
+  not satisfying compojure.api.routes/Routing -protocol."
+  [& handlers]
+  (apply core/undocumented handlers))
+
+(defmacro middleware
+  "Wraps routes with given middlewares using thread-first macro.
+  Note that middlewares will be executed even if routes in body
+  do not match the request uri. Be careful with middlewares that
+  have side-effects."
+  {:style/indent 1}
+  [middleware & body]
+  `(core/middleware ~middleware ~@body))
+
+(defmacro context {:style/indent 2} [& args] `(core/context ~@args))
+
+(defmacro GET     {:style/indent 2} [& args] `(core/GET ~@args))
+(defmacro ANY     {:style/indent 2} [& args] `(core/ANY ~@args))
+(defmacro HEAD    {:style/indent 2} [& args] `(core/HEAD ~@args))
+(defmacro PATCH   {:style/indent 2} [& args] `(core/PATCH ~@args))
+(defmacro DELETE  {:style/indent 2} [& args] `(core/DELETE ~@args))
+(defmacro OPTIONS {:style/indent 2} [& args] `(core/OPTIONS ~@args))
+(defmacro POST    {:style/indent 2} [& args] `(core/POST ~@args))
+(defmacro PUT     {:style/indent 2} [& args] `(core/PUT ~@args))

--- a/src/ctia/metrics/routes.clj
+++ b/src/ctia/metrics/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.metrics.routes
   (:require
-   [compojure.api.core :refer [context GET]]
+   [ctia.lib.compojure.api.core :refer [context GET]]
    [ctia.http.routes.common :as routes.common]
    [metrics
     [core :refer [default-registry]]

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -1,5 +1,5 @@
 (ns ctia.observable.routes
-  (:require [compojure.api.core :refer [GET routes]]
+  (:require [ctia.lib.compojure.api.core :refer [GET routes]]
             [ctia.domain.entities
              :refer
              [page-with-long-id short-id->long-id un-store-page]]

--- a/src/ctia/properties/routes.clj
+++ b/src/ctia/properties/routes.clj
@@ -1,5 +1,5 @@
 (ns ctia.properties.routes
-  (:require [compojure.api.core :refer [context GET]]
+  (:require [ctia.lib.compojure.api.core :refer [context GET]]
             [ctia.http.routes.common :as routes.common]
             [ctia.schemas.core :refer [APIHandlerServices]]
             [ring.util.http-response :refer [ok]]

--- a/src/ctia/status/routes.clj
+++ b/src/ctia/status/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.status.routes
   (:require
-   [compojure.api.core :refer [context GET]]
+   [ctia.lib.compojure.api.core :refer [context GET]]
    [schema.core :as s]
    [ctia.schemas.core :refer [StatusInfo]]
    [ring.util.http-response :refer [ok]]))

--- a/src/ctia/version/routes.clj
+++ b/src/ctia/version/routes.clj
@@ -1,6 +1,6 @@
 (ns ctia.version.routes
   (:require
-   [compojure.api.core :refer [context GET routes]]
+   [ctia.lib.compojure.api.core :refer [context GET routes]]
    [ctia.schemas.core :refer [APIHandlerServices VersionInfo]]
    [ctia.version :refer [version-data]]
    [ring.util.http-response :refer [ok]]

--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -6,7 +6,7 @@
             [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [compojure.api.api :refer [api]]
-            [compojure.api.core :refer [GET]]
+            [ctia.lib.compojure.api.core :refer [GET]]
             [compojure.api.routes :as routes]
             [compojure.api.swagger :as swagger]))
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Closes https://github.com/threatgrid/iroh/issues/4458

See above issue for more details. It's slightly less relevant in CTIA since we control the bootstrap, but regardless we use the same troublesome loading patterns.

Added todo in [tooling epic](https://github.com/threatgrid/iroh/issues/3985) to ban the appropriate namespaces.
<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Isolate compojure.api.core usage to guarantee ns loading order
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

