### PR TITLE
Remove disabled entities from GraphQl route

### DIFF
--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -13,8 +13,11 @@
   would not be visible in Swagger console."
   (feature-flags [this]
     "Returns all feature flags defined in the config")
-  (enabled? [this key]
-    "Returns `true` unless entity key is marked as Disabled in properties config"))
+  (enabled?
+    [this]
+    [this key]
+    "When called with no provided key - returns all entities except those that are explicitly disabled in properties config.
+     If the entity key argument used, it returns `true` unless the entity marked as disabled in properties config."))
 
 (tk/defservice features-service
   FeaturesService
@@ -33,4 +36,9 @@
        (map keyword x)
        (set x)
        (contains? x key)
-       (not x)))))
+       (not x))))
+  (enabled?
+   [this]
+   (->> (entities/all-entities)
+        keys
+        (filter (partial enabled? this)))))

--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -1,6 +1,8 @@
 (ns ctia.features-service
-  (:require [puppetlabs.trapperkeeper.core :as tk]
-            [clojure.string :as string]))
+  (:require
+   [clojure.string :as string]
+   [ctia.entity.entities :as entities]
+   [puppetlabs.trapperkeeper.core :as tk]))
 
 (defprotocol FeaturesService
   "Service to read configuration properties under [:ctia :features] key in config.
@@ -21,10 +23,14 @@
     (get-in-config [:ctia :features]))
   (enabled?
    [this key]
-   (as-> (get-in-config [:ctia :features :disable]) x
-     (str x)
-     (string/split x #",")
-     (map keyword x)
-     (set x)
-     (contains? x key)
-     (not x))))
+   (when (-> (entities/all-entities)
+             keys
+             set
+             (contains? key))
+     (as-> (get-in-config [:ctia :features :disable]) x
+       (str x)
+       (string/split x #",")
+       (map keyword x)
+       (set x)
+       (contains? x key)
+       (not x)))))

--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -25,6 +25,11 @@
   (feature-flags [this]
     (get-in-config [:ctia :features]))
   (enabled?
+   [this]
+   (->> (entities/all-entities)
+        keys
+        (filter (partial enabled? this))))
+  (enabled?
    [this key]
    (when (-> (entities/all-entities)
              keys
@@ -36,9 +41,4 @@
        (map keyword x)
        (set x)
        (contains? x key)
-       (not x))))
-  (enabled?
-   [this]
-   (->> (entities/all-entities)
-        keys
-        (filter (partial enabled? this)))))
+       (not x)))))

--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -13,22 +13,14 @@
   would not be visible in Swagger console."
   (feature-flags [this]
     "Returns all feature flags defined in the config")
