### PR TITLE
Introduce `ci-run-tests` alias

### DIFF
--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -2,5 +2,4 @@
 
 set -ex
 
-# shellcheck disable=SC1010
-lein with-profile -dev,+ci do clean, javac, split-test :no-gen
+lein ci-run-tests

--- a/project.clj
+++ b/project.clj
@@ -262,5 +262,7 @@
                           "with-profile" "+test,+ci" ;https://github.com/circleci/circleci.test/issues/13
                           "run" "-m" "ctia.dev.split-tests/dir" :project/test-paths]
             "tests" ["with-profile" "+ci" "run" "-m" "circleci.test"]
+
+            "ci-run-tests" ["with-profile" "-dev,+ci" "do" "clean," "javac," "split-test" ":no-gen"]
             ;"retest" ["run" "-m" "circleci.test.retest"]
             })


### PR DESCRIPTION
Addresses https://github.com/threatgrid/ctia/pull/1053#discussion_r552199279

Proof that it's still able to fail the build: https://github.com/threatgrid/ctia/actions/runs/464600753 (https://github.com/threatgrid/ctia/commit/1b29cbd960d5724d83e3fecee6b5a2eb701f267e)

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Introduce `ci-run-tests` alias
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

