### PR TITLE
Display schema error for the text/plain content type

### DIFF
--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -1,58 +1,55 @@
 (ns ctia.entity.feed
-  (:require
-   [clojure.string :as string]
-   [ctia.http.routes.crud :as crud]
-   [ctia.schemas.core :refer [APIHandlerServices]]
-   [ctia.lib.compojure.api.core :refer [DELETE GET POST PUT routes]]
-   [ctia.domain.entities
-    :refer
-    [page-with-long-id un-store un-store-page with-long-id]]
-   [ctia.entity.feed.schemas
-    :refer
-    [Feed
-     NewFeed
-     PartialFeed
-     PartialFeedList
-     PartialStoredFeed
-     realize-feed
-     StoredFeed]]
-   [ctia.entity.judgement.schemas :refer [Judgement]]
-   [ctia.flows.crud :as flows]
-   [ctia.http.routes.common
-    :as routes.common
-    :refer
-    [BaseEntityFilterParams
-     created
-     filter-map-search-options
-     paginated-ok
-     PagingParams
-     search-options
-     search-query
-     wait_for->refresh]]
-   [ctia.schemas
-    [core :refer [Observable]]
-    [sorting :as sorting]]
-   [ctia.store :refer [create-record
-                       delete-record
-                       list-all-pages
-                       list-records
-                       read-record
-                       update-record
-                       query-string-count
-                       query-string-search
-                       delete-search]]
-   [ctia.stores.es
-    [mapping :as em]
-    [store :refer [def-es-store]]]
-   [ctim.domain.validity :as cdv]
-   [ring.swagger.schema :refer [describe]]
-   [ring.util.http-response :refer [no-content
-                                    not-found
-                                    ok
-                                    forbidden
-                                    unauthorized]]
-   [schema-tools.core :as st]
-   [schema.core :as s]))
+  (:require [clojure.string :as string]
+            [ctia.domain.entities
+             :refer
+             [page-with-long-id un-store un-store-page with-long-id]]
+            [ctia.entity.feed.schemas
+             :refer
+             [Feed
+              NewFeed
+              PartialFeed
+              PartialFeedList
+              PartialStoredFeed
+              realize-feed
+              StoredFeed]]
+            [ctia.entity.judgement.schemas :refer [Judgement]]
+            [ctia.flows.crud :as flows]
+            [ctia.http.routes.common
+             :as
+             routes.common
+             :refer
+             [BaseEntityFilterParams
+              created
+              paginated-ok
+              PagingParams
+              search-options
+              search-query
+              wait_for->refresh]]
+            [ctia.lib.compojure.api.core :refer [DELETE GET POST PUT routes]]
+            [ctia.schemas
+             [core :refer [APIHandlerServices Observable]]
+             [sorting :as sorting]]
+            [ctia.store
+             :refer
+             [create-record
+              delete-record
+              delete-search
+              list-all-pages
+              list-records
+              query-string-count
+              query-string-search
+              read-record
+              update-record]]
+            [ctia.stores.es
+             [mapping :as em]
+             [store :refer [def-es-store]]]
+            [ctim.domain.validity :as cdv]
+            [ring.swagger.schema :refer [describe]]
+            [ring.util.http-response
+             :refer
+             [forbidden no-content not-found ok unauthorized]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
 
 (def feed-mapping
   {"feed"
@@ -171,9 +168,9 @@
             :as feed}
            (-> (get-store :feed)
                (read-record
-                 id
-                 identity-map
-                 {}))]
+                id
+                identity-map
+                {}))]
     (cond
       (not feed) :not-found
       (not (valid-lifetime? lifetime)) :not-found
@@ -197,9 +194,9 @@
                            (keep :source_ref)
                            (map #(-> (get-store :judgement)
                                      (read-record
-                                       %
-                                       feed-identity
-                                       {})))
+                                      %
+                                      feed-identity
+                                      {})))
                            (remove nil?)
                            (map #(with-long-id % services)))]
               (cond-> {}
@@ -230,10 +227,12 @@
      :summary "Get a Feed View as newline separated entries"
      :path-params [id :- s/Str]
      :return s/Str
-     :coercion (constantly nil)
      :produces #{"text/plain"}
+     :responses {404 {:schema s/Str}
+                 401 {:schema s/Str}}
      :query-params [s :- (describe s/Str "The feed share token")]
-     (let [{:keys [output]
+     (ok "hello")
+     #_(let [{:keys [output]
             :as feed} (fetch-feed id s services)]
        (case feed
          :not-found (not-found "feed not found")
@@ -242,9 +241,7 @@
                transformed (some->> (sorted-observable-values data)
                                     (map :value)
                                     (string/join \newline))]
-           (into (ok transformed)
-                 {:compojure.api.meta/serializable? false
-                  :headers {"Content-Type" "text/plain; charset=utf8"}})))))
+           (ok transformed)))))
    (GET "/:id/view" []
      :summary "Get a Feed View"
      :path-params [id :- s/Str]
@@ -252,208 +249,208 @@
      :query-params [s :- (describe s/Str "The feed share token")]
      (let [feed (fetch-feed id s services)]
        (case feed
-         :not-found (not-found "feed not found")
+         :not-found (not-found {:a "feed not found"})
          :unauthorized (unauthorized "wrong secret")
          (ok (dissoc feed :output)))))))
 
 (s/defn feed-routes [{{:keys [get-store]} :StoreService
                       :as services} :- APIHandlerServices]
   (routes
-    (let [capabilities :create-feed]
-      (POST "/" []
-        :return Feed
-        :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
-        :body [new-entity NewFeed {:description "a new Feed"}]
-        :summary "Adds a new Feed"
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (-> (flows/create-flow
-             :services services
-             :entity-type :feed
-             :realize-fn realize-feed
-             :store-fn #(-> (get-store :feed)
-                            (create-record
-                              %
-                              identity-map
-                              (wait_for->refresh wait_for)))
-             :long-id-fn #(with-long-id % services)
-             :entity-type :feed
-             :identity identity
-             :entities [new-entity]
-             :spec :new-feed/map)
-            first
-            un-store
-            (decrypt-feed services)
-            created)))
-
-    (let [capabilities :create-feed]
-      (PUT "/:id" []
-        :return Feed
-        :body [entity-update NewFeed {:description "an updated Feed"}]
-        :summary "Updates a Feed"
-        :query-params [{wait_for :- (describe s/Bool "wait for updated entity to be available for search") nil}]
-        :path-params [id :- s/Str]
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (if-let [updated-rec
-                 (-> (flows/update-flow
-                      :services services
-                      :get-fn #(-> (get-store :feed)
-                                   (read-record
-                                     %
-                                     identity-map
-                                     {}))
-                      :realize-fn realize-feed
-                      :update-fn #(-> (get-store :feed)
-                                      (update-record
-                                        (:id %)
-                                        %
-                                        identity-map
-                                        (wait_for->refresh wait_for)))
-                      :long-id-fn #(with-long-id % services)
-                      :entity-type :feed
-                      :entity-id id
-                      :identity identity
-                      :entity entity-update
-                      :spec :new-feed/map)
-                     un-store
-                     (decrypt-feed services))]
-          (ok updated-rec)
-          (not-found))))
-
-    (let [capabilities :read-feed]
-      (GET "/external_id/:external_id" []
-        :return PartialFeedList
-        :query [q FeedByExternalIdQueryParams]
-        :path-params [external_id :- s/Str]
-        :summary "List Feeds by external_id"
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (-> (get-store :feed)
-            (list-records
-              {:all-of {:external_ids external_id}}
-              identity-map
-              q)
-            (page-with-long-id services)
-            un-store-page
-            (decrypt-feed-page services)
-            paginated-ok)))
-
-    (let [capabilities :search-feed]
-      (GET "/search" []
-        :return PartialFeedList
-        :summary "Search for a Feed using a Lucene/ES query string"
-        :query [params FeedSearchParams]
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (-> (get-store :feed)
-            (query-string-search
-              (search-query :created params)
-              identity-map
-              (select-keys params search-options))
-            (page-with-long-id services)
-            un-store-page
-            (decrypt-feed-page services)
-            paginated-ok)))
-
-    (let [capabilities :search-feed]
-      (GET "/search/count" []
-           :return s/Int
-           :summary "Count Feed entities matching given search filters."
-           :query [params FeedCountParams]
-           :description (routes.common/capabilities->description capabilities)
-           :capabilities capabilities
-           :auth-identity identity
-           :identity-map identity-map
-           (ok (-> (get-store :feed)
-                   (query-string-count
-                     (search-query :created params)
-                     identity-map)))))
-
-
-    (let [capabilities #{:search-feed :delete-feed}]
-      (DELETE "/search" []
-        :capabilities capabilities
-        :description (routes.common/capabilities->description capabilities)
-        :return s/Int
-        :summary (format "Delete Feed entities matching given Lucene/ES query string or/and field filters")
-        :auth-identity identity
-        :identity-map identity-map
-        :query [params FeedDeleteSearchParams]
-        (let [query (->> (dissoc params :wait_for :REALLY_DELETE_ALL_THESE_ENTITIES)
-                         (search-query :created))]
-          (if (empty? query)
-            (forbidden {:error "you must provide at least one of from, to, query or any field filter."})
-            (ok
-             (if (:REALLY_DELETE_ALL_THESE_ENTITIES params)
-               (-> (get-store :feed)
-                   (delete-search
-                     query
-                     identity-map
-                     (wait_for->refresh (:wait_for params))))
-               (-> (get-store :feed)
-                   (query-string-count
-                     query
-                     identity-map))))))))
-
-    (let [capabilities :read-feed]
-      (GET "/:id" []
-        :return (s/maybe PartialFeed)
-        :summary "Gets a Feed by ID"
-        :path-params [id :- s/Str]
-        :query [params FeedGetParams]
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (if-let [rec (-> (get-store :feed)
-                         (read-record
-                           id
-                           identity-map
-                           params))]
-          (-> rec
-              (with-long-id services)
-              un-store
-              (decrypt-feed services)
-              ok)
-          (not-found))))
-
-    (let [capabilities :delete-feed]
-      (DELETE "/:id" []
-        :no-doc false
-        :path-params [id :- s/Str]
-        :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]
-        :summary "Deletes a Feed"
-        :description (routes.common/capabilities->description capabilities)
-        :capabilities capabilities
-        :auth-identity identity
-        :identity-map identity-map
-        (if (flows/delete-flow
-             :services services
-             :get-fn #(-> (get-store :feed)
-                          (read-record
+   (let [capabilities :create-feed]
+     (POST "/" []
+       :return Feed
+       :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
+       :body [new-entity NewFeed {:description "a new Feed"}]
+       :summary "Adds a new Feed"
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (-> (flows/create-flow
+            :services services
+            :entity-type :feed
+            :realize-fn realize-feed
+            :store-fn #(-> (get-store :feed)
+                           (create-record
                             %
                             identity-map
-                            {}))
-             :delete-fn #(-> (get-store :feed)
-                             (delete-record
-                               %
-                               identity-map
-                               (wait_for->refresh wait_for)))
-             :entity-type :feed
-             :long-id-fn #(with-long-id % services)
-             :entity-id id
-             :identity identity)
-          (no-content)
-          (not-found))))))
+                            (wait_for->refresh wait_for)))
+            :long-id-fn #(with-long-id % services)
+            :entity-type :feed
+            :identity identity
+            :entities [new-entity]
+            :spec :new-feed/map)
+           first
+           un-store
+           (decrypt-feed services)
+           created)))
+
+   (let [capabilities :create-feed]
+     (PUT "/:id" []
+       :return Feed
+       :body [entity-update NewFeed {:description "an updated Feed"}]
+       :summary "Updates a Feed"
+       :query-params [{wait_for :- (describe s/Bool "wait for updated entity to be available for search") nil}]
+       :path-params [id :- s/Str]
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (if-let [updated-rec
+                (-> (flows/update-flow
+                     :services services
+                     :get-fn #(-> (get-store :feed)
+                                  (read-record
+                                   %
+                                   identity-map
+                                   {}))
+                     :realize-fn realize-feed
+                     :update-fn #(-> (get-store :feed)
+                                     (update-record
+                                      (:id %)
+                                      %
+                                      identity-map
+                                      (wait_for->refresh wait_for)))
+                     :long-id-fn #(with-long-id % services)
+                     :entity-type :feed
+                     :entity-id id
+                     :identity identity
+                     :entity entity-update
+                     :spec :new-feed/map)
+                    un-store
+                    (decrypt-feed services))]
+         (ok updated-rec)
+         (not-found))))
+
+   (let [capabilities :read-feed]
+     (GET "/external_id/:external_id" []
+       :return PartialFeedList
+       :query [q FeedByExternalIdQueryParams]
+       :path-params [external_id :- s/Str]
+       :summary "List Feeds by external_id"
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (-> (get-store :feed)
+           (list-records
+            {:all-of {:external_ids external_id}}
+            identity-map
+            q)
+           (page-with-long-id services)
+           un-store-page
+           (decrypt-feed-page services)
+           paginated-ok)))
+
+   (let [capabilities :search-feed]
+     (GET "/search" []
+       :return PartialFeedList
+       :summary "Search for a Feed using a Lucene/ES query string"
+       :query [params FeedSearchParams]
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (-> (get-store :feed)
+           (query-string-search
+            (search-query :created params)
+            identity-map
+            (select-keys params search-options))
+           (page-with-long-id services)
+           un-store-page
+           (decrypt-feed-page services)
+           paginated-ok)))
+
+   (let [capabilities :search-feed]
+     (GET "/search/count" []
+       :return s/Int
+       :summary "Count Feed entities matching given search filters."
+       :query [params FeedCountParams]
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (ok (-> (get-store :feed)
+               (query-string-count
+                (search-query :created params)
+                identity-map)))))
+
+
+   (let [capabilities #{:search-feed :delete-feed}]
+     (DELETE "/search" []
+       :capabilities capabilities
+       :description (routes.common/capabilities->description capabilities)
+       :return s/Int
+       :summary (format "Delete Feed entities matching given Lucene/ES query string or/and field filters")
+       :auth-identity identity
+       :identity-map identity-map
+       :query [params FeedDeleteSearchParams]
+       (let [query (->> (dissoc params :wait_for :REALLY_DELETE_ALL_THESE_ENTITIES)
+                        (search-query :created))]
+         (if (empty? query)
+           (forbidden {:error "you must provide at least one of from, to, query or any field filter."})
+           (ok
+            (if (:REALLY_DELETE_ALL_THESE_ENTITIES params)
+              (-> (get-store :feed)
+                  (delete-search
+                   query
+                   identity-map
+                   (wait_for->refresh (:wait_for params))))
+              (-> (get-store :feed)
+                  (query-string-count
+                   query
+                   identity-map))))))))
+
+   (let [capabilities :read-feed]
+     (GET "/:id" []
+       :return (s/maybe PartialFeed)
+       :summary "Gets a Feed by ID"
+       :path-params [id :- s/Str]
+       :query [params FeedGetParams]
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (if-let [rec (-> (get-store :feed)
+                        (read-record
+                         id
+                         identity-map
+                         params))]
+         (-> rec
+             (with-long-id services)
+             un-store
+             (decrypt-feed services)
+             ok)
+         (not-found))))
+
+   (let [capabilities :delete-feed]
+     (DELETE "/:id" []
+       :no-doc false
+       :path-params [id :- s/Str]
+       :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]
+       :summary "Deletes a Feed"
+       :description (routes.common/capabilities->description capabilities)
+       :capabilities capabilities
+       :auth-identity identity
+       :identity-map identity-map
+       (if (flows/delete-flow
+            :services services
+            :get-fn #(-> (get-store :feed)
+                         (read-record
+                          %
+                          identity-map
+                          {}))
+            :delete-fn #(-> (get-store :feed)
+                            (delete-record
+                             %
+                             identity-map
+                             (wait_for->refresh wait_for)))
+            :entity-type :feed
+            :long-id-fn #(with-long-id % services)
+            :entity-id id
+            :identity identity)
+         (no-content)
+         (not-found))))))
 
 (def capabilities
   #{:create-feed
@@ -478,5 +475,5 @@
    :es-store ->FeedStore
    :es-mapping feed-mapping
    :services->routes (routes.common/reloadable-function
-                       feed-routes)
+                      feed-routes)
    :capabilities capabilities})

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -231,8 +231,7 @@
      :responses {404 {:schema s/Str}
                  401 {:schema s/Str}}
      :query-params [s :- (describe s/Str "The feed share token")]