-  (enabled?
-    [this]
-    [this key]
-    "When called with no provided key - returns all entities except those that are explicitly disabled in properties config.
-     If the entity key argument used, it returns `true` unless the entity marked as disabled in properties config."))
+  (enabled? [this key]
+    "Returns `true` unless entity key is marked as Disabled in properties config"))
 
 (tk/defservice features-service
   FeaturesService
   [[:ConfigService get-in-config]]
   (feature-flags [this]
     (get-in-config [:ctia :features]))
-  (enabled?
-   [this]
-   (->> (entities/all-entities)
-        keys
-        (filter (partial enabled? this))))
   (enabled?
    [this key]
    (when (-> (entities/all-entities)

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -1,10 +1,12 @@
 (ns ctia.graphql.schemas
   (:require
+   [clojure.string :as string]
    [ctia.entity.asset-mapping.graphql-schemas :as asset-mapping :refer [AssetMappingType AssetMappingConnectionType]]
    [ctia.entity.asset-properties.graphql-schemas :as asset-properties :refer [AssetPropertiesType AssetPropertiesConnectionType]]
    [ctia.entity.asset.graphql-schemas :as asset :refer [AssetType AssetConnectionType]]
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
+   [ctia.entity.entities :as entities]
    [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
    [ctia.entity.indicator :as indicator :refer [IndicatorConnectionType IndicatorType]]
    [ctia.entity.investigation.graphql-schemas :as investigation :refer [InvestigationConnectionType InvestigationType]]
@@ -42,137 +44,167 @@
 (def search-by-id-args
   {:id {:type (g/non-null Scalars/GraphQLString)}})
 
-(s/def QueryType :- (RealizeFnResult GraphQLObjectType)
+(s/def graphql-fields :- g/GraphQLFields
+  {:asset            {:type    AssetType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :asset)}
+   :assets           {:type    AssetConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      asset/asset-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :asset)}
+   :asset_mapping    {:type    AssetMappingType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :asset-mapping)}
+   :asset_mappings   {:type    AssetMappingConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      asset-mapping/asset-mapping-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :asset-mapping)}
+   :asset_properties {:type    AssetPropertiesConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      asset-properties/asset-properties-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :asset-properties)}
+   :attack_pattern   {:type    AttackPatternType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :attack-pattern)}
+   :attack_patterns  {:type    AttackPatternConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      attack-pattern/attack-pattern-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :attack-pattern)}
+   :casebook         {:type    CasebookType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :casebook)}
+   :casebooks        {:type    CasebookConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      casebook/casebook-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :casebook)}
+   :incident         {:type    IncidentType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :incident)}
+   :incidents        {:type    IncidentConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      incident/incident-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :incident)}
+   :indicator        {:type    IndicatorType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :indicator)}
+   :indicators       {:type    IndicatorConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      indicator/indicator-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :indicator)}
+   :investigation    {:type    InvestigationType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :investigation)}
+   :investigations   {:type    InvestigationConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      investigation/investigation-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :investigation)}
+   :judgement        {:type    JudgementType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :judgement)}
+   :judgements       {:type    JudgementConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      judgement/judgement-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :judgement)}
+   :malware          {:type    MalwareType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :malware)}
+   :malwares         {:type    MalwareConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      malware/malware-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :malware)}
+   :observable       {:type    ObservableType
+                      :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
+                                :value {:type (g/non-null Scalars/GraphQLString)}}
+                      :resolve (fn [_ args _ _] args)}
+   :sighting         {:type    SightingType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :sighting)}
+   :sightings        {:type    SightingConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      sighting/sighting-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :sighting)}
+   :target_record    {:type    TargetRecordType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :target-record)}
+   :target_records   {:type    TargetRecordConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      target-record/target-record-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :target-record)}
+   :tool             {:type    ToolType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :tool)}
+   :tools            {:type    ToolConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      tool/tool-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :tool)}
+   :vulnerability    {:type    VulnerabilityType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :vulnerability)}
+   :vulnerabilities  {:type    VulnerabilityConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      vulnerability/vulnerability-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :vulnerability)}
+   :weakness         {:type    WeaknessType
+                      :args    search-by-id-args
+                      :resolve (res/entity-by-id-resolver :weakness)}
+   :weaknesses       {:type    WeaknessConnectionType
+                      :args    (merge common/lucene-query-arguments
+                                      weakness/weakness-order-arg
+                                      p/connection-arguments)
+                      :resolve (res/search-entity-resolver :weakness)}})
+
+(defn- dash->underscore [k]
+  (-> k
+      name
+      (string/replace "-" "_")
+      keyword))
+
+(defn- disabled-entities
+  [{{:keys [enabled?]} :FeaturesService}]
+  (->> (entities/all-entities)
+       keys
+       (filter #(not (enabled? %)))))
+
+(defn- remove-disabled
+  "Removes GraphQl fields of keys of disabled entities."
+  [services graphql-fields]
+  (let [+plurals (reduce
+                  (fn [a n] (let [k      (dash->underscore n)
+                                  plural (-> k name (str "s") keyword)]
+                              (into a [k plural])))
+                  []
+                  (disabled-entities services))]
+    (apply dissoc graphql-fields +plurals)))
+
+(s/defn QueryType :- (RealizeFnResult GraphQLObjectType)
+  [services :- APIHandlerServices]
   (g/new-object
    "Root"
    ""
    []
-   {:asset            {:type    AssetType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :asset)}
-    :assets           {:type    AssetConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       asset/asset-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :asset)}
-    :asset_mapping    {:type    AssetMappingType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :asset-mapping)}
-    :asset_mappings   {:type    AssetMappingConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       asset-mapping/asset-mapping-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :asset-mapping)}
-    :asset_properties {:type    AssetPropertiesConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       asset-properties/asset-properties-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :asset-properties)}
-    :attack_pattern   {:type    AttackPatternType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :attack-pattern)}
-    :attack_patterns  {:type    AttackPatternConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       attack-pattern/attack-pattern-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :attack-pattern)}
-    :casebook         {:type    CasebookType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :casebook)}
-    :casebooks        {:type    CasebookConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       casebook/casebook-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :casebook)}
-    :incident         {:type    IncidentType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :incident)}
-    :incidents        {:type    IncidentConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       incident/incident-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :incident)}
-    :indicator        {:type    IndicatorType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :indicator)}
-    :indicators       {:type    IndicatorConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       indicator/indicator-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :indicator)}
-    :investigation    {:type    InvestigationType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :investigation)}
-    :investigations   {:type    InvestigationConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       investigation/investigation-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :investigation)}
-    :judgement        {:type    JudgementType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :judgement)}
-    :judgements       {:type    JudgementConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       judgement/judgement-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :judgement)}
-    :malware          {:type    MalwareType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :malware)}
-    :malwares         {:type    MalwareConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       malware/malware-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :malware)}
-    :observable       {:type    ObservableType
-                       :args    {:type  {:type (g/non-null Scalars/GraphQLString)}
-                                 :value {:type (g/non-null Scalars/GraphQLString)}}
-                       :resolve (fn [_ args _ _] args)}
-    :sighting         {:type    SightingType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :sighting)}
-    :sightings        {:type    SightingConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       sighting/sighting-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :sighting)}
-    :target_record    {:type    TargetRecordType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :target-record)}
-    :target_records   {:type    TargetRecordConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       target-record/target-record-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :target-record)}
-    :tool             {:type    ToolType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :tool)}
-    :tools            {:type    ToolConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       tool/tool-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :tool)}
-    :vulnerability    {:type    VulnerabilityType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :vulnerability)}
-    :vulnerabilities  {:type    VulnerabilityConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       vulnerability/vulnerability-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :vulnerability)}
-    :weakness         {:type    WeaknessType
-                       :args    search-by-id-args
-                       :resolve (res/entity-by-id-resolver :weakness)}
-    :weaknesses       {:type    WeaknessConnectionType
-                       :args    (merge common/lucene-query-arguments
-                                       weakness/weakness-order-arg
-                                       p/connection-arguments)
-                       :resolve (res/search-entity-resolver :weakness)}}))
+   (remove-disabled services graphql-fields)))
 
