### PR TITLE
Add asset entities to graphql route #4521

### DIFF
--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -1,16 +1,17 @@
 (ns ctia.entity.asset
-  (:require [ctia.domain.entities :refer [default-realize-fn]]
-            [ctia.http.routes.common :as routes.common]
-            [ctia.http.routes.crud :refer [services->entity-crud-routes]]
-            [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
-            [ctia.schemas.sorting :as sorting]
-            [ctia.schemas.utils :as csu]
-            [ctia.stores.es.mapping :as em]
-            [ctia.stores.es.store :refer [def-es-store]]
-            [ctim.schemas.asset :as asset-schema]
-            [flanders.utils :as fu]
-            [schema-tools.core :as st]
-            [schema.core :as s]))
+  (:require
+   [ctia.domain.entities :refer [default-realize-fn]]
+   [ctia.http.routes.common :as routes.common]
+   [ctia.http.routes.crud :refer [services->entity-crud-routes]]
+   [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
+   [ctia.schemas.sorting :as sorting]
+   [ctia.schemas.utils :as csu]
+   [ctia.stores.es.mapping :as em]
+   [ctia.stores.es.store :refer [def-es-store]]
+   [ctim.schemas.asset :as asset-schema]
+   [flanders.utils :as fu]
+   [schema-tools.core :as st]
+   [schema.core :as s]))
 
 (def-acl-schema Asset
   asset-schema/Asset

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -8,6 +8,8 @@
             [ctia.schemas.graphql.flanders :as flanders]
             [ctia.schemas.graphql.helpers :as g]
             [ctia.schemas.graphql.ownership :as go]
+            [ctia.schemas.graphql.pagination :as pagination]
+            [ctia.schemas.graphql.sorting :as graphql-sorting]
             [ctia.schemas.sorting :as sorting]
             [ctia.schemas.utils :as csu]
             [ctia.stores.es.mapping :as em]
@@ -126,6 +128,17 @@
             feedback/feedback-connection-field
             relationship-graphql/relatable-entity-fields
             go/graphql-ownership-fields))))
+
+(def asset-order-arg
+  (graphql-sorting/order-by-arg
+   "AssetOrder"
+   "assets"
+   (into {}
+         (map (juxt graphql-sorting/sorting-kw->enum-name name)
+              asset-fields))))
+
+(def AssetConnectionType
+  (pagination/new-connection AssetType))
 
 (def capabilities
   #{:create-asset

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -1,15 +1,20 @@
 (ns ctia.entity.asset
   (:require [ctia.domain.entities :refer [default-realize-fn]]
+            [ctia.entity.feedback.graphql-schemas :as feedback]
+            [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
+            [ctia.http.routes.common :as routes.common]
+            [ctia.http.routes.crud :refer [services->entity-crud-routes]]
             [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
-            [ctia.schemas.utils :as csu]
+            [ctia.schemas.graphql.flanders :as flanders]
+            [ctia.schemas.graphql.helpers :as g]
+            [ctia.schemas.graphql.ownership :as go]
             [ctia.schemas.sorting :as sorting]
+            [ctia.schemas.utils :as csu]
             [ctia.stores.es.mapping :as em]
             [ctia.stores.es.store :refer [def-es-store]]
             [ctim.schemas.asset :as asset-schema]
-            [schema-tools.core :as st]
-            [ctia.http.routes.crud :refer [services->entity-crud-routes]]
-            [ctia.http.routes.common :as routes.common]
             [flanders.utils :as fu]
+            [schema-tools.core :as st]
             [schema.core :as s]))
 
 (def-acl-schema Asset

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -1,15 +1,8 @@
 (ns ctia.entity.asset
   (:require [ctia.domain.entities :refer [default-realize-fn]]
-            [ctia.entity.feedback.graphql-schemas :as feedback]
-            [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
             [ctia.http.routes.common :as routes.common]
             [ctia.http.routes.crud :refer [services->entity-crud-routes]]
             [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
-            [ctia.schemas.graphql.flanders :as flanders]
-            [ctia.schemas.graphql.helpers :as g]
-            [ctia.schemas.graphql.ownership :as go]
-            [ctia.schemas.graphql.pagination :as pagination]
-            [ctia.schemas.graphql.sorting :as graphql-sorting]
             [ctia.schemas.sorting :as sorting]
             [ctia.schemas.utils :as csu]
             [ctia.stores.es.mapping :as em]
@@ -114,31 +107,6 @@
     :can-aggregate?           true
     :histogram-fields         asset-histogram-fields
     :enumerable-fields        asset-enumerable-fields}))
-
-(def AssetType
-  (let [{:keys [fields name description]}
-        (flanders/->graphql
-         (fu/optionalize-all asset-schema/Asset)
-         {})]
-    (g/new-object
-     name
-     description
-     []
-     (merge fields
-            feedback/feedback-connection-field
-            relationship-graphql/relatable-entity-fields
-            go/graphql-ownership-fields))))
-
-(def asset-order-arg
-  (graphql-sorting/order-by-arg
-   "AssetOrder"
-   "assets"
-   (into {}
-         (map (juxt graphql-sorting/sorting-kw->enum-name name)
-              asset-fields))))
-
-(def AssetConnectionType
-  (pagination/new-connection AssetType))
 
 (def capabilities
   #{:create-asset

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -111,8 +111,21 @@
     :external-id-capabilities :read-asset
     :can-aggregate?           true
     :histogram-fields         asset-histogram-fields
-    :enumerable-fields        asset-enumerable-fields
-    }))
+    :enumerable-fields        asset-enumerable-fields}))
+
+(def AssetType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all asset-schema/Asset)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship-graphql/relatable-entity-fields
+            go/graphql-ownership-fields))))
 
 (def capabilities
   #{:create-asset

--- a/src/ctia/entity/asset/graphql_schemas.clj
+++ b/src/ctia/entity/asset/graphql_schemas.clj
@@ -1,0 +1,36 @@
+(ns ctia.entity.asset.graphql-schemas
+  (:require [ctia.entity.asset :as asset]
+            [ctia.entity.feedback.graphql-schemas :as feedback]
+            [ctia.entity.relationship.graphql-schemas :as relationship]
+            [ctia.schemas.graphql.flanders :as flanders]
+            [ctia.schemas.graphql.helpers :as g]
+            [ctia.schemas.graphql.ownership :as go]
+            [ctia.schemas.graphql.pagination :as pagination]
+            [ctia.schemas.graphql.sorting :as sorting]
+            [ctim.schemas.asset :as asset-schema]
+            [flanders.utils :as fu]))
+
+(def AssetType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all asset-schema/Asset)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship/relatable-entity-fields
+            go/graphql-ownership-fields))))
+
+(def asset-order-arg
+  (sorting/order-by-arg
+   "AssetOrder"
+   "assets"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              asset/asset-fields))))
+
+(def AssetConnectionType
+  (pagination/new-connection AssetType))

