### PR TITLE
bulk delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,12 @@ since "foogroup" and "bargroup" are marked as `authorized_groups` identities in 
    "authorized_groups": ["foogroup" "bargroup"]}
 ```
 
-## Bundle import
+## Bulk and Bundle
+
+CTIA provides Bulk and Bundle routes to help processing multiple entities.
+see [Bulk and Bundle documentation](doc/bulk-bundle.org)
+
+### Bundle import
 
 The `/bundle` API endpoint allows users with the correct permissions to POST a CTIM [bundle object](https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/bundle.cljc).
 
@@ -291,7 +296,7 @@ When a bundle is submitted:
 2. If they are identified by transient IDs, a mapping table between transient and stored IDs is built.
 3. Only new entities are created in the same way as the `/bulk` API endpoint with transient IDs resolutions. Existing entities are not modified.
 
-If more than one entity is referenced by the same external ID, an error is reported.
+If more than one entity is referenced by the same external ID, the first one which is retrieved is picked.
 
 Response of the bundle API endpoint:
 
@@ -303,13 +308,13 @@ Response of the bundle API endpoint:
             :error "An error occurs"}]
 ```
 
-|Field          |Description|
-|---------------|-----------|
-|`:id`          |The real ID|
-|`:original_id` |Provided ID if different from real ID (ex: transient ID) |
-|`:result`      |`error`, `created` or `exists` |
-|`:external_id` |External ID used to identify the entity|
-|`:error`       |Error message|
+| Field          | Description                                              |
+|----------------|----------------------------------------------------------|
+| `:id`          | The real ID                                              |
+| `:original_id` | Provided ID if different from real ID (ex: transient ID) |
+| `:result`      | `error`, `created` or `exists`                           |
+| `:external_id` | External ID used to identify the entity                  |
+| `:error`       | Error message                                            |
 
 
 ### Feeds

--- a/doc/bulk-bundle.org
+++ b/doc/bulk-bundle.org
@@ -115,7 +115,7 @@ which returns
 
 
 ** export
-Bundle Export enables to retrieve entities
+Bundle Export enables us to retrieve many entities.
 
 Bulk Export Params
 #+begin_src clojure
@@ -326,8 +326,8 @@ returns
   ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}}
 #+end_src
 
