### PR TITLE
`c/described-entity-entries` in Malware, Tool, Attack Pattern

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.0.23"]
+                 [threatgrid/ctim "1.0.24-SNAPSHOT"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -48,6 +48,7 @@
                  [org.clojure/tools.logging "1.1.0"]
                  [org.clojure/tools.cli "1.0.194"]
                  [pandect "0.6.1"]
+                 [org.clojure/math.combinatorics "0.1.6"]
 
                  ;; Trapperkeeper
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]

--- a/project.clj
+++ b/project.clj
@@ -59,7 +59,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.0.24-SNAPSHOT"]
+                 [threatgrid/ctim "1.1.0-SNAPSHOT"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.1.0"]
+                 [threatgrid/ctim "1.1.2-SNAPSHOT"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.1.0-SNAPSHOT"]
+                 [threatgrid/ctim "1.1.0"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
 
-                 [threatgrid/ctim "1.1.2-SNAPSHOT"]
+                 [threatgrid/ctim "1.1.1"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -1,3 +1,5 @@
+# properties documentation: https://github.com/threatgrid/ctia/blob/master/doc/properties.org
+
 ctia.auth.type=allow-all
 ctia.auth.threatgrid.cache=true
 ctia.auth.entities.scope=private-intel
@@ -9,13 +11,6 @@ ctia.access-control.max-record-visibility everyone
 
 ctia.encryption.type=default
 ctia.encryption.key.filepath=resources/cert/ctia-encryption.key
-#ctia.encryption.secret=...
-
-# You can optionaly require a specific API key
-#ctia.auth.type=static
-#ctia.auth.static.name=example
-#ctia.auth.static.secret=password
-#ctia.auth.static.readonly-for-anonymous=true
 
 ctia.http.enabled=true
 ctia.http.port=3000
@@ -166,34 +161,8 @@ ctia.migration.store-keys=malware,tool
 ctia.migration.batch-size=100
 ctia.migration.buffer-size=3
 
-#ctia.migration.store.es.default.host=localhost
-#ctia.migration.store.es.default.port=9205
-#ctia.migration.store.es.default.protocol=http
-#ctia.migration.store.es.default.replicas=1
-#ctia.migration.store.es.default.refresh_interval=1s
-#ctia.migration.store.es.default.default_operator=AND
-#ctia.migration.store.es.default.shards=1
-#ctia.migration.store.es.default.refresh=false
-#ctia.migration.store.es.default.rollover.max_docs=10000000
-#ctia.migration.store.es.default.aliased=true
-#ctia.migration.store.es.default.version=5
-
+# migration properties
+# see https://github.com/threatgrid/ctia/blob/master/doc/migration.md
 ctia.migration.store.es.migration.indexname=ctia_migration
-#ctia.migration.store.es.malware.indexname=v1.2.0_ctia_malware
-
-#ctia.hook.kafkrestart?    a.enabled=false
-#ctia.hook.kafka.compression.type=gzip
-#ctia.hook.kafka.ssl.enabled=true
-#ctia.hook.kafka.ssl.truststore.location=containers/dev/truststore/kafka.truststore.jks
-#ctia.hook.kafka.ssl.truststore.password=Cisco42
-#ctia.hook.kafka.ssl.keystore.location=containers/dev/keystore/kafka.keystore.jks
-#ctia.hook.kafka.ssl.keystore.password=Cisco42
-#ctia.hook.kafka.ssl.key.password=Cisco42
-
-#ctia.hook.kafka.request-size=307200
-#ctia.hook.kafka.zk.address=127.0.0.1:2181
-#ctia.hook.kafka.topic.name=ctia-events
-#ctia.hook.kafka.topic.num-partitions=1
-#ctia.hook.kafka.topic.replication-factor=1
 
 ctia.versions.config=local

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -166,17 +166,17 @@ ctia.migration.store-keys=malware,tool
 ctia.migration.batch-size=100
 ctia.migration.buffer-size=3
 
-ctia.migration.store.es.default.host=localhost
-ctia.migration.store.es.default.port=9205
-ctia.migration.store.es.default.protocol=http
+#ctia.migration.store.es.default.host=localhost
+#ctia.migration.store.es.default.port=9205
+#ctia.migration.store.es.default.protocol=http
 #ctia.migration.store.es.default.replicas=1
 #ctia.migration.store.es.default.refresh_interval=1s
 #ctia.migration.store.es.default.default_operator=AND
-ctia.migration.store.es.default.shards=1
+#ctia.migration.store.es.default.shards=1
 #ctia.migration.store.es.default.refresh=false
 #ctia.migration.store.es.default.rollover.max_docs=10000000
 #ctia.migration.store.es.default.aliased=true
-ctia.migration.store.es.default.version=5
+#ctia.migration.store.es.default.version=5
 
 ctia.migration.store.es.migration.indexname=ctia_migration
 #ctia.migration.store.es.malware.indexname=v1.2.0_ctia_malware

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -48,10 +48,7 @@
 (def realize-attack-pattern
   (default-realize-fn "attack-pattern" NewAttackPattern StoredAttackPattern))
 
-(def attack-pattern-fields
-  (concat sorting/base-entity-sort-fields
-          sorting/sourcable-entity-sort-fields
-          [:name]))
+(def attack-pattern-fields sorting/default-entity-sort-fields)
 
 (def attack-pattern-sort-fields
   (apply s/enum attack-pattern-fields))
@@ -63,10 +60,9 @@
     (merge
      em/base-entity-mapping
      em/sourcable-entity-mapping
+     em/describable-entity-mapping
      em/stored-entity-mapping
      {:abstraction_level em/token
-      :name em/token
-      :description em/text
       :kill_chain_phases em/kill-chain-phase
       :x_mitre_data_sources em/token
       :x_mitre_platforms em/token

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -54,20 +54,16 @@
     (merge
      em/base-entity-mapping
      em/sourcable-entity-mapping
+     em/describable-entity-mapping
      em/stored-entity-mapping
-     {:name em/token
-      :description em/text
-      :labels em/token
+     {:labels em/token
       :kill_chain_phases em/kill-chain-phase
       :x_mitre_aliases em/token
       :abstraction_level em/token})}})
 
 (def-es-store MalwareStore :malware StoredMalware PartialStoredMalware)
 
-(def malware-fields
-  (concat sorting/base-entity-sort-fields
-          sorting/sourcable-entity-sort-fields
-          [:name]))
+(def malware-fields sorting/default-entity-sort-fields)
 
 (def malware-sort-fields
   (apply s/enum malware-fields))

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -1,6 +1,5 @@
 (ns ctia.entity.tool
   (:require [ctia.entity.tool.schemas :as ts]
-            [ctia.entity.tool.graphql-schemas :as tgs]
             [ctia.http.routes
              [common :refer [BaseEntityFilterParams PagingParams SourcableEntityFilterParams]
               :as routes.common]
@@ -18,11 +17,10 @@
     :properties
     (merge
      em/base-entity-mapping
+     em/describable-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:name em/token
-      :description em/text
-      :labels em/token
+     {:labels em/token
       :kill_chain_phases em/kill-chain-phase
       :tool_version em/token
       :x_mitre_aliases em/token})}})

--- a/src/ctia/entity/tool/schemas.clj
+++ b/src/ctia/entity/tool/schemas.clj
@@ -29,7 +29,4 @@
 (def realize-tool
   (default-realize-fn "tool" NewTool StoredTool))
 
-(def tool-fields
-  (concat sorting/base-entity-sort-fields
-          sorting/sourcable-entity-sort-fields
-          [:name]))
+(def tool-fields sorting/default-entity-sort-fields)

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -3,7 +3,7 @@
              [coerce :as time-coerce]
              [core :as time-core]]
             [clojure.set :as set]
-            [ctia.task.migration.migrations.describe :refer [describe]]
+            [ctia.task.migration.migrations.describe :refer [migrate-describe]]
             [ctia.task.migration.migrations.investigation-actions :refer [migrate-action-data]]))
 
 (def add-groups
@@ -169,4 +169,4 @@
    :investigation-actions (comp (append-version "1.1.0")
                                 migrate-action-data)
    :describe (comp (append-version "1.1.0")
-                   describe)})
+                   migrate-describe)})

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -3,7 +3,8 @@
              [coerce :as time-coerce]
              [core :as time-core]]
             [clojure.set :as set]