--- a/src/ctia/entity/asset/graphql_schemas.clj
+++ b/src/ctia/entity/asset/graphql_schemas.clj
@@ -1,14 +1,15 @@
 (ns ctia.entity.asset.graphql-schemas
-  (:require [ctia.entity.asset :as asset]
-            [ctia.entity.feedback.graphql-schemas :as feedback]
-            [ctia.entity.relationship.graphql-schemas :as relationship]
-            [ctia.schemas.graphql.flanders :as flanders]
-            [ctia.schemas.graphql.helpers :as g]
-            [ctia.schemas.graphql.ownership :as go]
-            [ctia.schemas.graphql.pagination :as pagination]
-            [ctia.schemas.graphql.sorting :as sorting]
-            [ctim.schemas.asset :as asset-schema]
-            [flanders.utils :as fu]))
+  (:require
+   [ctia.entity.asset :as asset]
+   [ctia.entity.feedback.graphql-schemas :as feedback]
+   [ctia.entity.relationship.graphql-schemas :as relationship]
+   [ctia.schemas.graphql.flanders :as flanders]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.ownership :as go]
+   [ctia.schemas.graphql.pagination :as pagination]
+   [ctia.schemas.graphql.sorting :as sorting]
+   [ctim.schemas.asset :as asset-schema]
+   [flanders.utils :as fu]))
 
 (def AssetType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/asset_mapping/graphql_schemas.clj
+++ b/src/ctia/entity/asset_mapping/graphql_schemas.clj
@@ -1,0 +1,36 @@
+(ns ctia.entity.asset-mapping.graphql-schemas
+  (:require [ctia.entity.asset-mapping :as asset-mapping]
+            [ctia.entity.feedback.graphql-schemas :as feedback]
+            [ctia.entity.relationship.graphql-schemas :as relationship]
+            [ctia.schemas.graphql.flanders :as flanders]
+            [ctia.schemas.graphql.helpers :as g]
+            [ctia.schemas.graphql.ownership :as go]
+            [ctia.schemas.graphql.pagination :as pagination]
+            [ctia.schemas.graphql.sorting :as sorting]
+            [ctim.schemas.asset-mapping :as asset-mapping-schema]
+            [flanders.utils :as fu]))
+
+(def AssetMappingType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all asset-mapping-schema/AssetMapping)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship/relatable-entity-fields
+            go/graphql-ownership-fields))))
+
+(def asset-mapping-order-arg
+  (sorting/order-by-arg
+   "AssetMappingOrder"
+   "asset-mappings"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              asset-mapping/asset-mapping-fields))))
+
+(def AssetMappingConnectionType
+  (pagination/new-connection AssetMappingType))

