### PR TITLE
remove clj-momo time lib from aggregate test helper ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,7 @@
 
   :dependencies [[org.clojure/clojure ~clj-version]
                  [clj-time "0.15.2"]
+                 [org.threeten/threeten-extra "1.2"]
                  [clojure.java-time "0.3.2"]
                  [org.clojure/core.async "1.0.567"]
                  [org.slf4j/slf4j-log4j12 "1.8.0-beta0"]

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -1,6 +1,5 @@
 (ns ctia.entity.judgement.schemas
-  (:require [clj-momo.lib.time :as time]
-            [ctia.domain
+  (:require [ctia.domain
              [entities :refer [default-realize-fn]]]
             [ctia.graphql.delayed :as delayed]
             [ctia.schemas
@@ -16,10 +15,7 @@
              [common :refer [determine-disposition-id disposition-map]]
              [judgement :as js]]
             [flanders.utils :as fu]
-            [ring.util.http-response :as http-response]
-            [schema-tools.core :as st]
             [schema.core :as s]
-            [ctim.schemas.incident :as is]
             [ctia.flows.schemas :refer [with-error]]))
 
 (def-acl-schema Judgement
@@ -70,7 +66,7 @@
      (catch clojure.lang.ExceptionInfo e
        (let [{error-type :type} (ex-data e)]
          (if (= error-type :ctim.schemas.common/disposition-missing)
-           {:error "Mismatching disposition and dispositon_name for judgement"
+           {:error "Mismatched disposition and dispositon_name for judgement"
             :id id
             :type :realize-entity-error
             :judgement new-judgement}

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -9,9 +9,7 @@
              [judgement-fields
               judgement-sort-fields
               judgement-enumerable-fields
-              judgement-histogram-fields
-              NewJudgement]]
-            [ctia.properties :as p]
+              judgement-histogram-fields]]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
@@ -330,7 +328,7 @@
               (dissoc judgement
                       :id)))))
 
-     (testing "POST a judgement with mismatching disposition/disposition_name"
+     (testing "POST a judgement with mismatched disposition/disposition_name"
        (let [{status :status
               judgement :parsed-body}
              (POST app
@@ -347,7 +345,7 @@
                    :headers {"Authorization" "45c1f5e3f05d0"})]
          (is (= 400 status))
          (is (=
-              {:error "Mismatching disposition and dispositon_name for judgement",
+              {:error "Mismatched disposition and dispositon_name for judgement",
                :judgement {:observable {:value "1.2.3.4"
                                         :type "ip"}
                            :disposition 1
@@ -359,7 +357,7 @@
                            :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"}}}
               judgement))))
 
-     (testing "POST a judgement with mismatching disposition/disposition_name"
+     (testing "POST a judgement with mismatched disposition/disposition_name"
        (let [{status :status
               judgement :parsed-body}
              (POST app
@@ -375,7 +373,7 @@
                           :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"}}
                    :headers {"Authorization" "45c1f5e3f05d0"})]
          (is (= 400 status))
-         (is (= {:error "Mismatching disposition and dispositon_name for judgement",
+         (is (= {:error "Mismatched disposition and dispositon_name for judgement",
                  :judgement {:observable {:value "1.2.3.4"
                                           :type "ip"}
                              :disposition 1

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -73,7 +73,6 @@
         capital-word (unique-word "CAPITAL")
         base-possessive-word "possessive"
         possessive-word (str base-possessive-word "'s")
-        base-possessive-word (str/replace possessive-word "'s" "")
         base-domain (unique-word "cisco")
         domain-word (format "www.%s.com" base-domain)
         url-word (unique-word (format "http://%s/" domain-word))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related https://github.com/threatgrid/iroh/issues/4575
Related https://github.com/threatgrid/ctia/pull/1054
Close https://github.com/threatgrid/iroh/issues/4585

This PR complements the bug fix on aggregate test helper by replacing all use of clj-momo time lib by java-time in this ns.
This PR also fix a strangely named error message.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.


<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: remove clj-momo time lib from aggregate test helper ns
```