-     (ok "hello")
-     #_(let [{:keys [output]
+     (let [{:keys [output]
             :as feed} (fetch-feed id s services)]
        (case feed
          :not-found (not-found "feed not found")

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -248,8 +248,8 @@
      :query-params [s :- (describe s/Str "The feed share token")]
      (let [feed (fetch-feed id s services)]
        (case feed
-         :not-found (not-found {:a "feed not found"})
-         :unauthorized (unauthorized "wrong secret")
+         :not-found (not-found {:error "feed not found"})
+         :unauthorized (unauthorized {:error "wrong secret"})
          (ok (dissoc feed :output)))))))
 
 (s/defn feed-routes [{{:keys [get-store]} :StoreService

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -197,7 +197,11 @@
    See the `ring.middleware.format-response/wrap-restful-response`
    middleware used by compojure API for more details"
   []
-  (make-encoder (fn [body] (str body)) "text/plain"))
+  (make-encoder (fn text-plain-encoder [body]
+                  (if (string? body)
+                    body
+                    (pr-str body)))
+                "text/plain"))
 
 (s/defn api-handler [{{:keys [get-in-config]} :ConfigService
                       :as services} :- APIHandlerServices]

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -122,6 +122,17 @@
         (update :headers (fn [response-headers]
                            (into headers response-headers)))))))
 