--- a/src/ctia/entity/asset_mapping/graphql_schemas.clj
+++ b/src/ctia/entity/asset_mapping/graphql_schemas.clj
@@ -1,14 +1,15 @@
 (ns ctia.entity.asset-mapping.graphql-schemas
-  (:require [ctia.entity.asset-mapping :as asset-mapping]
-            [ctia.entity.feedback.graphql-schemas :as feedback]
-            [ctia.entity.relationship.graphql-schemas :as relationship]
-            [ctia.schemas.graphql.flanders :as flanders]
-            [ctia.schemas.graphql.helpers :as g]
-            [ctia.schemas.graphql.ownership :as go]
-            [ctia.schemas.graphql.pagination :as pagination]
-            [ctia.schemas.graphql.sorting :as sorting]
-            [ctim.schemas.asset-mapping :as asset-mapping-schema]
-            [flanders.utils :as fu]))
+  (:require
+   [ctia.entity.asset-mapping :as asset-mapping]
+   [ctia.entity.feedback.graphql-schemas :as feedback]
+   [ctia.entity.relationship.graphql-schemas :as relationship]
+   [ctia.schemas.graphql.flanders :as flanders]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.ownership :as go]
+   [ctia.schemas.graphql.pagination :as pagination]
+   [ctia.schemas.graphql.sorting :as sorting]
+   [ctim.schemas.asset-mapping :as asset-mapping-schema]
+   [flanders.utils :as fu]))
 
 (def AssetMappingType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/asset_properties/graphql_schemas.clj
+++ b/src/ctia/entity/asset_properties/graphql_schemas.clj
@@ -1,0 +1,37 @@
+(ns ctia.entity.asset-properties.graphql-schemas
+  (:require
+   [ctia.entity.asset-properties :as asset-properties]
+   [ctia.entity.feedback.graphql-schemas :as feedback]
+   [ctia.entity.relationship.graphql-schemas :as relationship]
+   [ctia.schemas.graphql.flanders :as flanders]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.ownership :as go]
+   [ctia.schemas.graphql.pagination :as pagination]
+   [ctia.schemas.graphql.sorting :as sorting]
+   [ctim.schemas.asset-properties :as asset-properties-schema]
+   [flanders.utils :as fu]))
+
+(def AssetPropertiesType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all asset-properties-schema/AssetProperties)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship/relatable-entity-fields
+            go/graphql-ownership-fields))))
+
+(def asset-properties-order-arg
+  (sorting/order-by-arg
+   "AssetPropertiesOrder"
+   "asset-properties"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              asset-properties/asset-properties-fields))))
+
+(def AssetPropertiesConnectionType
+  (pagination/new-connection AssetPropertiesType))

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -1,24 +1,25 @@
 (ns ctia.entity.attack-pattern
-  (:require [ctia.domain.entities :refer [default-realize-fn]]
-            [ctia.entity.feedback.graphql-schemas :as feedback]
-            [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
-            [ctia.http.routes.common :as routes.common
-             :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams] ]
-            [ctia.http.routes.crud :refer [services->entity-crud-routes]]
-            [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
-            [ctia.schemas.graphql.flanders :as flanders]
-            [ctia.schemas.graphql.helpers :as g]
-            [ctia.schemas.graphql.ownership :as go]
-            [ctia.schemas.graphql.pagination :as pagination]
-            [ctia.schemas.graphql.sorting :as graphql-sorting]
-            [ctia.schemas.sorting :as sorting]
-            [ctia.schemas.utils :as csu]
-            [ctia.stores.es.mapping :as em]
-            [ctia.stores.es.store :refer [def-es-store]]
-            [ctim.schemas.attack-pattern :as attack]
-            [flanders.utils :as fu]
-            [schema-tools.core :as st]
-            [schema.core :as s]))
+  (:require
+   [ctia.domain.entities :refer [default-realize-fn]]
+   [ctia.entity.feedback.graphql-schemas :as feedback]
+   [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
+   [ctia.http.routes.common :as routes.common
+    :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams] ]
+   [ctia.http.routes.crud :refer [services->entity-crud-routes]]
+   [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
+   [ctia.schemas.graphql.flanders :as flanders]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.ownership :as go]
+   [ctia.schemas.graphql.pagination :as pagination]
+   [ctia.schemas.graphql.sorting :as graphql-sorting]
+   [ctia.schemas.sorting :as sorting]
+   [ctia.schemas.utils :as csu]
+   [ctia.stores.es.mapping :as em]
+   [ctia.stores.es.store :refer [def-es-store]]
+   [ctim.schemas.attack-pattern :as attack]
+   [flanders.utils :as fu]
+   [schema-tools.core :as st]
+   [schema.core :as s]))
 
 (def-acl-schema AttackPattern
   attack/AttackPattern

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -1,25 +1,20 @@
 (ns ctia.entity.attack-pattern
   (:require [ctia.domain.entities :refer [default-realize-fn]]
             [ctia.entity.feedback.graphql-schemas :as feedback]
-            [ctia.entity.relationship.graphql-schemas
-             :as relationship-graphql]
-            [ctia.http.routes
-             [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]
-              :as routes.common]
-             [crud :refer [services->entity-crud-routes]]]
-            [ctia.schemas
-             [utils :as csu]
-             [core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
-             [sorting :as sorting]]
-            [ctia.schemas.graphql
-             [flanders :as flanders]
-             [helpers :as g]
-             [pagination :as pagination]
-             [sorting :as graphql-sorting]]
-            [ctia.stores.es
-             [mapping :as em]
-             [store :refer [def-es-store]]]
+            [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
+            [ctia.http.routes.common :as routes.common
+             :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams] ]
+            [ctia.http.routes.crud :refer [services->entity-crud-routes]]
+            [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
+            [ctia.schemas.graphql.flanders :as flanders]
+            [ctia.schemas.graphql.helpers :as g]
             [ctia.schemas.graphql.ownership :as go]
+            [ctia.schemas.graphql.pagination :as pagination]
+            [ctia.schemas.graphql.sorting :as graphql-sorting]
+            [ctia.schemas.sorting :as sorting]
+            [ctia.schemas.utils :as csu]
+            [ctia.stores.es.mapping :as em]
+            [ctia.stores.es.store :refer [def-es-store]]
             [ctim.schemas.attack-pattern :as attack]
             [flanders.utils :as fu]
             [schema-tools.core :as st]

--- a/src/ctia/entity/target_record/graphql_schemas.clj
+++ b/src/ctia/entity/target_record/graphql_schemas.clj
@@ -1,0 +1,38 @@
+(ns ctia.entity.target-record.graphql-schemas
+  (:require
+   [ctia.entity.feedback.graphql-schemas :as feedback]
+   [ctia.entity.relationship.graphql-schemas :as relationship]
+   [ctia.entity.target-record :as target-record]
+   [ctia.schemas.graphql.flanders :as flanders]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.ownership :as go]
+   [ctia.schemas.graphql.pagination :as pagination]
+   [ctia.schemas.graphql.refs :as refs]
+   [ctia.schemas.graphql.sorting :as sorting]
+   [ctim.schemas.target-record :as target-record-schema]
+   [flanders.utils :as fu]))
+
+(def TargetRecordType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all target-record-schema/TargetRecord)
+         {refs/observable-type-name refs/ObservableTypeRef})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship/relatable-entity-fields
+            go/graphql-ownership-fields))))
+
+(def target-record-order-arg
+  (sorting/order-by-arg
+   "TargetRecordOrder"
+   "target-records"
+   (into {}
+         (map (juxt sorting/sorting-kw->enum-name name)
+              target-record/target-record-fields))))
+
+(def TargetRecordConnectionType
+  (pagination/new-connection TargetRecordType))

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,7 +1,8 @@
 (ns ctia.graphql.schemas
   (:require
-   [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.asset-mapping.graphql-schemas :as asset-mapping :refer [AssetMappingType AssetMappingConnectionType]]
+   [ctia.entity.asset-properties.graphql-schemas :as asset-properties :refer [AssetPropertiesConnectionType]]
+   [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
    [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
@@ -45,114 +46,119 @@
    "Root"
    ""
    []
-   {:asset           {:type    AssetType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :asset)}
-    :assets          {:type    AssetConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      asset/asset-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :asset)}
-    :asset_mapping   {:type    AssetMappingType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :asset-mapping)}
-    :asset_mappings  {:type    AssetMappingConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      asset-mapping/asset-mapping-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :asset-mapping)}
-    :attack_pattern  {:type    AttackPatternType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :attack-pattern)}
-    :attack_patterns {:type    AttackPatternConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      attack-pattern/attack-pattern-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :attack-pattern)}
-    :casebook        {:type    CasebookType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :casebook)}
-    :casebooks       {:type    CasebookConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      casebook/casebook-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :casebook)}
-    :incident        {:type    IncidentType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :incident)}
-    :incidents       {:type    IncidentConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      incident/incident-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :incident)}
-    :indicator       {:type    IndicatorType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :indicator)}
-    :indicators      {:type    IndicatorConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      indicator/indicator-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :indicator)}
-    :investigation   {:type    InvestigationType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :investigation)}
-    :investigations  {:type    InvestigationConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      investigation/investigation-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :investigation)}
-    :judgement       {:type    JudgementType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :judgement)}
-    :judgements      {:type    JudgementConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      judgement/judgement-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :judgement)}
-    :malware         {:type    MalwareType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :malware)}
-    :malwares        {:type    MalwareConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      malware/malware-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :malware)}
-    :observable      {:type    ObservableType
-                      :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
-                                :value {:type (g/non-null Scalars/GraphQLString)}}
-                      :resolve (fn [_ args _ _] args)}
-    :sighting        {:type    SightingType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :sighting)}
-    :sightings       {:type    SightingConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      sighting/sighting-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :sighting)}
-    :tool            {:type    ToolType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :tool)}
-    :tools           {:type    ToolConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      tool/tool-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :tool)}
-    :vulnerability   {:type    VulnerabilityType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :vulnerability)}
-    :vulnerabilities {:type    VulnerabilityConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      vulnerability/vulnerability-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :vulnerability)}
-    :weakness        {:type    WeaknessType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :weakness)}
-    :weaknesses      {:type    WeaknessConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                      weakness/weakness-order-arg
-                                      p/connection-arguments)
-                      :resolve (res/search-entity-resolver :weakness)}}))
+   {:asset            {:type    AssetType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :asset)}
+    :assets           {:type    AssetConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       asset/asset-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :asset)}
+    :asset_mapping    {:type    AssetMappingType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :asset-mapping)}
+    :asset_mappings   {:type    AssetMappingConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       asset-mapping/asset-mapping-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :asset-mapping)}
+    :asset_properties {:type    AssetPropertiesConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       asset-properties/asset-properties-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :asset-properties)}
+    :attack_pattern   {:type    AttackPatternType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :attack-pattern)}
+    :attack_patterns  {:type    AttackPatternConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       attack-pattern/attack-pattern-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :attack-pattern)}
+    :casebook         {:type    CasebookType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :casebook)}
+    :casebooks        {:type    CasebookConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       casebook/casebook-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :casebook)}
+    :incident         {:type    IncidentType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :incident)}
+    :incidents        {:type    IncidentConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       incident/incident-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :incident)}
+    :indicator        {:type    IndicatorType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :indicator)}
+    :indicators       {:type    IndicatorConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       indicator/indicator-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :indicator)}
+    :investigation    {:type    InvestigationType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :investigation)}
+    :investigations   {:type    InvestigationConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       investigation/investigation-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :investigation)}
+    :judgement        {:type    JudgementType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :judgement)}
+    :judgements       {:type    JudgementConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       judgement/judgement-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :judgement)}
+    :malware          {:type    MalwareType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :malware)}
+    :malwares         {:type    MalwareConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       malware/malware-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :malware)}
+    :observable       {:type    ObservableType
+                       :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
+                                 :value {:type (g/non-null Scalars/GraphQLString)}}
+                       :resolve (fn [_ args _ _] args)}
+    :sighting         {:type    SightingType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :sighting)}
+    :sightings        {:type    SightingConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       sighting/sighting-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :sighting)}
+    :tool             {:type    ToolType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :tool)}
+    :tools            {:type    ToolConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       tool/tool-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :tool)}
+    :vulnerability    {:type    VulnerabilityType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :vulnerability)}
+    :vulnerabilities  {:type    VulnerabilityConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       vulnerability/vulnerability-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :vulnerability)}
+    :weakness         {:type    WeaknessType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :weakness)}
+    :weaknesses       {:type    WeaknessConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       weakness/weakness-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :weakness)}}))
 
 (s/def schema :- (RealizeFnResult GraphQLSchema)
   (g/new-schema QueryType))

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,46 +1,23 @@
 (ns ctia.graphql.schemas
   (:require
-   [ctia.schemas.graphql
-    [common :as common]
-    [helpers :as g]
-    [pagination :as p]
-    [resolvers :as res]]
-   [ctia.entity.attack-pattern :as attack-pattern
-    :refer [AttackPatternConnectionType
-            AttackPatternType]]
-   [ctia.entity.incident :as incident
-    :refer [IncidentConnectionType
-            IncidentType]]
-   [ctia.entity.indicator :as indicator
-    :refer [IndicatorConnectionType
-            IndicatorType]]
-   [ctia.entity.investigation.graphql-schemas :as investigation
-    :refer [InvestigationConnectionType
-            InvestigationType]]
-   [ctia.entity.casebook :as casebook
-    :refer [CasebookConnectionType
-            CasebookType]]
-   [ctia.entity.judgement
-    :as judgement
-    :refer [JudgementConnectionType
-            JudgementType]]
-   [ctia.entity.malware :as malware
-    :refer [MalwareConnectionType
-            MalwareType]]
-   [ctia.observable.graphql.schemas :as observable
-    :refer [ObservableType]]
-   [ctia.entity.sighting.graphql-schemas
-    :as sighting
-    :refer [SightingConnectionType
-            SightingType]]
-   [ctia.entity.tool.graphql-schemas :as tool
-    :refer [ToolConnectionType ToolType]]
-   [ctia.entity.vulnerability :as vulnerability
-    :refer [VulnerabilityConnectionType VulnerabilityType]]
-   [ctia.entity.weakness :as weakness
-    :refer [WeaknessConnectionType WeaknessType]]
-   [ctia.schemas.core :refer [APIHandlerServices
-                              RealizeFnResult]]
+   [ctia.entity.asset :as asset :refer [AssetType]]
+   [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
+   [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
+   [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
+   [ctia.entity.indicator :as indicator :refer [IndicatorConnectionType IndicatorType]]
+   [ctia.entity.investigation.graphql-schemas :as investigation :refer [InvestigationConnectionType InvestigationType]]
+   [ctia.entity.judgement :as judgement :refer [JudgementConnectionType JudgementType]]
+   [ctia.entity.malware :as malware :refer [MalwareConnectionType MalwareType]]
+   [ctia.entity.sighting.graphql-schemas :as sighting :refer [SightingConnectionType SightingType]]
+   [ctia.entity.tool.graphql-schemas :as tool :refer [ToolConnectionType ToolType]]
+   [ctia.entity.vulnerability :as vulnerability :refer [VulnerabilityConnectionType VulnerabilityType]]
+   [ctia.entity.weakness :as weakness :refer [WeaknessConnectionType WeaknessType]]
+   [ctia.observable.graphql.schemas :as observable :refer [ObservableType]]
+   [ctia.schemas.core :refer [APIHandlerServices RealizeFnResult]]
+   [ctia.schemas.graphql.common :as common]
+   [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.pagination :as p]
+   [ctia.schemas.graphql.resolvers :as res]
    [schema.core :as s])
   (:import [graphql GraphQL Scalars]
            [graphql.schema

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,6 +1,6 @@
 (ns ctia.graphql.schemas
   (:require
-   [ctia.entity.asset :as asset :refer [AssetType]]
+   [ctia.entity.asset :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
    [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
@@ -44,100 +44,105 @@
    "Root"
    ""
    []
-   {:attack_pattern  {:type    AttackPatternType
+   {:asset           {:type    AssetType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :asset)}
+    :assets          {:type    AssetConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      asset/asset-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :attack-pattern)}
+    :attack_pattern  {:type    AttackPatternType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :attack-pattern)}
     :attack_patterns {:type    AttackPatternConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   attack-pattern/attack-pattern-order-arg
-                                   p/connection-arguments)
+                                      attack-pattern/attack-pattern-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :attack-pattern)}
-    :asset           {:type    AssetType
+    :casebook        {:type    CasebookType
                       :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :asset)}
+                      :resolve (res/entity-by-id-resolver :casebook)}
+    :casebooks       {:type    CasebookConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      casebook/casebook-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :casebook)}
     :incident        {:type    IncidentType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :incident)}
     :incidents       {:type    IncidentConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   incident/incident-order-arg
-                                   p/connection-arguments)
+                                      incident/incident-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :incident)}
     :indicator       {:type    IndicatorType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :indicator)}
     :indicators      {:type    IndicatorConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   indicator/indicator-order-arg
-                                   p/connection-arguments)
+                                      indicator/indicator-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :indicator)}
     :investigation   {:type    InvestigationType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :investigation)}
     :investigations  {:type    InvestigationConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   investigation/investigation-order-arg
-                                   p/connection-arguments)
+                                      investigation/investigation-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :investigation)}
     :judgement       {:type    JudgementType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :judgement)}
     :judgements      {:type    JudgementConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   judgement/judgement-order-arg
-                                   p/connection-arguments)
+                                      judgement/judgement-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :judgement)}
     :malware         {:type    MalwareType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :malware)}
     :malwares        {:type    MalwareConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   malware/malware-order-arg
-                                   p/connection-arguments)
+                                      malware/malware-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :malware)}
     :observable      {:type    ObservableType
                       :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
                                 :value {:type (g/non-null Scalars/GraphQLString)}}
                       :resolve (fn [_ args _ _] args)}
