### PR TITLE
ES Auth

### DIFF
--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -17,6 +17,10 @@ services:
     environment:
       - cluster.name=elasticsearch7
       - discovery.type=single-node
+      - xpack.security.enabled=true
+      - xpack.security.authc.api_key.enabled=true
+      #- xpack.security.authc.anonymous.roles=superuser # allows no auth for test purpose
+      - ELASTIC_PASSWORD=ductile
     ports:
       - "9207:9200"
       - "9307:9300"

--- a/doc/properties.org
+++ b/doc/properties.org
@@ -341,27 +341,40 @@ Rate limit related configuration
 Set ES Store implementation settings, 
 one can set defaults for all ES stores using =default= as entity
 
-| Property                                 | Description                                                          | Possible values |
-|------------------------------------------+----------------------------------------------------------------------+-----------------|
-| ctia.store.es.[entity].host              | ES instance host                                                     | string          |
-| ctia.store.es.[entity].port              | ES instance port                                                     | port            |
-| ctia.store.es.[entity].indexname         | ES index name to use                                                 | string          |
-| ctia.store.es.[entity].refresh           | control when changes made by this request are made visible to search | string          |
-| ctia.store.es.[entity].replicas          | how many replicas to setup at index creation                         | number          |
-| ctia.store.es.[entity].shards            | how many shards to setup at index creation                           | number          |
-| ctia.store.es.[entity].default_operator  | default operator for free text search                                | "AND" / "OR"    |
-| ctia.store.es.[entity].aliased           | should the index be aliased                                          | boolean         |
-| ctia.store.es.[entity].rollover.max_docs | trigger rollover when store size exceeds that value                  | integer         |
-| ctia.store.es.[entity].rollover.max_age  | trigger rollover when store age exceeds that period (ex: 2m, 1y)     | string          |
+| Property                                 | Description                                                          | Possible values            |
+|------------------------------------------+----------------------------------------------------------------------+----------------------------|
+| ctia.store.es.[entity].host              | ES instance host                                                     | string                     |
+| ctia.store.es.[entity].port              | ES instance port                                                     | port                       |
+| ctia.store.es.[entity].indexname         | ES index name to use                                                 | string                     |
+| ctia.store.es.[entity].refresh           | control when changes made by this request are made visible to search | string                     |
+| ctia.store.es.[entity].replicas          | how many replicas to setup at index creation                         | number                     |
+| ctia.store.es.[entity].shards            | how many shards to setup at index creation                           | number                     |
+| ctia.store.es.[entity].default_operator  | default operator for free text search                                | "AND" / "OR"               |
+| ctia.store.es.[entity].aliased           | should the index be aliased                                          | boolean                    |
+| ctia.store.es.[entity].rollover.max_docs | trigger rollover when store size exceeds that value                  | integer                    |
+| ctia.store.es.[entity].rollover.max_age  | trigger rollover when store age exceeds that period (ex: 2m, 1y)     | string                     |
+| ctia.store.es.[entity].version           | major version of used Elasticsearch                                  | integer                    |
+| ctia.store.es.[entity].update-mappings   | if true, automatically updates index mappings at startup             | boolean                    |
+| ctia.store.es.[entity].update-settings   | if true, automatically updates index settings at startup             | boolean                    |
+| ctia.store.es.[entity].auth              | authentication parameters for ES, see [[https://github.com/threatgrid/ductile][ductile documentation]]          | ductile.schemas/AuthParams |
 
 ** Migration
 
-ES Migration related settings
+ES Migration related settings (see [[migration.md][./migration.md]] for more details)
 
-| Property                     | Description                                                                                                | Possible values |
-|------------------------------+------------------------------------------------------------------------------------------------------------+-----------------|
-| ctia.migration.optimizations | Speed up the migration process disabling indexing and replicas while migrating,                            |boolean          |
-|                              | settings are reverted to their actual values when the process is complete, this should be considered safe. |                 |
+*** base properties
+
+| Property                    | description                                      | example      | default value |
+|-----------------------------+--------------------------------------------------+--------------+---------------|
+| ctia.migration.migration-id | id of the migration state to create or restart   | migration-1  | required      |
+| ctia.migration.prefix       | prefix of the newly created indices              | 1.1.0        | required      |
+| ctia.migration.migrations   | a comma separated list of migration ids to apply | 0.4.28,1.0.0 | required      |
+| ctia.migration.batch-size   | number of migrated documents per batch           | 1000         | required      |
+| ctia.migration.buffer-size  | max batches in buffer between source and target  | 10           | required      |
+| ctia.migration.stores       | comma separated list of stores to migrate        | tool,malware | required      |
+
+*** target store properties
+The generated stores can have different properties than the source store and can be configured with the same properties by using the format `ctia.migration.store.es.<store>.<property>`.
 
 ** Versions
 

--- a/project.clj
+++ b/project.clj
@@ -61,7 +61,7 @@
 
                  [threatgrid/ctim "1.0.23"]
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.2.0"]
+                 [threatgrid/ductile "0.3.0"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -42,7 +42,7 @@
       exception-data
       (assoc :ex-data exception-data))))
 
