### PR TITLE
Bundle Import for Asset-refs

### DIFF
--- a/test/ctia/bundle/bundle_debug_test.clj
+++ b/test/ctia/bundle/bundle_debug_test.clj
@@ -1,0 +1,135 @@
+(ns ctia.bundle.bundle-debug-test
+  (:require
+   [clojure.test :refer [deftest is are testing]]
+   [ctia.bulk.core :as bulk]
+   [ctia.bundle.core :as bundle]
+   [ctia.domain.entities :as ent]
+   [ctia.flows.crud :as flows]
+   [ctia.store :as store]
+   [ctia.test-helpers.auth :refer [all-capabilities]]
+   [ctia.test-helpers.core :as th]
+   [hashp.core]
+   [puppetlabs.trapperkeeper.app :as app]))
+
+(def bundle-ents
+  {
+   ;; :asset_mappings   #{{:asset_ref           "transient:asset-1"
+   ;;                      :asset_type          "device"
+   ;;                      :confidence          "High"
+   ;;                      :external_ids        ["d2dcbd00e9bb49719d3fa0a59b1ddfdf"]
+   ;;                      :external_references [{:description "Description text"
+   ;;                                             :external_id "T1061"
+   ;;                                             :hashes      ["#section1"]
+   ;;                                             :source_name "source"
+   ;;                                             :url         "https://ex.tld/wiki/T1061"}]
+   ;;                      :language            "language"
+   ;;                      :observable          {:type "email" :value "tester@test.com"}
+   ;;                      :revision            1
+   ;;                      :schema_version      "1.0"
+   ;;                      :source              "cisco:unified_connect"
+   ;;                      :source_uri          "http://example.com/asset-mapping-2"
+   ;;                      :specificity         "Unique"
+   ;;                      :stability           "Managed"
+   ;;                      :timestamp           #inst "2016-02-11T00:40:48.000-00:00"
+   ;;                      :tlp                 "green"
+   ;;                      :type                "asset-mapping"
+   ;;                      :valid_time          {:end_time   #inst "2525-01-01T00:00:00.000-00:00"
+   ;;                                            :start_time #inst "2020-01-11T00:40:48.000-00:00"}}
+   ;;                     {:asset_ref           "transient:asset-1"
+   ;;                      :asset_type          "device"
+   ;;                      :confidence          "High"
+   ;;                      :external_ids        ["d2dcbd00e9bb49719d3fa0a59b1ddfdf"]
+   ;;                      :external_references [{:description "Description text"
+   ;;                                             :external_id "T1061"
+   ;;                                             :hashes      ["#section1"]
+   ;;                                             :source_name "source"
+   ;;                                             :url         "https://ex.tld/wiki/T1061"}]
+   ;;                      :language            "language"
+   ;;                      :observable          {:type "ip" :value "100.213.110.122"}
+   ;;                      :revision            1
+   ;;                      :schema_version      "1.0"
+   ;;                      :source              "cisco:unified_connect"
+   ;;                      :source_uri          "http://example.com/asset-mapping-1"
+   ;;                      :specificity         "Unique"
+   ;;                      :stability           "Managed"
+   ;;                      :timestamp           #inst "2016-02-11T00:40:48.000-00:00"
+   ;;                      :tlp                 "green"
+   ;;                      :type                "asset-mapping"
+   ;;                      :valid_time          {:end_time   #inst "2525-01-01T00:00:00.000-00:00"
+   ;;                                            :start_time #inst "2020-01-11T00:40:48.000-00:00"}}}
+   ;; :asset_properties #{{:properties          [{:name "cisco:securex:posture:score", :value "23"}
+   ;;                                            {:name "asus:router:model", :value "RT-AC68U"}],
+   ;;                      :valid_time          {:start_time "2020-01-11T00:40:48Z",
+   ;;                                            :end_time   "2525-01-01T00:00:00Z"},
+   ;;                      :schema_version      "1.0",
+   ;;                      :revision            1,
+   ;;                      :asset_ref           "transient:asset-1",
+   ;;                      :type                "asset-properties",
+   ;;                      :source              "cisco:unified_connect",
+   ;;                      :external_ids        ["29a4b476-a187-4160-8b36-81f7a0dbf137"],
+   ;;                      :external_references [{:source_name "source",
+   ;;                                             :external_id "T1061",
+   ;;                                             :url         "https://ex.tld/wiki/T1061",
+   ;;                                             :hashes      ["#section1"],
+   ;;                                             :description "Description text"}],
+   ;;                      :source_uri          "http://example.com/asset-properties",
+   ;;                      :language            "language",
+   ;;                      :tlp                 "green",
+   ;;                      :timestamp           "2016-02-11T00:40:48Z"}}
+   :assets           #{{:asset_type          "device"
+                        :description         "asus router"
+                        :external_ids        ["61884b14e2734930a5ffdcce69207724"]
+                        :external_references [{:description "doesn't matter"
+                                               :external_id "T1061"
+                                               :hashes      ["#section1"]
+                                               :source_name "source"
+                                               :url         "https://ex.tld/wiki/T1061"}]
+                        :id                  "transient:asset-1"
+                        :language            "EN"
+                        :revision            1
+                        :schema_version      "1.0"
+                        :short_description   "awesome router"
+                        :source              "source"
+                        :source_uri          "http://example.com/asset/asus-router-1"
+                        :timestamp           #inst "2020-02-11T00:40:48.000-00:00"
+                        :title               "ASUS-ROUTER"
+                        :tlp                 "green"
+                        :type                "asset"
+                        :valid_time          {:end_time   #inst "2525-01-01T00:00:00.000-00:00"
+                                              :start_time #inst "2020-01-11T00:40:48.000-00:00"}}}})
+(deftest bulk-test
+  (th/fixture-ctia-with-app
+   (fn [app]
+     ;; (th/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+     (let [services (app/service-graph app)
+           {{:keys [get-store all-stores]} :StoreService} services
+           login  #ctia.auth.allow_all.Identity {}
+           bundle-import-data (bundle/prepare-import bundle-ents nil login services)
+           bulk               (bundle/prepare-bulk bundle-import-data)
+           tempids            (->> bundle-import-data
+                                   (map (fn [[_ entities-import-data]]
+                                          (bundle/entities-import-data->tempids entities-import-data)))
+                                   (apply merge {}))
+           identity-map {:authorized-anonymous true}
+           {:keys [tempids]} (bulk/create-bulk
+                              bulk
+                              tempids
+                              login
+                              {}
+                              services)
+           ;; short-ids (->> tempids vals (map (comp :short-id ent/long-id->id)))
+           ]
+
+
+       ;; (-> (get-store :asset) :state :index)
+
+       (clojure.pprint/pprint
+        (store/list-all-pages
+         :asset
+         store/list-fn
+         {:query "*"}
+         identity-map
+         {}
+         services))
+
+       ))))


### PR DESCRIPTION
This PR is solely to discuss the issue, it's not to be merged!

@ereteog @frenchy64 Can you guys help me? I can't figure this out. I've created a fake test so you can try this in the REPL. 

What I need is:

- Create new bulk, this should add a single Asset. I removed asset-properties
and asset-mapping from the map, because of t[his issue](https://github.com/threatgrid/ctim/issues/333)
- After new entity gets created, I need to confirm by reading it from the ES
- But for some reason [it's not returning anything](https://github.com/threatgrid/ctia/pull/1080/files#diff-e2e5fd63a75fb1621caca70aa67a750d4c91ea89b4b4a2fe930d543bc83b3f69R127)

Either this is:

- identity issue. I'm not sure what values should be passed into `ctia.store` functions
- or, the index issue
  even though I tried retrieving the index `(-> (get-store :asset) :state :index)` and checked that the data is there, e.g:
  
    #+begin_src http
    GET http://localhost:9205/ctia_assets5acfc496-a698-49b2-bd31-b8342391e262-2021.03.04-000001?pretty
    #+end_src

shows my asset.

Can you take a look?