### PR TITLE
Remove disabled entities from Bulk routes

### DIFF
--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -34,7 +34,7 @@
                          :create-vulnerability
                          :create-weakness}]
       (POST "/" []
-            :return BulkRefs
+            :return (BulkRefs services)
             :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
             :body [bulk (NewBulk services) {:description "a new Bulk object"}]
             :summary "POST many new entities using a single HTTP call"

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -1,10 +1,9 @@
 (ns ctia.bulk.routes
   (:require
-   [ctia.lib.compojure.api.core :refer [GET POST routes]]
-   [ctia.bulk
-    [core :refer [bulk-size create-bulk fetch-bulk get-bulk-max-size]]
-    [schemas :refer [Bulk BulkRefs NewBulk]]]
+   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk get-bulk-max-size]]
+   [ctia.bulk.schemas :refer [Bulk BulkRefs NewBulk]]
    [ctia.http.routes.common :as common]
+   [ctia.lib.compojure.api.core :refer [GET POST routes]]
    [ctia.schemas.core :refer [APIHandlerServices Reference]]
    [ring.swagger.json-schema :refer [describe]]
    [ring.util.http-response :refer [bad-request ok]]
@@ -37,7 +36,7 @@
       (POST "/" []
             :return BulkRefs
             :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
-            :body [bulk NewBulk {:description "a new Bulk object"}]
+            :body [bulk (NewBulk services) {:description "a new Bulk object"}]
             :summary "POST many new entities using a single HTTP call"
             :auth-identity login
             :description (common/capabilities->description capabilities)

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -73,7 +73,7 @@
                         :read-vulnerability
                         :read-weakness}]
      (GET "/" []
-          :return (s/maybe Bulk)
+          :return (s/maybe (Bulk services))
           :summary "GET many entities at once"
           :query-params [{actors              :- [Reference] []}
                          {asset_mappings      :- [Reference] []}

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -1,7 +1,7 @@
 (ns ctia.bulk.schemas
   (:require [clojure.string :as str]
             [ctia.entity.entities :as entities]
-            [ctia.schemas.core :refer [TempIDs Reference]]
+            [ctia.schemas.core :refer [TempIDs Reference APIHandlerServices]]
             [schema-tools.core :as st]
             [schema.core :as s]))
 
@@ -42,6 +42,8 @@
    (entities-bulk-schema (entities/all-entities) [(s/maybe Reference)])
    (s/optional-key :tempids) TempIDs))
 