-    :casebook        {:type    CasebookType
-                      :args    search-by-id-args
-                      :resolve (res/entity-by-id-resolver :casebook)}
-    :casebooks       {:type    CasebookConnectionType
-                      :args    (merge common/lucene-query-arguments
-                                   casebook/casebook-order-arg
-                                   p/connection-arguments)
-                      :resolve (res/search-entity-resolver :casebook)}
     :sighting        {:type    SightingType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :sighting)}
     :sightings       {:type    SightingConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   sighting/sighting-order-arg
-                                   p/connection-arguments)
+                                      sighting/sighting-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :sighting)}
     :tool            {:type    ToolType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :tool)}
     :tools           {:type    ToolConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   tool/tool-order-arg
-                                   p/connection-arguments)
+                                      tool/tool-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :tool)}
     :vulnerability   {:type    VulnerabilityType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :vulnerability)}
     :vulnerabilities {:type    VulnerabilityConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   vulnerability/vulnerability-order-arg
-                                   p/connection-arguments)
+                                      vulnerability/vulnerability-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :vulnerability)}
     :weakness        {:type    WeaknessType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :weakness)}
     :weaknesses      {:type    WeaknessConnectionType
                       :args    (merge common/lucene-query-arguments
-                                   weakness/weakness-order-arg
-                                   p/connection-arguments)
+                                      weakness/weakness-order-arg
+                                      p/connection-arguments)
                       :resolve (res/search-entity-resolver :weakness)}}))
 
 (s/def schema :- (RealizeFnResult GraphQLSchema)

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -11,6 +11,7 @@
    [ctia.entity.judgement :as judgement :refer [JudgementConnectionType JudgementType]]
    [ctia.entity.malware :as malware :refer [MalwareConnectionType MalwareType]]
    [ctia.entity.sighting.graphql-schemas :as sighting :refer [SightingConnectionType SightingType]]
+   [ctia.entity.target-record.graphql-schemas :as target-record :refer [TargetRecordType TargetRecordConnectionType]]
    [ctia.entity.tool.graphql-schemas :as tool :refer [ToolConnectionType ToolType]]
    [ctia.entity.vulnerability :as vulnerability :refer [VulnerabilityConnectionType VulnerabilityType]]
    [ctia.entity.weakness :as weakness :refer [WeaknessConnectionType WeaknessType]]
@@ -135,6 +136,14 @@
                                        sighting/sighting-order-arg
                                        p/connection-arguments)
                        :resolve (res/search-entity-resolver :sighting)}