-errors are handled per entities. If an entitiy is not visible to a user or does not exists, its id will be indicated as not found. If the user can read the entity but not delete it (ex: tlp green and max-record-visibility set to "everyone"), its id id will be indicated as not found.
-the example below shows a response with a mix of found, forbidden and deleted entities:
+Errors are handled per entities. If an entitiy is not visible to a user or does not exist, its id will be indicated as not found. If the user can read the entity but not delete it (ex: tlp green and max-record-visibility set to "everyone"), its id will be indicated as not found.
+The example below shows a response with a mix of not-found, forbidden and deleted entities:
 #+begin_src clojure
 {:incidents
  {:errors

--- a/doc/bulk-bundle.org
+++ b/doc/bulk-bundle.org
@@ -1,0 +1,347 @@
+* Bulk
+
+** create
+BulkCreate schema
+#+begin_src clojure
+(s/defschema NewBulk
+   (st/optional-keys
+    {:actors          [NewActor]
+     :assets          [NewAsset]
+     :asset_mappings  [NewAssetMappings]
+     :asset_properties[NewAssetProperties]
+     :attack_patterns [NewAttackPattern]
+     :campaigns       [NewCampaing]
+     :coas            [NewCOA]
+     :incidents       [NewIncident]
+     :indicators      [NewIndicator]
+     :investigations  [NewInvestigation]
+     :judgements      [NewJudgment]
+     :malwares        [NewMalware]
+     :relationships   [NewRelationship]
+     :casebooks       [NewCasebook]
+     :sightings       [NewSighting]
+     :target_records  [NewTargetRecord]
+     :tools           [NewTool]
+     :vulnerabilities [NewVulnerability]
+     :weaknesses      [NewWeakness]})
+#+end_src
+
+Bulk Create Result is a BulkRefs
+#+begin_src clojure
+(s/defschema BulkRefs
+   (st/optional-keys
+    {:tempids         {TransientID ID}
+     :actors           [(s/maybe Reference)]
+     :assets           [(s/maybe Reference)]
+     :asset_mappings   [(s/maybe Reference)]
+     :asset_properties [(s/maybe Reference)]
+     :attack_patterns  [(s/maybe Reference)]
+     :campaigns        [(s/maybe Reference)]
+     :coas             [(s/maybe Reference)]
+     :incidents        [(s/maybe Reference)]
+     :indicators       [(s/maybe Reference)]
+     :investigations   [(s/maybe Reference)]
+     :judgements       [(s/maybe Reference)]
+     :malwares         [(s/maybe Reference)]
+     :relationships    [(s/maybe Reference)]
+     :casebooks        [(s/maybe Reference)]
+     :sightings        [(s/maybe Reference)]
+     :target_records   [(s/maybe Reference)]
+     :tools            [(s/maybe Reference)]
+     :vulnerabilities  [(s/maybe Reference)]
+     :weaknesses       [(s/maybe Reference)]}))
+#+end_src
+
+example:
+#+begin_src clojure
+{:incidents
+ [{:description
+   "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
+   :assignees ["saintx"],
+   :type "incident",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :external_ids ["ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"],
+   :short_description
+   "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+   :title "2020-06-15-0334-emotet-botnet-report",
+   :incident_time
+   {:opened "2020-06-15T03:43:27.368Z",
+    :reported "2020-06-15T03:34:36.298Z"},
+   :discovery_method "NIDS",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :categories ["Malicious Code"],
+   :status "Containment Achieved",
+   :id "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+   :confidence "High"}],
+ :sightings
+ [{:observables [{:type "ip", :value "98.15.140.226"}],
+   :type "sighting",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :external_ids ["ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"],
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :id "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :count 1,
+   :severity "High",
+   :tlp "green",
+   :timestamp "2020-06-15T03:34:36.298Z",
+   :confidence "High",
+   :observed_time {:start_time "2020-06-15T03:34:36.298Z"}}],
+ :relationships
+ [{:type "relationship",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :target_ref "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+   :relationship_type "member-of",
+   :external_ids ["ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"]}
+  {:type "relationship",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :target_ref "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
+   :description "Sighting of host communication with known Emotet Epoch 2 C&C server",
+   :relationship_type "sighting-of",
+   :external_ids ["ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"]}]}
+
+   #+end_src
+
+which returns
+#+begin_src clojure
+{:incidents ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"],
+ :sightings ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"],
+ :relationships ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"],
+ :tempids {:transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55", :transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"}}
+#+end_src
+
+
+** export
+Bundle Export enables to retrieve entities
+
+Bulk Export Params
+#+begin_src clojure
+(s/defschema BulkRefs
+   (st/optional-keys
+    {:actors           [Reference]
+     :assets           [Reference]
+     :asset_mappings   [Reference]
+     :asset_properties [Reference]
+     :attack_patterns  [Reference]
+     :campaigns        [Reference]
+     :coas             [Reference]
+     :feedbacks        [Reference]
+     :incidents        [Reference]
+     :indicators       [Reference]
+     :investigations   [Reference]
+     :judgements       [Reference]
+     :malwares         [Reference]
+     :relationships    [Reference]
+     :casebooks        [Reference]
+     :sightings        [Reference]
+     :target_records   [Reference]
+     :tools            [Reference]
+     :vulnerabilities  [Reference]
+     :weaknesses       [Reference]}))
+#+end_src
+
+#+begin_src clojure
+(s/defschema BulkRefs
+   (st/optional-keys
+    {:actors          [Actor]
+     :assets          [Asset]
+     :asset_mappings  [AssetMappings]
+     :asset_properties[AssetProperties]
+     :attack_patterns [AttackPattern]
+     :campaigns       [Campaing]
+     :coas            [COA]
+     :incidents       [Incident]
+     :indicators      [Indicator]
+     :investigations  [Investigation]
+     :judgements      [Judgment]
+     :malwares        [Malware]
+     :relationships   [Relationship]
+     :casebooks       [Casebook]
+     :sightings       [Sighting]
+     :target_records  [TargetRecord]
+     :tools           [Tool]
+     :vulnerabilities [Vulnerability]
+     :weaknesses      [Weakness]})
+#+end_src
+
+example:
+
+#+begin_src HTTP
+GET /ctia/bulk?incidents=incident-36c956ee-fde8-4e84-8396-7be9201a9c55&sightings=sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27&relationships=relationship-94b5d199-6353-490d-9b75-38bef7f2dc5aérelationships=relationship-eca9e3c6-1c32-484e-b8a5-685719142090 HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
+#+end_src
+
+returns:
+#+begin_src clojure
+{:incidents
+ [{:id "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"
+   :created "2021-07-05T09:52:39.743Z"
+   :owner "gereteo"
+   :groups "ireaux"
+   :id ""
+   :description
+   "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
+   :assignees ["saintx"],
+   :type "incident",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :external_ids ["ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"],
+   :short_description
+   "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+   :title "2020-06-15-0334-emotet-botnet-report",
+   :incident_time
+   {:opened "2020-06-15T03:43:27.368Z",
+    :reported "2020-06-15T03:34:36.298Z"},
+   :discovery_method "NIDS",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :categories ["Malicious Code"],
+   :status "Containment Achieved",
+   :id "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+   :confidence "High"}],
+ :sightings
+ [{:id "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"
+   :created "2021-07-05T09:52:39.743Z"
+   :owner "gereteo"
+   :groups "ireaux"
+   :observables [{:type "ip", :value "98.15.140.226"}],
+   :type "sighting",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :external_ids ["ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"],
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :id "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :count 1,
+   :severity "High",
+   :tlp "green",
+   :timestamp "2020-06-15T03:34:36.298Z",
+   :confidence "High",
+   :observed_time {:start_time "2020-06-15T03:34:36.298Z"}}],
+ [{:id "http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a"
+   :created "2021-07-05T09:52:39.743Z"
+   :owner "gereteo"
+   :groups "ireaux"
+   :type "relationship",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :target_ref "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+   :relationship_type "member-of",
+   :external_ids ["ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"]}
+  {:id "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"
+   :created "2021-07-05T09:52:39.743Z"
+   :owner "gereteo"
+   :groups "ireaux"
+   :type "relationship",
+   :source "Modeling Incidents in CTIM Tutorial",
+   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+   :target_ref "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
+   :description "Sighting of host communication with known Emotet Epoch 2 C&C server",
+   :relationship_type "sighting-of",
+   :external_ids ["ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"]}]}
+#+end_src
+
+** delete
+
+#+begin_src clojure
+(s/defschema NewBulkDelete
+   (st/optional-keys
+    {:actors           [Reference]
+     :assets           [Reference]
+     :asset_mappings   [Reference]
+     :asset_properties [Reference]
+     :attack_patterns  [Reference]
+     :campaigns        [Reference]
+     :coas             [Reference]
+     :incidents        [Reference]
+     :indicators       [Reference]
+     :investigations   [Reference]
+     :judgements       [Reference]
+     :malwares         [Reference]
+     :relationships    [Reference]
+     :casebooks        [Reference]
+     :sightings        [Reference]
+     :target_records   [Reference]
+     :tools            [Reference]
+     :vulnerabilities  [Reference]
+     :weaknesses       [Reference]}))
+#+end_src
+
+#+begin_src clojure
+(s/defschema BulkErrors
+  (st/optional-keys
+   {:not-found [Reference]
+    :forbidden [Reference]
+    :internal-error [Reference]}))
+
+(s/defschema BulkActions
+  (st/optional-keys
+   {:deleted [Reference]
+    :updated [Reference]
+    :errors BulkErrors}))
+
+(s/defschema BulkDeleteRes
+   (st/optional-keys
+    {:actors           BulkAction
+     :assets           BulkAction
+     :asset_mappings   BulkAction
+     :asset_properties BulkAction
+     :attack_patterns  BulkAction
+     :campaigns        BulkAction
+     :coas             BulkAction
+     :incidents        BulkAction
+     :indicators       BulkAction
+     :investigations   BulkAction
+     :judgements       BulkAction
+     :malwares         BulkAction
+     :relationships    BulkAction
+     :casebooks        BulkAction
+     :sightings        BulkAction
+     :target_records   BulkAction
+     :tools            BulkAction
+     :vulnerabilities  BulkAction
+     :weaknesses       BulkAction}))
+#+end_src
+
+example:
+#+begin_src clojure
+{:incidents ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"],
+ :sightings ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"],
+ :relationships ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}
+#+end_src
+
+returns
+#+begin_src clojure
+{:incidents
+ {:deleted
+  ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"]}
+ :sightings
+ {:deleted
+  ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"]},
+ :relationships
+ {:deleted
+  ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}}
+#+end_src
+
+errors are handled per entities. If an entitiy is not visible to a user or does not exists, its id will be indicated as not found. If the user can read the entity but not delete it (ex: tlp green and max-record-visibility set to "everyone"), its id id will be indicated as not found.
+the example below shows a response with a mix of found, forbidden and deleted entities:
+#+begin_src clojure
+{:incidents
+ {:errors
+  {:not-found
+   ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"]}}
+ :sightings
+ {:deleted
+  ["http://localhost:3000/ctia/incident/sighting-48c057ee-fde9-8e94-8396-5be3261a7c44"]
+  :errors
+  {:not-found
+   ["http://localhost:3000/ctia/sighting/sighting-13cb98d6-123e-2b3c-0b8b-cddc4fb3ce57"]
+   :forbidden
+   ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"]}},
+ :relationships
+ {:deleted
+  ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}}
+#+end_src

--- a/doc/bulk-bundle.org
+++ b/doc/bulk-bundle.org
@@ -1,36 +1,40 @@
+#+TITLE: Bulk and Bundle
+#+AUTHOR: Guillaume ERETEO
+#+OPTIONS: toc:nil
+
 * Bulk
 
-** create
-BulkCreate schema
+** Create
+Bulk Create schema
 #+begin_src clojure
 (s/defschema NewBulk
    (st/optional-keys
-    {:actors          [NewActor]
-     :assets          [NewAsset]
-     :asset_mappings  [NewAssetMappings]
-     :asset_properties[NewAssetProperties]
-     :attack_patterns [NewAttackPattern]
-     :campaigns       [NewCampaing]
-     :coas            [NewCOA]
-     :incidents       [NewIncident]
-     :indicators      [NewIndicator]
-     :investigations  [NewInvestigation]
-     :judgements      [NewJudgment]
-     :malwares        [NewMalware]
-     :relationships   [NewRelationship]
-     :casebooks       [NewCasebook]
-     :sightings       [NewSighting]
-     :target_records  [NewTargetRecord]
-     :tools           [NewTool]
-     :vulnerabilities [NewVulnerability]
-     :weaknesses      [NewWeakness]})
+    {:actors           [NewActor]
+     :assets           [NewAsset]
+     :asset_mappings   [NewAssetMappings]
+     :asset_properties [NewAssetProperties]
+     :attack_patterns  [NewAttackPattern]
+     :campaigns        [NewCampaing]
+     :coas             [NewCOA]
+     :incidents        [NewIncident]
+     :indicators       [NewIndicator]
+     :investigations   [NewInvestigation]
+     :judgements       [NewJudgment]
+     :malwares         [NewMalware]
+     :relationships    [NewRelationship]
+     :casebooks        [NewCasebook]
+     :sightings        [NewSighting]
+     :target_records   [NewTargetRecord]
+     :tools            [NewTool]
+     :vulnerabilities  [NewVulnerability]
+     :weaknesses       [NewWeakness]})
 #+end_src
 
-Bulk Create Result is a BulkRefs
+Bulk Create Result is a BulkRefs with tempids
 #+begin_src clojure
-(s/defschema BulkRefs
+(s/defschema BulkCreateRes
    (st/optional-keys
-    {:tempids         {TransientID ID}
+    {:tempids          {TransientID ID}
      :actors           [(s/maybe Reference)]
      :assets           [(s/maybe Reference)]
      :asset_mappings   [(s/maybe Reference)]
@@ -52,70 +56,117 @@ Bulk Create Result is a BulkRefs
      :weaknesses       [(s/maybe Reference)]}))
 #+end_src
 
-example:
-#+begin_src clojure
-{:incidents
- [{:description
-   "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
-   :assignees ["saintx"],
-   :type "incident",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :external_ids ["ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"],
-   :short_description
-   "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
-   :title "2020-06-15-0334-emotet-botnet-report",
-   :incident_time
-   {:opened "2020-06-15T03:43:27.368Z",
-    :reported "2020-06-15T03:34:36.298Z"},
-   :discovery_method "NIDS",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :categories ["Malicious Code"],
-   :status "Containment Achieved",
-   :id "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
-   :confidence "High"}],
- :sightings
- [{:observables [{:type "ip", :value "98.15.140.226"}],
-   :type "sighting",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :external_ids ["ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"],
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :id "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :count 1,
-   :severity "High",
-   :tlp "green",
-   :timestamp "2020-06-15T03:34:36.298Z",
-   :confidence "High",
-   :observed_time {:start_time "2020-06-15T03:34:36.298Z"}}],
- :relationships
- [{:type "relationship",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :target_ref "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
-   :relationship_type "member-of",
-   :external_ids ["ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"]}
-  {:type "relationship",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :target_ref "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
-   :description "Sighting of host communication with known Emotet Epoch 2 C&C server",
-   :relationship_type "sighting-of",
-   :external_ids ["ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"]}]}
+Example:
+#+begin_src HTTP
+POST /ctia/bulk HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
 
-   #+end_src
+{
+  "incidents": [
+    {
+      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
+      "assignees": [
+        "saintx"
+      ],
+      "type": "incident",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"
+      ],
+      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+      "title": "2020-06-15-0334-emotet-botnet-report",
+      "incident_time": {
+        "opened": "2020-06-15T03:43:27.368Z",
+        "reported": "2020-06-15T03:34:36.298Z"
+      },
+      "discovery_method": "NIDS",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "categories": [
+        "Malicious Code"
+      ],
+      "status": "Containment Achieved",
+      "id": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+      "confidence": "High"
+    }
+  ],
+  "sightings": [
+    {
+      "observables": [
+        {
+          "type": "ip",
+          "value": "98.15.140.226"
+        }
+      ],
+      "type": "sighting",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
+      ],
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "id": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "count": 1,
+      "severity": "High",
+      "tlp": "green",
+      "timestamp": "2020-06-15T03:34:36.298Z",
+      "confidence": "High",
+      "observed_time": {
+        "start_time": "2020-06-15T03:34:36.298Z"
+      }
+    }
+  ],
+  "relationships": [
+    {
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "target_ref": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+      "relationship_type": "member-of",
+      "external_ids": [
+        "ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"
+      ]
+    },
+    {
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "target_ref": "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
+      "description": "Sighting of host communication with known Emotet Epoch 2 C&C server",
+      "relationship_type": "sighting-of",
+      "external_ids": [
+        "ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"
+      ]
+    }
+  ]
+}
+#+end_src
 
-which returns
-#+begin_src clojure
-{:incidents ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"],
- :sightings ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"],
- :relationships ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"],
- :tempids {:transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55", :transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"}}
+Which returns
+#+begin_src javascript
+{
+  "incidents": [
+    "http://localhost:3000/ctia/incident/incident-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32"
+  ],
+  "sightings": [
+    "http://localhost:3000/ctia/sighting/sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2"
+  ],
+  "relationships": [
+    "http://localhost:3000/ctia/relationship/relationship-00922b6b-f387-4176-84c4-a07bf70ebb26",
+    "http://localhost:3000/ctia/relationship/relationship-deaa021c-8467-464a-9eea-7118fe8e9c42"
+  ],
+  "tempids": {
+    "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f": "http://localhost:3000/ctia/incident/incident-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32",
+    "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d": "http://localhost:3000/ctia/sighting/sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2"
+  }
+}
 #+end_src
 
 
 ** export
-Bundle Export enables us to retrieve many entities.
+Bulk Export enables us to retrieve many entities.
 
 Bulk Export Params
 #+begin_src clojure
@@ -143,132 +194,154 @@ Bulk Export Params
      :weaknesses       [Reference]}))
 #+end_src
 
+It returns a Bulk
 #+begin_src clojure
-(s/defschema BulkRefs
+(s/defschema Bulk
    (st/optional-keys
-    {:actors          [Actor]
-     :assets          [Asset]
-     :asset_mappings  [AssetMappings]
-     :asset_properties[AssetProperties]
-     :attack_patterns [AttackPattern]
-     :campaigns       [Campaing]
-     :coas            [COA]
-     :incidents       [Incident]
-     :indicators      [Indicator]
-     :investigations  [Investigation]
-     :judgements      [Judgment]
-     :malwares        [Malware]
-     :relationships   [Relationship]
-     :casebooks       [Casebook]
-     :sightings       [Sighting]
-     :target_records  [TargetRecord]
-     :tools           [Tool]
-     :vulnerabilities [Vulnerability]
-     :weaknesses      [Weakness]})
+    {:actors           [Actor]
+     :assets           [Asset]
+     :asset_mappings   [AssetMappings]
+     :asset_properties [AssetProperties]
+     :attack_patterns  [AttackPattern]
+     :campaigns        [Campaing]
+     :coas             [COA]
+     :incidents        [Incident]
+     :indicators       [Indicator]
+     :investigations   [Investigation]
+     :judgements       [Judgment]
+     :malwares         [Malware]
+     :relationships    [Relationship]
+     :casebooks        [Casebook]
+     :sightings        [Sighting]
+     :target_records   [TargetRecord]
+     :tools            [Tool]
+     :vulnerabilities  [Vulnerability]
+     :weaknesses       [Weakness]})
 #+end_src
 
-example:
+Example:
 
 #+begin_src HTTP
-GET /ctia/bulk?incidents=incident-36c956ee-fde8-4e84-8396-7be9201a9c55&sightings=sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27&relationships=relationship-94b5d199-6353-490d-9b75-38bef7f2dc5aérelationships=relationship-eca9e3c6-1c32-484e-b8a5-685719142090 HTTP/1.1
+GET /ctia/bulk?incidents=incident-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32&relationships=relationship-00922b6b-f387-4176-84c4-a07bf70ebb26&relationships=relationship-deaa021c-8467-464a-9eea-7118fe8e9c42&sightings=sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2 HTTP/1.1
 Host: localhost:3000
 Authorization: "Bearer ..."
 accept: application/json
 #+end_src
 
-returns:
-#+begin_src clojure
-{:incidents
- [{:id "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"
-   :created "2021-07-05T09:52:39.743Z"
-   :owner "gereteo"
-   :groups "ireaux"
-   :id ""
-   :description
-   "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
-   :assignees ["saintx"],
-   :type "incident",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :external_ids ["ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"],
-   :short_description
-   "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
-   :title "2020-06-15-0334-emotet-botnet-report",
-   :incident_time
-   {:opened "2020-06-15T03:43:27.368Z",
-    :reported "2020-06-15T03:34:36.298Z"},
-   :discovery_method "NIDS",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :categories ["Malicious Code"],
-   :status "Containment Achieved",
-   :id "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
-   :confidence "High"}],
- :sightings
- [{:id "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"
-   :created "2021-07-05T09:52:39.743Z"
-   :owner "gereteo"
-   :groups "ireaux"
-   :observables [{:type "ip", :value "98.15.140.226"}],
-   :type "sighting",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :external_ids ["ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"],
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :id "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :count 1,
-   :severity "High",
-   :tlp "green",
-   :timestamp "2020-06-15T03:34:36.298Z",
-   :confidence "High",
-   :observed_time {:start_time "2020-06-15T03:34:36.298Z"}}],
- [{:id "http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a"
-   :created "2021-07-05T09:52:39.743Z"
-   :owner "gereteo"
-   :groups "ireaux"
-   :type "relationship",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :target_ref "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
-   :relationship_type "member-of",
-   :external_ids ["ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"]}
-  {:id "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"
-   :created "2021-07-05T09:52:39.743Z"
-   :owner "gereteo"
-   :groups "ireaux"
-   :type "relationship",
-   :source "Modeling Incidents in CTIM Tutorial",
-   :source_uri "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
-   :source_ref "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
-   :target_ref "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
-   :description "Sighting of host communication with known Emotet Epoch 2 C&C server",
-   :relationship_type "sighting-of",
-   :external_ids ["ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"]}]}
+Returns:
+#+begin_src javascript
+{
+  "incidents": [
+    {
+      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
+      "assignees": [
+        "saintx"
+      ],
+      "schema_version": "1.1.3",
+      "type": "incident",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"
+      ],
+      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+      "title": "2020-06-15-0334-emotet-botnet-report",
+      "incident_time": {
+        "opened": "2020-06-15T03:43:27.368Z",
+        "reported": "2020-06-15T03:34:36.298Z"
+      },
+      "discovery_method": "NIDS",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "categories": [
+        "Malicious Code"
+      ],
+      "status": "Containment Achieved",
+      "id": "http://localhost:3000/ctia/incident/incident-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2021-08-11T09:32:18.059Z",
+      "confidence": "High",
+      "owner": "Unknown"
+    }
+  ],
+  "relationships": [
+    {
+      "schema_version": "1.1.3",
+      "target_ref": "http://localhost:3000/ctia/incident/incident-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32",
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-relationship-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"
+      ],
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref": "http://localhost:3000/ctia/sighting/sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2",
+      "id": "http://localhost:3000/ctia/relationship/relationship-00922b6b-f387-4176-84c4-a07bf70ebb26",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2021-08-11T09:32:18.458Z",
+      "owner": "Unknown",
+      "relationship_type": "member-of"
+    },
+    {
+      "description": "Sighting of host communication with known Emotet Epoch 2 C&C server",
+      "schema_version": "1.1.3",
+      "target_ref": "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-relationship-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"
+      ],
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref": "http://localhost:3000/ctia/sighting/sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2",
+      "id": "http://localhost:3000/ctia/relationship/relationship-deaa021c-8467-464a-9eea-7118fe8e9c42",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2021-08-11T09:32:18.458Z",
+      "owner": "Unknown",
+      "relationship_type": "sighting-of"
+    }
+  ],
+  "sightings": [
+    {
+      "schema_version": "1.1.3",
+      "observables": [
+        {
+          "value": "98.15.140.226",
+          "type": "ip"
+        }
+      ],
+      "type": "sighting",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
+      ],
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "id": "http://localhost:3000/ctia/sighting/sighting-20e12700-20b1-4e3a-8e79-cb9fdc1579a2",
+      "count": 1,
+      "severity": "High",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2020-06-15T03:34:36.298Z",
+      "confidence": "High",
+      "observed_time": {
+        "start_time": "2020-06-15T03:34:36.298Z"
+      },
+      "owner": "Unknown"
+    }
+  ]
+}
 #+end_src
 
-** delete
+** Delete
 
-#+begin_src clojure
-(s/defschema NewBulkDelete
-   (st/optional-keys
-    {:actors           [Reference]
-     :assets           [Reference]
-     :asset_mappings   [Reference]
-     :asset_properties [Reference]
-     :attack_patterns  [Reference]
-     :campaigns        [Reference]
-     :coas             [Reference]
-     :incidents        [Reference]
-     :indicators       [Reference]
-     :investigations   [Reference]
-     :judgements       [Reference]
-     :malwares         [Reference]
-     :relationships    [Reference]
-     :casebooks        [Reference]
-     :sightings        [Reference]
-     :target_records   [Reference]
-     :tools            [Reference]
-     :vulnerabilities  [Reference]
-     :weaknesses       [Reference]}))
-#+end_src
+A Bulk Delete takes a BulkRefs like the Bulk Export but returns a BulkDeleteRes with more specific errors.
 
 #+begin_src clojure
 (s/defschema BulkErrors
@@ -306,42 +379,315 @@ returns:
      :weaknesses       BulkAction}))
 #+end_src
 
-example:
-#+begin_src clojure
-{:incidents ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"],
- :sightings ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"],
- :relationships ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}
+Example:
+
+#+begin_src HTTP
+DELETE /ctia/bulk HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
+
+{
+  "incidents": [
+    "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"
+  ],
+  "sightings": [
+    "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"
+  ],
+  "relationships": [
+    "http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a",
+    "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"
+  ]
+}
 #+end_src
 
-returns
-#+begin_src clojure
-{:incidents
- {:deleted
-  ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"]}
- :sightings
- {:deleted
-  ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"]},
- :relationships
- {:deleted
-  ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}}
+Returns
+#+begin_src javascript
+{
+  "incidents": {
+    "deleted": [
+      "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"
+    ]
+  },
+  "sightings": {
+    "deleted": [
+      "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"
+    ]
+  },
+  "relationships": {
+    "deleted": [
+      "http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a",
+      "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"
+    ]
+  }
+}
 #+end_src
 
 Errors are handled per entities. If an entitiy is not visible to a user or does not exist, its id will be indicated as not found. If the user can read the entity but not delete it (ex: tlp green and max-record-visibility set to "everyone"), its id will be indicated as not found.
 The example below shows a response with a mix of not-found, forbidden and deleted entities:
-#+begin_src clojure
-{:incidents
- {:errors
-  {:not-found
-   ["http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"]}}
- :sightings
- {:deleted
-  ["http://localhost:3000/ctia/incident/sighting-48c057ee-fde9-8e94-8396-5be3261a7c44"]
-  :errors
-  {:not-found
-   ["http://localhost:3000/ctia/sighting/sighting-13cb98d6-123e-2b3c-0b8b-cddc4fb3ce57"]
-   :forbidden
-   ["http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"]}},
- :relationships
- {:deleted
-  ["http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a" "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"]}}
+#+begin_src javascript
+{
+  "incidents": {
+    "errors": {
+      "not-found": [
+        "http://localhost:3000/ctia/incident/incident-36c956ee-fde8-4e84-8396-7be9201a9c55"
+      ]
+    }
+  },
+  "sightings": {
+    "deleted": [
+      "http://localhost:3000/ctia/incident/sighting-48c057ee-fde9-8e94-8396-5be3261a7c44"
+    ],
+    "errors": {
+      "not-found": [
+        "http://localhost:3000/ctia/sighting/sighting-13cb98d6-123e-2b3c-0b8b-cddc4fb3ce57"
+      ],
+      "forbidden": [
+        "http://localhost:3000/ctia/sighting/sighting-68cb80d5-826e-4b5c-9b9b-cddc5fb1ce27"
+      ]
+    }
+  },
+  "relationships": {
+    "deleted": [
+      "http://localhost:3000/ctia/relationship/relationship-94b5d199-6353-490d-9b75-38bef7f2dc5a",
+      "http://localhost:3000/ctia/relationship/relationship-eca9e3c6-1c32-484e-b8a5-685719142090"
+    ]
+  }
+}
+#+end_src
+
+* Bundle
+
+The bundle routes are like bulk but with extra processing helpers to ease large import/export.
+
+** Bundle Import
+
+The `/bundle` API endpoint allows users with the correct permissions to POST a CTIM [bundle object](https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/bundle.cljc).
+
+The ability to post bundles is controlled by the `import-bundle` capability.
+
+When a bundle is submitted:
+
+1. All entities that have already been imported with the external ID whose prefix has been configured with the `ctia.store.external-key-prefixes` property are searched.
+2. If they are identified by transient IDs, a mapping table between transient and stored IDs is built.
+3. Only new entities are created in the same way as the `/bulk` API endpoint with transient IDs resolutions. Existing entities are not modified.
+
+If more than one entity is referenced by the same external ID, an error is reported.
+
+Example for an incident along with its context, note the transient ids
+#+begin_src HTTP
+POST /ctia/bundle/import HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
+
+{
+  "type" : "bundle",
+  "source": "Modeling Incidents in CTIM Tutorial",
+  "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+  "incidents" : [ {
+    "type": "incident",
+    "source": "Modeling Incidents in CTIM Tutorial",
+    "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+    "title": "2020-06-15-0334-emotet-botnet-report",
+    "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+    "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm. Incident responders isolated the host for further analysis.\n\n## Additional Details:\n\nSMTP traffic log analysis underway to determine the method of initial infection. Phishing attack suspected. No evidence of lateral movement across VLAN 414.",
+    "external_ids": ["ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"],
+    "id": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+    "confidence": "High",
+    "status": "Containment Achieved",
+    "incident_time":
+    {"opened": "2020-06-15T03:43:27.368Z",
+     "reported": "2020-06-15T03:34:36.298Z"},
+     "assignees": ["saintx"],
+     "categories": ["Malicious Code"],
+     "discovery_method": "NIDS"
+  } ],
+  "sightings" : [ {
+      "observables" : [ {
+        "type" : "ip",
+        "value" : "98.15.140.226"
+      } ],
+      "type" : "sighting",
+    "source": "Modeling Incidents in CTIM Tutorial",
+    "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "external_ids" : [ "ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d" ],
+      "id" : "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "count" : 1,
+      "severity" : "High",
+      "tlp" : "green",
+      "timestamp" : "2020-06-15T03:34:36.298Z",
+      "confidence" : "High",
+      "observed_time" : {
+        "start_time" : "2020-06-15T03:34:36.298Z"
+      }
+    } ],
+    "relationships": [ {
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref" : "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "target_ref" : "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+      "relationship_type" : "member-of"
+    },
+    {
+      "type": "relationship",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "source_ref" : "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "target_ref" : "https://intel.tutorial.iroh.site:443/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
+      "description": "Sighting of host communication with known Emotet Epoch 2 C&C server",
+      "relationship_type" : "sighting-of"
+    }]
+}
+#+end_src
+
+#+begin_src javascript
+{
+  "results": [
+    {
+      "id": "http://localhost:3000/ctia/incident/incident-c545ab34-33c3-4a27-b9af-426220951d75",
+      "original_id": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
+      "result": "created",
+      "type": "incident",
+      "external_ids": [
+        "ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"
+      ]
+    },
+    {
+      "id": "http://localhost:3000/ctia/sighting/sighting-cdf7d784-ac0e-41f3-9191-f362df293721",
+      "original_id": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
+      "result": "created",
+      "type": "sighting",
+      "external_ids": [
+        "ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
+      ]
+    },
+    {
+      "id": "http://localhost:3000/ctia/relationship/relationship-56c4ad42-7e75-43b6-a331-4907ec394b5d",
+      "result": "created",
+      "type": "relationship"
+    },
+    {
+      "id": "http://localhost:3000/ctia/relationship/relationship-61fab80f-d097-44de-82e4-95a164b16f61",
+      "result": "created",
+      "type": "relationship"
+    }
+  ]
+}
+#+end_src
+
+| Field          | Description                                              |
+|----------------+----------------------------------------------------------|
+| `:id`          | The real ID                                              |
+| `:original_id` | Provided ID if different from real ID (ex: transient ID) |
+| `:result`      | `error`, `created` or `exists`                           |
+| `:external_id` | External ID used to identify the entity                  |
+| `:error`       | Error message                                            |
+
+** Bundle Export
+
+Bundle Export offers to retrieve many entities from their ids along with corresponding relationships and directly linked entities.
+
+| query Params                | values                     | Description                                           |
+|-----------------------------+----------------------------+-------------------------------------------------------|
+| `:related_to`               | `target_ref`, `source_ref` | The direction of the relationships to retrieve.       |
+| `:source_type`              | valid entity type          | the type of the source entities.                      |
+| `:target_type`              | valid entity type          | the type of the target entitites                      |
+| `:include_related_entities` | `true`, `false``           | Shall the related entities be included in the result? |
+
+The Bundle Export is exposed with a POST and a GET route. The Post route is meant for large Bundle Export queries.
+
+Examples:
+#+begin_src HTTP
+POST /ctia/bundle/export HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
+
+{
+  "ids": [
+    "incident-1",  "incident-2", ... "incident-100"
+  ]
+
+#+end_src
+
+#+begin_src HTTP
+GET /ctia/bundle/export?id=incident-1&id=incident-2 HTTP/1.1
+Host: localhost:3000
+Authorization: "Bearer ..."
+accept: application/json
+#+end_src
+
+Returns
+
+#+begin_src javascript
+{
+  "type": "bundle",
+  "incidents": [
+    {
+      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm. Incident responders isolated the host for further analysis.\n\n## Additional Details:\n\nSMTP traffic log analysis underway to determine the method of initial infection. Phishing attack suspected. No evidence of lateral movement across VLAN 414.",
+      "assignees": [
+        "saintx"
+      ],
+      "schema_version": "1.1.3",
+      "type": "incident",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"
+      ],
+      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
+      "title": "2020-06-15-0334-emotet-botnet-report",
+      "incident_time": {
+        "opened": "2020-06-15T03:43:27.368Z",
+        "reported": "2020-06-15T03:34:36.298Z"
+      },
+      "discovery_method": "NIDS",
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "categories": [
+        "Malicious Code"
+      ],
+      "status": "Containment Achieved",
+      "id": "http://localhost:3000/ctia/incident/incident-c545ab34-33c3-4a27-b9af-426220951d75",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2021-08-10T15:22:24.967Z",
+      "confidence": "High",
+      "owner": "Unknown"
+    }
+  ],
+  "source": "ctia",
+  "sightings": [
+    {
+      "schema_version": "1.1.3",
+      "observables": [
+        {
+          "value": "98.15.140.226",
+          "type": "ip"
+        }
+      ],
+      "type": "sighting",
+      "source": "Modeling Incidents in CTIM Tutorial",
+      "external_ids": [
+        "ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
+      ],
+      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
+      "id": "http://localhost:3000/ctia/sighting/sighting-cdf7d784-ac0e-41f3-9191-f362df293721",
+      "count": 1,
+      "severity": "High",
+      "tlp": "green",
+      "groups": [
+        "Administrators"
+      ],
+      "timestamp": "2020-06-15T03:34:36.298Z",
+      "confidence": "High",
+      "observed_time": {
+        "start_time": "2020-06-15T03:34:36.298Z"
+      },
+      "owner": "Unknown"
+    }
+  ]
+}
 #+end_src

--- a/project.clj
+++ b/project.clj
@@ -82,7 +82,7 @@
                  [threatgrid/flanders "0.1.23"]
                  [threatgrid/ctim "1.1.6"]
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.3.0"]
+                 [threatgrid/ductile "0.4.1"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -1,22 +1,17 @@
 (ns ctia.auth.threatgrid
-  (:require
-   [ctia.auth.capabilities
-    :refer [default-capabilities]]
-   [cheshire.core :as json]
-   [clj-http.client :as http]
-   [clj-momo.lib.set :refer [as-set]]
-   [clojure
-    [set :as set]
-    [string :as str]]
-   [clojure.core.memoize :as memo]
-   [ctia.store-service.schemas :refer [GetStoreFn]]
-   [ctia
-    [auth :as auth]
-    [properties :as p]
-    [store :as store]]
-   [puppetlabs.trapperkeeper.core :as tk]
-   [puppetlabs.trapperkeeper.services :refer [service-context]]
-   [schema.core :as s]))
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
+            [clj-momo.lib.set :refer [as-set]]
+            [clojure.core.memoize :as memo]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [ctia.auth :as auth]
+            [ctia.auth.capabilities :refer [default-capabilities]]
+            [ctia.store :as store]
+            [ctia.store-service.schemas :refer [GetStoreFn]]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.trapperkeeper.services :refer [service-context]]
+            [schema.core :as s]))
 
 (declare make-auth-service)
 

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -4,10 +4,9 @@
    [clojure.string :as str]
    [clojure.tools.logging :as log]
    [ctia.auth :as auth]
-   [ctia.domain.entities :as ent :refer [with-long-id]]
+   [ctia.domain.entities :as ent :refer [with-long-id short-id->long-id]]
    [ctia.entity.entities :refer [all-entities]]
    [ctia.flows.crud :as flows]
-   [ctia.properties :as p]
    [ctia.schemas.core :as schemas :refer [APIHandlerServices]]
    [ctia.schemas.utils :as csu]
    [ctia.store :as store]
@@ -81,8 +80,9 @@
                 :entities new-entities
                 :tempids tempids
                 :spec (-> entities entity-type :new-spec))
-              :data (partial map (fn [{:keys [error id] :as result}]
-                                   (if error result id)))))))
+              :data
+              (partial map (fn [{:keys [error id] :as result}]
+                             (if error result id)))))))
 
 (s/defschema ReadEntitiesServices
   {:ConfigService (-> APIHandlerServices
@@ -106,7 +106,45 @@
                      (with-long-id services))
              (catch Exception e
                (do (log/error (pr-str e))
-                   nil)))) ids)))
+                   nil))))
+         ids)))
+
+(s/defn delete-fn
+  "return the delete function provided an entity type key"
+  [k auth-identity params
+   {{:keys [get-store]} :StoreService} :- APIHandlerServices]
+  #(-> (get-store k)
+       (store/bulk-delete
+         %
+         (auth/ident->map auth-identity)
+         params)))
+
+(defn format-bulk-flow-res
+  "format delete res with-long-id for a given entity type result"
+  [bulk-flow-res services]
+  (into {}
+        (map (fn [[action res]]
+               {action
+                (case action
+                  :errors (format-bulk-flow-res res services)
+                  (map #(short-id->long-id % services) res))}))
+        bulk-flow-res))
+
+(s/defn delete-entities
+  "Create many entities provided their type and returns a list of ids"
+  [entity-ids entity-type auth-identity params
+   services :- APIHandlerServices]
+  (when (seq entity-ids)
+    (let [get-fn #(read-entities %  entity-type auth-identity services)
+          delete-flow-res (flows/delete-flow
+                           :services services
+                           :entity-type entity-type
+                           :entity-ids entity-ids
+                           :get-fn get-fn
+                           :delete-fn (delete-fn entity-type auth-identity params services)
+                           :long-id-fn #(with-long-id % services)
+                           :identity auth-identity)]
+      (format-bulk-flow-res delete-flow-res services))))
 
 (defn gen-bulk-from-fn
   "Kind of fmap but adapted for bulk
@@ -165,8 +203,9 @@
    1. Creates all entities except Relationships
    2. Creates Relationships with mapping between transient and real IDs"
   ([bulk login services :- APIHandlerServices] (create-bulk bulk {} login {} services))
-  ([bulk tempids login params {{:keys [get-in-config]} :ConfigService :as services} :- APIHandlerServices]
-   (let [{:keys [refresh] :as params
+  ([bulk tempids login params
+    {{:keys [get-in-config]} :ConfigService :as services} :- APIHandlerServices]
+   (let [{:keys [refresh]
           :or   {refresh (bulk-refresh? get-in-config)}} params
          new-entities (gen-bulk-from-fn
                        create-entities
@@ -219,3 +258,13 @@
       (bad-request (str "Bulk max nb of entities: " (get-bulk-max-size get-in-config)))
       (ent/un-store-map
        (gen-bulk-from-fn read-entities bulk auth-identity services)))))
+
+(s/defn delete-bulk
+  [entities-map auth-identity params
+   {{:keys [get-in-config]} :ConfigService
+    :as services} :- APIHandlerServices]
+  (let [bulk (into {} (remove (comp empty? second) entities-map))]
+    (if (> (bulk-size bulk) (get-bulk-max-size get-in-config))
+      (bad-request (str "Bulk max nb of entities: "
+                        (get-bulk-max-size get-in-config)))
+      (gen-bulk-from-fn delete-entities bulk auth-identity params services))))

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -1,9 +1,9 @@
 (ns ctia.bulk.routes
   (:require
-   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk get-bulk-max-size]]
-   [ctia.bulk.schemas :refer [Bulk BulkRefs NewBulk]]
+   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk delete-bulk get-bulk-max-size]]
+   [ctia.bulk.schemas :refer [Bulk BulkRefs NewBulk BulkActionsRefs]]
    [ctia.http.routes.common :as common]
-   [ctia.lib.compojure.api.core :refer [GET POST routes]]
+   [ctia.lib.compojure.api.core :refer [GET POST DELETE routes]]
    [ctia.schemas.core :refer [APIHandlerServices Reference]]
    [ring.swagger.json-schema :refer [describe]]
    [ring.util.http-response :refer [bad-request ok]]
@@ -122,4 +122,78 @@
                               :tools               tools
                               :vulnerabilities     vulnerabilities
                               :weaknesses          weaknesses}]
-            (ok (fetch-bulk entities-map auth-identity services)))))))
+            (ok (fetch-bulk entities-map auth-identity services)))))
+
+    (let [capabilities #{:delete-actor
+                         :delete-asset
+                         :delete-asset-mapping
+                         :delete-asset-properties
+                         :delete-attack-pattern
+                         :delete-campaign
+                         :delete-coa
+                         :delete-data-table
+                         :delete-feedback
+                         :delete-incident
+                         :delete-investigation
+                         :delete-indicator
+                         :delete-judgement
+                         :delete-malware
+                         :delete-relationship
+                         :delete-casebook
+                         :delete-sighting
+                         :delete-identity-assertion
+                         :delete-target-record
+                         :delete-tool
+                         :delete-vulnerability
+                         :delete-weakness}]
+     (DELETE "/" []
+          :return (s/maybe (BulkActionsRefs services))
+          :summary "DELETE many entities at once"
+          :query-params [{actors              :- [Reference] []}
+                         {asset_mappings      :- [Reference] []}
+                         {assets              :- [Reference] []}
+                         {asset_properties    :- [Reference] []}
+                         {attack_patterns     :- [Reference] []}
+                         {campaigns           :- [Reference] []}
+                         {casebooks           :- [Reference] []}
+                         {coas                :- [Reference] []}
+                         {data_tables         :- [Reference] []}
+                         {feedbacks           :- [Reference] []}
+                         {identity_assertions :- [Reference] []}
+                         {incidents           :- [Reference] []}
+                         {indicators          :- [Reference] []}
+                         {investigations      :- [Reference] []}
+                         {judgements          :- [Reference] []}
+                         {malwares            :- [Reference] []}
+                         {relationships       :- [Reference] []}
+                         {sightings           :- [Reference] []}
+                         {target_records      :- [Reference] []}
+                         {tools               :- [Reference] []}
+                         {vulnerabilities     :- [Reference] []}
+                         {weaknesses          :- [Reference] []}]
+          :description (common/capabilities->description capabilities)
+          :capabilities capabilities
+          :auth-identity auth-identity
+          (let [entities-map {:actors              actors
+                              :asset_mappings      asset_mappings
+                              :assets              assets
+                              :asset_properties    asset_properties
+                              :attack_patterns     attack_patterns
+                              :campaigns           campaigns
+                              :casebooks           casebooks
+                              :coas                coas
+                              :data_tables         data_tables
+                              :feedbacks           feedbacks
+                              :identity_assertions identity_assertions
+                              :incidents           incidents
+                              :indicators          indicators
+                              :investigations      investigations
+                              :judgements          judgements
+                              :malwares            malwares
+                              :relationships       relationships
+                              :sightings           sightings
+                              :target_records      target_records
+                              :tools               tools
+                              :vulnerabilities     vulnerabilities
+                              :weaknesses          weaknesses}]
+            (ok (delete-bulk entities-map auth-identity {} services)))))))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -16,7 +16,8 @@
            (let [bulk-schema
                  (if (keyword? sch)
                    [(s/maybe
-                     (get entity sch))] sch)]
+                     (get entity sch))]
+                   sch)]
              {(-> plural
                   name
                   (str/replace #"-" "_")
@@ -48,3 +49,19 @@
   "Returns NewBulk schema without disabled entities"
   [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :new-schema))
+
+(s/defschema BulkErrors
+  (st/optional-keys
+   {:not-found [Reference]
+    :forbidden [Reference]
+    :internal-error [Reference]}))
+
+(s/defschema BulkActions
+  (st/optional-keys
+   {:deleted [Reference]
+    :updated [Reference]
+    :errors BulkErrors}))
+
+(s/defn BulkActionsRefs :- (s/protocol s/Schema)
+  [services :- GetEntitiesServices]
+  (entities-bulk-schema (get-entities services) BulkActions))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -41,14 +41,23 @@
 
 (s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- GetEntitiesServices]
-  (st/assoc
-   (entities-bulk-schema (get-entities services) [(s/maybe Reference)])
-   (s/optional-key :tempids) TempIDs))
+  (entities-bulk-schema (get-entities services) [(s/maybe Reference)]))
+
+(s/defn BulkCreateRes :- (s/protocol s/Schema)
+  [services :- GetEntitiesServices]
+  (st/assoc (BulkRefs services)
+            (s/optional-key :tempids)
+            TempIDs))
 
 (s/defn NewBulk :- (s/protocol s/Schema)
   "Returns NewBulk schema without disabled entities"
   [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :new-schema))
+
+(s/defn NewBulkDelete
+  "Returns NewBulk schema without disabled entities"
+  [services :- GetEntitiesServices]
+  (entities-bulk-schema (get-entities services) [(s/maybe Reference)]))
 
 (s/defschema BulkErrors
   (st/optional-keys

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -5,7 +5,6 @@
             [ctia.schemas.core :as ctia-schemas
              :refer [GraphQLRuntimeContext
                      HTTPShowServices
-                     RealizeFn
                      RealizeFnResult
                      TempIDs]]
             [ctim.domain.id :as id]

--- a/src/ctia/entity/event/schemas.clj
+++ b/src/ctia/entity/event/schemas.clj
@@ -1,7 +1,6 @@
 (ns ctia.entity.event.schemas
   (:require
    [ctia.schemas.core :refer [TLP]]
-   [flanders.schema :as fs]
    [schema.core :as s]
    [schema-tools.core :as st]))
 

--- a/src/ctia/entity/event/store.clj
+++ b/src/ctia/entity/event/store.clj
@@ -1,6 +1,5 @@
 (ns ctia.entity.event.store
   (:require
-   [ctia.entity.event.schemas :refer [PartialEvent]]
    [ctia.store :refer [IStore IQueryStringSearchableStore IEventStore]]
    [ctia.entity.event.crud :as crud]
    [ctia.stores.es.store :refer [close-connections!]]))

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -418,22 +418,27 @@
        :capabilities capabilities
        :auth-identity identity
        :identity-map identity-map
-       (if (flows/delete-flow
-            :services services
-            :get-fn #(-> (get-store :feed)
-                         (read-record
-                          %
-                          identity-map
-                          {}))
-            :delete-fn #(-> (get-store :feed)
-                            (delete-record
-                             %
-                             identity-map
-                             (routes.common/wait_for->refresh wait_for)))
-            :entity-type :feed
-            :long-id-fn #(with-long-id % services)
-            :entity-id id
-            :identity identity)
+       (if (first
+            (flows/delete-flow
+             :services services
+             :get-fn (fn [ids]
+                       (let [read-fn #(-> (get-store :feed)
+                                          (read-record
+                                           %
+                                           identity-map
+                                           {}))]
+                         (map read-fn ids)))
+             :delete-fn (fn [ids]
+                          (let [delete-fn #(-> (get-store :feed)
+                                               (delete-record
+                                                %
+                                                identity-map
+                                                (routes.common/wait_for->refresh wait_for)))]
+                            (map delete-fn ids)))
+             :entity-type :feed
+             :long-id-fn #(with-long-id % services)
+             :entity-ids [id]
+             :identity identity))
          (no-content)
          (not-found))))))
 

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -436,6 +436,9 @@
                                                 (routes.common/wait_for->refresh wait_for)))]
                             (map delete-fn ids)))
              :entity-type :feed
+             :get-success-entities (fn [fm]
+                                     (when (first (:results fm))
+                                         (:entities fm)))
              :long-id-fn #(with-long-id % services)
              :entity-ids [id]
              :identity identity))

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -1,7 +1,6 @@
 (ns ctia.entity.judgement.es-store
   (:require [ductile.document :refer [search-docs]]
             [clj-momo.lib.time :as time]
-            [ctia.domain.access-control :refer [allow-write?]]
             [ctia.entity.judgement.schemas
              :refer
              [PartialStoredJudgement StoredJudgement]]
@@ -47,6 +46,7 @@
 (def handle-read (crud/handle-read PartialStoredJudgement))
 (def handle-delete (crud/handle-delete :judgement))
 (def handle-list (crud/handle-find PartialStoredJudgement))
+(def handle-bulk-delete crud/bulk-delete)
 (def handle-query-string-search (crud/handle-query-string-search PartialStoredJudgement))
 (def handle-query-string-count crud/handle-query-string-count)
 (def handle-aggregate crud/handle-aggregate)
@@ -112,6 +112,8 @@
     (handle-delete state id ident params))
   (update-record [_ id judgement ident params]
     (handle-update state id judgement ident params))
+  (bulk-delete [_ ids ident params]
+    (handle-bulk-delete state ids ident params))
   (list-records [_ filter-map ident params]
     (handle-list state filter-map ident params))
   (close [_] (close-connections! state))

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -59,6 +59,7 @@
 (def handle-query-string-count crud/handle-query-string-count)
 (def handle-aggregate crud/handle-aggregate)
 (def handle-delete-search crud/handle-delete-search)
+(def handle-bulk-delete crud/bulk-delete)
 
 (s/defn observable->observable-hash :- s/Str
   "transform an observable to a hash of the form type:value"
@@ -163,6 +164,8 @@
     (handle-delete state id ident params))
   (list-records [_ filter-map ident params]
     (handle-list state filter-map ident params))
+  (bulk-delete [_ ids ident params]
+    (handle-bulk-delete state ids ident params))
   (close [_] (close-connections! state))
   ISightingStore
   (list-sightings-by-observables [_ observables ident params]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -488,6 +488,9 @@
                                                         identity-map
                                                         (wait_for->refresh wait_for)))]
                                     (map delete-fn ids)))
+                     :get-success-entities (fn [fm]
+                                             (when (first (:results fm))
+                                                 (:entities fm)))
                      :entity-type entity
                      :long-id-fn #(with-long-id % services)
                      :entity-ids [id]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -12,7 +12,6 @@
    [ctia.http.middleware.auth]
    [ctia.http.routes.common :refer [capabilities->description
                                     created
-                                    filter-map-search-options
                                     paginated-ok
                                     search-options
                                     wait_for->refresh
@@ -472,22 +471,27 @@
                :capabilities capabilities
                :auth-identity identity
                :identity-map identity-map
-               (if (flows/delete-flow
-                    :services services
-                    :get-fn #(-> (get-store entity)
-                                 (read-record
-                                   %
-                                   identity-map
-                                   {}))
-                    :delete-fn #(-> (get-store entity)
-                                    (delete-record
-                                      %
-                                      identity-map
-                                      (wait_for->refresh wait_for)))
-                    :entity-type entity
-                    :long-id-fn #(with-long-id % services)
-                    :entity-id id
-                    :identity identity)
+               (if (first
+                    (flows/delete-flow
+                     :services services
+                     :get-fn (fn [ids]
+                               (let [read-fn #(-> (get-store entity)
+                                                  (read-record
+                                                   %
+                                                   identity-map
+                                                   {}))]
+                                 (map read-fn ids)))
+                     :delete-fn (fn [ids]
+                                  (let [delete-fn #(-> (get-store entity)
+                                                       (delete-record
+                                                        %
+                                                        identity-map
+                                                        (wait_for->refresh wait_for)))]
+                                    (map delete-fn ids)))
+                     :entity-type entity
+                     :long-id-fn #(with-long-id % services)
+                     :entity-ids [id]
+                     :identity identity))
                  (no-content)
                  (not-found))))
 

--- a/src/ctia/http/server_service.clj
+++ b/src/ctia/http/server_service.clj
@@ -1,7 +1,5 @@
 (ns ctia.http.server-service
   (:require [ctia.http.server-service-core :as core]
-            [ctia.properties :as p]
-            [ctia.flows.hooks-service :as hooks-svc]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -21,26 +21,27 @@
 
 (s/defschema APIHandlerServices
   "Maps of services available to routes"
-  {:ConfigService                   (-> external-svc-fns/ConfigServiceFns
-                                        (csu/select-all-keys
+  (csu/open-service-schema
+   {:ConfigService                   (-> external-svc-fns/ConfigServiceFns
+                                         (csu/select-all-keys
                                           #{:get-config
                                             :get-in-config}))
-   :CTIAHTTPServerService           {:get-port    (s/=> Port)
-                                     :get-graphql (s/=> graphql.GraphQL)}
-   :HooksService                    (-> hooks-schemas/ServiceFns
-                                        (csu/select-all-keys
+    :CTIAHTTPServerService           {:get-port    (s/=> Port)
+                                      :get-graphql (s/=> graphql.GraphQL)}
+    :HooksService                    (-> hooks-schemas/ServiceFns
+                                         (csu/select-all-keys
                                           #{:apply-event-hooks
                                             :apply-hooks}))
-   :StoreService                    {:get-store GetStoreFn}
-   :IAuth                           {:identity-for-token (s/=> s/Any s/Any)}
-   :GraphQLNamedTypeRegistryService {:get-or-update-named-type-registry
-                                     (s/=> graphql.schema.GraphQLType
-                                           s/Str
-                                           (s/=> graphql.schema.GraphQLType))}
-   :IEncryption                     {:encrypt (s/=> s/Any s/Any)
-                                     :decrypt (s/=> s/Any s/Any)}
-   :FeaturesService                 {:enabled?      (s/=> s/Bool s/Keyword)
-                                     :feature-flags (s/=> [s/Str])}})
+    :StoreService                    {:get-store GetStoreFn}
+    :IAuth                           {:identity-for-token (s/=> s/Any s/Any)}
+    :GraphQLNamedTypeRegistryService {:get-or-update-named-type-registry
+                                      (s/=> graphql.schema.GraphQLType
+                                            s/Str
+                                            (s/=> graphql.schema.GraphQLType))}
+    :IEncryption                     {:encrypt (s/=> s/Any s/Any)
+                                      :decrypt (s/=> s/Any s/Any)}
+    :FeaturesService                 {:enabled?      (s/=> s/Bool s/Keyword)
+                                      :feature-flags (s/=> [s/Str])}}))
 
 (s/defschema HTTPShowServices
   (-> APIHandlerServices

--- a/src/ctia/schemas/utils.clj
+++ b/src/ctia/schemas/utils.clj
@@ -1,7 +1,6 @@
 (ns ctia.schemas.utils
   (:require [clojure.set :as set]
             [schema-tools.walk :as sw]
-            [schema-tools.util :as stu]
             [schema-tools.core :as st]
             [schema.core :as s]))
 

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -7,6 +7,7 @@
   (read-record [this id ident params])
   (update-record [this id record ident params])
   (delete-record [this id ident params])
+  (bulk-delete [this ids ident params])
   (list-records [this filtermap ident params])
   (close [this]))
 

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -1,27 +1,22 @@
 (ns ctia.stores.es.crud
-  (:require [ductile
-             [document :as ductile.doc]
-             [query :as q]]
+  (:require [clojure.set :as set]
             [clojure.string :as string]
+            [clojure.tools.logging :as log]
             [ctia.domain.access-control
              :refer
-             [restricted-read?
-              acl-fields
-              allow-read?
-              allow-write?]]
+             [acl-fields allow-read? allow-write? restricted-read?]]
             [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.schemas.search-agg :refer [SearchQuery
-                                             HistogramQuery
-                                             TopnQuery
-                                             CardinalityQuery
-                                             AggQuery]]
+            [ctia.schemas.search-agg
+             :refer
+             [AggQuery CardinalityQuery HistogramQuery SearchQuery TopnQuery]]
             [ctia.stores.es.query :refer [find-restriction-query-part]]
             [ctia.stores.es.schemas :refer [ESConnState]]
+            [ductile.document :as ductile.doc]
+            [ductile.query :as q]
             [ring.swagger.coerce :as sc]
-            [schema
-             [coerce :as c]
-             [core :as s]]
-            [schema-tools.core :as st]))
+            [schema-tools.core :as st]
+            [schema.coerce :as c]
+            [schema.core :as s]))
 
 (defn make-es-read-params
   "Prepare ES Params for read operations, setting the _source field
@@ -83,7 +78,7 @@
     {:error \"Error message item2\"}
     {model3}]"
   [exception-data models coerce-fn]
-  (let [{{:keys [_errors items]}
+  (let [{{:keys [items]}
          :es-http-res-body} exception-data]
     {:data (map (fn [{:keys [error _id]} model]
                   (if error
@@ -92,19 +87,19 @@
                     (build-create-result model coerce-fn)))
                 (remove-es-actions items) models)}))
 
-
-(s/defn get-docs-with-indices
+(defn get-docs-with-indices
   "Retrieves a documents from a search \"ids\" query. It enables to retrieves
  documents from an alias that points to multiple indices.
 It returns the documents with full hits meta data including the real index in which is stored the document."
-  [{:keys [conn index]} :- ESConnState
-   ids :- [s/Str]
+  [{:keys [conn index] :as _conn-state}
+   ids
    es-params]
   (let [ids-query (q/ids (map ensure-document-id ids))
         res (ductile.doc/query conn
                                index
                                ids-query
                                (assoc (make-es-read-params es-params)
+                                      :limit (count ids)
                                       :full-hits?
                                       true))]
     (:data res)))
@@ -117,7 +112,6 @@ It returns the documents with full hits meta data including the real index in wh
    es-params]
   (first (get-docs-with-indices conn-state [_id] es-params)))
 
-
 (defn ^:private prepare-opts
   [{:keys [props]}
    {:keys [refresh]}]
@@ -125,24 +119,41 @@ It returns the documents with full hits meta data including the real index in wh
                 (:refresh props)
                 "false")})
 
+(s/defn bulk-schema
+  [Model :- (s/pred map?)]
+  (st/optional-keys
+   {:create [Model]
+    :index [Model]
+    :update [(st/optional-keys Model)]
+    :delete [s/Str]}))
+
+(s/defn ^:private prepare-bulk-doc
+  [{:keys [props]} :- ESConnState
+   mapping :- s/Keyword
+   doc :- (s/pred map?)]
+  (assoc doc
+         :_id (:id doc)
+         :_index (:write-index props)
+         :_type (name mapping)))
+
 (defn handle-create
   "Generate an ES create handler using some mapping and schema"
   [mapping Model]
   (let [coerce! (coerce-to-fn (s/maybe Model))]
     (s/fn :- (s/maybe [Model])
-      [{:keys [conn props] :as conn-state} :- ESConnState
+      [{:keys [conn] :as conn-state} :- ESConnState
        docs :- [Model]
        _ident
        es-params]
-      (let [prepare-doc #(assoc %
-                                :_id (:id %)
-                                :_index (:write-index props)
-                                :_type (name mapping))]
+      (let [prepare-doc (partial prepare-bulk-doc conn-state mapping)
+            prepared (doall
+                      (map prepare-doc docs))]
         (try
-          (map #(build-create-result % coerce!)
-               (ductile.doc/bulk-create-doc conn
-                                            (map prepare-doc docs)
-                                            (prepare-opts conn-state es-params)))
+          (ductile.doc/bulk-index-docs conn
+                                       prepared
+                                       (prepare-opts conn-state es-params)
+                                       50000)
+          docs
           (catch Exception e
             (throw
              (if-let [ex-data (ex-data e)]
@@ -161,8 +172,8 @@ It returns the documents with full hits meta data including the real index in wh
        realized :- Model
        ident
        es-params]
-      (when-let [{index :_index current-doc :_source}
-                 (get-doc-with-index conn-state id {})]
+      (when-let [[{index :_index current-doc :_source}]
+                 (get-docs-with-indices conn-state [id] {})]
         (if (allow-write? current-doc ident)
           (let [update-doc (assoc realized
                                   :id (ensure-document-id id))]
@@ -202,16 +213,116 @@ It returns the documents with full hits meta data including the real index in wh
   [docs ident get-in-config]
   (filter #(allow-read? % ident get-in-config) docs))
 
+(s/defschema BulkResult
+  (st/optional-keys
+   {:deleted [s/Str]
+    :updated [s/Str]
+    :errors (st/optional-keys
+             {:forbidden [s/Str]
+              :not-found [s/Str]
+              :internal-error [s/Str]})}))
+
+(defn- format-bulk-res
+  [bulk-res]
+  (let [{:keys [deleted updated not_found] :as res}
+        (->> (:items bulk-res)
+             (map (comp first vals))
+             (group-by :result)
+             (into {}
+                   (map (fn [[result items]]
+                          {(keyword result) (map :_id items)}))))]
+    (cond-> {}
+      deleted (assoc :deleted deleted)
+      updated (assoc :updated updated)
+      not_found (assoc-in [:errors :not-found] not_found))))
+
+(defn check-and-prepare-bulk
+  [{{{:keys [get-in-config]} :ConfigService} :services
+    :as conn-state}
+   ids
+   ident]
+  (let [doc-ids (map ensure-document-id ids)
+        docs-with-indices (get-docs-with-indices conn-state doc-ids {})
+        {authorized true forbidden-write false}
+        (group-by #(allow-write? (:_source %) ident)
+                  docs-with-indices)
+        {forbidden true not-visible false}
+        (group-by #(allow-read? (:_source %) ident get-in-config)
+                  forbidden-write)
+        missing (set/difference (set doc-ids)
+                                (set (map :_id docs-with-indices)))
+        not-found (into (map :_id not-visible) missing)
+        prepared-docs (map #(select-keys % [:_index :_type :_id])
+                           authorized)]
+    (cond-> {}
+      forbidden (assoc-in [:errors :forbidden] (map :_id forbidden))
+      (seq not-found) (assoc-in [:errors :not-found] not-found)
+      authorized (assoc :prepared prepared-docs))))
+
+(s/defn bulk-delete :- BulkResult
+  [{:keys [conn] :as conn-state}
+   ids :- [s/Str]
+   ident
+   es-params]
+  (let [{:keys [prepared errors]} (check-and-prepare-bulk conn-state ids ident)
+        bulk-res (when prepared
+                   (try
+                     (format-bulk-res
+                      (ductile.doc/bulk-delete-docs conn
+                                                    prepared
+                                                    (prepare-opts conn-state es-params)))
+                     (catch Exception e
+                       (log/error (str "bulk delete failed: " (.getMessage e))
+                                  (pr-str prepared))
+                       {:errors {:internal-error (map :_id prepared)}})))]
+    (cond-> bulk-res
+      errors (update :errors
+                     #(merge-with concat errors %)))))
+
+(s/defn bulk-update
+  "Generate an ES bulk update handler using some mapping and schema"
+  [Model]
+  (s/fn :- BulkResult
+    [{:keys [conn] :as conn-state}
+     docs :- [Model]
+     ident
+     es-params]
+    (let [by-id (group-by :id docs)
+          ids (seq (keys by-id))
+          {:keys [prepared errors]} (check-and-prepare-bulk conn-state
+                                                            ids
+                                                            ident)
+
+          prepared-docs (map (fn [meta]
+                               (-> (:_id meta)
+                                   by-id
+                                   first
+                                   (into meta)))
+                             prepared)
+          bulk-res (when prepared
+                     (try
+                       (format-bulk-res
+                        (ductile.doc/bulk-index-docs conn
+                                                     prepared-docs
+                                                     (prepare-opts conn-state es-params)))
+                       (catch Exception e
+                         (log/error (str "bulk update failed: " (.getMessage e))
+                                    (pr-str prepared))
+                         {:errors {:internal-error (map :_id prepared)}})))]
+      (cond-> bulk-res
+        errors (update :errors
+                       #(merge-with concat errors %))))))
+
 (defn handle-delete
-  "Generate an ES delete handler using some mapping and schema"
+  "Generate an ES delete handler using some mapping"
   [mapping]
   (s/fn :- s/Bool
     [{:keys [conn] :as conn-state} :- ESConnState
      id :- s/Str
      ident
      es-params]
-    (when-let [{index :_index doc :_source}
-               (get-doc-with-index conn-state id {})]
+    (if-let [{index :_index doc :_source}
+             (get-doc-with-index conn-state id {})]
       (if (allow-write? doc ident)
         (ductile.doc/delete-doc conn
                                 index
@@ -219,7 +330,8 @@ It returns the documents with full hits meta data including the real index in wh
                                 (ensure-document-id id)
                                 (prepare-opts conn-state es-params))
         (throw (ex-info "You are not allowed to delete this document"
-                        {:type :access-control-error}))))))
+                        {:type :access-control-error})))
+      false)))
 
 (def default-sort-field "_doc,id")
 
@@ -288,8 +400,7 @@ It returns the documents with full hits meta data including the real index in wh
         coerce! (coerce-to-fn response-schema)]
     (s/fn :- response-schema
       [{{{:keys [get-in-config]} :ConfigService} :services
-        :keys [conn index]
-        :as conn-state} :- ESConnState
+        :keys [conn index]} :- ESConnState
        {:keys [all-of one-of query]
         :or {all-of {} one-of {}}} :- FilterSchema
        ident
@@ -377,7 +488,7 @@ It returns the documents with full hits meta data including the real index in wh
 (s/defn handle-delete-search
   "ES delete by query handler"
   [{:keys [conn index] :as es-conn-state} :- ESConnState
-   {:keys [filter-map] :as search-query} :- SearchQuery
+   search-query :- SearchQuery
    ident
    es-params]
   (let [query (make-search-query es-conn-state search-query ident)]
@@ -392,7 +503,7 @@ It returns the documents with full hits meta data including the real index in wh
   [{conn :conn
     index :index
     :as es-conn-state} :- ESConnState
-   {:keys [filter-map] :as search-query} :- SearchQuery
+   search-query :- SearchQuery
    ident]
   (let [query (make-search-query es-conn-state search-query ident)]
     (ductile.doc/count-docs conn
@@ -449,7 +560,7 @@ It returns the documents with full hits meta data including the real index in wh
 (s/defn handle-aggregate
   "Generate an ES aggregation handler for given schema"
   [{:keys [conn index] :as es-conn-state} :- ESConnState
-   {:keys [filter-map] :as search-query} :- SearchQuery
+   search-query :- SearchQuery
    {:keys [agg-type] :as agg-query} :- AggQuery
    ident]
   (let [query (make-search-query es-conn-state search-query ident)

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,6 +1,5 @@
 (ns ctia.stores.es.store
   (:require [schema.core :as s]
-            [schema-tools.core :as st]
             [ductile
              [conn :as es-conn]
              [index :as es-index]
@@ -41,6 +40,8 @@
      (~(symbol "delete-record") [_# id# ident# params#]
       ((crud/handle-delete ~entity)
        ~(symbol "state") id# ident# params#))
+     (~(symbol "bulk-delete") [_# ids# ident# params#]
+      (crud/bulk-delete ~(symbol "state") ids# ident# params#))
      (~(symbol "list-records") [_# filter-map# ident# params#]
       ((crud/handle-find ~partial-stored-schema)
        ~(symbol "state") filter-map# ident# params#))

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -244,8 +244,7 @@
   and uses them to set :_index meta for these documents"
   [{:keys [mapping]
     {:keys [aliased write-index]} :props
-    {:keys [version]} :conn
-    :as store-map}
+     :as store-map}
    docs
    services :- MigrationStoreServices]
   (let [with-metas (map #(assoc %
@@ -271,7 +270,7 @@
               mapping
               (count batch))
   (retry es-max-retry
-         ductile.doc/bulk-create-doc
+         ductile.doc/bulk-index-docs
          conn
          (prepare-docs store-map batch services)
          {:refresh "false"}

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -1,16 +1,22 @@
 (ns ctia.bulk.core-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.set :as set]
-            [clojure.test :refer [deftest testing is use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [ctia.auth.allow-all :refer [identity-singleton]]
-            [ctia.bulk.core :as sut :refer [read-fn]]
+            [ctia.store :refer [read-record]]
+            [ctia.bulk.core :as sut]
             [ctia.bulk.schemas :refer [NewBulk]]
             [ctia.features-service :as features-svc]
+            [ctia.flows.crud :refer [make-id]]
             [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.fixtures :as fixt]
+            [ctia.auth.threatgrid :refer [map->Identity]]
+            [ctia.domain.entities :refer [short-id->long-id]]
             [puppetlabs.trapperkeeper.app :as app]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
-            [schema-tools.core :as st]
-            [schema.core :as s]))
+            [puppetlabs.trapperkeeper.testutils.bootstrap
+             :refer
+             [with-app-with-config]]
+            [schema-tools.core :as st]))
 
 (use-fixtures :once mth/fixture-schema-validation)
 
@@ -42,3 +48,107 @@
       {:ctia {:features {:disable "asset,actor"}}}
       (let [bulk-schema (NewBulk (helpers/app->GetEntitiesServices app))]
         (is (false? (set/subset? #{:assets :actors} (schema->keys bulk-schema))))))))
+
+(deftest test-format-bulk-flow-res
+  (helpers/fixture-ctia-with-app
+   (fn [app]
+     (let [services (app/service-graph app)
+           bulk-flow-res
+           {:deleted
+            '("tool-2ea50927-d4e7-449a-bb86-b3be4737437a"
+              "tool-4487e07d-a442-432b-9e19-2b934e5dff42"
+              "tool-e270b53e-f6bf-47c4-81d9-52611c75d9d3")
+            :errors {:not-found '("tool-71240bee-3915-44dd-af7d-d4b650d71723")
+                     :forbidden '("tool-82240bee-3915-44dd-af7d-d4b650d71724")}}
+           port (helpers/get-http-port app)
+           to-long-ids #(format "http://localhost:%d/ctia/tool/%s" port %)
+           expected
+           {:deleted
+            (map to-long-ids
+                 '("tool-2ea50927-d4e7-449a-bb86-b3be4737437a"
+                   "tool-4487e07d-a442-432b-9e19-2b934e5dff42"
+                   "tool-e270b53e-f6bf-47c4-81d9-52611c75d9d3"))
+            :errors {:not-found [(to-long-ids "tool-71240bee-3915-44dd-af7d-d4b650d71723")]
+                     :forbidden [(to-long-ids "tool-82240bee-3915-44dd-af7d-d4b650d71724")]}}]
+       (is (= expected (sut/format-bulk-flow-res bulk-flow-res services)))))))
+
+
+(defn with-tlp
+  [fixtures tlp]
+  (into {}
+        (map (fn [[k v]]
+               {k (map #(assoc % :tlp tlp) v)}))
+        fixtures))
+
+(deftest bulk-create-delete
+  (helpers/with-properties
+    ["ctia.access-control.max-record-visibility" "everyone"]
+    (helpers/fixture-ctia-with-app
+     (fn [app]
+       (let [services (app/service-graph app)
+             sighting-store (helpers/get-store app :sighting)
+             indicator-store (helpers/get-store app :indicator)
+             ident-map {:login "guigui"
+                        :groups ["ireaux"]}
+             ident (map->Identity ident-map)
+
+             fixtures-green (with-tlp (select-keys (fixt/bundle 3 false) [:sightings :indicators])
+                              "green")
+             fixtures-amber (with-tlp (select-keys (fixt/bundle 2 false) [:sightings :indicators])
+                              "amber")
+             fixtures (merge-with concat fixtures-green fixtures-amber)
+             with-errors (assoc fixtures
+                                :actors
+                                [{:a 1}])
+             {sighting-ids :sightings indicator-ids :indicators :keys [tempids]}
+             (sut/create-bulk with-errors
+                              {}
+                              ident
+                              {:refresh "true"} services)]
+         (testing "bulk-create shall properly create submitties entitites"
+           (is (= 5
+                  (count sighting-ids)
+                  (count indicator-ids)))
+           (is (= (set (vals tempids))
+                  (into (set sighting-ids) (set indicator-ids))))
+           (doseq [sighting-id sighting-ids]
+             (is (some? (read-record sighting-store sighting-id ident-map {}))))
+           (doseq [indicator-id indicator-ids]
+             (is (some? (read-record indicator-store indicator-id ident-map {})))))
+
+         (testing "bulk-delete shall properly delete entities with allowed entities and manage visibilities"
+           (let [other-group-ident {:login "john doe"
+                                    :groups ["another group"]}
+                 other-group-res (sut/delete-bulk {:sightings sighting-ids
+                                                   :indicators indicator-ids}
+                                                  (map->Identity other-group-ident)
+                                                  {:refresh "true"}
+                                                  services)
+                 nb-not-found (fn [res ent] (-> res ent :errors :not-found count))
+                 nb-forbidden (fn [res ent] (-> res ent :errors :forbidden count))
+                 _ (is (= 2
+                          (nb-not-found other-group-res :sightings)
+                          (nb-not-found other-group-res :indicators))
+                       "non visible entities are returned as not-found errors")
+                 _ (is (= 3
+                          (nb-forbidden other-group-res :sightings)
+                          (nb-forbidden other-group-res :indicators))
+                       "visible entities the user is not allowed to delete are returned as forbidden errors")
+                 missing-id-1 (short-id->long-id (make-id "indicator") services)
+                 missing-id-2 (short-id->long-id (make-id "indicator") services)
+                 {:keys [sightings indicators] :as res}
+                 (sut/delete-bulk {:sightings sighting-ids
+                                   :indicators (concat indicator-ids
+                                                       [missing-id-1
+                                                        missing-id-2])}
+                                  ident
+                                  {:refresh "true"}
+                                  services)]
+             (is (= #{missing-id-1 missing-id-2} (set (get-in indicators [:errors :not-found]))))
+             (is (nil? (:not-found sightings)))
+             (is (= (set sighting-ids) (set (:deleted sightings))))
+             (is (= (set indicator-ids) (set (:deleted indicators))))
+             (doseq [sighting-id (:deleted sightings)]
+               (is (nil? (read-record sighting-store sighting-id ident-map {}))))
+             (doseq [indicator-id (:deleted indicators)]
+               (is (nil? (read-record indicator-store indicator-id ident-map {})))))))))))

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -1,28 +1,25 @@
 (ns ctia.bulk.routes-test
   (:require [cheshire.core :refer [parse-string]]
-            [ductile.index :as es-index]
-            [clj-momo.test-helpers
-             [core :as mth]
-             [http :refer [encode]]]
-            [clojure.java.io :as io]
-            [clojure
-             [string :as str]
-             [test :refer [deftest is join-fixtures testing use-fixtures]]]
             [clj-http.fake :refer [with-global-fake-routes]]
+            [clj-momo.test-helpers.core :as mth]
+            [clj-momo.test-helpers.http :refer [encode]]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.bulk.core :refer [bulk-size gen-bulk-from-fn get-bulk-max-size]]
             [ctia.properties :refer [get-http-show]]
-            [ctia.bulk.core
+            [ctia.store :refer [query-string-search]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers :refer [DELETE GET POST]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.http :refer [app->HTTPShowServices]]
+            [ctia.test-helpers.store
              :refer
-             [bulk-size gen-bulk-from-fn get-bulk-max-size]]
-            [ctia.test-helpers
-             [es :as es-helpers]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [GET POST DELETE]]
-             [fake-whoami-service :as whoami-helpers]
-             [http :refer [app->HTTPShowServices]]
-             [store :refer [test-for-each-store-with-app
-                            test-selected-stores-with-app]]]
+             [test-for-each-store-with-app test-selected-stores-with-app]]
             [ctim.domain.id :as id]
-            [ctim.examples.incidents :refer [new-incident-maximal]]))
+            [ctim.examples.incidents :refer [new-incident-maximal]]
+            [ductile.index :as es-index]
+            [schema.core :as s]))
 
 (defn fixture-properties:small-max-bulk-size [t]
   ;; Note: These properties may be overwritten by ENV variables
@@ -190,9 +187,11 @@
              (fn [type]
                (str/join "&"
                          (map (fn [id]
-                                (let [id (if (vector? id) (last id) id)
+                                (let [id (cond-> id (vector? id) last)
                                       short-id (:short-id (id/long-id->id id))]
-                                  (str (encode (name type)) "=" (encode short-id))))
+                                  (str (encode (name type))
+                                       "="
+                                       (encode short-id))))
                               (get bulk-ids type))))
              (keys bulk-ids))))
 
@@ -259,6 +258,23 @@
          (check-refresh false "Bulk imports should not wait for index refresh when wait_for is false")
          (check-refresh nil "Configured ctia.store.bundle-refresh value is applied when wait_for is not specified"))))))
 
+
+(s/defn check-events
+  [event-store
+   ident
+   entity-ids
+   event-type :- (s/enum :record-created :record-deleted)]
+  (let [events (:data (query-string-search
+                       event-store
+                       {:filter-map {:entity.id entity-ids
+                                     :event_type event-type
+                                     }}
+                       ident
+                       {}))]
+    (is (= (count entity-ids) (count events))
+        (format "only one %s event can be generated for each entity"
+                entity-ids))))
+
 (deftest test-bulk-routes
   (test-for-each-store-with-app
    (fn [app]
@@ -269,7 +285,9 @@
                                          "foogroup"
                                          "user")
      (testing "POST /ctia/bulk"
-       (let [nb 7
+       (let [event-store (helpers/get-store app :event)
+             ident {:login "foouser" :groups ["foogroup"]}
+             nb 7
              indicators (map mk-new-indicator (range nb))
              judgements (map mk-new-judgement (range nb))
              new-bulk {:actors (map mk-new-actor (range nb))
@@ -295,7 +313,12 @@
            (testing (str "number of created " (name type))
              (is (= (count (get new-bulk type))
                     (count (get bulk-ids type))))))
-
+         (testing "created events are generated"
+           (let [expected-created-ids (mapcat val (dissoc bulk-ids :tempids))]
+               (check-events event-store
+                             ident
+                             expected-created-ids
+                             :record-created)))
          (testing "GET /ctia/bulk"
            (let [{status :status
                   response :parsed-body}
@@ -320,34 +343,50 @@
 
          (testing "DELETE /ctia/bulk"
            ;; edge cases are tested in bulk/core-test
-           (let [deleted-bulk-ids (into {}
-                                        (map (fn [[k ids]]
-                                               {k (take 2 ids)}))
-                                        (dissoc bulk-ids :tempids))
-                 expected-delete-res (into {}
-                                        (map (fn [[k ids]]
-                                               {k {:deleted ids}}))
-                                        deleted-bulk-ids)
-                 {status :status delete-res :parsed-body :as res}
+           (let [delete-bulk-query (into {}
+                                         (map (fn [[k ids]]
+                                                {k (take 2 ids)}))
+                                         (dissoc bulk-ids :tempids))
+                 expected-deleted (into {}
+                                       (map (fn [[k ids]]
+                                              {k {:deleted ids}}))
+                                       delete-bulk-query)
+                 expected-not-found (into {}
+                                       (map (fn [[k ids]]
+                                              {k {:errors {:not-found ids}}}))
+                                       delete-bulk-query)
+                 delete-bulk-url "ctia/bulk?wait_for=true"
+                 {delete-status-1 :status delete-res-1 :parsed-body}
                  (DELETE app
-                         (str "ctia/bulk?"
-                              (make-get-query-str-from-bulkrefs deleted-bulk-ids))
+                         delete-bulk-url
+                         :form-params delete-bulk-query
+                         :headers {"Authorization" "45c1f5e3f05d0"})
+                 {delete-status-2 :status delete-res-2 :parsed-body}
+                 (DELETE app
+                         delete-bulk-url
+                         :form-params delete-bulk-query
                          :headers {"Authorization" "45c1f5e3f05d0"})
                  {get-res :parsed-body}
                  (GET app
                       (str "ctia/bulk?"
                            (make-get-query-str-from-bulkrefs bulk-ids))
                       :headers {"Authorization" "45c1f5e3f05d0"})]
-             (clojure.pprint/pprint res)
-             (is (= 200 status))
-             (doseq [[k res] delete-res]
-               (is (= (-> (get expected-delete-res k)
-                          :deleted
-                          set)
+             (is (= 200 delete-status-1))
+             (is (= 200 delete-status-2))
+             (doseq [[k res] delete-res-1]
+               (is (= (set (get-in expected-deleted [k :deleted]))
                       (set (:deleted res)))))
+             (doseq [[k res] delete-res-2]
+               (is (= (set (get-in expected-not-found [k :errors :not-found]))
+                      (set (get-in res [:errors :not-found])))))
              (doseq [[_k entity-res] (dissoc get-res :tempids)]
                (is (= [nil nil] (take 2 entity-res))
-                   "the deleted entities must not be found")))))))))
+                   "the deleted entities must not be found"))
+             (let [expected-deleted-ids (mapcat val delete-bulk-query)]
+               (check-events event-store
+                             ident
+                             expected-deleted-ids
+                             :record-deleted)))))))))
 
 (deftest get-bulk-max-size-test
   (let [nb 10
@@ -425,7 +464,6 @@
                              :sightings sightings
                              :tools (map mk-new-tool (range nb))}
            {status-ok :status
-            response :body
             response-ok :parsed-body} (POST app
                                             "ctia/bulk"
                                             :body new-ok-bulk
@@ -551,11 +589,6 @@
            sighting (assoc (mk-new-sighting 1)
                            :id
                            (id/make-transient-id nil))
-           vulnerability (assoc-in (mk-new-vulnerability 1)
-                                   [:impact :cvss_v2]
-                                   {:base_severity "Low"
-                                    :base_score 1
-                                    :vector_string "CLEARLY INVALID STRING"})
            ;; Submit all entities to create
            {status-create :status
             bulk-ids :parsed-body}
@@ -575,7 +608,7 @@
                 :headers {"Authorization" "45c1f5e3f05d0"})]
        (is (= 201 status-create) "The bulk create should be successfull")
        (is (= 200 status-get) "All valid entities should be retrieved")
-       (is (not (empty? (:tools bulk-ids))))
+       (is (seq (:tools bulk-ids)))
        (is (every? #(contains? % :error) (:tools bulk-ids)))
        (is (every? #(contains? % :error) (:vulnerabilities bulk-ids)))
        (is (= (:description sighting)

--- a/test/ctia/entity/actor_test.clj
+++ b/test/ctia/entity/actor_test.clj
@@ -1,19 +1,19 @@
 (ns ctia.entity.actor-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest join-fixtures use-fixtures]]
+  (:require [clojure.test :refer [deftest join-fixtures use-fixtures]]
             [ctia.entity.actor :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
              [auth :refer [all-capabilities]]
-             [core :as helpers :refer [POST-entity-bulk]]
+             [core :as helpers]
              [crud :refer [entity-crud-test]]
              [aggregate :refer [test-metric-routes]]
              [fake-whoami-service :as whoami-helpers]
              [store :refer [test-for-each-store-with-app]]]
-            [ctim.examples.actors :refer [new-actor-maximal new-actor-minimal]]))
+            [ctim.examples.actors :refer [new-actor-maximal new-actor-minimal]]
+            [schema.test :refer [validate-schemas]]))
 
 (use-fixtures :once
-  (join-fixtures [mth/fixture-schema-validation
+  (join-fixtures [validate-schemas
                   whoami-helpers/fixture-server]))
 
 (deftest test-actor-routes

--- a/test/ctia/entity/attack_pattern_test.clj
+++ b/test/ctia/entity/attack_pattern_test.clj
@@ -1,20 +1,19 @@
 (ns ctia.entity.attack-pattern-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest join-fixtures use-fixtures]]
+  (:require [clojure.test :refer [deftest join-fixtures use-fixtures]]
             [ctia.entity.attack-pattern :as sut]
-            [ctia.test-helpers
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [POST-entity-bulk ]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store-with-app]]]
+            [ctia.test-helpers.access-control :refer [access-control-test]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.examples.attack-patterns
              :refer
-             [new-attack-pattern-maximal new-attack-pattern-minimal]]))
+             [new-attack-pattern-maximal new-attack-pattern-minimal]]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+(use-fixtures :once (join-fixtures [validate-schemas
                                     whoami-helpers/fixture-server]))
 
 (deftest test-attack-pattern-crud-routes

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -9,7 +9,7 @@
    [ctia.test-helpers
     [access-control :refer [access-control-test]]
     [auth :refer [all-capabilities]]
-    [core :as helpers :refer [POST PUT POST-entity-bulk]]
+    [core :as helpers :refer [POST PUT]]
     [crud :refer [entity-crud-test]]
     [aggregate :refer [test-metric-routes]]
     [fake-whoami-service :as whoami-helpers]

--- a/test/ctia/entity/coa_test.clj
+++ b/test/ctia/entity/coa_test.clj
@@ -1,18 +1,17 @@
 (ns ctia.entity.coa-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest join-fixtures use-fixtures]]
+  (:require [clojure.test :refer [deftest join-fixtures use-fixtures]]
             [ctia.entity.coa :as sut]
-            [ctia.test-helpers
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [POST-entity-bulk]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store-with-app]]]
-            [ctim.examples.coas :refer [new-coa-maximal new-coa-minimal]]))
+            [ctia.test-helpers.access-control :refer [access-control-test]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+            [ctim.examples.coas :refer [new-coa-maximal new-coa-minimal]]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+(use-fixtures :once (join-fixtures [validate-schemas
                                     whoami-helpers/fixture-server]))
 
 (deftest test-coa-crud-routes

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -2,12 +2,9 @@
   (:require
    [ctia.entity.feed :as sut]
    [clojure.string :as string]
-   [clj-momo.test-helpers.core :as mth]
    [clj-http.client :as client]
    [ctim.schemas.common :as c]
    [clojure.test :refer [deftest testing is join-fixtures use-fixtures]]
-   [ctia.entity.feed
-    :refer [sort-restricted-feed-fields]]
    [ctia.stores.es.crud :as es.crud]
    [ctia.test-helpers
     [access-control :refer [access-control-test]]
@@ -15,7 +12,8 @@
     [core :as helpers]
     [crud :refer [entity-crud-test]]
     [fake-whoami-service :as whoami-helpers]
-    [store :refer [test-for-each-store-with-app]]]))
+    [store :refer [test-for-each-store-with-app]]]
+   [schema.test :refer [validate-schemas]]))
 
 (def new-feed-maximal
   {:revision 0
@@ -126,7 +124,7 @@
    :relationships relationships})
 
 (use-fixtures :once
-  (join-fixtures [mth/fixture-schema-validation
+  (join-fixtures [validate-schemas
                   whoami-helpers/fixture-server]))
 
 (defn feed-view-tests [app feed-id feed]

--- a/test/ctia/entity/identity_assertion_test.clj
+++ b/test/ctia/entity/identity_assertion_test.clj
@@ -1,22 +1,19 @@
 (ns ctia.entity.identity-assertion-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is testing join-fixtures use-fixtures]]
+  (:require [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [ctia.entity.identity-assertion :as sut]
-            [ctia.properties :as p]
-            [ctia.test-helpers
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [POST-entity-bulk]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [http :refer [api-key]]
-             [core :as helpers :refer [GET]]
-             [store :refer [test-for-each-store-with-app]]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers :refer [GET]]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.http :refer [api-key]]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.examples.identity-assertions
              :refer
-             [new-identity-assertion-maximal new-identity-assertion-minimal]]))
+             [new-identity-assertion-maximal new-identity-assertion-minimal]]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
+(use-fixtures :once (join-fixtures [validate-schemas
                                     whoami-helpers/fixture-server]))
 
 (def new-identity-assertion

--- a/test/ctia/entity/relationship_test.clj
+++ b/test/ctia/entity/relationship_test.clj
@@ -1,9 +1,7 @@
 (ns ctia.entity.relationship-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.math.combinatorics :as comb]
+  (:require [clojure.math.combinatorics :as comb]
             [clojure.string :as str]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
-            [ctia.entity.relationship.schemas :as rs]
             [ctia.entity.relationship :as sut]
             [ctia.test-helpers
              [access-control :refer [access-control-test]]
@@ -18,10 +16,12 @@
              [casebooks :refer [new-casebook-minimal]]
              [incidents :refer [new-incident-minimal]]
              [investigations :refer [new-investigation-minimal]]
-             [relationships :refer [new-relationship-maximal new-relationship-minimal]]]))
+             [relationships :refer [new-relationship-maximal new-relationship-minimal]]]
+            [schema.test :refer [validate-schemas]]))
 
-(use-fixtures :once (join-fixtures [mth/fixture-schema-validation
-                                    whoami-helpers/fixture-server]))
+(use-fixtures :once
+  (join-fixtures [validate-schemas
+                  whoami-helpers/fixture-server]))
 
 (defn establish-user! [app]
   (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
@@ -57,8 +57,7 @@
                   ["http://ex.tld/ctia/relationship/relationship-123"
                    "http://ex.tld/ctia/relationship/relationship-456"])
                  (dissoc :id))
-             {status :status
-              {error :error} :parsed-body}
+             {status :status}
              (POST app
                    "ctia/relationship"
                    :body new-relationship

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -1,7 +1,11 @@
 (ns ctia.flows.crud-test
   (:require [clj-momo.lib.map :refer [deep-merge-with]]
+            [ctim.examples.sightings :refer [sighting-minimal]]
             [clojure.test :refer [deftest testing is]]
+            [ctia.store :refer [query-string-search]]
             [ctia.auth.threatgrid :refer [map->Identity]]
+            [ctia.test-helpers.core :as helpers]
+            [puppetlabs.trapperkeeper.app :as app]
             [ctia.flows.crud :as flows.crud]
             [ctia.lib.collection :as coll]))
 
@@ -122,3 +126,113 @@
                  (#'flows.crud/create-events flow-map))
               (format "create-events shall properly handle %s flow type"
                       (:flow-type flow-map)))))))
+
+(defn search-events
+  [event-store ident entity-id]
+  (-> (query-string-search
+       event-store
+       {:filter-map {:entity.id entity-id}}
+       ident
+       {})
+      :data
+      first))
+
+(deftest delete-flow-test
+  (helpers/fixture-ctia-with-app
+   (fn [app]
+     (let [services (app/service-graph app)
+           store (atom {"sighting-1" (assoc sighting-minimal
+                                            :title "sighting one"
+                                            :id "sighting-1"
+                                            :tlp "green"
+                                            :groups ["groups1"])
+                        "sighting-2" (assoc sighting-minimal
+                                            :title "sighting two"
+                                            :id "sighting-2"
+                                            :tlp "green"
+                                            :groups ["groups1"])})
+           ident {:login "login"
+                  :groups ["group1"]}
+           event-store (helpers/get-store app :event)
+           get-fn (fn [ids] (vals (select-keys @store ids)))
+           delete-flow (fn [entity-id deleted?]
+                         (let [res
+                               (flows.crud/delete-flow
+                                :entity-type :sighting
+                                :get-fn get-fn
+                                :delete-fn (fn [[id]]
+                                             (not= @store
+                                                   (swap! store dissoc id)))
+                                :entity-ids [entity-id]
+                                :long-id-fn identity
+                                :services services
+                                :identity (map->Identity ident))
+                               _ (Thread/sleep 1000)
+                               deleted-event (search-events event-store
+                                                             ident
+                                                             entity-id)]
+                           (is (= deleted? res)
+                               (str "flow shall return " deleted?))
+                           (is (= deleted? (some? deleted-event))
+                               "delete flow shall create event only on successful delete")))]
+       (delete-flow "sighting-1" true)
+       (delete-flow "missing" false)))))
+
+
+(deftest bulk-delete-flow-test
+  (helpers/fixture-ctia-with-app
+   (fn [app]
+     (let [services (app/service-graph app)
+           store (atom {"sighting-1" (assoc sighting-minimal
+                                            :title "sighting one"
+                                            :id "sighting-1"
+                                            :tlp "green"
+                                            :groups ["groups1"])
+                        "sighting-2" (assoc sighting-minimal
+                                            :title "sighting two"
+                                            :id "sighting-2"
+                                            :tlp "green"
+                                            :groups ["groups1"])
+                        "sighting-3" (assoc sighting-minimal
+                                            :title "sighting three"
+                                            :id "sighting-3"
+                                            :tlp "green"
+                                            :groups ["groups1"])})
+           ident {:login "login"
+                  :groups ["group1"]}
+           event-store (helpers/get-store app :event)
+           get-fn (fn [ids] (vals (select-keys @store ids)))
+           delete-fn (fn [ids]
+                       (into {}
+                             (map #(array-map
+                                        %
+                                        (not= @store
+                                              (swap! store dissoc %))))
+                             ids))
+           delete-flow (fn [expected]
+                         (let [entity-ids (seq (keys expected))
+                               res
+                               (flows.crud/delete-flow
+                                :entity-type :sighting
+                                :get-fn get-fn
+                                :delete-fn delete-fn
+                                :entity-ids entity-ids
+                                :long-id-fn identity
+                                :services services
+                                :identity (map->Identity ident))
+                               _ (Thread/sleep 1000)
+                               deleted-events? (into {}
+                                                     (map #(->> (search-events event-store
+                                                                              ident
+                                                                              %)
+                                                                first
+                                                                some?
+                                                                (array-map %)))
+                                                     entity-ids)]
+                           (is (= expected
+                                  (into {} res)))
+                           (is (= expected deleted-events?)
+                               (str "flow shall return " expected))))]
+       (delete-flow {"sighting-1" true
+                     "sighting-2" true})
+       (delete-flow {"sighting-3" true "missing" false})))))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -678,8 +678,11 @@
                      :groups ["group2"]}
 
              [docs-1 docs-2 docs-3] (partition-all (/ total 3) sightings)
+             ;; amber documents created and owned
              docs1-ident1 (map (partial with-owner ident1) docs-1)
+             ;; documents created but owned by someone else with amber tlp
              docs2-ident2 (map (partial with-owner ident2) docs-2)
+             ;; documents not created
              docs3-ident1 (map (partial with-owner ident1) docs-3)
              bulk-update-handler (sut/bulk-update ss/Sighting)
 

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.stores.es.crud-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.instant :as inst]
+            [clojure.string :as string]
             [clojure.test :as t
              :refer
              [are deftest is testing use-fixtures]]
@@ -12,6 +13,8 @@
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.es :as es-helpers]
             [ductile.index :as es-index]
+            [ctia.entity.sighting.schemas :as ss]
+            [ctim.examples.sightings :refer [sighting-minimal sighting-maximal]]
             [schema.core :as s]))
 
 (use-fixtures :once mth/fixture-schema-validation)
@@ -82,6 +85,30 @@
                                                        "title.whole:ASC,"
                                                        "schema_version:DESC")))
 
+(deftest bulk-schema-test
+  (testing "bulk-schema shall generate a proper bulk schema"
+    (let [partial-sighting {:title "new title"
+                            :observables [{:type "ip" :value "8.8.8.8"}]}
+          schema (sut/bulk-schema ss/Sighting)
+          check-fn (fn [input valid?]
+                     (is (= valid?
+                            (nil? (s/check schema input)))))
+          ok-inputs [{:create [sighting-minimal]}
+                     {:update [partial-sighting]}
+                     {:index [sighting-minimal]}
+                     {:delete ["id1" "id2" "id3"]}
+                     {:create [sighting-minimal]
+                      :update [partial-sighting sighting-maximal]
+                      :index [sighting-minimal sighting-maximal]
+                      :delete ["id1" "id2" "id3"]}]
+          ko-inputs [{:index [partial-sighting]}
+                     {:delete [1 2 3]}
+                     {:delete [sighting-minimal]}]]
+      (doseq [tested ok-inputs]
+        (check-fn tested true))
+      (doseq [tested ko-inputs]
+        (check-fn tested false)))))
+
 (def create-fn (sut/handle-create :sighting s/Any))
 (def update-fn (sut/handle-update :sighting s/Any))
 (def read-fn (sut/handle-read s/Any))
@@ -112,6 +139,12 @@
    :port 9205
    :refresh "true"
    :version 5})
+
+(defn get-conn-state
+  [app store-kw]
+  (-> (helpers/get-store app store-kw)
+      :state
+      (update :props assoc :default_operator "AND")))
 
 (deftest crud-aliased-test
   (es-helpers/for-each-es-version
@@ -218,13 +251,6 @@
                                ident
                                {}))))))))
 
-(defn sighting-conn-state
-  [app]
-  (let [{:keys [get-store]} (helpers/get-service-map app :StoreService)]
-    (-> (get-store :sighting)
-        :state
-        (update :props assoc :default_operator "AND"))))
-
 (deftest make-search-query-test
   (es-helpers/for-each-es-version
       "make-search-query shall build a proper query from given query string, filter map and date range"
@@ -232,7 +258,7 @@
     #(es-index/delete! % "ctia_*")
     (helpers/fixture-ctia-with-app
      (fn [app]
-       (let [es-conn-state (sighting-conn-state app)
+       (let [es-conn-state (get-conn-state app :sighting)
              simple-access-ctrl-query {:terms {"groups" (:groups ident)}}]
        (with-redefs [find-restriction-query-part (constantly simple-access-ctrl-query)]
          (let [query-string "*"
@@ -397,7 +423,7 @@
    #(es-index/delete! % "ctia_*")
    (helpers/fixture-ctia-with-app
     (fn [app]
-      (let [es-conn-state (sighting-conn-state app)
+      (let [es-conn-state (get-conn-state app :sighting)
              _ (create-fn es-conn-state
                           search-metrics-entities
                           ident
@@ -456,7 +482,7 @@
     #(es-index/delete! % "ctia_*")
     (helpers/fixture-ctia-with-app
      (fn [app]
-       (let [es-conn-state (sighting-conn-state app)
+       (let [es-conn-state (get-conn-state app :sighting)
              _ (create-fn es-conn-state
                           search-metrics-entities
                           ident
@@ -534,7 +560,7 @@
       #(es-index/delete! % "ctia_*")
     (helpers/fixture-ctia-with-app
         (fn [app]
-          (let [es-conn-state (sighting-conn-state app)
+          (let [es-conn-state (get-conn-state app :sighting)
                 ident-1 {:login "johndoe"
                          :groups ["group1"]}
                 ident-2 {:login "janedoe"
@@ -543,7 +569,7 @@
                                            :user (:login ident-1)
                                            :tlp  "amber"))
                           search-metrics-entities)
-                check-fn (fn [{:keys [msg query matched ident deleted?] :as params}]
+                check-fn (fn [{:keys [msg query matched ident deleted?]}]
                            (create-fn es-conn-state
                                       data
                                       ident-1
@@ -581,3 +607,105 @@
               :matched high-t1-title1
               :ident ident-1
               :deleted? true}))))))
+
+(deftest docs-with-indices-test
+  (es-helpers/for-each-es-version
+      "get-docs-with-indices (and variants) shall properly return documents for given ids"
+      [5 7]
+    #(es-index/delete! % "ctia_*")
+    (helpers/fixture-ctia-with-app
+     (fn [app]
+       (let [conn-state (get-conn-state app :sighting)
+             base-sighting {:tlp "green"
+                            :groups ["group1"]}
+             total 200
+             sighting-ids (map #(str "sighting-"  %) (range total))
+             mk-title #(str "title "%)
+             sightings (map #(assoc base-sighting
+                                    :id %
+                                    :title (mk-title %))
+                            sighting-ids)
+             ;; drop some docs to check that we only match requested ids
+             tested-sample (drop (/ total 10)
+                                 (shuffle sightings))
+             ;; create-docs
+             _ (create-fn conn-state
+                          sightings
+                          ident
+                          {})
+             base-check (fn [{:keys [_index _type _id _source]}]
+                          (is (= base-sighting (select-keys _source [:tlp :groups])))
+                          (is (= _id (:id _source)))
+                          (is (string/starts-with? _index "ctia_sighting"))
+                          (when (= version 5)
+                            (is (= _type "sighting"))))]
+         (let [tested-sighting (rand-nth sightings)
+               res (sut/get-doc-with-index conn-state
+                                           (:id tested-sighting)
+                                           {})]
+           (base-check res)
+           (is (= (:_source res) tested-sighting)))
+
+         (let [tested-sample (drop (/ total 10) ;; drop some
+                                   (shuffle sightings))
+               res (sut/get-docs-with-indices conn-state
+                                              (map :id tested-sample)
+                                              {:limit total})]
+           (is (= (set tested-sample)
+                  (set (map :_source res))))
+           (doseq [elem res]
+             (base-check elem))))))))
+
+(deftest bulk-delete-update-test
+  (es-helpers/for-each-es-version
+      "bulk-delete and bulk-update shall properly handle authorization and not-found errors"
+      [5 7]
+    nil
+    (helpers/fixture-ctia-with-app
+     (fn [app]
+       (let [conn-state (get-conn-state app :sighting)
+             base-sighting (assoc sighting-minimal :tlp "amber")
+             total 10
+             sighting-ids (map #(str "sighting-" %) (range total))
+             sightings (map #(assoc base-sighting :id %) sighting-ids)
+             with-owner (fn [{:keys [login groups]} doc]
+                             (assoc doc
+                                    :owner login
+                                    :groups groups))
+             ident1 {:login "john-doe"
+                     :groups ["group1"]}
+             ident2 {:login "jane-doe"
+                     :groups ["group2"]}
+
+             [docs-1 docs-2 docs-3] (partition-all (/ total 3) sightings)
+             docs1-ident1 (map (partial with-owner ident1) docs-1)
+             docs2-ident2 (map (partial with-owner ident2) docs-2)
+             docs3-ident1 (map (partial with-owner ident1) docs-3)
+             bulk-update-handler (sut/bulk-update ss/Sighting)
+
+             _ (create-fn conn-state
+                       (concat docs1-ident1 docs2-ident2)
+                       ident
+                       {})
+             to-update-docs (map #(assoc % :title "updated title")
+                                 (concat docs1-ident1 docs2-ident2 docs3-ident1))
+             update-res (bulk-update-handler conn-state
+                                             to-update-docs
+                                             ident1
+                                             {})
+             delete-res (sut/bulk-delete conn-state
+                                         sighting-ids
+                                         ident1
+                                         {})
+             expected-not-found (set (concat (map :id docs-3)
+                                             (map :id docs-2)))
+             expected-delete-result {:deleted (set (map :id docs-1))
+                                     :errors {:not-found expected-not-found}}
+             expected-update-result {:updated (set (map :id docs-1))
+                                     :errors {:not-found expected-not-found}}]
+         (is (= expected-update-result
+                (-> (update-in update-res [:errors :not-found] set)
+                    (update :updated set))))
+         (is (= expected-delete-result
+                (-> (update-in delete-res [:errors :not-found] set)
+                    (update :deleted set)))))))))

--- a/test/ctia/stores/es/mapping_test.clj
+++ b/test/ctia/stores/es/mapping_test.clj
@@ -80,7 +80,7 @@
                                     filters
                                     opts)))]
      (index/create! conn indexname settings)
-     (doc/bulk-create-doc conn docs {:refresh "true"})
+     (doc/bulk-index-docs conn docs {:refresh "true"})
      (index/refresh! conn indexname)
      (testing "token should be matched with exact values, and can be directly used for aggregating and sorting on without fielddata"
        (let [res-doc0 (search nil

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -4,7 +4,7 @@
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [fake-whoami-service :as helpers.whoami]
-             [core :as helpers.core :refer [GET POST-bulk]]
+             [core :as helpers.core :refer [GET POST-bulk fixture-ctia-with-app]]
              [store :refer [test-selected-stores-with-app]]]
             [clojure.string :as string]
             [clojure.pprint :refer [pprint]]
@@ -261,8 +261,10 @@
            plural
            enumerable-fields
            date-fields] :as metric-params}]
+
   ;; enforce 1 shard to avoid ES terms approximation used by topn which is not simulated here by the manual aggregation here.
   ;; see ES details: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts
+
   (helpers.core/with-config-transformer*
     #(assoc-in % [:ctia :store :es :default :shards] 1)
     #(test-selected-stores-with-app

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -85,6 +85,11 @@
     (assert (map? m) (str "No service " svc-kw ", found " (keys graph)))
     m))
 
+(defn get-store
+  [app store-kw]
+  ((:get-store (get-service-map app :StoreService))
+   store-kw))
+
 (s/defn with-config-transformer*
   "For use in a test fixture to dynamically transform a Trapperkeeper
   config before creating an app."
@@ -387,6 +392,7 @@
    (let [{{:keys [error message] :as bulk-res} :parsed-body}
          (POST app
                "ctia/bulk"
+               :query-params {:wait_for true}
                :body examples
                :socket-timeout (* 5 60000)
                :headers {"Authorization" "45c1f5e3f05d0"})]

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -211,7 +211,7 @@
 (defn load-bulk
   ([conn docs] (load-bulk conn docs "wait_for"))
   ([{:keys [version] :as conn} docs refresh?]
-   (es-doc/bulk-create-doc conn
+   (es-doc/bulk-index-docs conn
                            (cond->> docs
                              (> version 5) (map #(dissoc % :_type)))
                            {:refresh refresh?})))

--- a/test/ctia/test_helpers/fake_whoami_service.clj
+++ b/test/ctia/test_helpers/fake_whoami_service.clj
@@ -1,16 +1,13 @@
 (ns ctia.test-helpers.fake-whoami-service
   (:require [cheshire.core :as json]
-            [clj-momo.lib.net :as net]
-            [ctia.auth :as auth]
             [ctia.auth.threatgrid :as threatgrid]
             [ctia.test-helpers.core :as helpers-core]
-            [schema.core :as s]
-            [ctia.auth :as ctia-auth]
-            [ring.adapter.jetty :as jetty]
-            [ring.middleware.params :as params]
+            [puppetlabs.trapperkeeper.app :as app]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
-            [puppetlabs.trapperkeeper.app :as app])
+            [ring.adapter.jetty :as jetty]
+            [ring.middleware.params :as params]
+            [schema.core :as s])
   (:import org.eclipse.jetty.server.Server))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -49,9 +49,7 @@
 (def base-opts
   {:accept :edn
    :content-type :edn
-   :throw-exceptions false
-   :socket-timeout 10000
-   :conn-timeout 10000})
+   :throw-exceptions false})
 
 (defn with-parsed-body
   [response]
@@ -69,7 +67,6 @@
   (let [{:keys [body content-type]
          :as options}
         (merge base-opts opts)
-
         response
         (http/post (local-url path port)
                    (-> options
@@ -77,9 +74,9 @@
     (with-parsed-body response)))
 
 (defn delete [path port & {:as opts}]
-  (http/delete (local-url path port)
-               (merge {:throw-exceptions false}
-                      opts)))
+  (->> (http/delete (local-url path port)
+                    (merge base-opts opts))
+       with-parsed-body))
 
 (defn put [path port & {:as opts}]
   (let [{:keys [body content-type]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> related #https://github.com/threatgrid/iroh/issues/2250
> related #https://github.com/threatgrid/iroh/issues/4960

This PR implements bulk delete (and few cleaning).
Don't be afraid by the size, 1/3 is documentation.
For a quicker review, I recommend this order
* ES store
  * ctia.stores.es.crud
  * ctia.stores.es.crud-test
* flow
  * ctia.flow.crud
  * ctia.flow.crud-test
* bulk core
  * ctia.bulk.core
  * ctia.bulk.core-test
* bulk route
  * ctia.bulk.route
  * ctia.bulk.route-test

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================
### Standard scenario

1) Bulk create the following entities and note the all the created ids
[bulk-delete-test.json.zip](https://github.com/threatgrid/ctia/files/6755357/bulk-delete-test.json.zip)
2) Bulk delete 2 of the created indicators (`indicator-id-1`, `indicator-id-2`) and one the created malwares (`malware-id-1`) with the following body:
``` javascript
{
   "indicators":[
      "indicator-id-1",
      "indicator-id-2"
   ],
   "malware":[
      "malware-id"
   ]
}
```
check that the body of the response is
``` javascript
{
   "indicators":{
      "deleted":[
         "indicator-id-1",
         "indicator-id-2"
      ]
   },
   "malware":{
      "deleted":[
         "malware-id-1"
      ]
   }
}
```
3) try to retrieve `indicator-id-1`, `indicator-id-2` and `malware-id-1` and check that you get a 404 for each of them.
4) try to delete all previously created indicators (including those already deleted)
``` javascript
{
   "indicators":[
      "indicator-id-1",
      "indicator-id-2",
      "indicator-id-3",
      "indicator-id-4"
   ],
   "malware":[
      "malware-id-1",
      "malware-id-2",
      "malware-id-3"
   ]
}
```
check that the body of the response is
``` javascript
{
   "indicators":{
      "deleted":[
         "indicator-id-3",
         "indicator-id-4"
      ],
      "errors":{
         "not-found":[
            "indicator-id-1",
            "indicator-id-2"
         ]
      }
   },
   "malware":{
      "deleted":[
         "malware-id-2",
         "malware-id-3"
      ],
      "errors":{
         "not-found":[
            "malware-id-1"
         ]
      }
   }
}
```

### Access right tests 
IN public intel
1) with user1 from group1 create 2 judgements with TLP amber and 1 judgement with tlp green:
``` javascript
{
        "judgements": [
            {
                "valid_time": {
                    "start_time": "2016-02-11T00:40:48.212Z",
                    "end_time": "2016-07-11T00:40:48.212Z"
                },
                "observable": {
                    "value": "10.0.0.0",
                    "type": "ip"
                },
                "disposition": 2,
                "source": "test",
                "priority": 100,
                "severity": "High",
                "confidence": "Low",
                "tlp": "amber"
            },
            {
                "valid_time": {
                    "start_time": "2016-02-11T00:40:48.212Z",
                    "end_time": "2016-07-11T00:40:48.212Z"
                },
                "observable": {
                    "value": "10.0.0.1",
                    "type": "ip"
                },
                "disposition": 2,
                "source": "test",
                "priority": 100,
                "severity": "High",
                "confidence": "Low",
                "tlp": "amber"
            },
            {
                "valid_time": {
                    "start_time": "2016-02-11T00:40:48.212Z",
                    "end_time": "2016-07-11T00:40:48.212Z"
                },
                "observable": {
                    "value": "10.0.0.6",
                    "type": "ip"
                },
                "disposition": 2,
                "source": "test",
                "priority": 100,
                "severity": "High",
                "confidence": "Low",
                "tlp": "green"
            }
        ]
}
```
2) with user2 from group2 with write access, bulk delete these entities, they should all not be found since the user must not have the visibility on these entities:
``` javascript
{
   "judgement":{
      "errors":{
         "not-found":[
            "jugment-id-1",
            "jugment-id-2"
         ],
         "forbidden": [
             "jugment-id-3"
          ]
      }
   }
}
```
Check, with user1, that these entities are still retrievable.
 
3) with user3 from group1 bulk delete these entities :
``` javascript
{
   "judgement":{
      "deleted": [
            "jugment-id-1",
            "jugment-id-2",
            "jugment-id-3"
      ]
   }
}
```
check with user1 that these entities are actually deleted.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Bulk delete route in CTIA.
```