+(defn wrap-txt-accept-header
+  "Enforces the `accept` request header to `text/plain` when the
+   uri ends with `.txt`. Mainly used by the `/feed/{id}/view.txt` endpoint"
+  [handler]
+  (fn [{:keys [uri] :as request}]
+    (let [new-request
+          (cond-> request
+            (string/ends-with? uri ".txt")
+            (assoc-in [:headers "accept"] "text/plain"))]
+      (handler new-request))))
+
 (defn build-csp
   "Build the Content Security Policy header from the http configuration"
   [{:keys [swagger] :as http-config}]
@@ -189,6 +200,8 @@
                                           {}))}))
             (when-let [lifetime (:lifetime-in-sec jwt)]
               {:jwt-max-lifetime-in-sec lifetime}))))
+
+         true wrap-txt-accept-header
 
          access-control-allow-origin
          (wrap-cors :access-control-allow-origin

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -1,7 +1,8 @@
 (ns ctia.http.server
-  (:require [clojure.string :as string]
+  (:require [clj-http.client :as http]
+            [clojure.core.memoize :as memo]
+            [clojure.string :as string]
             [clojure.tools.logging :as log]
-            [clj-http.client :as http]
             [ctia.auth.jwt :as auth-jwt]
             [ctia.http.handler :as handler]
             [ctia.http.middleware.auth :as auth]
@@ -13,12 +14,10 @@
              [cors :refer [wrap-cors]]
              [params :refer [wrap-params]]
              [reload :refer [wrap-reload]]]
-            [schema.core :as s]
-            [clojure.core.memoize :as memo])
-  (:import org.eclipse.jetty.server.Server
-           (java.util.concurrent TimeoutException)
-           (java.net UnknownHostException
-                     SocketTimeoutException)))
+            [schema.core :as s])
+  (:import [java.net SocketTimeoutException UnknownHostException]
+           java.util.concurrent.TimeoutException
+           org.eclipse.jetty.server.Server))
 
 (defn- allow-origin-regexps
   "take a CORS allowed origin config string
@@ -82,8 +81,8 @@
                    check-jwt-url)
         [])
       (catch UnknownHostException e
-          (log/errorf "The server for checking JWT seems down: %s"
-                      check-jwt-url)
+        (log/errorf "The server for checking JWT seems down: %s"
+                    check-jwt-url)
         [])
       (catch Exception e
         (log/warnf e "Couldn't check jwt status due to an error calling %s"
@@ -123,13 +122,17 @@
                            (into headers response-headers)))))))
 
 (defn wrap-txt-accept-header
-  "Enforces the `accept` request header to `text/plain` when the
-   uri ends with `.txt`. Mainly used by the `/feed/{id}/view.txt` endpoint"
+  "Set the `accept` request header to `text/plain` when the
+   uri ends with `.txt`. It applies only if the header is not already
+   set or set with `*/*` (Any MIME type).
+   Mainly used by the `/feed/{id}/view.txt` endpoint."
   [handler]
-  (fn [{:keys [uri] :as request}]
-    (let [new-request
+  (fn [{:keys [uri headers] :as request}]
+    (let [accept (get headers "accept" "*/*")
+          new-request
           (cond-> request
-            (string/ends-with? uri ".txt")
+            (and (= accept "*/*")
+                 (string/ends-with? uri ".txt"))
             (assoc-in [:headers "accept"] "text/plain"))]
       (handler new-request))))
 
@@ -162,10 +165,14 @@
     :as http-config}
    {{:keys [identity-for-token]} :IAuth
     {:keys [get-in-config]} :ConfigService
-     :as services} :- APIHandlerServices]
+    :as services} :- APIHandlerServices]
   (doto
       (jetty/run-jetty
        (cond-> (handler/api-handler services)
+
+         ;; After compojure api middleawares
+         true wrap-txt-accept-header
+
          true (auth/wrap-authentication identity-for-token)
 
          (:enabled jwt)
@@ -189,7 +196,7 @@
              :no-jwt-handler rjwt/authorize-no-jwt-header-strategy}
 
             (let [{:keys [endpoints timeout cache-ttl]}
-                       (:http-check jwt)]
+                  (:http-check jwt)]
               (when-let [external-endpoints (parse-external-endpoints endpoints)]
                 {:jwt-check-fn (partial check-external-endpoints
                                         (http-get-fn (or cache-ttl 5000))
@@ -200,8 +207,6 @@
                                           {}))}))
             (when-let [lifetime (:lifetime-in-sec jwt)]
               {:jwt-max-lifetime-in-sec lifetime}))))
