### PR TITLE
Fix master: Revert "Actually pin JVM heap in CI"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -181,15 +181,15 @@
                                  ; docker reserves 4GB. here's how to customize it:
                                  ; - https://docs.travis-ci.com/user/enterprise/worker-configuration/#configuring-jobs-allowed-memory-usage
                                  ; this reserves 3GB jvm
-                                 (System/getenv "TRAVIS") (into ["-Xms3g"
-                                                                 "-Xmx3g"])
+                                 (System/getProperty "TRAVIS") (into ["-Xms3g"
+                                                                      "-Xmx3g"])
                                  ; we have 7GB RAM on Actions
                                  ; - https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources
                                  ; docker reserves an unknown amount of RAM.
                                  ; reserving 3GB for jvm -- this might need tweaking as we learn
                                  ; more about docker on actions.
-                                 (System/getenv "GITHUB_ACTIONS") (into ["-Xms3g"
-                                                                         "-Xmx3g"]))
+                                 (System/getProperty "GITHUB_ACTIONS") (into ["-Xms3g"
+                                                                              "-Xmx3g"]))
                     :dependencies [[clj-http-fake ~clj-http-fake-version]
                                    [com.gfredericks/test.chuck ~test-chuck-version]
                                    [org.clojure/test.check ~test-check-version]


### PR DESCRIPTION
Reverts threatgrid/ctia#1081

Please merge if/when approved.

threatgrid/ctia#1081 fails the master Travis build. https://travis-ci.com/github/threatgrid/ctia/builds/219157547

My guess is the heap numbers need tweaking.