-(s/def schema :- (RealizeFnResult GraphQLSchema)
-  (g/new-schema QueryType))
-(s/def graphql :- (RealizeFnResult GraphQL)
-  (g/new-graphql schema))
+(s/defn schema :- (RealizeFnResult GraphQLSchema)
+  [services :- APIHandlerServices]
+  (g/new-schema (QueryType services)))
+
+(s/defn graphql :- (RealizeFnResult GraphQL)
+  [services :- APIHandlerServices]
+  (g/new-graphql (schema services)))
 
 (s/defn execute [query
                  operation-name

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -179,12 +179,22 @@
        keys
        (filter #(not (enabled? %)))))
 
+(defn- entities+plural-forms
+  "Gets map of entity keys with their plural forms."
+  []
+  (let [ents (entities/all-entities)]
+    (->> ents
+         vals
+         (map :plural)
+         (zipmap (keys ents)))))
+
 (defn- remove-disabled
   "Removes GraphQl fields of keys of disabled entities."
   [services graphql-fields]
-  (let [+plurals (reduce
+  (let [ents     (entities+plural-forms)
+        +plurals (reduce
                   (fn [a n] (let [k      (dash->underscore n)
-                                  plural (-> k name (str "s") keyword)]
+                                  plural (-> ents n dash->underscore)]
                               (into a [k plural])))
                   []
                   (disabled-entities services))]

--- a/src/ctia/http/server_service.clj
+++ b/src/ctia/http/server_service.clj
@@ -20,18 +20,18 @@
    FeaturesService]
   (start [this context] (core/start context
                                     ((:get-in-config ConfigService) [:ctia :http])
-                                    {:ConfigService (-> ConfigService
+                                    {:ConfigService                   (-> ConfigService
                                                         (select-keys #{:get-config
                                                                        :get-in-config}))
-                                     :HooksService (-> HooksService 
+                                     :HooksService                    (-> HooksService
                                                        (select-keys #{:apply-event-hooks
                                                                       :apply-hooks}))
-                                     :StoreService (-> StoreService 
+                                     :StoreService                    (-> StoreService
                                                        (select-keys #{:get-store}))
-                                     :IAuth IAuth
+                                     :IAuth                           IAuth
                                      :GraphQLNamedTypeRegistryService GraphQLNamedTypeRegistryService
-                                     :IEncryption IEncryption
-                                     :FeaturesService FeaturesService}))
+                                     :IEncryption                     IEncryption
+                                     :FeaturesService                 FeaturesService}))
   (stop [this context] (core/stop context))
   (get-port [this]
             (core/get-port (service-context this)))

--- a/src/ctia/http/server_service_core.clj
+++ b/src/ctia/http/server_service_core.clj
@@ -36,7 +36,7 @@
                                                       #(deref graphql-prm)))]
                            (deliver server-prm (new-jetty-instance http-config services))
                            (deliver graphql-prm
-                                    (-> graphql.schemas/graphql
+                                    (-> (graphql.schemas/graphql services)
                                         (resolve-with-rt-ctx
                                           {:services (APIHandlerServices->RealizeFnServices
                                                        services)})))

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -40,7 +40,7 @@
                                            (s/=> graphql.schema.GraphQLType))}
    :IEncryption                     {:encrypt (s/=> s/Any s/Any)
                                      :decrypt (s/=> s/Any s/Any)}
-   :FeaturesService                 {:enabled?      (s/=> s/Keyword s/Bool)
+   :FeaturesService                 {:enabled?      (s/=> s/Bool s/Keyword)
                                      :feature-flags (s/=> [s/Str])}})
 
 (s/defschema HTTPShowServices
@@ -325,6 +325,6 @@
   "vocab.observable-type-id")
 
 (s/defschema GetEntitiesServices
-  {:FeaturesService {:enabled? (s/=> s/Keyword s/Bool)
+  {:FeaturesService {:enabled? (s/=> s/Bool s/Keyword)
                      s/Keyword s/Any}
    s/Keyword        s/Any})

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -22,26 +22,26 @@
 
 (s/defschema APIHandlerServices
   "Maps of services available to routes"
-  {:ConfigService                             (-> external-svc-fns/ConfigServiceFns
+  {:ConfigService                   (-> external-svc-fns/ConfigServiceFns
                                                   (csutils/select-all-keys
-                                                    #{:get-config
-                                                      :get-in-config}))
-   :CTIAHTTPServerService                     {:get-port    (s/=> Port)
-                                               :get-graphql (s/=> graphql.GraphQL)}
-   :HooksService                              (-> hooks-schemas/ServiceFns
+                                                   #{:get-config
+                                                     :get-in-config}))
+   :CTIAHTTPServerService           {:get-port    (s/=> Port)
+                                     :get-graphql (s/=> graphql.GraphQL)}
+   :HooksService                    (-> hooks-schemas/ServiceFns
                                                   (csutils/select-all-keys
-                                                    #{:apply-event-hooks
-                                                      :apply-hooks}))
-   :StoreService                              {:get-store GetStoreFn}
-   :IAuth                                     {:identity-for-token (s/=> s/Any s/Any)}
-   :GraphQLNamedTypeRegistryService           {:get-or-update-named-type-registry
-                                               (s/=> graphql.schema.GraphQLType
-                                                     s/Str
-                                                     (s/=> graphql.schema.GraphQLType))}
-   :IEncryption                               {:encrypt (s/=> s/Any s/Any)
-                                               :decrypt (s/=> s/Any s/Any)}
-   :FeaturesService                           {:enabled?      (s/=> s/Bool s/Keyword)
-                                               :feature-flags (s/=> [s/Str])}})
+                                                   #{:apply-event-hooks
+                                                     :apply-hooks}))
+   :StoreService                    {:get-store GetStoreFn}
+   :IAuth                           {:identity-for-token (s/=> s/Any s/Any)}
+   :GraphQLNamedTypeRegistryService {:get-or-update-named-type-registry
+                                     (s/=> graphql.schema.GraphQLType
+                                           s/Str
+                                           (s/=> graphql.schema.GraphQLType))}
+   :IEncryption                     {:encrypt (s/=> s/Any s/Any)
+                                     :decrypt (s/=> s/Any s/Any)}
+   :FeaturesService                 {:enabled?      (s/=> s/Keyword s/Bool)
+                                     :feature-flags (s/=> [s/Str])}})
 
 (s/defschema HTTPShowServices
   ;; TODO describe in terms of APIHandlerServices, while preserving openness
@@ -325,6 +325,6 @@
   "vocab.observable-type-id")
 
 (s/defschema GetEntitiesServices
-  {:FeaturesService {:enabled? (s/=> s/Bool s/Keyword)
+  {:FeaturesService {:enabled? (s/=> s/Keyword s/Bool)
                      s/Keyword s/Any}
    s/Keyword        s/Any})

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -1,8 +1,10 @@
 (ns ctia.features-service-test
-  (:require  [clojure.test :refer [deftest are is testing use-fixtures]]
-             [ctia.test-helpers
-              [core :as th]
-              [es :as es-helpers]]))
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest are is testing use-fixtures]]
+   [ctia.entity.entities :as entities]
+   [ctia.test-helpers.core :as th]
+   [ctia.test-helpers.es :as es-helpers]))
 
 (use-fixtures :each es-helpers/fixture-properties:es-store)
 
