### PR TITLE
Issue-4744: Search vulnerabilities by CPEs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -59,6 +59,7 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
+
                  [threatgrid/ctim "1.1.4"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
@@ -143,7 +144,7 @@
                                   (:out (clojure.java.shell/sh
                                          "git" "symbolic-ref" "--short" "HEAD")))})}]
 
-  
+
   :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~trapperkeeper-version
                                    :classifier "test"]
                                   [puppetlabs/kitchensink ~trapperkeeper-version
@@ -254,7 +255,7 @@
             "init-properties" ^{:doc (str "create an initial `ctia.properties`"
                                           " using docker machine ip")}
             ["shell" "scripts/init-properties-for-docker.sh"]
-            
+
             ; circleci.test
             ;"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
             "split-test" ["trampoline"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -1,10 +1,11 @@
 (ns ctia.entity.vulnerability
   (:require
+   [ctia.lib.compojure.api.core :refer [context GET routes]]
    [flanders.utils :as fu]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.relationship.graphql-schemas :as relationship]
    [ctia.entity.vulnerability.mapping :refer [vulnerability-mapping]]
-   [ctia.domain.entities :refer [default-realize-fn]]
+   [ctia.domain.entities :as ent]
    [ctia.schemas.graphql
     [sorting :as graphql-sorting]
     [flanders :as flanders]
@@ -23,7 +24,11 @@
    [schema-tools.core :as st]
    [schema.core :as s]
    [ctia.schemas.sorting :as sorting]
-   [ctia.schemas.graphql.ownership :as go]))
+   [ctia.schemas.graphql.ownership :as go]
+   [ring.swagger.schema :as swagger-schema]
+   [ctia.entity.vulnerability.cpe :as cpe]
+   [ctia.store :as ctia-store]
+   [clojure.string :as str]))
 
 (def-acl-schema Vulnerability
   ws/Vulnerability
@@ -46,13 +51,14 @@
   (csu/optional-keys-schema StoredVulnerability))
 
 (def realize-vulnerability
-  (default-realize-fn "vulnerability" NewVulnerability StoredVulnerability))
+  (ent/default-realize-fn "vulnerability" NewVulnerability StoredVulnerability))
 
 (def-es-store VulnerabilityStore :vulnerability StoredVulnerability PartialStoredVulnerability)
 
 (def vulnerability-fields
   (concat sorting/base-entity-sort-fields
           sorting/sourcable-entity-sort-fields
+          sorting/describable-entity-sort-fields
           []))
 
 (def vulnerability-sort-fields
@@ -109,29 +115,69 @@
 (def vulnerability-enumerable-fields
   [:source])
 
+(s/defn search-by-cpe-ids [{{:keys [get-store]} :StoreService
+                            :as services} :- APIHandlerServices]
+  (context "/cpe_ids" []
+    (let [capabilities :search-vulnerability]
+      (GET "/" []
+        :return PartialVulnerabilityList
+        :query [{cpe-ids-string :cpe_ids :as params}
+                (st/merge VulnerabilitySearchParams {:cpe_ids (swagger-schema/describe s/Str "CPE ids to search by")})]
+        :summary "List Vulnerabilities by CPE ids"
+        :description (routes.common/capabilities->description capabilities)
+        :capabilities capabilities
+        :auth-identity identity
+        :identity-map identity-map
+        (let [cpe-ids (str/split cpe-ids-string #"\s+")
+              vulnerability-ids
+              (loop [query-params params
+                     results []]
+                (let [{:keys [data paging]}
+                      (ctia-store/list-records (get-store :vulnerability)
+                                               {:one-of {:configurations.nodes.cpe_match.cpe23Uri cpe-ids
+                                                         :configurations.nodes.children.cpe_match.cpe23Uri cpe-ids}}
+                                               identity-map
+                                               (merge query-params {:fields [:configurations.nodes :id]}))
+                      ids (cpe/vulnerabilities->ids cpe-ids data)]
+                  (if-let [next-params (:next paging)]
+                    (recur (into query-params next-params)
+                           (into results ids))
+                    (into results ids))))]
+          (-> (get-store :vulnerability)
+              (ctia-store/query-string-search (merge (routes.common/search-query :timestamp
+                                                                                 (dissoc params :cpe_ids))
+                                                     {:filter-map [[:id vulnerability-ids]]})
+                                              identity-map
+                                              (select-keys params routes.common/search-options))
+              (ent/page-with-long-id services)
+              ent/un-store-page
+              routes.common/paginated-ok))))))
+
 (s/defn vulnerability-routes [services :- APIHandlerServices]
-  (services->entity-crud-routes
-   services
-   {:entity :vulnerability
-    :new-schema NewVulnerability
-    :entity-schema Vulnerability
-    :get-schema PartialVulnerability
-    :get-params VulnerabilityGetParams
-    :list-schema PartialVulnerabilityList
-    :search-schema PartialVulnerabilityList
-    :external-id-q-params VulnerabilityByExternalIdQueryParams
-    :search-q-params VulnerabilitySearchParams
-    :new-spec :new-vulnerability/map
-    :realize-fn realize-vulnerability
-    :get-capabilities :read-vulnerability
-    :post-capabilities :create-vulnerability
-    :put-capabilities :create-vulnerability
-    :delete-capabilities :delete-vulnerability
-    :search-capabilities :search-vulnerability
-    :external-id-capabilities :read-vulnerability
-    :can-aggregate? true
-    :histogram-fields vulnerability-histogram-fields
-    :enumerable-fields vulnerability-enumerable-fields}))
+  (routes
+   (search-by-cpe-ids services)
+   (services->entity-crud-routes
+    services
+    {:entity :vulnerability
+     :new-schema NewVulnerability
+     :entity-schema Vulnerability
+     :get-schema PartialVulnerability
+     :get-params VulnerabilityGetParams
+     :list-schema PartialVulnerabilityList
+     :search-schema PartialVulnerabilityList
+     :external-id-q-params VulnerabilityByExternalIdQueryParams
+     :search-q-params VulnerabilitySearchParams
+     :new-spec :new-vulnerability/map
+     :realize-fn realize-vulnerability
+     :get-capabilities :read-vulnerability
+     :post-capabilities :create-vulnerability
+     :put-capabilities :create-vulnerability
+     :delete-capabilities :delete-vulnerability
+     :search-capabilities :search-vulnerability
+     :external-id-capabilities :read-vulnerability
+     :can-aggregate? true
+     :histogram-fields vulnerability-histogram-fields
+     :enumerable-fields vulnerability-enumerable-fields})))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/vulnerability/cpe.clj
+++ b/src/ctia/entity/vulnerability/cpe.clj
@@ -1,0 +1,47 @@
+(ns ctia.entity.vulnerability.cpe)
+
+(defn apply-operator
+  [{:keys [negate operands operator result]}]
+  (case operator
+    "OR" (when (if negate
+                 (not (some identity operands))
+                 (some identity operands))
+           result)
+    "AND" (when (if negate
+                  (not (every? identity operands))
+                  (every? identity operands))
+            result)))
+
+(defn query-cpe-matches
+  [{:keys [cpe_match negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (for [uri (map :cpe23Uri cpe_match)]
+                               (some #{uri} cpes))
+                   :operator operator
+                   :result cpe_match}))
+
+(defn query-children
+  [{:keys [children negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (map (fn query-child [child]
+                                    (query-cpe-matches child cpes))
+                                  children)
+                   :operator operator
+                   :result children}))
+
+(defn query-node
+  [{:keys [children cpe_match] :as node} cpes]
+  (cond
+    (seq cpe_match) (query-cpe-matches node cpes)
+    (seq children) (query-children node cpes)))
+
+(defn vulnerabilities->ids
+  [cpes vulnerabilities]
+  (letfn [(query-vulnerability
+            [{{:keys [nodes]} :configurations
+              id :id}]
+            (when (seq (keep (fn [node]
+                               (query-node node cpes))
+                             nodes))
+              id))]
+    (keep query-vulnerability vulnerabilities)))

--- a/src/ctia/entity/vulnerability/cpe_search.clj
+++ b/src/ctia/entity/vulnerability/cpe_search.clj
@@ -1,0 +1,53 @@
+(ns ctia.entity.vulnerability.cpe-search)
+
+(defn apply-operator
+  [{:keys [negate operands operator result]}]
+  (case operator
+    "OR" (when (if negate
+                 (not (some identity operands))
+                 (some identity operands))
+           result)
+    "AND" (when (if negate
+                  (not (every? identity operands))
+                  (every? identity operands))
+            result)))
+
+(defn query-cpe-matches
+  [{:keys [cpe_match negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (for [uri (map :cpe23Uri cpe_match)]
+                               (some #{uri} cpes))
+                   :operator operator
+                   :result cpe_match}))
+
+(defn query-children
+  [{:keys [children negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (map (fn query-child [child]
+                                    (query-cpe-matches child cpes))
+                                  children)
+                   :operator operator
+                   :result children}))
+
+(defn query-node
+  [{:keys [children cpe_match] :as node} cpes]
+  (cond
+    (seq cpe_match) (query-cpe-matches node cpes)
+    (seq children) (query-children node cpes)))
+
+(defn query-cve
+  [id nodes cpes]
+  (when (seq (keep (fn [node]
+                     (query-node node cpes))
+                   nodes))
+    id))
+
+(defn find-vulnerabilities
+  [cpes vulnerabilities]
+  (reduce (fn cpe-match-rf
+            [acc [id [{{:keys [nodes]} :configurations}]]]
+            (if-let [matching-id (query-cve id nodes cpes)]
+              (conj acc matching-id)
+              acc))
+          []
+          (group-by :id vulnerabilities)))

--- a/src/ctia/entity/vulnerability/mapping.clj
+++ b/src/ctia/entity/vulnerability/mapping.clj
@@ -75,7 +75,7 @@
 (def cpe-match
   {:properties
    {:vulnerable em/boolean-type
-    :cpe23uri em/token
+    :cpe23Uri em/token
     :versionStartIncluding em/token
     :versionEndIncluding em/token
     :versionStartExcluding em/token
@@ -86,8 +86,10 @@
    {:operator em/token
     :children {:properties
                {:operator em/token
-                :cpe_match cpe-match}}
-    :cpe_match cpe-match}})
+                :cpe_match cpe-match
+                :negate em/boolean-type}}
+    :cpe_match cpe-match
+    :negate em/boolean-type}})
 
 (def configurations
   {:properties

--- a/test/ctia/entity/vulnerability/cpe_test.clj
+++ b/test/ctia/entity/vulnerability/cpe_test.clj
@@ -1,0 +1,164 @@
+(ns ctia.entity.vulnerability.cpe-test
+  (:require
+   [clojure.test :refer :all]
+   [ctia.entity.vulnerability.cpe :as sut]))
+
+(def single-configuration-no-children
+  {:configurations {:nodes [{:operator "OR",
+                             :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"}
+                                         {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"}
+                                         {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"}]}]}
+   :id "vulnerability-one"})
+
+(def single-configuration-with-children
+  {:configurations {:nodes [{:operator "AND"
+                             :children [{:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}]}
+                                        {:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:o:citrix:hypervisor:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:nutanix:ahv:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:vmware:vsphere:-:*:*:*:*:*:*:*"}]}]}]}
+   :id "vulnerability-two"})
+
+(def multiple-configurations
+  {:configurations {:nodes [{:operator "AND"
+                             :children
+                             [{:operator "OR"
+                               :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}]}
+                              {:operator "OR"
+                               :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"}]}]}
+                            {:operator "AND"
+                             :children [{:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}]}
+                                        {:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"}]}]}]}
+   :id "vulnerability-three"})
+
+(deftest test-apply-operator
+  (testing "should return truthy"
+    (are [operator operands]
+        (sut/apply-operator {:negate false
+                             :operands operands
+                             :operator operator
+                             :result true})
+      "OR" [false false true]
+      "OR" [false true false]
+      "OR" [["ted"] nil "fred"]
+      "AND" [true true true]
+      "AND" [true true true 18]
+      "AND" [["ted"] true "fred" true]))
+
+  (testing "should return truthy"
+    (are [operator operands]
+        (sut/apply-operator {:negate true
+                             :operands operands
+                             :operator operator
+                             :result true})
+
+      "OR" [false false false]
+      "OR" [false false false]
+      "AND" [false false false]
+      "AND" [false false false]))
+
+  (testing "should return falsey"
+    (are [operator operands]
+        (not (sut/apply-operator {:negate true
+                                  :operands operands
+                                  :operator operator
+                                  :result true}))
+      "OR" [false false true]
+      "OR" [false true false]
+      "OR" [["ted"] nil "fred"]
+      "AND" [true true true]
+      "AND" [true true true 18]
+      "AND" [["ted"] true "fred" true]))
+
+  (testing "should return falsey"
+    (are [operator operands]
+        (not (sut/apply-operator {:operands operands
+                                  :operator operator
+                                  :result true}))
+      "OR" [false false false]
+      "OR" [false false false]
+      "AND" [false false false]
+      "AND" [false false false])))
+
+(deftest test-cpe-match
+  (let [or-cpe-match {:operator "OR",
+                      :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1803:*:*:*:*:*:*:*"}]}
+        and-cpe-match {:operator "AND"
+                       :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}
+                                   {:cpe23Uri "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"}]}]
+    (testing "OR CPEs should match"
+      (are [cpes] (sut/query-cpe-matches or-cpe-match cpes)
+        ["cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:1803:*:*:*:*:*:*:*"]
+
+        ["cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))
+    (testing "OR CPEs should not match"
+      (are [cpes] (not (sut/query-cpe-matches or-cpe-match cpes))
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))
+    (testing "AND CPEs should match"
+      (are [cpes] (sut/query-cpe-matches and-cpe-match cpes)
+        ["cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"
+         "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]))
+    (testing "AND CPEs should not match"
+      (are [cpes] (not (sut/query-cpe-matches and-cpe-match cpes))
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))))
+
+(deftest test-vulnerability->ids
+  (is (= ["CVE-2021-0301"]
+         (sut/vulnerabilities->ids ["cpe:2.3:o:google:android:-:*:*:*:*:*:*:*"]
+                                   [{:id "CVE-2021-0301"
+                                     :configurations {:nodes [{:operator "OR",
+                                                               :cpe_match
+                                                               [{:vulnerable true,
+                                                                 :cpe23Uri "cpe:2.3:o:google:android:-:*:*:*:*:*:*:*"}]}]}}])))
+  (testing "CPEs should match these CVEs"
+    (are [cve cpes]
+        (= [(:id cve)] (sut/vulnerabilities->ids cpes [cve]))
+      single-configuration-no-children ["cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"]
+      single-configuration-with-children ["cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"
+                                          "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"]))
+  (testing "CPEs should not match these CVEs"
+    (are [cve cpes]
+        (empty? (sut/vulnerabilities->ids cpes [cve]))
+      single-configuration-no-children ["cpe:2.3:o:fred:windows_server_2019:-:*:*:*:*:*:*:*"]
+      single-configuration-with-children ["cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:android:android_kernel:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:openbsd:openbsd_kernel:-:*:*:*:*:*:*:*"]))
+  (testing "Should match vulnerability-one and vulnerability-three"
+    (is (= ["vulnerability-one"
+            "vulnerability-three"]
+           (sut/vulnerabilities->ids ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                                      "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"
+                                      "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"]
+                                     [single-configuration-no-children
+                                      single-configuration-with-children
+                                      multiple-configurations])))))


### PR DESCRIPTION
Progress toward #4744

> **Epic** https://github.com/threatgrid/iroh/issues/4744

> Related https://github.com/threatgrid/iroh/issues/4789

Add route for finding vulnerabilities associated with specific combinations of CPEs (Common Platform Enumerations).

Proposed route:
GET /ctia/vulnerability/search/cpes?cpes-string=space delimited list of cpes


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