-; TODO def => defn
-(s/defschema NewBulk
-  (entities-bulk-schema (entities/all-entities) :new-schema))
+(s/defn NewBulk :- s/Any
+  "Returns NewBulk schema without disabled entities"
+  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  (let [ents (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k))))]
+    (entities-bulk-schema ents :new-schema)))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -35,18 +35,18 @@
   [{{:keys [enabled?]} :FeaturesService} :- ConfigurationServices]
   (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
 
-(s/defn Bulk :- s/Any
+(s/defn Bulk :- (s/protocol s/Schema)
   "Returns Bulk schema without disabled entities"
   [services :- ConfigurationServices]
   (entities-bulk-schema (get-entities services) :schema))
 
-(s/defn BulkRefs :- s/Any
+(s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- ConfigurationServices]
   (st/assoc
    (entities-bulk-schema (get-entities services) [(s/maybe Reference)])
    (s/optional-key :tempids) TempIDs))
 
-(s/defn NewBulk :- s/Any
+(s/defn NewBulk :- (s/protocol s/Schema)
   "Returns NewBulk schema without disabled entities"
   [services :- ConfigurationServices]
   (entities-bulk-schema (get-entities services) :new-schema))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -42,10 +42,10 @@
 (s/defschema StoredBulk
   (entities-bulk-schema (entities/all-entities) :stored-schema))
 
-; TODO def => defn
-(s/defschema BulkRefs
+(s/defn BulkRefs :- s/Any
+  [services :- APIHandlerServices]
   (st/assoc
-   (entities-bulk-schema (entities/all-entities) [(s/maybe Reference)])
+   (entities-bulk-schema (get-entities services) [(s/maybe Reference)])
    (s/optional-key :tempids) TempIDs))
 
 (s/defn NewBulk :- s/Any

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -1,9 +1,7 @@
 (ns ctia.bulk.schemas
   (:require [clojure.string :as str]
             [ctia.entity.entities :as entities]
-            [ctia.schemas.core :refer [TempIDs Reference APIHandlerServices
-                                       ConfigurationServices
-                                       ]]
+            [ctia.schemas.core :refer [TempIDs Reference GetEntitiesServices]]
             [schema-tools.core :as st]
             [schema.core :as s]))
 
@@ -32,21 +30,21 @@
 
 (s/defn get-entities :- [s/Any]
   "Returns list of enabled entities"
-  [{{:keys [enabled?]} :FeaturesService} :- ConfigurationServices]
+  [{{:keys [enabled?]} :FeaturesService} :- GetEntitiesServices]
   (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
 
 (s/defn Bulk :- (s/protocol s/Schema)
   "Returns Bulk schema without disabled entities"
-  [services :- ConfigurationServices]
+  [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :schema))
 
 (s/defn BulkRefs :- (s/protocol s/Schema)
-  [services :- ConfigurationServices]
+  [services :- GetEntitiesServices]
   (st/assoc
    (entities-bulk-schema (get-entities services) [(s/maybe Reference)])
    (s/optional-key :tempids) TempIDs))
 
 (s/defn NewBulk :- (s/protocol s/Schema)
   "Returns NewBulk schema without disabled entities"
-  [services :- ConfigurationServices]
+  [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :new-schema))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -28,9 +28,15 @@
   "Error related to one entity of the bulk"
   {:error s/Any})
 
-; TODO def => defn
-(s/defschema Bulk
-  (entities-bulk-schema (entities/all-entities) :schema))
+(s/defn get-entities :- [s/Keyword]
+  "Returns list of enabled entities"
+  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
+
+(s/defn Bulk :- s/Any
+  "Returns Bulk schema without disabled entities"
+  [services :- APIHandlerServices]
+  (entities-bulk-schema (get-entities services) :schema))
 
 ; TODO def => defn
 (s/defschema StoredBulk
@@ -44,6 +50,5 @@
 
 (s/defn NewBulk :- s/Any
   "Returns NewBulk schema without disabled entities"
-  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
-  (let [ents (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k))))]
-    (entities-bulk-schema ents :new-schema)))
+  [services :- APIHandlerServices]
+  (entities-bulk-schema (get-entities services) :new-schema))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -1,7 +1,9 @@
 (ns ctia.bulk.schemas
   (:require [clojure.string :as str]
             [ctia.entity.entities :as entities]
-            [ctia.schemas.core :refer [TempIDs Reference APIHandlerServices]]
+            [ctia.schemas.core :refer [TempIDs Reference APIHandlerServices
+                                       ConfigurationServices
+                                       ]]
             [schema-tools.core :as st]
             [schema.core :as s]))
 
@@ -30,21 +32,21 @@
 
 (s/defn get-entities :- [s/Any]
   "Returns list of enabled entities"
-  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  [{{:keys [enabled?]} :FeaturesService} :- ConfigurationServices]
   (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
 
 (s/defn Bulk :- s/Any
   "Returns Bulk schema without disabled entities"
-  [services :- APIHandlerServices]
+  [services :- ConfigurationServices]
   (entities-bulk-schema (get-entities services) :schema))
 
 (s/defn BulkRefs :- s/Any
-  [services :- APIHandlerServices]
+  [services :- ConfigurationServices]
   (st/assoc
    (entities-bulk-schema (get-entities services) [(s/maybe Reference)])
    (s/optional-key :tempids) TempIDs))
 
 (s/defn NewBulk :- s/Any
   "Returns NewBulk schema without disabled entities"
-  [services :- APIHandlerServices]
+  [services :- ConfigurationServices]
   (entities-bulk-schema (get-entities services) :new-schema))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -28,7 +28,7 @@
   "Error related to one entity of the bulk"
   {:error s/Any})
 
-(s/defn get-entities :- [s/Keyword]
+(s/defn get-entities :- [s/Any]
   "Returns list of enabled entities"
   [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
   (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
@@ -37,10 +37,6 @@
   "Returns Bulk schema without disabled entities"
   [services :- APIHandlerServices]
   (entities-bulk-schema (get-entities services) :schema))
-
-; TODO def => defn
-(s/defschema StoredBulk
-  (entities-bulk-schema (entities/all-entities) :stored-schema))
 
 (s/defn BulkRefs :- s/Any
   [services :- APIHandlerServices]

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -323,3 +323,12 @@
 (defschema ObservableTypeIdentifier
   vocs/ObservableTypeIdentifier
   "vocab.observable-type-id")
+
+(s/defschema ConfigurationServices
+  {:ConfigService   {:get-in-config (s/=>* s/Any
+                                           [[s/Any]]
+                                           [[s/Any] s/Any])
+                     s/Keyword      s/Any}
+   :FeaturesService {:enabled?      (s/=> s/Bool s/Keyword)
+                     :feature-flags (s/=> [s/Str])}
+   s/Keyword        s/Any})

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -324,11 +324,7 @@
   vocs/ObservableTypeIdentifier
   "vocab.observable-type-id")
 
-(s/defschema ConfigurationServices
-  {:ConfigService   {:get-in-config (s/=>* s/Any
-                                           [[s/Any]]
-                                           [[s/Any] s/Any])
-                     s/Keyword      s/Any}
-   :FeaturesService {:enabled?      (s/=> s/Bool s/Keyword)
-                     :feature-flags (s/=> [s/Str])}
+(s/defschema GetEntitiesServices
+  {:FeaturesService {:enabled? (s/=> s/Bool s/Keyword)
+                     s/Keyword s/Any}
    s/Keyword        s/Any})

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -33,14 +33,13 @@
 
 (deftest bulk-schema-excludes-disabled-test
   (testing "ensure NewBulk schema includes only enabled entities"
-    (s/set-fn-validation! false) ;; otherwise it fails for incomplete :APIHandlerServices (we only need :FeaturesService for the test)
     (with-app-with-config app
       [features-svc/features-service] {:ctia {:features {}}}
-      (let [bulk-schema (NewBulk (app/service-graph app))]
+      (let [bulk-schema (NewBulk (helpers/app->ConfigurationServices app))]
         (schema->keys bulk-schema)
         (is (true? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))
     (with-app-with-config app
       [features-svc/features-service]
       {:ctia {:features {:disable "asset,actor"}}}
-      (let [bulk-schema (NewBulk (app/service-graph app))]
+      (let [bulk-schema (NewBulk (helpers/app->ConfigurationServices app))]
         (is (false? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))))

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -1,9 +1,16 @@
 (ns ctia.bulk.core-test
-  (:require [ctia.auth.allow-all :refer [identity-singleton]]
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.set :as set]
+            [clojure.test :refer [deftest testing is use-fixtures]]
+            [ctia.auth.allow-all :refer [identity-singleton]]
             [ctia.bulk.core :as sut :refer [read-fn]]
+            [ctia.bulk.schemas :refer [NewBulk]]
+            [ctia.features-service :as features-svc]
             [ctia.test-helpers.core :as helpers]
-            [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest testing is use-fixtures]]))
+            [puppetlabs.trapperkeeper.app :as app]
+            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
 
 (use-fixtures :once mth/fixture-schema-validation)
 
@@ -16,3 +23,24 @@
                                  {:ConfigService {:get-in-config get-in-config}
                                   :StoreService {:get-store (constantly nil)}})]
       (is (= [nil] res)))))
+
+(defn schema->keys
+  "Extracts both: required and optional keys of schema as set of keywords"
+  [schema]
+  (let [reqs (->> schema st/required-keys keys)
+        opts (->> schema st/optional-keys keys (map :k))]
+    (set (concat reqs opts))))
+
+(deftest bulk-schema-excludes-disabled-test
+  (testing "ensure NewBulk schema includes only enabled entities"
+    (s/set-fn-validation! false) ;; otherwise it fails for incomplete :APIHandlerServices (we only need :FeaturesService for the test)
+    (with-app-with-config app
+      [features-svc/features-service] {:ctia {:features {}}}
+      (let [bulk-schema (NewBulk (app/service-graph app))]
+        (schema->keys bulk-schema)
+        (is (true? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))
+    (with-app-with-config app
+      [features-svc/features-service]
+      {:ctia {:features {:disable "asset,actor"}}}
+      (let [bulk-schema (NewBulk (app/service-graph app))]
+        (is (false? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))))

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -35,11 +35,10 @@
   (testing "ensure NewBulk schema includes only enabled entities"
     (with-app-with-config app
       [features-svc/features-service] {:ctia {:features {}}}
-      (let [bulk-schema (NewBulk (helpers/app->ConfigurationServices app))]
-        (schema->keys bulk-schema)
-        (is (true? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))
+      (let [bulk-schema (NewBulk (helpers/app->GetEntitiesServices app))]
+        (is (set/subset? #{:assets :actors} (schema->keys bulk-schema)))))
     (with-app-with-config app
       [features-svc/features-service]
       {:ctia {:features {:disable "asset,actor"}}}
-      (let [bulk-schema (NewBulk (helpers/app->ConfigurationServices app))]
+      (let [bulk-schema (NewBulk (helpers/app->GetEntitiesServices app))]
         (is (false? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -12,7 +12,7 @@
             [ctia.init :as init]
             [ctia.lib.utils :as utils]
             [ctia.properties :as p :refer [PropertiesSchema]]
-            [ctia.schemas.core :refer [ConfigurationServices HTTPShowServices Port]]
+            [ctia.schemas.core :refer [GetEntitiesServices HTTPShowServices Port]]
             [ctia.store :as store]
             [ctim.domain.id :as id]
             [ctim.generators.common :as cgc]
@@ -507,10 +507,9 @@
       (reset! uuid-counter
               uuid-counter-start))))
 
-(s/defn app->ConfigurationServices :- ConfigurationServices
+(s/defn app->GetEntitiesServices :- GetEntitiesServices
   [app]
   (-> app
       app/service-graph
       (utils/service-subgraph
-       :FeaturesService [:enabled? :feature-flags]
-       :ConfigService [:get-in-config :get-in-config])))
+       :FeaturesService [:enabled?])))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -506,3 +506,11 @@
       (f)
       (reset! uuid-counter
               uuid-counter-start))))
+
+(s/defn app->ConfigurationServices :- ConfigurationServices
+  [app]
+  (-> app
+      app/service-graph
+      (utils/service-subgraph
+       :FeaturesService [:enabled? :feature-flags]
+       :ConfigService [:get-in-config :get-in-config])))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -1,28 +1,23 @@
 (ns ctia.test-helpers.core
   (:require [clj-momo.properties :refer [coerce-properties read-property-files]]
             [clj-momo.test-helpers.http :as mthh]
-            [clojure
-             [walk :refer [prewalk]]]
             [clojure.spec.alpha :as cs]
             [clojure.string :as str]
             [clojure.test :as test]
             [clojure.test.check.generators :as gen]
             [clojure.tools.logging :as log]
             [clojure.tools.logging.test :as tlog]
-            [ctia
-             [auth :as auth]
-             [init :as init]
-             [properties :as p :refer [PropertiesSchema]]
-             [store :as store]]
-            [ctia.auth.allow-all :as aa]
-            [ctia.encryption :as encryption]
+            [clojure.walk :refer [prewalk]]
             [ctia.flows.crud :as crud]
-            [ctia.schemas.core :refer [HTTPShowServices Port]]
+            [ctia.init :as init]
+            [ctia.lib.utils :as utils]
+            [ctia.properties :as p :refer [PropertiesSchema]]
+            [ctia.schemas.core :refer [ConfigurationServices HTTPShowServices Port]]
+            [ctia.store :as store]
             [ctim.domain.id :as id]
             [ctim.generators.common :as cgc]
-            [flanders
-             [spec :as fs]
-             [utils :as fu]]
+            [flanders.spec :as fs]
+            [flanders.utils :as fu]
             [puppetlabs.trapperkeeper.app :as app]
             [schema.core :as s])
   (:import [java.util UUID]))


### PR DESCRIPTION
Prevent disabled entities to be used in Bulk Routes

> **Epic** #
> Close https://github.com/threatgrid/iroh/issues/4549
> Related: https://github.com/threatgrid/iroh/issues/4630, https://github.com/threatgrid/iroh/issues/4471

We've added ability to disable entities, using `:FeaturesService`, see: https://github.com/threatgrid/ctia/pull/1020
Now we don't want them to be used in Bulk routes

<a name="qa">[§](#qa)</a> QA
============================

Testing path is similar to one described in https://github.com/threatgrid/ctia/pull/1020

1. Check property configuration for `ctia.features.disabled` record
3. Try to use Bulk routes with entities like  Asset, AssetMapping, AssetProperties, TargetRecord (they typically should be disabled on Prod)

For testing locally:

1. add `ctia.features.disable=asset,actor,sighting` to `resources/ctia-default.properties`
2. start the server, open Swagger console
3. try issuing request through Bulk routes using disabled entities (it should not be permitted)

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

9b6ccc2b rename as suggested
c091e123 change the signature, so fn denotes returning schema
335d06b8 use more permissive schema
c6ffb811 clean up ns declaration
bbe650ae remove unused schema
632f3ac2 propagate changes to BulkRefs schema
ed16e67e propagate changes to Bulk schema
bb9ed74b remove disabled entities from the schema