@@ -17,7 +19,12 @@
            (testing "Incident, Indicator entities are enabled"
              (is (every? enabled? [:incident :indicator])))
            (testing "It should not return `true` for non-existing entity keys"
-             (is (not (enabled? :lorem-ipsum))))))))))
+             (is (not (enabled? :lorem-ipsum))))
+           (testing "It should return all enabled entities when no key argument is used"
+             (is (= #{:asset :actor :sighting}
+                    (set/difference
+                     (-> (entities/all-entities) keys set)
+                     (set (enabled?))))))))))))
 
 (deftest routes-for-disabled-entities-test
   (let [try-route (fn [app entity]

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -19,12 +19,7 @@
            (testing "Incident, Indicator entities are enabled"
              (is (every? enabled? [:incident :indicator])))
            (testing "It should not return `true` for non-existing entity keys"
-             (is (not (enabled? :lorem-ipsum))))
-           (testing "It should return all enabled entities when no key argument is used"
-             (is (= #{:asset :actor :sighting}
-                    (set/difference
-                     (-> (entities/all-entities) keys set)
-                     (set (enabled?))))))))))))
+             (is (not (enabled? :lorem-ipsum))))))))))
 
 (deftest routes-for-disabled-entities-test
   (let [try-route (fn [app entity]

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -11,11 +11,13 @@
     (th/with-properties ["ctia.features.disable" "asset,actor,sighting"]
       (th/fixture-ctia-with-app
        (fn [app]
-         (let [{:keys [disabled? enabled?]} (th/get-service-map app :FeaturesService)]
+         (let [{:keys [enabled?]} (th/get-service-map app :FeaturesService)]
            (testing "Asset, Actor and Sighting are disabled"
              (is (not-any? enabled? [:asset :actor :sighting])))
            (testing "Incident, Indicator entities are enabled"
-             (is (every? enabled? [:incident :indicator])))))))))
+             (is (every? enabled? [:incident :indicator])))
+           (testing "It should not return `true` for non-existing entity keys"
+             (is (not (enabled? :lorem-ipsum))))))))))
 
 (deftest routes-for-disabled-entities-test
   (let [try-route (fn [app entity]

--- a/test/ctia/graphql/schemas_test.clj
+++ b/test/ctia/graphql/schemas_test.clj
@@ -32,4 +32,11 @@
                             graphql-keys)))
                (is (set/subset?
                     #{:asset_properties :indicator :indicators}
-                    graphql-keys))))))))))
+                    graphql-keys))))))))
+    (testing "entities+plural-forms"
+      (let [ents (#'schemas/entities+plural-forms)]
+        (are [ent-key plural-form] (= plural-form (get ents ent-key))
+          :asset            :assets
+          :asset-mapping    :asset-mappings
+          :asset-properties :asset-properties
+          :weakness         :weaknesses)))))