-            [cheshire.core :as json]))
+            [ctia.task.migration.migrations.describe :refer [describe]]
+            [ctia.task.migration.migrations.investigation-actions :refer [migrate-action-data]]))
 
 (def add-groups
   "set a document group to [\"tenzin\"] if unset"
@@ -150,96 +151,6 @@
                (update :incident_time simplify-incident-time))
            doc))))
 
-;; Add new investigation fields
-
-(defn transient-id? [id]
-  (and (string? id)
-       (re-find #"\Atransient" (str id))))
-
-(defn object-id [doc]
-  (let [id (get doc :id)]
-    (when (not (transient-id? id))
-      id)))
-
-(defn read-actions [investigation]
-  (let [actions (get investigation :actions)]
-    (if (string? actions)
-      (try
-        (let [x (json/parse-string actions true)]
-          (if (sequential? x)
-            x
-            []))
-        (catch Exception _
-          []))
-      [])))
-
-(def empty-action-data
-  {:object_ids #{}
-   :investigated_observables #{}
-   :targets #{}})
-
-(defn merge-action-data
-  ([] empty-action-data)
-  ([m] m)
-  ([m1 m2]
-   (merge m1 {:object_ids (into (get m1 :object_ids)
-                                (get m2 :object_ids))
-              :investigated_observables (into (get m1 :investigated_observables)
-                                              (get m2 :investigated_observables))
-              :targets (into (get m1 :targets)
-                             (get m2 :targets))})))
-
-(defn derive-collect-action-data
-  {:private true}
-  [action]
-  (let [investigated-observables (into #{} (map (fn [{:keys [type value]}]
-                                                  (str type ":" value)))
-                                       (:result action))]
-    (assoc empty-action-data :investigated_observables investigated-observables)))
-
-(defn derive-investigate-action-data
-  {:private true}
-  [action]
-  (let [data (get-in action [:result :data])]
-    (transduce (comp (map :data)
-                     (mapcat vals)
-                     (mapcat :docs))
-               (fn
-                 ([result] result)
-                 ([result doc]
-                  (let [result (if-some [object-id (object-id doc)]
-                                 (update result :object_ids conj object-id)
-                                 result)
-                        result (update result :targets into (get doc :targets))]
-                    result)))
-               {:object_ids #{}
-                :investigated_observables []
-                :targets #{}}
-               data)))
-
-(defn derive-action-data [action]
-  (let [action-type (get action :type)]
-    (case action-type
-      "collect"
-      (derive-collect-action-data action)
-
-      "investigate"
-      (derive-investigate-action-data action)
-
-      ;; else
-      empty-action-data)))
-
-(defn migrate-investigation-action-data [investigation]
-  (transduce (map derive-action-data)
-             merge-action-data
-             (merge investigation empty-action-data)
-             (read-actions investigation)))
-
-(def migrate-action-data
-  (map (fn [{entity-type :type :as doc}]
-         (if (= entity-type "investigation")
-           (migrate-investigation-action-data doc)
-           doc))))
 
 (def available-migrations
   {:identity identity
@@ -256,4 +167,6 @@
                 (rename-observable-type "pki-serial" "pki_serial")
                 simplify-incident)
    :investigation-actions (comp (append-version "1.1.0")
-                migrate-action-data)})
+                                migrate-action-data)
+   :describe (comp (append-version "1.1.0")
+                   describe)})

--- a/src/ctia/task/migration/migrations/describe.clj
+++ b/src/ctia/task/migration/migrations/describe.clj
@@ -11,3 +11,6 @@
         (assoc :title new-title
                :description new-description
                :short_description new-short-description))))
+
+(def migrate-describe
+  (map describe))

--- a/src/ctia/task/migration/migrations/describe.clj
+++ b/src/ctia/task/migration/migrations/describe.clj
@@ -1,0 +1,13 @@
+(ns ctia.task.migration.migrations.describe)
+
+(defn describe
+  [{:keys [name title description short_description]
+    :as entity}]
+  (let [new-title (or name title "No title provided")
+        new-description (or description name title "No description provided")
+        new-short-description (or short_description name title "No description provided")]
+    (-> entity
+        (dissoc :name)
+        (assoc :title new-title
+               :description new-description
+               :short_description new-short-description))))