+    :target_record    {:type    TargetRecordType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :target-record)}
+    :target_records   {:type    TargetRecordConnectionType
+                       :args    (merge common/lucene-query-arguments
+                                       target-record/target-record-order-arg
+                                       p/connection-arguments)
+                       :resolve (res/search-entity-resolver :target-record)}
     :tool             {:type    ToolType
                        :args    search-by-id-args
                        :resolve (res/entity-by-id-resolver :tool)}

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -44,98 +44,101 @@
    "Root"
    ""
    []
-   {:attack_pattern {:type AttackPatternType
-                     :args search-by-id-args
-                     :resolve (res/entity-by-id-resolver :attack-pattern)}
-    :attack_patterns {:type AttackPatternConnectionType
-                      :args (merge common/lucene-query-arguments
+   {:attack_pattern  {:type    AttackPatternType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :attack-pattern)}
+    :attack_patterns {:type    AttackPatternConnectionType
+                      :args    (merge common/lucene-query-arguments
                                    attack-pattern/attack-pattern-order-arg
                                    p/connection-arguments)
                       :resolve (res/search-entity-resolver :attack-pattern)}
-    :incident {:type IncidentType
-               :args search-by-id-args
-               :resolve (res/entity-by-id-resolver :incident)}
-    :incidents {:type IncidentConnectionType
-                :args (merge common/lucene-query-arguments
-                             incident/incident-order-arg
-                             p/connection-arguments)
-                :resolve (res/search-entity-resolver :incident)}
-    :indicator {:type IndicatorType
-                :args search-by-id-args
-                :resolve (res/entity-by-id-resolver :indicator)}
-    :indicators {:type IndicatorConnectionType
-                 :args (merge common/lucene-query-arguments
-                              indicator/indicator-order-arg
-                              p/connection-arguments)
-                 :resolve (res/search-entity-resolver :indicator)}
-    :investigation {:type InvestigationType
-                    :args search-by-id-args
-                    :resolve (res/entity-by-id-resolver :investigation)}
-    :investigations {:type InvestigationConnectionType
-                     :args (merge common/lucene-query-arguments
-                                  investigation/investigation-order-arg
-                                  p/connection-arguments)
-                     :resolve (res/search-entity-resolver :investigation)}
-    :judgement {:type JudgementType
-                :args search-by-id-args
-                :resolve (res/entity-by-id-resolver :judgement)}
-    :judgements {:type JudgementConnectionType
-                 :args (merge common/lucene-query-arguments
-                              judgement/judgement-order-arg
-                              p/connection-arguments)
-                 :resolve (res/search-entity-resolver :judgement)}
-    :malware {:type MalwareType
-              :args search-by-id-args
-              :resolve (res/entity-by-id-resolver :malware)}
-    :malwares {:type MalwareConnectionType
-               :args (merge common/lucene-query-arguments
-                            malware/malware-order-arg
-                            p/connection-arguments)
-               :resolve (res/search-entity-resolver :malware)}
-    :observable {:type ObservableType
-                 :args {:type {:type (g/non-null Scalars/GraphQLString)}
-                        :value {:type (g/non-null Scalars/GraphQLString)}}
-                 :resolve (fn [_ args _ _] args)}
-    :casebook {:type CasebookType
-               :args search-by-id-args
-               :resolve (res/entity-by-id-resolver :casebook)}
-    :casebooks {:type CasebookConnectionType
-                :args (merge common/lucene-query-arguments
-                             casebook/casebook-order-arg
-                             p/connection-arguments)
-                :resolve (res/search-entity-resolver :casebook)}
-    :sighting {:type SightingType
-               :args search-by-id-args
-               :resolve (res/entity-by-id-resolver :sighting)}
-    :sightings {:type SightingConnectionType
-                :args (merge common/lucene-query-arguments
-                             sighting/sighting-order-arg
-                             p/connection-arguments)
-                :resolve (res/search-entity-resolver :sighting)}
-    :tool {:type ToolType
-           :args search-by-id-args
-           :resolve (res/entity-by-id-resolver :tool)}
-    :tools {:type ToolConnectionType
-            :args (merge common/lucene-query-arguments
-                         tool/tool-order-arg
-                         p/connection-arguments)
-            :resolve (res/search-entity-resolver :tool)}
-    :vulnerability {:type VulnerabilityType
-                    :args search-by-id-args
-                    :resolve (res/entity-by-id-resolver :vulnerability)}
-    :vulnerabilities {:type VulnerabilityConnectionType
-                      :args (merge common/lucene-query-arguments
+    :asset           {:type    AssetType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :asset)}
+    :incident        {:type    IncidentType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :incident)}
+    :incidents       {:type    IncidentConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   incident/incident-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :incident)}
+    :indicator       {:type    IndicatorType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :indicator)}
+    :indicators      {:type    IndicatorConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   indicator/indicator-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :indicator)}
+    :investigation   {:type    InvestigationType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :investigation)}
+    :investigations  {:type    InvestigationConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   investigation/investigation-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :investigation)}
+    :judgement       {:type    JudgementType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :judgement)}
+    :judgements      {:type    JudgementConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   judgement/judgement-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :judgement)}
+    :malware         {:type    MalwareType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :malware)}
+    :malwares        {:type    MalwareConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   malware/malware-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :malware)}
+    :observable      {:type    ObservableType
+                      :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
+                                :value {:type (g/non-null Scalars/GraphQLString)}}
+                      :resolve (fn [_ args _ _] args)}
+    :casebook        {:type    CasebookType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :casebook)}
+    :casebooks       {:type    CasebookConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   casebook/casebook-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :casebook)}
+    :sighting        {:type    SightingType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :sighting)}
+    :sightings       {:type    SightingConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   sighting/sighting-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :sighting)}
+    :tool            {:type    ToolType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :tool)}
+    :tools           {:type    ToolConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   tool/tool-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :tool)}
+    :vulnerability   {:type    VulnerabilityType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :vulnerability)}
+    :vulnerabilities {:type    VulnerabilityConnectionType
+                      :args    (merge common/lucene-query-arguments
                                    vulnerability/vulnerability-order-arg
                                    p/connection-arguments)
                       :resolve (res/search-entity-resolver :vulnerability)}
-    :weakness {:type WeaknessType
-               :args search-by-id-args
-               :resolve (res/entity-by-id-resolver :weakness)}
-    :weaknesses {:type WeaknessConnectionType
-                 :args (merge common/lucene-query-arguments
-                              weakness/weakness-order-arg
-                              p/connection-arguments)
-                 :resolve (res/search-entity-resolver :weakness)}}))
+    :weakness        {:type    WeaknessType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :weakness)}
+    :weaknesses      {:type    WeaknessConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                   weakness/weakness-order-arg
+                                   p/connection-arguments)
+                      :resolve (res/search-entity-resolver :weakness)}}))
 
 (s/def schema :- (RealizeFnResult GraphQLSchema)
   (g/new-schema QueryType))

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,6 +1,7 @@
 (ns ctia.graphql.schemas
   (:require
    [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
+   [ctia.entity.asset-mapping.graphql-schemas :as asset-mapping :refer [AssetMappingType AssetMappingConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
    [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
@@ -52,6 +53,14 @@
                                       asset/asset-order-arg
                                       p/connection-arguments)
                       :resolve (res/search-entity-resolver :asset)}
+    :asset_mapping   {:type    AssetMappingType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :asset-mapping)}
+    :asset_mappings  {:type    AssetMappingConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      asset-mapping/asset-mapping-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :asset-mapping)}
     :attack_pattern  {:type    AttackPatternType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :attack-pattern)}

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -51,7 +51,7 @@
                       :args    (merge common/lucene-query-arguments
                                       asset/asset-order-arg
                                       p/connection-arguments)
-                      :resolve (res/search-entity-resolver :attack-pattern)}
+                      :resolve (res/search-entity-resolver :asset)}
     :attack_pattern  {:type    AttackPatternType
                       :args    search-by-id-args
                       :resolve (res/entity-by-id-resolver :attack-pattern)}

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -62,9 +62,6 @@
                                        asset-mapping/asset-mapping-order-arg
                                        p/connection-arguments)
                        :resolve (res/search-entity-resolver :asset-mapping)}
