### PR TITLE
fix bad entity owner in events / use identity for event owner

### DIFF
--- a/src/ctia/entity/event/obj_to_event.clj
+++ b/src/ctia/entity/event/obj_to_event.clj
@@ -1,8 +1,6 @@
 (ns ctia.entity.event.obj-to-event
   (:require [ctia.entity.event.schemas :as vs]
-            [clojure.data :refer [diff]]
             [clojure.set :as set]
-            [clj-momo.lib.time :as time]
             [clj-momo.lib.clj-time.core :as t]
             [schema.core :as s]))
 
@@ -17,33 +15,6 @@
    :type "event"
    :tlp (:tlp object)
    :event_type vs/CreateEventType})
-
-(s/defn ^:deprecated diff-to-list-of-changes :- [vs/Update]
-  "Deprecated in favor of `update-changes`.
-
-  Given the output of a `diff` between maps return a list
-  of edit distance operation under the form of an Update map"
-  [[diff-after diff-before _]]
-  (filter
-   (fn [{:keys [change]}]
-     (seq change))
-   (concat
-    (map (fn [k]
-           (if (contains? diff-after k)
-             {:field k
-              :action "modified"
-              :change {:before (get diff-before k)
-                       :after (get diff-after k)}}
-             {:field k
-              :action "deleted"
-              :change {}}))
-         (keys diff-before))
-    (map (fn [k]
-           {:field k
-            :action "added"
-            :change {}})
-         (remove #(contains? diff-before %)
-                 (keys diff-after))))))
 
 (defn update-changes
   "Returns a list of changes for an Update event"
@@ -88,8 +59,8 @@
    The two arguments `object` and `prev-object` should have the same schema.
    The fields should contain enough information to retrieve all information,
    but the complete object is given for simplicity."
-  [object prev-object event-id]
-  {:owner (:owner object)
+  [object prev-object event-id owner]
+  {:owner owner
    :groups (:groups object)
    :entity object
    :timestamp (t/internal-now)
@@ -103,8 +74,8 @@
 
 (s/defn to-delete-event :- vs/Event
   "transform an object (generally a `StoredObject`) to its corresponding `Event`"
-  [object id]
-  {:owner (:owner object)
+  [object id owner]
+  {:owner owner
    :groups (:groups object)
    :entity object
    :timestamp (t/internal-now)

--- a/src/ctia/entity/event/obj_to_event.clj
+++ b/src/ctia/entity/event/obj_to_event.clj
@@ -6,8 +6,8 @@
 
 (s/defn to-create-event :- vs/Event
   "Create a CreateEvent from a StoredX object"
-  [object id]
-  {:owner (:owner object)
+  [object id owner]
+  {:owner owner
    :groups (:groups object)
    :entity object
    :timestamp (t/internal-now)

--- a/src/ctia/events_service_core.clj
+++ b/src/ctia/events_service_core.clj
@@ -2,10 +2,8 @@
   (:require [clj-momo.lib.time :as time]
             [ctia.lib.async :as la]
             [ctia.entity.event.schemas :as es]
-            [ctim.schemas.common :as c]
             [clojure.core.async :as a :refer [go-loop alt! chan tap]]
-            [schema.core :as s]
-            [schema-tools.core :as st])
+            [schema.core :as s])
   (:import [clojure.core.async.impl.protocols Channel]
            [java.util Map]))
 
@@ -28,7 +26,7 @@
    (send-event context central-channel event))
   ([_context_
     {ch :chan :as echan} :- la/ChannelData
-    {:keys [owner timestamp http-params] :as event} :- es/Event]
+    {:keys [owner timestamp] :as event} :- es/Event]
    (assert owner "Events cannot be registered without user info")
    (let [event (if timestamp event (assoc event :timestamp (time/now)))]
      (a/>!! ch event))))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -328,7 +328,7 @@
   "Builds a mapping table between short and long IDs"
   [entities long-id-fn]
   (->> entities
-       (filter #(nil? (:error %)))
+       (remove :error)
        (map (fn [{:keys [_ id] :as entity}]
               [id (:id (long-id-fn entity))]))
        (into {})))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -240,10 +240,9 @@
           create-event (fn [entity]
                          (let [event-id (make-id "event")]
                            (try
-                             (case flow-type
-                               :create (create-event-fn entity event-id)
-                               :update (create-event-fn entity prev-entity event-id login)
-                               :delete (create-event-fn entity event-id login))
+                             (if (= flow-type :update)
+                               (create-event-fn entity prev-entity event-id login)
+                               (create-event-fn entity event-id login))
                              (catch Throwable e
                                (log/error "Could not create event" e)
                                (throw (ex-info "Could not create event"

--- a/test/ctia/entity/event/obj_to_event_test.clj
+++ b/test/ctia/entity/event/obj_to_event_test.clj
@@ -12,19 +12,22 @@
            (:fields
              (o2e/to-update-event
                (assoc old :new "bar") old
-               "foo"))))
+               "foo"
+               "john-doe"))))
     (is (= [{:field :data, :action "deleted", :change {:before 2}}]
            (:fields
              (o2e/to-update-event
                (dissoc old :data) old
-               "foo"))))
+               "foo"
+               "john-doe"))))
     (is (= [{:field :data, :action "modified",
              :change {:before 2
                       :after 3}}]
            (:fields
              (o2e/to-update-event
                (assoc old :data 3) old
-               "foo"))))
+               "foo"
+               "john-doe"))))
     (is (= [{:field :data,
              :action "modified",
              :change {:before [1], :after [1 2]}}]
@@ -32,7 +35,8 @@
              (o2e/to-update-event
                (assoc old :data [1 2])
                (assoc old :data [1])
-               "foo"))))
+               "foo"
+               "john-doe"))))
     (is (= [{:action "added"
              :field :added
              :change {:after 1}}
@@ -50,4 +54,5 @@
                           :added 1)
                    (dissoc :removed))
                (assoc old :data {} :removed 1)
-               "foo"))))))
+               "foo"
+               "john-doe"))))))

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -86,8 +86,7 @@
                                        :tlp "amber"
                                        :description "my description")
                           :headers {"Authorization" "user3"})
