### PR TITLE
fix flaky rate limit test

### DIFF
--- a/src/ctia/http/middleware/ratelimit.clj
+++ b/src/ctia/http/middleware/ratelimit.clj
@@ -2,8 +2,7 @@
   (:require [clojure.string :as string]
             [clojure.tools.logging :as log]
             [ctia
-             [auth :as auth]
-             [properties :as p]]
+             [auth :as auth]]
             [ctia.lib
              [collection :refer [fmap]]
              [redis :refer [server-connection]]]
@@ -90,12 +89,11 @@
       (let [turnstile-mw
             (turnstile/wrap-rate-limit
              handler
-             (do
-               {:redis-conn (server-connection redis)
-                 :limit-fns [(with-identity-rate-limit-fn
-                               (group-limit-fn conf))]
-                 :rate-limit-handler rate-limited-request-handler
-                 :key-prefix key-prefix}))]
+             {:redis-conn (server-connection redis)
+              :limit-fns [(with-identity-rate-limit-fn
+                            (group-limit-fn conf))]
+              :rate-limit-handler rate-limited-request-handler
+              :key-prefix key-prefix})]
         (fn [request]
           (try
             (turnstile-mw request)

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -122,7 +122,8 @@
                (dotimes [_ 4] (call app))
                (let [response (call app)]
                  (is (= 429 (:status response)))
-                 (is (= "3600" (get-in response [:headers "Retry-After"])))
+                 (is (#{"3599" "3600"} ;; avoid flakyness on slow test server.
+                      (get-in response [:headers "Retry-After"])))
                  (is (= "{\"error\": \"Too Many Requests\"}"
                         (:body response)))))))))
       (testing "Custom group limits"

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -6,7 +6,6 @@
             [schema.test :refer [validate-schemas]]
             [ctia.auth :as auth :refer [IIdentity]]
             [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.es :as es-helpers]
             [taoensso.carmine :as car]
             [clj-momo.lib.clj-time.core :as time]))
@@ -122,8 +121,10 @@
                (dotimes [_ 4] (call app))
                (let [response (call app)]
                  (is (= 429 (:status response)))
-                 (is (#{"3599" "3600"} ;; avoid flakyness on slow test server.
-                      (get-in response [:headers "Retry-After"])))
+                 (is (contains? (->> (range 3590 3601) ;; avoid flakyness on slow test server.
+                                     (map str)
+                                     set)
+                                (get-in response [:headers "Retry-After"])))
                  (is (= "{\"error\": \"Too Many Requests\"}"
                         (:body response)))))))))
       (testing "Custom group limits"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/threatgrid/iroh/issues/4899

The value returned by `turnstile` and `turnstile-middleware` is not always the exact expected duration while properly doing its job for `Retry-After` value.
We could probably make it more deterministic on turnstile [`here`](https://github.com/threatgrid/turnstile/blob/1390ffa520ca7b31f9101ac2970ce84772b626f2/src/turnstile/core.clj#L25), [`here`](https://github.com/threatgrid/ring-turnstile-middleware/blob/6bef68919a0038d55721c44a84c03e7827a26f42/src/ring/middleware/turnstile.clj#L85), or [`here`](https://github.com/threatgrid/ring-turnstile-middleware/blob/6bef68919a0038d55721c44a84c03e7827a26f42/src/ring/middleware/turnstile.clj#L144), I don't think that it worths the effort (the rate limiting doing its job).

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->