-    :asset_property   {:type    AssetPropertiesType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :asset-properties)}
     :asset_properties {:type    AssetPropertiesConnectionType
                        :args    (merge common/lucene-query-arguments
                                        asset-properties/asset-properties-order-arg

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,6 +1,6 @@
 (ns ctia.graphql.schemas
   (:require
-   [ctia.entity.asset :as asset :refer [AssetType AssetConnectionType]]
+   [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
    [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,7 +1,7 @@
 (ns ctia.graphql.schemas
   (:require
    [ctia.entity.asset-mapping.graphql-schemas :as asset-mapping :refer [AssetMappingType AssetMappingConnectionType]]
-   [ctia.entity.asset-properties.graphql-schemas :as asset-properties :refer [AssetPropertiesConnectionType]]
+   [ctia.entity.asset-properties.graphql-schemas :as asset-properties :refer [AssetPropertiesType AssetPropertiesConnectionType]]
    [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
@@ -62,6 +62,9 @@
                                        asset-mapping/asset-mapping-order-arg
                                        p/connection-arguments)
                        :resolve (res/search-entity-resolver :asset-mapping)}
+    :asset_property   {:type    AssetPropertiesType
+                       :args    search-by-id-args
+                       :resolve (res/entity-by-id-resolver :asset-properties)}
     :asset_properties {:type    AssetPropertiesConnectionType
                        :args    (merge common/lucene-query-arguments
                                        asset-properties/asset-properties-order-arg

--- a/test/ctia/http/routes/graphql/asset_mapping_test.clj
+++ b/test/ctia/http/routes/graphql/asset_mapping_test.clj
@@ -1,0 +1,87 @@
+(ns ctia.http.routes.graphql.asset-mapping-test
+  (:require
+   [clj-momo.test-helpers.core :as mth]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+   [ctia.entity.asset-mapping :as asset-mapping]
+   [ctia.test-helpers.auth :refer [all-capabilities]]
+   [ctia.test-helpers.core :as helpers]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.fixtures :as fixt]
+   [ctia.test-helpers.graphql :as gh]
+   [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+   [ctim.examples.asset-mappings :refer [asset-mapping-maximal]]))
+
+(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+                                    whoami-helpers/fixture-server]))
+
+(def ownership-data-fixture
+  {:owner "foouser"
+   :groups ["foogroup"]})
+
+(def asset-mapping-1 (fixt/randomize asset-mapping-maximal))
+(def asset-mapping-2 (assoc
+                      (fixt/randomize asset-mapping-maximal)
+                      :source "ngfw"))
+
+(defn prepare-result
+  [asset-mapping]
+  (dissoc asset-mapping :search-txt))
+
+(deftest asset-mapping-graphql-test
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [asset-mapping1  (prepare-result
+                           (gh/create-object app "asset-mapping" asset-mapping-1))
+           asset-mapping2  (prepare-result
+                           (gh/create-object app "asset-mapping" asset-mapping-2))
+           graphql-queries (slurp "test/data/asset_mapping.graphql")]
+
+       (testing "asset mapping query"
+         (let [{:keys [data
+                       errors
+                       status]} (gh/query
+                                 app graphql-queries
+                                 {:id (:id asset-mapping1)}
+                                 "AssetMappingQueryTest")]
+
+           (is (= 200 status))
+           (is (empty? errors) "No errors")
+
+           (testing "the asset-mapping" (is (= asset-mapping1 (:asset_mapping data))))))
+       (testing "asset-mappings query"
+         (testing "asset-mappings connection"
+           (gh/connection-test
+            app
+            "AssetMappingsQueryTest"
+            graphql-queries
+            {"query" "*"}
+            [:asset_mappings]
+            (map #(merge % ownership-data-fixture)
+                 [asset-mapping1 asset-mapping2]))
+           (testing "sorting"
+             (gh/connection-sort-test
+              app
+              "AssetMappingsQueryTest"
+              graphql-queries
+              {:query "*"}
+              [:asset_mappings]
+              asset-mapping/asset-mapping-fields)))
+         (testing "query argument"
+           (let [{:keys [data errors status]}
+                 (gh/query app
+                           graphql-queries
+                           {:query "source:\"ngfw\""}
+                           "AssetMappingsQueryTest")]
+             (is (= 200 status))
+             (is (empty? errors) "No errors")
+             (is (= 1 (get-in data [:asset_mappings :totalCount]))
+                 "Only one asset-mapping matches the query")
+             (is (= [asset-mapping2]
+                    (get-in data [:asset_mappings :nodes]))
+                 "The asset-mapping matches the search query"))))))))

--- a/test/ctia/http/routes/graphql/asset_properties_test.clj
+++ b/test/ctia/http/routes/graphql/asset_properties_test.clj
@@ -42,19 +42,6 @@
            asset-properties2  (prepare-result
                                (gh/create-object app "asset-properties" asset-properties-2))
            graphql-queries (slurp "test/data/asset_properties.graphql")]
-
-       (testing "asset properties query"
-         (let [{:keys [data
-                       errors
-                       status]} (gh/query
-                                 app graphql-queries
-                                 {:id (:id asset-properties1)}
-                                 "AssetPropertyQueryTest")]
-
-           (is (= 200 status))
-           (is (empty? errors) "No errors")
-
-           (testing "the asset-properties" (is (= asset-properties1 (:asset_property data))))))
        (testing "asset-propertiess query"
          (testing "asset-propertiess connection"
            (gh/connection-test

--- a/test/ctia/http/routes/graphql/asset_properties_test.clj
+++ b/test/ctia/http/routes/graphql/asset_properties_test.clj
@@ -1,0 +1,88 @@
+(ns ctia.http.routes.graphql.asset-properties-test
+  (:require
+   [clj-momo.test-helpers.core :as mth]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+   [ctia.entity.asset-properties :as asset-properties]
+   [ctia.test-helpers.auth :refer [all-capabilities]]
+   [ctia.test-helpers.core :as helpers]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.fixtures :as fixt]
+   [ctia.test-helpers.graphql :as gh]
+   [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+   [ctim.examples.asset-properties :refer [asset-properties-maximal]]))
+
+(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+                                    whoami-helpers/fixture-server]))
+
+(def ownership-data-fixture
+  {:owner "foouser"
+   :groups ["foogroup"]})
+
+(def asset-properties-1 (fixt/randomize asset-properties-maximal))
+(def asset-properties-2 (assoc
+                      (fixt/randomize asset-properties-maximal)
+                      :source "ngfw"))
+
+(defn prepare-result
+  [asset-properties]
+  (dissoc asset-properties :search-txt))
+
+
+(deftest asset-properties-graphql-test
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [asset-properties1 (prepare-result
+                              (gh/create-object app "asset-properties" asset-properties-1))
+           asset-properties2  (prepare-result
+                               (gh/create-object app "asset-properties" asset-properties-2))
+           graphql-queries (slurp "test/data/asset_properties.graphql")]
+
+       (testing "asset properties query"
+         (let [{:keys [data
+                       errors
+                       status]} (gh/query
+                                 app graphql-queries
+                                 {:id (:id asset-properties1)}
+                                 "AssetPropertyQueryTest")]
+
+           (is (= 200 status))
+           (is (empty? errors) "No errors")
+
+           (testing "the asset-properties" (is (= asset-properties1 (:asset_property data))))))
+       (testing "asset-propertiess query"
+         (testing "asset-propertiess connection"
+           (gh/connection-test
+            app
+            "AssetPropertiesQueryTest"
+            graphql-queries
+            {"query" "*"}
+            [:asset_properties]
+            (map #(merge % ownership-data-fixture)
+                 [asset-properties1 asset-properties2]))
+           (testing "sorting"
+             (gh/connection-sort-test
+              app
+              "AssetPropertiesQueryTest"
+              graphql-queries
+              {:query "*"}
+              [:asset_properties]
+              asset-properties/asset-properties-fields)))
+         (testing "query argument"
+           (let [{:keys [data errors status]}
+                 (gh/query app
+                           graphql-queries
+                           {:query "source:\"ngfw\""}
+                           "AssetPropertiesQueryTest")]
+             (is (= 200 status))
+             (is (empty? errors) "No errors")
+             (is (= 1 (get-in data [:asset_properties :totalCount]))
+                 "Only one asset-properties matches the query")
+             (is (= [asset-properties2]
+                    (get-in data [:asset_properties :nodes]))
+                 "The asset-properties matches the search query"))))))))

--- a/test/ctia/http/routes/graphql/asset_test.clj
+++ b/test/ctia/http/routes/graphql/asset_test.clj
@@ -1,0 +1,86 @@
+(ns ctia.http.routes.graphql.asset-test
+  (:require [clj-momo.test-helpers.core :as mth]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.entity.asset :as asset]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.fixtures :as fixt]
+            [ctia.test-helpers.graphql :as gh]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+            [ctim.examples.assets :refer [asset-maximal]]))
+
+(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+                                    whoami-helpers/fixture-server]))
+
+(def ownership-data-fixture
+  {:owner "foouser"
+   :groups ["foogroup"]})
+
+(def asset-1 (fixt/randomize asset-maximal))
+(def asset-2 (assoc
+              (fixt/randomize asset-maximal)
+              :source "ngfw"))
+
+(defn prepare-result
+  [asset]
+  (dissoc asset :search-txt))
+
+(deftest asset-graphql-test
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [asset1 (prepare-result
+                   (gh/create-object app "asset" asset-1))
+           asset2 (prepare-result
+                   (gh/create-object app "asset" asset-2))
+           graphql-queries (slurp "test/data/asset.graphql")]
+
+       (testing "asset query"
+         (let [{:keys [data
+                       errors
+                       status]} (gh/query
+                                 app graphql-queries
+                                 {:id (:id asset1)}
+                                 "AssetQueryTest")]
+
+           (is (= 200 status))
+           (is (empty? errors) "No errors")
+
+           (testing "the asset" (is (= asset1 (:asset data))))))
+       (testing "assets query"
+         (testing "assets connection"
+           (gh/connection-test
+            app
+            "AssetsQueryTest"
+            graphql-queries
+            {"query" "*"}
+            [:assets]
+            (map #(merge % ownership-data-fixture)
+                 [asset1 asset2]))
+           (testing "sorting"
+             (gh/connection-sort-test
+              app
+              "AssetsQueryTest"
+              graphql-queries
+              {:query "*"}
+              [:assets]
+              asset/asset-fields)))
+         (testing "query argument"
+           (let [{:keys [data errors status]}
+                 (gh/query app
+                           graphql-queries
+                           {:query "source:\"ngfw\""}
+                           "AssetsQueryTest")]
+             (is (= 200 status))
+             (is (empty? errors) "No errors")
+             (is (= 1 (get-in data [:assets :totalCount]))
+                 "Only one asset matches the query")
+             (is (= [asset2]
+                    (get-in data [:assets :nodes]))
+                 "The asset matches the search query"))))))))