--- a/test/ctia/graphql/schemas_test.clj
+++ b/test/ctia/graphql/schemas_test.clj
@@ -1,0 +1,35 @@
+(ns ctia.graphql.schemas-test
+  (:require
+   [clojure.set :as set]
+   [clojure.test :refer [deftest are is testing use-fixtures]]
+   [ctia.graphql.schemas :as schemas]
+   [ctia.test-helpers.core :as th]
+   [ctia.test-helpers.es :as es-helpers]
+   [puppetlabs.trapperkeeper.app :as tk-app]))
+
+(use-fixtures :each es-helpers/fixture-properties:es-store)
+
+(deftest graphql-schemas-test
+  (testing "auxiliary functions"
+    (th/with-properties ["ctia.features.disable" "asset,actor,sighting,asset-mapping"]
+      (th/fixture-ctia-with-app
+       (fn [app]
+         (let [services (tk-app/service-graph app)]
+           (testing "disabled entities are recognized"
+             (is (= #{:asset :actor :sighting :asset-mapping}
+                    (set (#'schemas/disabled-entities services)))))
+           (testing "graphql keys for disabled entities get removed"
+             (let [graphql-keys (->>
+                                 schemas/graphql-fields
+                                 (#'schemas/remove-disabled services)
+                                 keys
+                                 set)]
+               (is (false? (set/subset?
+                            #{:asset         :assets
+                              :actor         :actors
+                              :sighting      :sightings
+                              :asset_mapping :asset_mappings}
+                            graphql-keys)))
+               (is (set/subset?
+                    #{:asset_properties :indicator :indicators}
+                    graphql-keys))))))))))


### PR DESCRIPTION
Entities marked as disabled in the config no longer can be used in graphql queries

> **Epic** #
> Close https://github.com/threatgrid/iroh/issues/4522
> Related #1020, #1064

<a name="qa">[§](#qa)</a> QA
============================

1. Test on "public intel", where Asset, AssetMapping, AssetProperties, TargetRecord are [disabled in the config](https://github.com/threatgrid/tenzin-config/blob/master/ctia/TEST/us-east-1/ctia.properties#L101)
2. Run the app, open up the Swagger console. 
3. Make sure that no contexts shown for disabled entities (routes for Asset, AssetMapping, AssetProperties, TargetRecord should not be available)
4. Try to post graphql queries including the disabled entities, e.g.:
```
POST  /ctia/graphql
{
"query": "query Assets { assets { nodes {id} }}"
}
```
5.  Expected: The system should fail with the validation error (since the schema does not include Assets)


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

25390b27 test: add plural forms check
9626566a PR feedback
93976be1 proper plurals
014db209 removes disabled entities from GraphQL
d0de05c8 adds second arity to FeaturesService/enabled?
57b2c4a3 FeaturesService/enable? should ignore non-existing entities