-(defn es-query-parsing-error-handler
+(defn es-invalid-request
   "Handle ES query parsing error"
   [^Exception e data request]
   (logging/log! :error e (es-ex-data e data request))
@@ -53,7 +53,7 @@
                            (json/read-str :key-fn keyword))]
 
     (bad-request
-     {:type "ES query parsing error"
+     {:type "ES Invalid Request"
       :message (some-> es-message
                        :error
                        :root_cause
@@ -63,7 +63,7 @@
 
 (defn access-control-error-handler
   "Handle access control error"
-  [^Exception e data request]
+  [^Exception e _data _request]
   (logging/log! :info e (ex-message-and-data e))
   (forbidden
    {:error "Access Control validation Client Error"
@@ -73,7 +73,7 @@
 
 (defn spec-validation-error-handler
   "Handle spec validation error"
-  [^Exception e data request]
+  [^Exception e _data _request]
   (logging/log! :info e (ex-message-and-data e))
   (bad-request
    (let [entity (:entity (ex-data e))]
@@ -85,7 +85,7 @@
 
 (defn invalid-tlp-error-handler
   "Handle access control error"
-  [^Exception e data request]
+  [^Exception e _data _request]
   (logging/log! :info e (ex-message-and-data e))
   (bad-request
    (let [entity (:entity (ex-data e))]
@@ -96,7 +96,7 @@
 
 (defn realize-entity-error-handler
   "Handle error at the realize step"
-  [^Exception e data request]
+  [^Exception e _data _request]
   (logging/log! :info e (ex-message-and-data e))
   (bad-request
    (let [data (ex-data e)]
@@ -104,7 +104,7 @@
 
 (defn default-error-handler
   "Handle default error"
-  [^Exception e data request]
+  [^Exception e _data _request]
   (logging/log! :error e (ex-message-and-data e))
   (internal-server-error {:type "unknown-exception"
                           :class (.getName (class e))}))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -17,7 +17,7 @@
             [ctia.http.exceptions :as ex]
             [ctia.http.middleware
              [ratelimit :refer [wrap-rate-limit]]
-             [auth :refer :all]
+             [auth :refer [wrap-authenticated]]
              [cache-control :refer [wrap-cache-control]]
              [unknown :as unk]
              [version :refer [wrap-version]]]
@@ -26,7 +26,6 @@
             [ctia.properties :as p
              :refer [get-http-swagger]]
             [ctia.properties.routes :refer [properties-routes]]
-            [ctia.schemas.core :refer [APIHandlerServices]]
             [ctia.version :refer [current-version]]
             [ctia.version.routes :refer [version-routes]]
             [ctia.status.routes :refer [status-routes]]
@@ -107,7 +106,7 @@
   {:compojure.api.exception/request-parsing ex/request-parsing-handler
    :compojure.api.exception/request-validation ex/request-validation-handler
    :compojure.api.exception/response-validation ex/response-validation-handler
-   :ductile.conn/es-query-parsing-error ex/es-query-parsing-error-handler
+   :ductile.conn/invalid-request ex/es-invalid-request
    :access-control-error ex/access-control-error-handler
    :invalid-tlp-error ex/invalid-tlp-error-handler
    :realize-entity-error ex/realize-entity-error-handler

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -4,7 +4,7 @@
             alternative properties file on the classpath or by\n
             setting system properties."}
     ctia.properties
-  (:require [ductile.schemas :refer [Refresh]]
+  (:require [ductile.schemas :refer [Refresh AuthParams]]
             [clj-momo.lib.schema :as mls]
             [clj-momo.properties :as mp]
             [ctia.store :as store]
@@ -38,7 +38,8 @@
    (str prefix store ".timeout") s/Num
    (str prefix store ".version") s/Num
    (str prefix store ".update-mappings")  s/Bool
-   (str prefix store ".update-settings")  s/Bool})
+   (str prefix store ".update-settings")  s/Bool
+   (str prefix store ".auth")  AuthParams})
 
 (s/defschema StorePropertiesSchema
   "All entity store properties for every implementation"

--- a/src/ctia/task/rollover.clj
+++ b/src/ctia/task/rollover.clj
@@ -16,7 +16,7 @@
      conditions :rollover} :props} :- ESConnState]
   (when (and aliased (seq conditions))
     (let [{rolledover? :rolled_over :as response}
-          (ductile.index/rollover! conn write-index conditions)]
+          (ductile.index/rollover! conn write-index conditions {})]
       (when rolledover?
         (log/info "rolled over: " (pr-str response)))
       response)))

--- a/src/ctia/task/rollover.clj
+++ b/src/ctia/task/rollover.clj
@@ -16,7 +16,7 @@
      conditions :rollover} :props} :- ESConnState]
   (when (and aliased (seq conditions))
     (let [{rolledover? :rolled_over :as response}
-          (ductile.index/rollover! conn write-index conditions {})]
+          (ductile.index/rollover! conn write-index conditions)]
       (when rolledover?
         (log/info "rolled over: " (pr-str response)))
       response)))

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -1,5 +1,6 @@
 (ns ctia.properties-test
   (:require [ctia.properties :as sut]
+            [ductile.schemas :refer [AuthParams]]
             [clojure.test :refer [deftest is testing]]
             [ductile.schemas :refer [Refresh]]
             [schema.core :as s]))
@@ -22,7 +23,8 @@
             "ctia.store.es.malware.version" s/Num
             "ctia.store.es.malware.update-mappings" s/Bool
             "ctia.store.es.malware.update-settings" s/Bool
-            "ctia.store.es.malware.timeout" s/Num}
+            "ctia.store.es.malware.timeout" s/Num
+            "ctia.store.es.malware.auth" AuthParams}
            (sut/es-store-impl-properties "ctia.store.es." "malware")))
 
     (is (= {"prefix.sighting.host" s/Str
@@ -41,5 +43,6 @@
             "prefix.sighting.version" s/Num
             "prefix.sighting.update-mappings" s/Bool
             "prefix.sighting.update-settings" s/Bool
-            "prefix.sighting.timeout" s/Num}
+            "prefix.sighting.timeout" s/Num
+            "prefix.sighting.auth" AuthParams}
            (sut/es-store-impl-properties "prefix." "sighting")))))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -751,7 +751,6 @@
                             docs))))))
         (testing "restart migration shall properly handle inserts, updates and deletes"
           (let [;; retrieve the first 2 source indices for sighting store
-                {:keys [host port]} (get-in-config [:ctia :store :es :default])
                 [sighting-index-1 sighting-index-2 :as sighting-indices]
                 (->> (es-helpers/get-cat-indices conn)
                      keys

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -2,7 +2,6 @@
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.lib.clj-time.core :as time]
             [ductile
-             [conn :refer [connect]]
              [index :as ductile.index]
              [document :as es-doc]]
             [clojure.java.io :as io]
@@ -13,7 +12,6 @@
             [ctia.task.rollover :refer [rollover-stores]]
             [ctia.test-helpers.core :as helpers :refer [GET DELETE POST-bulk PUT]]
             [ctia.test-helpers.es :as es-helpers]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.fixtures :as fixt]
             [ctia.test-helpers.migration :refer [app->MigrationStoreServices]]
             [ctim.domain.id :refer [long-id->id]]
@@ -265,8 +263,7 @@
        (helpers/fixture-ctia-with-app
         (fn [app]
           (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-            (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)
-                  services (app->MigrationStoreServices app)
+            (let [services (app->MigrationStoreServices app)
                   storename (es-helpers/get-indexname app :relationship)
                   write-alias (str storename "-write")
                   max-docs 40

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -1,12 +1,11 @@
 (ns ctia.task.rollover-test
   (:require [ductile.index :as es-index]
             [clojure.string :as string]
-            [clojure.test :refer [deftest testing is]]
+            [clojure.test :refer [deftest is]]
             [ctia.stores.es.init :as init]
             [ctia.task.rollover :as sut]
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.es :as es-helpers]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.fixtures :as fixt]))
 
 (deftest rollover-aliased-test
@@ -17,6 +16,7 @@
    (helpers/with-properties
      ["ctia.store.es.default.port" es-port
       "ctia.store.es.default.version" version
+      "ctia.store.es.default.auth" es-helpers/basic-auth
       "ctia.auth.type" "allow-all"]
      (helpers/fixture-ctia-with-app
        (fn [app]
@@ -29,7 +29,8 @@
                                   :indexname (es-helpers/get-indexname app :malware)
                                   :host "localhost"
                                   :port es-port
-                                  :version version}
+                                  :version version
+                                  :auth es-helpers/basic-auth}
                state-not-aliased (init/init-es-conn! props-not-aliased services)
                rollover-not-aliased (sut/rollover-store state-not-aliased)
                props-aliased {:entity :sighting
@@ -39,17 +40,18 @@
                               :aliased true
                               :rollover {:max_docs 3}
                               :refresh "true"
-                              :version version}
+                              :version version
+                              :auth es-helpers/basic-auth}
                state-aliased (init/init-es-conn! props-aliased services)
                rollover-aliased (sut/rollover-store state-aliased)
                count-indices (fn []
                                (->> (str (:index state-aliased) "*")
-                                    (es-index/get (:conn state-aliased))
+                                    (es-index/get conn)
                                     count))
                post-bulk-fn (fn []
-                              (let [examples (fixt/bundle 100 false)
-                                    {:keys [error message]} (helpers/POST-bulk app examples true)]
-                                (es-index/refresh! (:conn state-aliased))))]
+                              (let [examples (fixt/bundle 100 false)]
+                                (helpers/POST-bulk app examples true)
+                                (es-index/refresh! conn)))]
            (is (nil? rollover-not-aliased))
            (is (seq rollover-aliased))
            (is (false? (:rolled_over rollover-aliased)))
@@ -64,7 +66,7 @@
            (is (= 3 (count-indices)))))))))
 
 (deftest rollover-stores-error-test
-  (with-redefs [es-index/rollover! (fn [_ alias _]
+  (with-redefs [es-index/rollover! (fn [_ alias _ _]
                                      (if (string/starts-with? alias "ok_index")
                                        {:rolled_over (rand-nth [true false])}
                                        (throw (ex-info "that's baaaaaaaddd"
@@ -73,7 +75,8 @@
     (helpers/with-properties*
       ["ctia.auth.type" "allow-all"
        "ctia.store.es.default.port" 9207
-       "ctia.store.es.default.version" 7]
+       "ctia.store.es.default.version" 7
+      "ctia.store.es.default.auth" es-helpers/basic-auth]
       #(helpers/fixture-ctia-with-app
         (fn [app]
           (let [services (es-helpers/app->ESConnServices app)

--- a/test/ctia/task/rollover_test.clj
+++ b/test/ctia/task/rollover_test.clj
@@ -66,7 +66,7 @@
            (is (= 3 (count-indices)))))))))
 
 (deftest rollover-stores-error-test
-  (with-redefs [es-index/rollover! (fn [_ alias _ _]
+  (with-redefs [es-index/rollover! (fn [_ alias _]
                                      (if (string/starts-with? alias "ok_index")
                                        {:rolled_over (rand-nth [true false])}
                                        (throw (ex-info "that's baaaaaaaddd"
@@ -76,7 +76,7 @@
       ["ctia.auth.type" "allow-all"
        "ctia.store.es.default.port" 9207
        "ctia.store.es.default.version" 7
-      "ctia.store.es.default.auth" es-helpers/basic-auth]
+       "ctia.store.es.default.auth" es-helpers/basic-auth]
       #(helpers/fixture-ctia-with-app
         (fn [app]
           (let [services (es-helpers/app->ESConnServices app)

--- a/test/ctia/task/settings_test.clj
+++ b/test/ctia/task/settings_test.clj
@@ -1,6 +1,5 @@
 (ns ctia.task.settings-test
   (:require [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
-            [ctia.properties :as p]
             [ctia.task.settings :as sut]
             [ctia.stores.es.init :as init]
             [ductile


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #threatgrid/iroh#4381

Enable ES authentication.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="ops">[§](#ops)</a> Ops
============================

Authentication is ready in CTIA. 

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: CTIA can now use an authenticated connection to Elasticsearch.
```