--- a/test/ctia/http/routes/graphql/asset_test.clj
+++ b/test/ctia/http/routes/graphql/asset_test.clj
@@ -1,14 +1,15 @@
 (ns ctia.http.routes.graphql.asset-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
-            [ctia.entity.asset :as asset]
-            [ctia.test-helpers.auth :refer [all-capabilities]]
-            [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-            [ctia.test-helpers.fixtures :as fixt]
-            [ctia.test-helpers.graphql :as gh]
-            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
-            [ctim.examples.assets :refer [asset-maximal]]))
+  (:require
+   [clj-momo.test-helpers.core :as mth]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+   [ctia.entity.asset :as asset]
+   [ctia.test-helpers.auth :refer [all-capabilities]]
+   [ctia.test-helpers.core :as helpers]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.fixtures :as fixt]
+   [ctia.test-helpers.graphql :as gh]
+   [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+   [ctim.examples.assets :refer [asset-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))

--- a/test/ctia/http/routes/graphql/target_record_test.clj
+++ b/test/ctia/http/routes/graphql/target_record_test.clj
@@ -27,8 +27,6 @@
   [target-record]
   (dissoc target-record :search-txt))
 
-;; (require '[hashp.core])
-
 (deftest target-record-graphql-test
   (test-for-each-store-with-app
    (fn [app]

--- a/test/ctia/http/routes/graphql/target_record_test.clj
+++ b/test/ctia/http/routes/graphql/target_record_test.clj
@@ -1,0 +1,89 @@
+(ns ctia.http.routes.graphql.target-record-test
+  (:require
+   [clj-momo.test-helpers.core :as mth]
+   [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+   [ctia.entity.target-record :as target-record]
+   [ctia.test-helpers.auth :refer [all-capabilities]]
+   [ctia.test-helpers.core :as helpers]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.fixtures :as fixt]
+   [ctia.test-helpers.graphql :as gh]
+   [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+   [ctim.examples.target-records :refer [target-record-maximal]]))
+
+(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+                                    whoami-helpers/fixture-server]))
+
+(def ownership-data-fixture
+  {:owner "foouser"
+   :groups ["foogroup"]})
+
+(def target-record-1 (fixt/randomize target-record-maximal))
+(def target-record-2 (assoc
+                      (fixt/randomize target-record-maximal)
+                      :source "ngfw"))
+
+(defn prepare-result
+  [target-record]
+  (dissoc target-record :search-txt))
+
+;; (require '[hashp.core])
+
+(deftest target-record-graphql-test
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [target-record1  (prepare-result
+                            (gh/create-object app "target-record" target-record-1))
+           target-record2  (prepare-result
+                            (gh/create-object app "target-record" target-record-2))
+           graphql-queries (slurp "test/data/target_record.graphql")]
+
+       (testing "target record query"
+         (let [{:keys [data
+                       errors
+                       status]} (gh/query
+                                 app graphql-queries
+                                 {:id (:id target-record1)}
+                                 "TargetRecordQueryTest")]
+
+           (is (= 200 status))
+           (is (empty? errors) "No errors")
+
+           (testing "the target-record" (is (= target-record1 (:target_record data))))))
+       (testing "Target-records query"
+         (testing "target-records connection"
+           (gh/connection-test
+            app
+            "TargetRecordsQueryTest"
+            graphql-queries
+            {"query" "*"}
+            [:target_records]
+            (map #(merge % ownership-data-fixture)
+                 [target-record1 target-record2]))
+           (testing "sorting"
+             (gh/connection-sort-test
+              app
+              "TargetRecordsQueryTest"
+              graphql-queries
+              {:query "*"}
+              [:target_records]
+              target-record/target-record-fields)))
+         (testing "query argument"
+           (let [{:keys [data errors status]}
+                 (gh/query app
+                           graphql-queries
+                           {:query "source:\"ngfw\""}
+                           "TargetRecordsQueryTest")]
+             (is (= 200 status))
+             (is (empty? errors) "No errors")
+             (is (= 1 (get-in data [:target_records :totalCount]))
+                 "Only one target-record matches the query")
+             (is (= [target-record2]
+                    (get-in data [:target_records :nodes]))
+                 "The target-record matches the search query"))))))))

--- a/test/data/asset.graphql
+++ b/test/data/asset.graphql
@@ -1,0 +1,63 @@
+fragment pageInfoFields on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
+
+fragment validTimeFields on ValidTime {
+  start_time
+  end_time
+}
+
+fragment assetFields on Asset {
+  asset_type
+  description
+  external_ids
+  external_references { ...externalReferenceFields}
+  id
+  language
+  revision
+  schema_version
+  short_description
+  source
+  source_uri
+  timestamp
+  title
+  tlp
+  type
+  valid_time { ...validTimeFields}
+  owner
+  groups
+}
+
+query AssetsQueryTest($query: String, $after: String, $first: Int, $sort_field:AssetOrderField = ID, $sort_direction: OrderDirection = asc) {
+  assets(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...assetFields
+    }
+    edges {
+      node {
+        ...assetFields
+      }
+    }
+  }
+}
+
+query AssetQueryTest($id: String!) {
+  asset(id: $id) {
+    ...assetFields
+  }
+}

