### PR TITLE
read relationships file only once, less batches for rollover-test

### DIFF
--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -252,8 +252,9 @@
 
 (def sample-relationships-1000
   "1000 real realtionships extracted from INT with ES doc meta"
-  (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
-    (doall (line-seq rdr))))
+  (delay
+    (with-open [rdr (io/reader "./test/data/indices/sample-relationships-1000.json")]
+      (doall (line-seq rdr)))))
 
 (deftest rollover-test
   (es-helpers/for-each-es-version
@@ -281,7 +282,7 @@
                           :type "relationship"
                           :settings {}
                           :config {}}
-                docs-all (->> sample-relationships-1000
+                docs-all (->> @sample-relationships-1000
                               (map (partial es-helpers/prepare-bulk-ops app))
                               (map #(assoc % :_index write-alias)))
                 batch-sizes (repeatedly 100 #(inc (rand-int max-batch-size)))
@@ -347,7 +348,7 @@
                          :type "relationship"
                          :settings {}
                          :config {}}
-               _ (->>  sample-relationships-1000
+               _ (->>  @sample-relationships-1000
                        (map (partial es-helpers/prepare-bulk-ops app))
                        (es-helpers/load-bulk conn))
                expected-queries [missing-modified-query
@@ -842,7 +843,6 @@
      (helpers/fixture-ctia-with-app
        (fn [app]
          (let [services (app->MigrationStoreServices app)
-
                _ (POST-bulk app examples true)
                _ (ductile.index/refresh! conn) ;; ensure indices refresh
                [sighting1 sighting2] (:parsed-body (GET app


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/threatgrid/iroh/issues/4920

This PR optimizes a little bit `ctia.task.migration.store-test` ns test by reading only once the relationships file samples. It also reduces the number of random batch size to test rollover-test. Not the win of year, but still useful :-)

_reviewers: hide white space changes._

build time observed [here](https://github.com/threatgrid/ctia/pull/1079/checks?check_run_id=2098372414): 
[ctia.task.migration.store-test {:elapsed-ns 235972437954}]
[ctia.task.migration.store-test/rollover-test {:elapsed-ns 6.3143038789E10}]
[ctia.task.migration.store-test/sliced-queries-test {:elapsed-ns 1.1595586681E10}]

This PR build (at time of writing):
[ctia.task.migration.store-test {:elapsed-ns 227022970930}]
[ctia.task.migration.store-test/rollover-test {:elapsed-ns 4.3493366775E10}]
[ctia.task.migration.store-test/sliced-queries-test {:elapsed-ns 1.20827999E10}]

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->
