### PR TITLE
don't throw an arity exception calling bundle export with an empty seq

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -451,6 +451,8 @@
    ident
    params
    services :- APIHandlerServices]
-  (->> (map #(export-entities % identity-map ident params services) ids)
-       (reduce #(deep-merge-with coll/add-colls %1 %2))
-       (into empty-bundle)))
+  (if (seq ids)
+    (->> (map #(export-entities % identity-map ident params services) ids)
+         (reduce #(deep-merge-with coll/add-colls %1 %2))
+         (into empty-bundle))
+    empty-bundle))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -692,6 +692,14 @@
                                         sighting-id-2]
                                   :related_to ["target_ref" "source_ref"]}
                    :headers {"Authorization" "45c1f5e3f05d0"}))
+
+             bundle-post-res-empty-ids
+             (:parsed-body
+              (POST app
+                   "ctia/bundle/export"
+                   :body {:ids nil}
+                   :headers {"Authorization" "45c1f5e3f05d0"}))
+
              bundle-post-res
              (:parsed-body
               (POST app
@@ -720,8 +728,10 @@
          (is (= bundle-get-res-3 bundle-get-res-5)
              "default related_to value should be [:source_ref :target_ref]")
          (is (= bundle-get-res-5 bundle-post-res)
-             "POST and GET bundle/export routes must return the same results"))))))
-
+             "POST and GET bundle/export routes must return the same results")
+         (is (= {:type "bundle"
+                 :source "ctia"} bundle-post-res-empty-ids)
+             "POST bundle/export with an empty ids list should return an empty bundle"))))))
 (deftest bundle-export-with-unreachable-entities
   (testing "external and deleted entities in fetched relationships should be ignored"
     (test-for-each-store-with-app


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close https://github.com/threatgrid/iroh/issues/4768
> Related #

Calling the Bundle export route with an empty sequence currently returns an ArityException
This PR fixes that behavior providing a val argument to a reduce.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1. Call CTIA POST bundle/export route with an empty ids array `{"ids": []}`
2. You should get back an empty map

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: hardened the Bundle Export route
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