--- a/test/data/asset_mapping.graphql
+++ b/test/data/asset_mapping.graphql
@@ -1,0 +1,71 @@
+fragment pageInfoFields on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
+
+fragment observableBaseFields on Observable {
+  type
+  value
+}
+
+fragment validTimeFields on ValidTime {
+  start_time
+  end_time
+}
+
+
+fragment assetMappingFields on AssetMapping {
+  asset_ref
+  asset_type
+  confidence
+  external_ids
+  external_references { ...externalReferenceFields}
+  id
+  language
+  observable { ...observableBaseFields}
+  revision
+  schema_version
+  source
+  source_uri
+  specificity
+  stability
+  timestamp
+  tlp
+  type
+  valid_time { ...validTimeFields}
+  owner
+  groups
+}
+
+query AssetMappingsQueryTest($query: String, $after: String, $first: Int, $sort_field:AssetMappingOrderField = ID, $sort_direction: OrderDirection = asc) {
+  asset_mappings(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...assetMappingFields
+    }
+    edges {
+      node {
+        ...assetMappingFields
+      }
+    }
+  }
+}
+
+query AssetMappingQueryTest($id: String!) {
+  asset_mapping(id: $id) {
+    ...assetMappingFields
+  }
+}

--- a/test/data/asset_properties.graphql
+++ b/test/data/asset_properties.graphql
@@ -58,10 +58,3 @@ query AssetPropertiesQueryTest($query: String, $after: String, $first: Int, $sor
     }
   }
 }
-
-
-query AssetPropertyQueryTest($id: String!) {
-  asset_property(id: $id) {
-    ...assetPropertiesFields
-  }
-}

--- a/test/data/asset_properties.graphql
+++ b/test/data/asset_properties.graphql
@@ -1,0 +1,67 @@
+fragment pageInfoFields on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
+
+fragment validTimeFields on ValidTime {
+  start_time
+  end_time
+}
+
+fragment propertiesFields on AssetProperty {
+  name
+  value
+}
+
+fragment assetPropertiesFields on AssetProperties {
+  asset_ref
+  external_ids
+  external_references { ...externalReferenceFields}
+  id
+  language
+  properties { ...propertiesFields}
+  revision
+  schema_version
+  source
+  source_uri
+  timestamp
+  tlp
+  type
+  valid_time { ...validTimeFields}
+  owner
+  groups
+}
+
+query AssetPropertiesQueryTest($query: String, $after: String, $first: Int, $sort_field:AssetPropertiesOrderField = ID, $sort_direction: OrderDirection = asc) {
+  asset_properties(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...assetPropertiesFields
+    }
+    edges {
+      node {
+        ...assetPropertiesFields
+      }
+    }
+  }
+}
+
+
+query AssetPropertyQueryTest($id: String!) {
+  asset_property(id: $id) {
+    ...assetPropertiesFields
+  }
+}

--- a/test/data/target_record.graphql
+++ b/test/data/target_record.graphql
@@ -1,0 +1,77 @@
+fragment pageInfoFields on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+
+fragment externalReferenceFields on ExternalReference {
+  source_name
+  external_id
+  url
+  description
+  hashes
+}
+
+fragment observedTimeFields on ObservedTime {
+  start_time
+  end_time
+}
+
+fragment observableBaseFields on Observable {
+  type
+  value
+}
+
+fragment targetsFields on Target {
+  internal
+  observables { ...observableBaseFields}
+  observed_time { ...observedTimeFields}
+  os
+  sensor
+  source_uri
+  type
+}
+
+fragment targetRecordFields on TargetRecord {
+  description
+  external_ids
+  external_references { ...externalReferenceFields}
+  id
+  language
+  revision
+  schema_version
+  short_description
+  source
+  source_uri
+  targets { ...targetsFields}
+  timestamp
+  title
+  tlp
+  type
+  owner
+  groups
+}
+
+query TargetRecordsQueryTest($query: String, $after: String, $first: Int, $sort_field:TargetRecordOrderField = ID, $sort_direction: OrderDirection = asc) {
+  target_records(first: $first, after: $after, query: $query, orderBy: [{field: $sort_field, direction: $sort_direction}, {field: ID, direction: $sort_direction}]) {
+    totalCount
+    pageInfo {
+      ...pageInfoFields
+    }
+    nodes {
+      ...targetRecordFields
+    }
+    edges {
+      node {
+        ...targetRecordFields
+      }
+    }
+  }
+}
+
+query TargetRecordQueryTest($id: String!) {
+  target_record(id: $id) {
+    ...targetRecordFields
+  }
+}


### PR DESCRIPTION
> **Epic** #
> Close 
> Related https://github.com/threatgrid/iroh/issues/4521

*Note: this is a multi-PR work. The second part is [here #1068 ](https://github.com/threatgrid/ctia/pull/1068)*

<a name="qa">[§](#qa)</a> QA
============================

1. Create one or multiple Assets by issuing requests to `POST ​/ctia​/asset` route
2. Try running simple graphql queries, e.g.: 

```
POST  /ctia/graphql
{
"query": "query Assets { assets { nodes {id} }}"
}
```

3. Make sure the results include all (previously created) assets
4. Similarly, test it for `AssetMapping`, `AssetProperties` and `TargetRecord`


<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: graphql queries for Asset, AssetMapping, AssetProperties and TargetRecord entities
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

2d651cc4 adds an asset-mapping specific test case
95357042 remove unused code
43710f3f adds target-record graphql tests
b97bc4f7 adds target-record graphql schema
6581d90c remove singular form of asset-properties
2b084878 adds AssetProperties tests
0ef440bf normalize ns headers
3785a4e9 adds asset-properties graphql schema
609fe710 adds basic asset-mapping graphql test
16bc4277 Adds graphql schemas for asset-mapping
214f34c1 extend asset graphql tests
883b3e3f move asset graphql schemas to its own namespace
657f7363 adds additional graphql schema things
7254460c adds AssetType to graphql/schemas
dd0f4d03 normalize and sort ns headers