--- a/src/ctia/task/migration/migrations/investigation_actions.clj
+++ b/src/ctia/task/migration/migrations/investigation_actions.clj
@@ -1,0 +1,91 @@
+(ns ctia.task.migration.migrations.investigation-actions
+  (:require [cheshire.core :as json]))
+
+(defn transient-id? [id]
+  (and (string? id)
+       (re-find #"\Atransient" (str id))))
+
+(defn object-id [doc]
+  (let [id (get doc :id)]
+    (when (not (transient-id? id))
+      id)))
+
+(defn read-actions [investigation]
+  (let [actions (get investigation :actions)]
+    (if (string? actions)
+      (try
+        (let [x (json/parse-string actions true)]
+          (if (sequential? x)
+            x
+            []))
+        (catch Exception _
+          []))
+      [])))
+
+(def empty-action-data
+  {:object_ids #{}
+   :investigated_observables #{}
+   :targets #{}})
+
+(defn merge-action-data
+  ([] empty-action-data)
+  ([m] m)
+  ([m1 m2]
+   (merge m1 {:object_ids (into (get m1 :object_ids)
+                                (get m2 :object_ids))
+              :investigated_observables (into (get m1 :investigated_observables)
+                                              (get m2 :investigated_observables))
+              :targets (into (get m1 :targets)
+                             (get m2 :targets))})))
+
+(defn derive-collect-action-data
+  {:private true}
+  [action]
+  (let [investigated-observables (into #{} (map (fn [{:keys [type value]}]
+                                                  (str type ":" value)))
+                                       (:result action))]
+    (assoc empty-action-data :investigated_observables investigated-observables)))
+
+(defn derive-investigate-action-data
+  {:private true}
+  [action]
+  (let [data (get-in action [:result :data])]
+    (transduce (comp (map :data)
+                     (mapcat vals)
+                     (mapcat :docs))
+               (fn
+                 ([result] result)
+                 ([result doc]
+                  (let [result (if-some [object-id (object-id doc)]
+                                 (update result :object_ids conj object-id)
+                                 result)
+                        result (update result :targets into (get doc :targets))]
+                    result)))
+               {:object_ids #{}
+                :investigated_observables []
+                :targets #{}}
+               data)))
+
+(defn derive-action-data [action]
+  (let [action-type (get action :type)]
+    (case action-type
+      "collect"
+      (derive-collect-action-data action)
+
+      "investigate"
+      (derive-investigate-action-data action)
+
+      ;; else
+      empty-action-data)))
+
+(defn migrate-investigation-action-data [investigation]
+  (transduce (map derive-action-data)
+             merge-action-data
+             (merge investigation empty-action-data)
+             (read-actions investigation)))
+
+(def migrate-action-data
+  (map (fn [{entity-type :type :as doc}]
+         (if (= entity-type "investigation")
+           (migrate-investigation-action-data doc)
+           doc))))

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -37,6 +37,7 @@
   {:id (str "transient:actor-" n)
    :title (str "actor-" n)
    :description (str "description: actor-" n)
+   :short_description (str "short_description: actor-" n)
    :actor_type "Hacker"
    :source "a source"
    :confidence "High"
@@ -45,13 +46,15 @@
 
 (defn mk-new-attack-pattern [n]
   {:id (str "transient:attack-pattern-" n)
-   :name (str "attack-pattern-" n)
-   :description (str "description: attack-pattern-" n)})
+   :title (str "attack-pattern-" n)
+   :description (str "description: attack-pattern-" n)
+   :short_description (str "short_description: attack-pattern-" n)})
 
 (defn mk-new-campaign [n]
   {:id (str "transient:campaign-" n)
    :title (str "campaign" n)
    :description "description"
+   :short_description "short_description"
    :campaign_type "anything goes here"
    :intended_effect ["Theft"]
    :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
@@ -112,7 +115,9 @@
 
 (defn mk-new-malware [n]
   {:id (str "transient:malware-" n)
-   :name (str "malware-" n)
+   :title (str "malware-" n)
+   :description (str "description: malware-" n)
+   :short_description (str "short_description: malware-" n)
    :labels [(str "malware-label-" n)]})
 
 (defn mk-new-relationship [n source_ref target_ref]
@@ -150,7 +155,9 @@
 
 (defn mk-new-tool [n]
   {:id (str "transient:tool-" n)
-   :name (str "tool-" n)
+   :title (str "tool-" n)
+   :description (str "description: tool-" n)
+   :short_description (str "short_description: tool-" n)
    :labels [(str "tool-label-" n)]})
 
 (defn mk-new-vulnerability [n]
@@ -446,9 +453,9 @@
            stored-tool-2 (get-entity tools source_ref)]
        (is (= 201 status-create) "The bulk create should be successfull")
        (is (= 200 status-get) "All entities should be retrieved")
-       (is (= (:name tool1) (:name stored-tool-1))
+       (is (= (:title tool1) (:title stored-tool-1))
            "The target ref should be the ID of the stored entity")
-       (is (= (:name tool2) (:name stored-tool-2))
+       (is (= (:title tool2) (:title stored-tool-2))
            "The source ref should be the ID of the stored entity")
        (is (= (hash-map (:id tool1) (:id stored-tool-1)
                         (:id tool2) (:id stored-tool-2)

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -39,8 +39,8 @@
             {:app app
              :example new-attack-pattern-maximal
              :headers {:Authorization "45c1f5e3f05d0"}
-             :update-field :name
-             :invalid-test-field :name})))))
+             :update-field :title
+             :invalid-test-field :title})))))
 
 (deftest test-attack-pattern-pagination-field-selection
   (test-for-each-store-with-app

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -42,13 +42,11 @@
 
   (testing "POST /ctia/casebook/:id/observables :add on non existing casebook"
     (let [new-observables [{:type "ip" :value "42.42.42.42"}]
-          expected-entity (update casebook :observables concat new-observables)
           response (POST app
                          (str "ctia/casebook/" (str (:short-id casebook-id) "42") "/observables")
                          :body {:operation :add
                                 :observables new-observables}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/observables :remove"
@@ -68,13 +66,11 @@
   (testing "POST /ctia/casebook/:id/observables :remove on non existing casebook"
     (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
                                {:value "42.42.42.42" :type "ip"}]
-          expected-entity (update casebook :observables #(remove (set deleted-observables) %))
           response (POST app
                          (str "ctia/casebook/" (:short-id casebook-id) "z" "/observables")
                          :body {:operation :remove
                                 :observables deleted-observables}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/observables :replace"
@@ -105,13 +101,11 @@
 
   (testing "POST /ctia/casebook/:id/observables :replace on non existing casebook"
     (let [observables (:observables new-casebook-maximal)
-          expected-entity (assoc casebook :observables observables)
           response (POST app
                          (str "ctia/casebook/" (:short-id casebook-id) "z" "/observables")
                          :body {:operation :replace
                                 :observables observables}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
   ;; texts
   (testing "POST /ctia/casebook/:id/texts :add"
@@ -130,13 +124,11 @@
 
   (testing "POST /ctia/casebook/:id/texts :add on non existing casebook"
     (let [new-texts [{:type "some" :text "text"}]
-          expected-entity (update casebook :texts concat new-texts)
           response (POST app
                          (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
                          :body {:operation :add
                                 :texts new-texts}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/texts :remove"
@@ -153,13 +145,11 @@
 
   (testing "POST /ctia/casebook/:id/texts :remove on non existing casebook"
     (let [deleted-texts [{:type "some" :text "text"}]
-          expected-entity (update casebook :texts #(remove (set deleted-texts) %))
           response (POST app
                          (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
                          :body {:operation :remove
                                 :texts deleted-texts}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
 
   (testing "POST /ctia/casebook/:id/texts :replace"
@@ -190,107 +180,80 @@
                          (str "ctia/casebook/" (:short-id casebook-id) "z" "/texts")
                          :body {:operation :replace
                                 :texts texts}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                         :headers {"Authorization" "45c1f5e3f05d0"})]
       (is (= 404 (:status response)))))
 
   ;; bundle
-  (testing "POST /ctia/casebook/:id/bundle :add"
-    (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
+  (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
                                             :type "malware"
                                             :schema_version ctim-schema-version
-                                            :name "TEST"
-                                            :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                         :body {:operation :add
-                                :bundle new-bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
+                                            :title "TEST"
+                                            :description "description"
+                                            :short_description "short_description"
+                                            :labels ["malware"]}}}]
+    (testing "POST /ctia/casebook/:id/bundle :add"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                           :body {:operation :add
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})
+            updated-casebook (:parsed-body response)]
 
-      (is (= 200 (:status response)))
-      (is (not= (:malwares updated-casebook)
-                (:malwares new-bundle-entities)))
-      (is (subset? (set (:malwares new-bundle-entities))
-                   (set (-> updated-casebook :bundle :malwares))))))
+        (is (= 200 (:status response)))
+        (is (not= (:malwares updated-casebook)
+                  (:malwares bundle-entities)))
+        (is (subset? (set (:malwares bundle-entities))
+                     (set (-> updated-casebook :bundle :malwares))))))
 
-  (testing "POST /ctia/casebook/:id/bundle :add on non existing casebook"
-    (let [new-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                            :type "malware"
-                                            :schema_version ctim-schema-version
-                                            :name "TEST"
-                                            :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
-                         :body {:operation :add
-                                :bundle new-bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 404 (:status response)))))
+    (testing "POST /ctia/casebook/:id/bundle :add on non existing casebook"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                           :body {:operation :add
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})]
+        (is (= 404 (:status response)))))
 
-  (testing "POST /ctia/casebook/:id/bundle :remove"
-    (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                                :type "malware"
-                                                :schema_version ctim-schema-version
-                                                :name "TEST"
-                                                :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                         :body {:operation :remove
-                                :bundle deleted-bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 200 (:status response)))
-      (is (deep= (update casebook :bundle dissoc :malwares)
-                 (update updated-casebook :bundle dissoc :malwares)))
-      (is (not (subset? (set (:malwares deleted-bundle-entities))
-                        (set (-> updated-casebook :bundle :malwares)))))))
+    (testing "POST /ctia/casebook/:id/bundle :remove"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                           :body {:operation :remove
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})
+            updated-casebook (:parsed-body response)]
+        (is (= 200 (:status response)))
+        (is (deep= (update casebook :bundle dissoc :malwares)
+                   (update updated-casebook :bundle dissoc :malwares)))
+        (is (not (subset? (set (:malwares bundle-entities))
+                          (set (-> updated-casebook :bundle :malwares)))))))
 
-  (testing "POST /ctia/casebook/:id/bundle :remove on non existing casebook"
-    (let [deleted-bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                                :type "malware"
-                                                :schema_version ctim-schema-version
-                                                :name "TEST"
-                                                :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
-                         :body {:operation :remove
-                                :bundle deleted-bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 404 (:status response)))))
+    (testing "POST /ctia/casebook/:id/bundle :remove on non existing casebook"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                           :body {:operation :remove
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})]
+        (is (= 404 (:status response)))))
 
-  (testing "POST /ctia/casebook/:id/bundle :replace"
-    (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                        :type "malware"
-                                        :schema_version ctim-schema-version
-                                        :name "TEST"
-                                        :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
-                         :body {:operation :replace
-                                :bundle bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 200 (:status response)))
-      (is (deep= (update casebook :bundle dissoc :malwares)
-                 (update updated-casebook :bundle dissoc :malwares)))
-      (is (= (:malwares bundle-entities)
-             (-> updated-casebook :bundle :malwares)))))
+    (testing "POST /ctia/casebook/:id/bundle :replace"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "/bundle")
+                           :body {:operation :replace
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})
+            updated-casebook (:parsed-body response)]
+        (is (= 200 (:status response)))
+        (is (deep= (update casebook :bundle dissoc :malwares)
+                   (update updated-casebook :bundle dissoc :malwares)))
+        (is (= (:malwares bundle-entities)
+               (-> updated-casebook :bundle :malwares)))))
 
-  (testing "POST /ctia/casebook/:id/bundle :replace on non existing casebook"
-    (let [bundle-entities {:malwares #{{:id "transient:616608f4-7658-49f1-8728-d9a3dde849d5"
-                                        :type "malware"
-                                        :schema_version ctim-schema-version
-                                        :name "TEST"
-                                        :labels ["malware"]}}}
-          response (POST app
-                         (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
-                         :body {:operation :replace
-                                :bundle bundle-entities}
-                         :headers {"Authorization" "45c1f5e3f05d0"})
-          updated-casebook (:parsed-body response)]
-      (is (= 404 (:status response)))))
+    (testing "POST /ctia/casebook/:id/bundle :replace on non existing casebook"
+      (let [response (POST app
+                           (str "ctia/casebook/" (:short-id casebook-id) "z" "/bundle")
+                           :body {:operation :replace
+                                  :bundle bundle-entities}
+                           :headers {"Authorization" "45c1f5e3f05d0"})]
+        (is (= 404 (:status response))))))
 
   (testing "schema_version changes with PATCH"
     (testing "Test setup: PATCH /ctia/casebook/:id redefing schema_version"

--- a/test/ctia/entity/tool_test.clj
+++ b/test/ctia/entity/tool_test.clj
@@ -38,7 +38,7 @@
       (into sut/tool-entity
             {:app app
              :example new-tool-maximal
-             :invalid-test-field :name
+             :invalid-test-field :title
              :update-field :description
              :headers {:Authorization "45c1f5e3f05d0"}})))))
 

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -35,6 +35,7 @@
                 "ctia/actor"
                 :body {:title "actor"
                        :description "description"
+                       :short_description "short description"
                        :actor_type "Hacker"
                        :source "a source"
                        :confidence "High"

--- a/test/ctia/http/routes/graphql/attack_pattern_test.clj
+++ b/test/ctia/http/routes/graphql/attack_pattern_test.clj
@@ -23,19 +23,19 @@
              app
              "attack-pattern"
              (-> new-attack-pattern-maximal
-                 (assoc :name "Attack Pattern 1")
+                 (assoc :title "Attack Pattern 1")
                  (dissoc :id)))
         ap2 (gh/create-object
              app
              "attack-pattern"
              (-> new-attack-pattern-maximal
-                 (assoc :name "Attack Pattern 2")
+                 (assoc :title "Attack Pattern 2")
                  (dissoc :id)))
         ap3 (gh/create-object
              app
              "attack-pattern"
              (-> new-attack-pattern-maximal
-                 (assoc :name "Attack Pattern 3")
+                 (assoc :title "Attack Pattern 3")
                  (dissoc :id)))
         f1 (gh/create-object app
                              "feedback"
@@ -182,10 +182,10 @@
              (let [{:keys [data errors status]}
                    (gh/query app
                              graphql-queries
-                             {:query (format "name:\"%s\""
+                             {:query (format "title:\"%s\""
                                              (get-in
                                               datamap
-                                              [:attack-pattern-1 :name]))}
+                                              [:attack-pattern-1 :title]))}
                              "AttackPatternsQueryTest")]
                (is (= 200 status))
                (is (empty? errors) "No errors")

--- a/test/ctia/http/routes/graphql/malware_test.clj
+++ b/test/ctia/http/routes/graphql/malware_test.clj
@@ -21,19 +21,19 @@
                   app
                   "malware"
                   (-> new-malware-maximal
-                      (assoc :name "Malware 1")
+                      (assoc :title "Malware 1")
                       (dissoc :id)))
         entity-2 (gh/create-object
                   app
                   "malware"
                   (-> new-malware-maximal
-                      (assoc :name "Malware 2")
+                      (assoc :title "Malware 2")
                       (dissoc :id)))
         entity-3 (gh/create-object
                   app
                   "malware"
                   (-> new-malware-maximal
-                      (assoc :name "Malware 3")
+                      (assoc :title "Malware 3")
                       (dissoc :id)))
         f1 (gh/create-object app "feedback" (gh/feedback-1 (:id entity-1) #inst "2042-01-01T00:00:00.000Z"))
         f2 (gh/create-object app "feedback" (gh/feedback-2 (:id entity-1) #inst "2042-01-01T00:00:00.000Z"))]
@@ -156,10 +156,10 @@
              (let [{:keys [data errors status]}
                    (gh/query app
                              graphql-queries
-                             {:query (format "name:\"%s\""
+                             {:query (format "title:\"%s\""
                                              (get-in
                                               datamap
-                                              [:malware-1 :name]))}
+                                              [:malware-1 :title]))}
                              "MalwaresQueryTest")]
                (is (= 200 status))
                (is (empty? errors) "No errors")

--- a/test/ctia/http/routes/graphql/tool_test.clj
+++ b/test/ctia/http/routes/graphql/tool_test.clj
@@ -21,19 +21,19 @@
                   app
                   "tool"
                   (-> new-tool-maximal
-                      (assoc :name "Tool 1")
+                      (assoc :title "Tool 1")
                       (dissoc :id)))
         entity-2 (gh/create-object
                   app
                   "tool"
                   (-> new-tool-maximal
-                      (assoc :name "Tool 2")
+                      (assoc :title "Tool 2")
                       (dissoc :id)))
         entity-3 (gh/create-object
                   app
                   "tool"
                   (-> new-tool-maximal
-                      (assoc :name "Tool 3")
+                      (assoc :title "Tool 3")
                       (dissoc :id)))
         f1 (gh/create-object app "feedback" (gh/feedback-1 (:id entity-1) #inst "2042-01-01T00:00:00.000Z"))
         f2 (gh/create-object app "feedback" (gh/feedback-2 (:id entity-1) #inst "2042-01-01T00:00:00.000Z")) ]
@@ -156,10 +156,10 @@
              (let [{:keys [data errors status]}
                    (gh/query app
                              graphql-queries
-                             {:query (format "name:\"%s\""
+                             {:query (format "title:\"%s\""
                                              (get-in
                                               datamap
-                                              [:tool-1 :name]))}
+                                              [:tool-1 :title]))}
                              "ToolsQueryTest")]
                (is (= 200 status))
                (is (empty? errors) "No errors")

--- a/test/ctia/task/migration/migrations/describe_test.clj
+++ b/test/ctia/task/migration/migrations/describe_test.clj
@@ -1,0 +1,203 @@
+(ns ctia.task.migration.migrations.describe-test
+  (:require  [ctia.task.migration.migrations.describe :as sut]
+             [clojure.test :refer [deftest testing is]]))
+
+;; describibable source entities
+(def actor
+  {:id "http://ex.tld/ctia/actor/actor-5023697b-3857-4652-9b53-ccda297f9c3e"
+   :type "actor"
+   :schema_version "1.0.0"
+    :title "title"
+   :description "description"
+   :short_description "short description"
+   :actor_type "Hacker",
+   :confidence "High",
+   :source "a source"
+   :valid_time {}})
+
+(def campaign
+  {:id "http://ex.tld/ctia/campaign/campaign-b1f8e40a-0e99-48fc-bb12-32a65421cfb5"
+   :type "campaign"
+   :schema_version "1.0.0"
+   :campaign_type "anything goes here"
+   :valid_time {}
+   :title "campaign"
+   :description "description"
+   :short_description "short description"})
+
+;; non describable source entities
+(def attack-pattern
+  {:name "Clear Command History",
+   :description
+   "macOS and Linux both keep track of the commands users type in their terminal so that users can easily remember what they've done. These logs can be accessed in a few different ways. While logged in, this command history is tracked in a file pointed to by the environment variable <code>HISTFILE</code>. When a user logs off a system, this information is flushed to a file in the user's home directory called <code>~/.bash_history</code>. The benefit of this is that it allows users to go back to commands they've used before in different sessions. Since everything typed on the command-line is saved, passwords passed in on the command line are also saved. Adversaries can abuse this by searching these files for cleartext passwords. Additionally, adversaries can use a variety of methods to prevent their own commands from appear in these logs such as <code>unset HISTFILE</code>, <code>export HISTFILESIZE=0</code>, <code>history -c</code>, <code>rm ~/.bash_history</code>.\n\nDetection: User authentication, especially via remote terminal services like SSH, without new entries in that user's <code>~/.bash_history</code> is suspicious. Additionally, the modification of the HISTFILE and HISTFILESIZE environment variables or the removal/clearing of the <code>~/.bash_history</code> file are indicators of suspicious activity.\n\nPlatforms: Linux, MacOS, OS X\n\nData Sources: Authentication logs, File monitoring",
+   :schema_version "1.0.0",
+   :type "attack-pattern",
+   :external_ids
+   ["attack-pattern--b344346f-1321-4639-abd0-df3c95f1c0b0"],
+   :external_references
+   [{:source_name "mitre-attack",
+     :url "https://attack.mitre.org/wiki/Technique/T1146",
+     :external_id "T1146"}],
+   :x_mitre_platforms ["Linux" "MacOS" "OS X"],
+   :id
+   "https://intel.amp.cisco.com:443/ctia/attack-pattern/attack-pattern-22bb86b3-900f-4a3f-b429-189f64a47904",
+   :tlp "green",
+   :x_mitre_data_sources ["Authentication logs" "File monitoring"],
+   :kill_chain_phases
+   [{:kill_chain_name "mitre-attack", :phase_name "defense-evasion"}
+    {:kill_chain_name "lockheed-martin-cyber-kill-chain",
+     :phase_name "installation"}],
+   :groups ["tenzin"],
+   :timestamp "2017-07-28T15:03:13.641Z",
+   :owner "Tenzin"})
+
+(def malware
+  {:name "ViperRAT",
+   :description
+   "[ViperRAT](https://attack.mitre.org/software/S0506) is sophisticated surveillanceware that has been in operation since at least 2015 and was used to target the Israeli Defense Force.(Citation: Lookout ViperRAT) ",
+   :labels ["malware"],
+   :abstraction_level "family",
+   :schema_version "1.0.23",
+   :type "malware",
+   :source "MITRE Device Access",
+   :external_ids
+   ["malware--f666e17c-b290-43b3-8947-b96bd5148fbb"
+    "hydrant-bade42ca32e73a13467cccc7ed827662d4330537490dc80125c67580dea7b3d5"
+    "ATT&CK-S0506"],
+   :external_references
+   [{:source_name "mitre-attack",
+     :url "https://attack.mitre.org/software/S0506",
+     :external_id "S0506"}
+    {:source_name "Lookout ViperRAT",
+     :description
+     "M. Flossman. (2017, February 16). ViperRAT: The mobile APT targeting the Israeli Defense Force that should be on your radar. Retrieved September 11, 2020.",
+     :url "https://blog.lookout.com/viperrat-mobile-apt"}],
+   :source_uri "https://attack.mitre.org",
+   :id
+   "https://intel.amp.cisco.com:443/ctia/malware/malware-01d0f465-7fd2-4e44-a7dc-8e982fbef7a9",
+   :tlp "green",
+   :groups ["tenzin"],
+   :timestamp "2020-09-29T20:03:42.662Z",
+   :owner "Tenzin"})
+
+(def tool
+  {:name "PoshC2",
+   :description
+   "[PoshC2](https://attack.mitre.org/software/S0378) is an open source remote administration and post-exploitation framework that is publicly available on GitHub. The server-side components of the tool are primarily written in Python, while the implants are written in [PowerShell](https://attack.mitre.org/techniques/T1086). Although [PoshC2](https://attack.mitre.org/software/S0378) is primarily focused on Windows implantation, it does contain a basic Python dropper for Linux/macOS.(Citation: GitHub PoshC2)",
+   :labels ["tool"],
+   :schema_version "1.0.16",
+   :type "tool",
+   :x_mitre_aliases ["PoshC2"],
+   :source "MITRE Enterprise ATT&CK",
+   :external_ids
+   ["tool--4b57c098-f043-4da2-83ef-7588a6d426bc"
+    "hydrant-05856bc0326b15f3d99036be057f9f7d06794dc57cac2f8f9d21c365c03f4d44"
+    "ATT&CK-S0378"],
+   :external_references
+   [{:source_name "mitre-attack",
+     :url "https://attack.mitre.org/software/S0378",
+     :external_id "S0378"}
+    {:source_name "GitHub PoshC2",
+     :description
+     "Nettitude. (2018, July 23). Python Server for PoshC2. Retrieved April 23, 2019.",
+     :url "https://github.com/nettitude/PoshC2_Python"}],
+   :source_uri "https://attack.mitre.org",
+   :id
+   "https://intel.amp.cisco.com:443/ctia/tool/tool-0b32dbc5-7207-4ffd-a484-ec6465d62586",
+   :tlp "green",
+   :groups ["tenzin"],
+   :timestamp "2020-03-30T02:37:23.626Z",
+   :owner "Tenzin"})
+
+
+(defn check-unchanged-fields
+  [source migrated]
+  (is (= (dissoc source :name :title :description :short_description)
+         (dissoc migrated :name :title :description :short_description))
+      "field not related to entity description shall be preserved."))
+
+(defn mutate-fn
+  [mutated-fields]
+  (fn [entity]
+    (let [properties (shuffle mutated-fields)
+          nb-mutations (-> (count mutated-fields)
+                           inc
+                           rand-int)]
+      (->> (take nb-mutations properties)
+           (apply (partial dissoc entity))))))
+
+(defn mutant-generator
+  [mutated-fields]
+  (let [mutate (mutate-fn mutated-fields)]
+    (fn [n entity] (repeatedly n #(mutate entity)))))
+
+(deftest migrate-non-describable-test
+  (testing "describe shall properly migrate non describable entities of type attack-pattern, malware and tool"
+    (let [gen-mutants (mutant-generator [:name :description])
+          source-entities (mapcat #(gen-mutants 5 %) [attack-pattern malware tool])
+          target-entities (map sut/describe source-entities)]
+      (doseq [[source migrated] (zipmap source-entities target-entities)]
+        (let [{src-name :name
+               src-desc :description} source
+
+              {migrated-name :name
+               migrated-title :title
+               migrated-desc :description
+               migrated-short-desc :short_description} migrated]
+
+          (is (nil? migrated-name))
+          (is (seq migrated-title))
+          (is (seq migrated-desc))
+          (is (seq migrated-short-desc))
+
+          (if src-name
+            (is (= src-name migrated-title)
+                "the name key must be renamed into title")
+            (is (= "No title provided" migrated-title)
+                "missing name on corrupted data should be fixed."))
+
+          (when (and (seq src-name) (nil? src-desc))
+            (is (= migrated-title migrated-short-desc)
+                "when provided, the title should be used as short_description on non describable entities"))
+
+          (when (and (nil? src-name) (nil? src-desc))
+            (is (= "No description provided" migrated-desc migrated-short-desc)))
+
+          (check-unchanged-fields source migrated))))))
+
+(deftest migrate-describable-test
+  (testing "describe shall properly migrate describable entities"
+    (let [gen-mutants (mutant-generator [:title :description :short_description])
+          source-entities (mapcat #(gen-mutants 10 %) [actor campaign])
+          target-entities (map sut/describe source-entities)]
+      (doseq [[source migrated] (zipmap source-entities target-entities)]
+        (let [{src-title :title
+               src-desc :description
+               src-short-desc :short_description} source
+
+              {migrated-title :title
+               migrated-desc :description
+               migrated-short-desc :short_description} migrated]
+
+          (is (seq migrated-title))
+          (is (seq migrated-desc))
+          (is (seq migrated-short-desc))
+
+          (when (seq src-title)
+            (is (= src-title migrated-title)))
+
+          (when (seq src-desc)
+            (is (= src-desc migrated-desc)))
+
+          (when (seq src-short-desc)
+            (is (= src-short-desc migrated-short-desc)))
+
+          (when (nil? src-title)
+            (is (= "No title provided" migrated-title)
+                "missing name on corrupted data should be fixed."))
+
+          (when (and (seq src-title) (nil? src-desc) (nil? src-short-desc))
+            (is (= migrated-title migrated-short-desc)
+                "when provided, the title should be used as short_description on non describable entities"))
+
+          (check-unchanged-fields source migrated))))))

--- a/test/ctia/task/migration/migrations/investigation_actions_test.clj
+++ b/test/ctia/task/migration/migrations/investigation_actions_test.clj
@@ -1,0 +1,82 @@
+(ns ctia.task.migration.migrations.investigation-actions-test
+  (:require [ctia.task.migration.migrations.investigation-actions :as sut]
+            [cheshire.core :as json]
+            [clojure.test :refer [deftest is]]))
+
+(deftest derive-action-data-test
+  (is (= sut/empty-action-data
+         (sut/derive-action-data {:type "judgement"
+                                  :observable {:type "pki-serial" :value "12345"}})))
+
+  (is (= sut/empty-action-data
+         (sut/derive-action-data {:type "collect"
+                                  :result []})))
+  (is (= {:object_ids #{}
+          :investigated_observables
+          #{"sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
+            "sha256:ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"}
+          :targets #{}}
+         (sut/derive-action-data {:type "collect"
+                                  :result [{:value "585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
+                                            :type "sha256"}
+                                           {:value "ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"
+                                            :type "sha256"}]})))
+
+  (is (= {:object_ids #{"https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
+                        "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
+                        "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}
+          :investigated_observables []
+          :targets #{}}
+         (sut/derive-action-data
+          {:type "investigate",
+           :result {:data [{:module "AMP Global Intel",
+                            :module-type "CTIAInvestigateModule",
+                            :data {:indicators {:docs [{:id "https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"}]}
+                                   :relationships {:docs [{:id "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}]}
+                                   :sightings {:docs [{:id "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"}]}}}]}})))
+
+
+  (is (= {:object_ids #{"https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
+                        "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
+                        "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"},
+          :investigated_observables [],
+          :targets #{{:type "endpoint",
+                      :observables [{:value "Demo_iOS_3", :type "hostname"}],
+                      :observed_time {:start_time "2019-04-01T20:45:11.000Z"},
+                      :os "iOS 10.3 (1)"}
+                     {:type "endpoint",
+                      :observables [{:value "Demo_iOS_1", :type "hostname"}],
+                      :observed_time {:start_time "2019-03-27T15:30:24.000Z"},
+                      :os "iOS 10.3 (1)"}}}
+         (sut/derive-action-data
+          {:type "investigate",
+           :result {:data [{:module "AMP Global Intel",
+                            :module-type "CTIAInvestigateModule",
+                            :data {:indicators {:docs [{:id "https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
+                                                        :targets [{:type "endpoint",
+                                                                   :observables [{:value "Demo_iOS_3", :type "hostname"}]
+                                                                   :observed_time {:start_time "2019-04-01T20:45:11.000Z"}
+                                                                   :os "iOS 10.3 (1)"}]}]}
+                                   :relationships {:docs [{:id "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}]}
+                                   :sightings {:docs [{:id "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
+                                                       :targets [{:type "endpoint",
+                                                                  :observables [{:value "Demo_iOS_1", :type "hostname"}]
+                                                                  :observed_time {:start_time "2019-03-27T15:30:24.000Z"},
+                                                                  :os "iOS 10.3 (1)"}]}]}}}]}}))))
+
+(deftest migrate-action-data-test
+   (let [actions [{:type "collect"
+                   :result [{:value "585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
+                             :type "sha256"}
+                            {:value "ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"
+                             :type "sha256"}]}]
+         actions-json (json/encode actions)
+         entities [{:type "investigation"
+                    :actions actions-json}]]
+     (is (= [{:type "investigation",
+              :actions actions-json
+              :object_ids #{}
+              :investigated_observables #{"sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
+                                          "sha256:ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"}
+              :targets #{}}]
+            (into [] sut/migrate-action-data entities)))))

--- a/test/ctia/task/migration/migrations_test.clj
+++ b/test/ctia/task/migration/migrations_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer [deftest is]]
             [ctia.entity.incident :refer [StoredIncident]]
             [ctia.task.migration.migrations :as sut]
-            [cheshire.core :as json]
             [schema.core :as s]))
 
 (deftest add-groups-test
@@ -310,80 +309,3 @@
                        verdict
                        casebook])))))
 
-(deftest derive-action-data-test
-  (is (= sut/empty-action-data
-         (sut/derive-action-data {:type "judgement"
-                                  :observable {:type "pki-serial" :value "12345"}})))
-
-  (is (= sut/empty-action-data
-         (sut/derive-action-data {:type "collect"
-                                  :result []})))
-  (is (= {:object_ids #{}
-          :investigated_observables
-          #{"sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
-            "sha256:ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"}
-          :targets #{}}
-         (sut/derive-action-data {:type "collect"
-                                  :result [{:value "585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
-                                            :type "sha256"}
-                                           {:value "ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"
-                                            :type "sha256"}]})))
-
-  (is (= {:object_ids #{"https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
-                        "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
-                        "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}
-          :investigated_observables []
-          :targets #{}}
-         (sut/derive-action-data
-          {:type "investigate",
-           :result {:data [{:module "AMP Global Intel",
-                            :module-type "CTIAInvestigateModule",
-                            :data {:indicators {:docs [{:id "https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"}]}
-                                   :relationships {:docs [{:id "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}]}
-                                   :sightings {:docs [{:id "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"}]}}}]}})))
-
-
-  (is (= {:object_ids #{"https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
-                        "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
-                        "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"},
-          :investigated_observables [],
-          :targets #{{:type "endpoint",
-                      :observables [{:value "Demo_iOS_3", :type "hostname"}],
-                      :observed_time {:start_time "2019-04-01T20:45:11.000Z"},
-                      :os "iOS 10.3 (1)"}
-                     {:type "endpoint",
-                      :observables [{:value "Demo_iOS_1", :type "hostname"}],
-                      :observed_time {:start_time "2019-03-27T15:30:24.000Z"},
-                      :os "iOS 10.3 (1)"}}}
-         (sut/derive-action-data
-          {:type "investigate",
-           :result {:data [{:module "AMP Global Intel",
-                            :module-type "CTIAInvestigateModule",
-                            :data {:indicators {:docs [{:id "https://intel.test.iroh.site:443/ctia/indicator/indicator-97c97157-6592-43e3-a54e-f126b4950787"
-                                                        :targets [{:type "endpoint",
-                                                                   :observables [{:value "Demo_iOS_3", :type "hostname"}]
-                                                                   :observed_time {:start_time "2019-04-01T20:45:11.000Z"}
-                                                                   :os "iOS 10.3 (1)"}]}]}
-                                   :relationships {:docs [{:id "https://intel.test.iroh.site:443/ctia/relationship/relationship-c3c89cb9-b09a-4fe3-b92a-5bae7faca36a"}]}
-                                   :sightings {:docs [{:id "https://intel.test.iroh.site:443/ctia/sighting/sighting-b1a75bb0-d10d-47e6-b70d-915a24f66a0b"
-                                                       :targets [{:type "endpoint",
-                                                                  :observables [{:value "Demo_iOS_1", :type "hostname"}]
-                                                                  :observed_time {:start_time "2019-03-27T15:30:24.000Z"},
-                                                                  :os "iOS 10.3 (1)"}]}]}}}]}}))))
-
-(deftest migrate-action-data-test
-   (let [actions [{:type "collect"
-                   :result [{:value "585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
-                             :type "sha256"}
-                            {:value "ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"
-                             :type "sha256"}]}]
-         actions-json (json/encode actions)
-         entities [{:type "investigation"
-                    :actions actions-json}]]
-     (is (= [{:type "investigation",
-              :actions actions-json
-              :object_ids #{}
-              :investigated_observables #{"sha256:585c2a90e4928f67af7be2d0bdc282b7eb6c90113ae588461a441d31b5268e88"
-                                          "sha256:ac517bb701f20fe2f1826a0170c8ba7ba3f0632c77d89ed2dfe1883f588e9d1f"}
-              :targets #{}}]
-            (into [] sut/migrate-action-data entities)))))

--- a/test/data/attack-pattern.graphql
+++ b/test/data/attack-pattern.graphql
@@ -85,8 +85,9 @@ fragment attackPatternFields on AttackPattern {
   tlp
   source
   source_uri
-  name
+  title
   description
+  short_description
   kill_chain_phases {
     ...killChainPhaseFields
   }

--- a/test/data/malware.graphql
+++ b/test/data/malware.graphql
@@ -85,9 +85,10 @@ fragment malwareFields on Malware {
   tlp
   source
   source_uri
-  name
   labels
+  title
   description
+  short_description
   kill_chain_phases {
     ...killChainPhaseFields
   }

--- a/test/data/tool.graphql
+++ b/test/data/tool.graphql
@@ -85,9 +85,10 @@ fragment toolFields on Tool {
   tlp
   source
   source_uri
-  name
   labels
+  title
   description
+  short_description
   kill_chain_phases {
     ...killChainPhaseFields
   }


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/threatgrid/ctim/pull/320
> Close #https://github.com/threatgrid/iroh/issues/4058

Makes Malware, Tool and Attack Pattern described entities and provide corresponding migration.
Campaing and Actor are also changed from describable to described entities making `title`, `description` and `short_description` required.

Most of the edits in `ctia.task.migration.migrations` are moving code to a separate `ns`.

<a name="qa">[§](#qa)</a> QA
============================

After the migration, Malware, Tool and Attack Pattern  entities do not have anymore the field name and must now have `title`, `description` and `short_description` fields. For Campaing and Actor entities these fields are no more optional but required.

<a name="ops">[§](#ops)</a> Ops
===============================

This schema change require a migration of the three corresponding entities. See [migration issue in tenzin-config](https://github.com/threatgrid/tenzin-config/issues/369).

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Makes Malware, Tool and Attack Pattern are now described entities with `title`, `description` and `short_description` fields.
```