-
-         true wrap-txt-accept-header
 
          access-control-allow-origin
          (wrap-cors :access-control-allow-origin

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -156,6 +156,15 @@
       (is (= "wrong secret"
              response-body-txt-wrong-secret))
 
+      (testing "bad request"
+        (let [url-with-invalid-query-params
+              (string/replace feed-view-url-txt #"s=" "invalid=")
+              {:keys [body headers status]}
+              (client/get url-with-invalid-query-params {:throw-exceptions false})]
+          (is (= 400 status))
+          (is (string/starts-with? (get headers "Content-Type") "text/plain"))
+          (is (= "{:errors {:s missing-required-key}}" body))))
+
       (testing "feed output judgements"
         (let [feed-update (assoc feed :output :judgements)
               updated-feed-response


### PR DESCRIPTION
> Close threatgrid/iroh#3151

- Defines a response format encoder for the `text/plain` content type.
- Set the `accept` header to `text/plain` if the request `uri` ends with `.txt`

If a request is made with the `text/plain` content type and a wrong request parameter instead of returning a 500 with an undefined exception `{"type":"unknown-exception","class":"clojure.lang.ExceptionInfo"}` it will return a 400 with the stringified schema error `{:errors {:s missing-required-key}}` as string.

Note for reviewers: Enable the `Hide whitespace changes` option

<a name="qa">[§](#qa)</a> QA
============================

1. Send a GET to /view.txt, but instead of using s as the query parameter use q, like:
`curl -X GET "https://private.intel.test.iroh.site/ctia/feed/https%3A%2F%2Fprivate.intel.test.iroh.site%3A443%2Fctia%2Ffeed%2Ffeed-2d3b363a-5740-43b9-8f05-91c062e68bb0/view.txt?q=9d1601de-9b64-4a17-aeca-5aa56b4b9792" -H "authorization: JWT"`

2. It should return a 400 with the following text `{:errors {:s missing-required-key}}`

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Display schema error for the text/plain content type
```