-                    {updated-incident :parsed-body
-                     updated-incident-status :status}
+                    {updated-incident-status :status}
                     (fixture-with-fixed-time
                      (time/timestamp "2042-01-02")
                      (fn []
@@ -109,8 +108,7 @@
                                        :tlp "amber")
                           :headers {"Authorization" "user1"})
 
-                    {incident-casebook-link :parsed-body
-                     incident-casebook-link-status :status}
+                    {incident-casebook-link-status :status}
                     (POST app
                           (format "ctia/%s/%s/link"
                                   "incident"
@@ -119,15 +117,14 @@
                                       :short-id))
                           :body {:casebook_id (:id casebook)}
                           :headers {"Authorization" "user1"})
-                    {incident-delete-body :parsed-body
-                     incident-delete-status :status}
+                    {incident-delete-status :status}
                     (DELETE app
                             (format "ctia/%s/%s"
                                     "incident"
                                     (-> (:id incident)
                                         id/long-id->id
                                         :short-id))
-                            :headers {"Authorization" "user1"})
+                            :headers {"Authorization" "user2"})
                     uri-timeline-incident-user1
                     (->> (:id incident)
                          uri/uri-encode
@@ -176,7 +173,7 @@
 
                 (testing "event timeline should contain all actions by user, with respect to their visibility"
 
-                  (is (= '(1 3) (map :count timeline1-body)))
+                  (is (= '(1 2 1) (map :count timeline1-body)))
                   (is (= #{"user1" "user2"}
                          (set (map :owner timeline1-body)))
                       "owners should differ")
@@ -184,7 +181,8 @@
                   (is (empty? timeline4-body))
                   (is (every? #(= "user3" (:owner %))
                               timeline5-body))
-                  (is (= '(1) (map :count timeline5-body))))
+                  (is (= '(1) (map :count timeline5-body)))
+                  (is (= timeline1-body timeline2-body)))
 
                 (testing "should be able to list all related incident events filtered with Access control"
                   (let [q (uri/uri-encode
@@ -250,7 +248,7 @@
                               :tlp "amber",
                               :groups ["group1"],
                               :confidence "High",
-                              :owner "user2"},
+                              :owner "user1"},
                              :id
                              (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111116"
                                      port),
@@ -266,10 +264,7 @@
                                :action "modified",
                                :change
                                {:before "2042-01-01T00:00:00.000Z",
-                                :after "2042-01-02T00:00:00.000Z"}}
-                              {:field  :owner,
-                               :action "modified",
-                               :change {:before "user1", :after "user2"}}]}
+                                :after "2042-01-02T00:00:00.000Z"}}]}
                             {:owner "user1",
                              :groups ["group1"],
                              :timestamp #inst "2042-01-01T00:00:00.000-00:00",
@@ -298,7 +293,7 @@
                                      port),
                              :type "event",
                              :event_type :record-created}
-                            {:owner "user1",
+                            {:owner "user2",
                              :groups ["group1"],
                              :timestamp #inst "2042-01-01T00:00:00.000-00:00",
                              :tlp "amber"

--- a/test/ctia/events_test.clj
+++ b/test/ctia/events_test.clj
@@ -3,8 +3,7 @@
    [clojure.test :refer [deftest
                          is
                          testing
-                         use-fixtures
-                         join-fixtures]]
+                         use-fixtures]]
    [clojure.core.async :refer [<!! chan poll! tap]]
    [ctia.entity.event.obj-to-event :as o2e]
    [ctia.lib.async :as la]
@@ -19,64 +18,70 @@
   helpers/fixture-ctia-fast)
 
 (deftest test-send-event
-  "Tests the basic action of sending an event"
-  (let [app (helpers/get-current-app)
-        {:keys [send-event]} (helpers/get-service-map app :EventsService)
+  (testing "Tests the basic action of sending an event"
+    (let [app (helpers/get-current-app)
+          {:keys [send-event]} (helpers/get-service-map app :EventsService)
 
-        {b :chan-buf c :chan m :mult :as ec} (la/new-channel)
-        output (chan)]
-    (try
-      (tap m output)
-      (send-event ec (o2e/to-create-event
+          {m :mult :as ec} (la/new-channel)
+          output (chan)]
+      (try
+        (tap m output)
+        (send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-1"
                          :tlp "white"
                          :type :test
                          :data 1}
-                        "test-1"))
-      (send-event ec (o2e/to-create-event
+                        "test-1"
+                        "tester"))
+        (send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-2"
                          :tlp "white"
                          :type :test
                          :data 2}
-                        "test-2"))
-      (send-event ec (o2e/to-create-event
+                        "test-2"
+                        "tester"))
+        (send-event ec (o2e/to-create-event
                         {:owner "tester"
                          :id "test-3"
                          :tlp "white"
                          :type :test
                          :data 3}
-                        "test-3"))
-      (is (= 1 (-> (<!! output) :entity :data)))
-      (is (= 2 (-> (<!! output) :entity :data)))
-      (is (= 3 (-> (<!! output) :entity :data)))
-      (finally
-        (la/shutdown-channel 100 ec)))))
+                        "test-3"
+                        "tester"))
+        (is (= 1 (-> (<!! output) :entity :data)))
+        (is (= 2 (-> (<!! output) :entity :data)))
+        (is (= 3 (-> (<!! output) :entity :data)))
+        (finally
+          (la/shutdown-channel 100 ec))))))
 
 (deftest test-central-events
-  "Tests the basic action of sending an event to the central channel"
-  (let [app (helpers/get-current-app)
-        {:keys [central-channel
-                send-event]} (helpers/get-service-map app :EventsService)
+  (testing
+      "Tests the basic action of sending an event to the central channel"
+    (let [app (helpers/get-current-app)
+          {:keys [central-channel
+                  send-event]} (helpers/get-service-map app :EventsService)
 
-        {b :chan-buf c :chan m :mult} (central-channel)
-        output (chan)]
-    (tap m output)
-    (send-event (o2e/to-create-event
+          {b :chan-buf c :chan m :mult} (central-channel)
+          output (chan)]
+      (tap m output)
+      (send-event (o2e/to-create-event
                    {:owner "tester"
                     :id "test-1"
                     :tlp "white"
                     :type :test
                     :data 1}
-                   "test-1"))
-    (send-event (o2e/to-create-event
+                   "test-1"
+                   "tester"))
+      (send-event (o2e/to-create-event
                    {:owner "teseter"
                     :id "test-2"
                     :tlp "white"
                     :type :test
                     :data 2}
-                   "test-2"))
-    (is (= 1 (-> (<!! output) :entity :data)))
-    (is (= 2 (-> (<!! output) :entity :data)))
-    (is (nil? (poll! output)))))
+                   "test-2"
+                   "tester"))
+      (is (= 1 (-> (<!! output) :entity :data)))
+      (is (= 2 (-> (<!! output) :entity :data)))
+      (is (nil? (poll! output))))))

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -86,14 +86,15 @@
         "store-fn shall be applied to every entities")))
 
 (deftest create-events-test
-  (testing "flow-type :update should update the owner"
+  (testing "flow-type :update should preserve the entity owner"
     (let [updated-entities (atom [])
           flow-map         {:services        {:ConfigService {:get-in-config (constantly true)}}
-                            :create-event-fn (fn [entity _ _] (swap! updated-entities conj entity))
+                            :create-event-fn (fn [entity _ _ _] (swap! updated-entities conj entity))
                             :identity        (map->Identity {:login "test-user"})
                             :flow-type       :update
                             :entities        [{:one 1 :owner "Huey"}
                                               {:two 2 :owner "Dewey"}
                                               {:three 3 :owner "Louie"}]}]
      (#'flows.crud/create-events flow-map)
-     (is (every? #(-> % :owner (= "test-user")) @updated-entities)))))
+     (is (= #{"Huey" "Dewey" "Louie"}
+            (set (map :owner @updated-entities)))))))

--- a/test/ctia/logger_test.clj
+++ b/test/ctia/logger_test.clj
@@ -18,9 +18,9 @@
   (let [app (test-helpers/get-current-app)
         {:keys [send-event]} (test-helpers/get-service-map app :EventsService)
         sb (StringBuilder.)
-        patched-log (fn [logger
-                         level
-                         throwable
+        patched-log (fn [_logger
+                         _level
+                         _throwable
                          message]
                       (.append sb message)
                       (.append sb "\n"))]
@@ -32,7 +32,8 @@
                       :type :test
                       :tlp "green"
                       :data 1}
-                     "test-1"))
+                     "test-1"
+                     "tester"))
       (send-event (o2e/to-create-event
                      {:owner "tester"
                       :groups ["foo"]
@@ -40,7 +41,8 @@
                       :type :test
                       :tlp "green"
                       :data 2}
-                     "test-2"))
+                     "test-2"
+                     "tester"))
       (Thread/sleep 100)   ;; wait until the go loop is done
       (let [scrubbed (-> (str sb)
                          (str/replace #"#inst \"[^\"]*\"" "#inst \"\"")

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -18,7 +18,7 @@
              incidents-2 (->> (fixt/n-doc incident-minimal 10)
                               (map #(assoc % :source "incident-2-source")))
              incidents (concat incidents-1 incidents-2)
-             bulk-result (helpers/POST-bulk app {:incidents incidents})]
+             _ (helpers/POST-bulk app {:incidents incidents})]
          (Thread/sleep 1500) ;; ensure index refresh
          (is
           (= (count incidents)


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/threatgrid/iroh/issues/4668
> Related #https://github.com/threatgrid/iroh/issues/3596

This PR fixes the event owner of an updated / deleted entity and uses current identity to assign owner to the event ([my initial recommendation](https://github.com/threatgrid/iroh/issues/3596#issuecomment-740155428) was misleading).

<a name="qa">[§](#qa)</a> QA
============================

Let 2 users: user1 and user2 in the same org.

1) create an entity of any type with user1 (tlp amber or green)
==> check that a corresponding create event is created with user1 as owner and that the `entity.owner` field is user1.

2) update this entity with user2
==> check that a corresponding update event is created with user2 as owner of the event and the value of `entity.owner` is not changed (= user1).

3) delete this entity with user2
==> check that a corresponding delete event is created with user2 as owner of the event and the value of `entity.owner` is not changed (= user1).

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: CTIA, fix event owner on entity update / delete.
```
