### PR TITLE
Issue-4744: Add endpoint to search vulnerabilities by CPEs

### DIFF
--- a/doc/search-vulnerabilities-by-cpe-match-strings.org
+++ b/doc/search-vulnerabilities-by-cpe-match-strings.org
@@ -1,0 +1,123 @@
+#+TITLE: Search Vulnerabilities by CPE Match Strings
+#+AUTHOR: Cisco Threat Response Services
+#+PROPERTY: eval no
+
+* CPE
+  #+BEGIN_QUOTE
+  Common Platform Enumeration (CPE) is a standardized method of
+  describing and identifying classes of applications, operating
+  systems, and hardware devices present among an enterprise's
+  computing assets. IT management tools can collect information about
+  installed products, identifying these products using their CPE
+  names, and then use this standardized information to help make fully
+  or partially automated decisions regarding the assets.
+  #+END_QUOTE
+
+  Further information on CPE can be found at:
+  - [[https://nvd.nist.gov/products/cpe]]
+  - https://csrc.nist.gov/projects/security-content-automation-protocol/specifications/cpe
+  - [[https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf][Common Platform Enumeration: Naming Specification Version 2.3]]
+  - [[https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf][Common Platform Enumeration: Name Matching Specification Version 2.3]]
+
+
+* Searching Vulnerabilities by CPE Match Strings
+  CTIA provides a way to query for vulnerabilities with configurations
+  that match combinations of CPE Match Strings.
+
+  The route is available through the endpoint ~GET
+  /ctia/vulnerability/cpe_match_strings~ and requires the query string
+  include an array of ~cpe23_match_strings~.
+
+  Many of the query string parameters documented in the endpoint [[file:search-metrics.org][~GET
+  /ctia/{entity-type}/search~]] are supported by ~GET
+  /ctia/vulnerability/cpe_match_strings~ with the following
+  exceptions:
+  - ~sort~
+  - ~offset~
+  - ~query~
+
+  A user can retrieve vulnerabilities applicable to various
+  combinations of hardware and software. The following example URL
+  encodes an array of the CPE match strings:
+  ~cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*~
+  ~cpe:2.3:o:juniper:advanced_threat_prevention:5.0.3:*:*:*:*:*:*:*~
+
+
+  #+BEGIN_SRC http
+    GET http://localhost:3000/ctia/vulnerability/cpe_match_strings?fields=title&cpe23_match_strings=cpe%3A2.3%3Ah%3Ajuniper%3Aatp400%3A*%3A*%3A*%3A*%3A*%3A*%3A*%3A*&cpe23_match_strings=cpe%3A2.3%3Ao%3Ajuniper%3Aadvanced_threat_prevention%3A5.0.3%3A*%3A*%3A*%3A*%3A*%3A*%3A*
+    Content-Type: application/json
+  #+END_SRC
+
+  Results:
+  #+BEGIN_SRC http
+  [
+    {
+      "groups": [
+        "Administrators"
+      ],
+      "tlp": "green",
+      "id": "http://localhost:3000/ctia/vulnerability/vulnerability-6b383506-48bb-4f20-bb0a-9844f9655efd",
+      "title": "CVE-2019-0021",
+      "owner": "Unknown"
+    }
+  ]
+  #+END_SRC
+
+  Response Headers:
+  #+BEGIN_SRC http
+   content-length: 186
+   content-type: application/json;charset=utf-8
+   date: Tue, 16 Mar 2021 19:14:30 GMT
+   etag: "87d3bcdea05c36e0c220de815c65d16b4676b65d"
+   x-content-type-options: nosniff
+   x-ctia-config: local
+   x-ctia-version: 10d96bac39a4c059be99b730e9d6ebbec81bcdb8
+   isue-4744-match-strings
+   x-ctim-version: 1.1.3
+   x-sort: ["vulnerability-6b383506-48bb-4f20-bb0a-9844f9655efd"]  x-total-hits: 1
+  #+END_SRC
+
+
+* Paging
+  Set the ~search_after~ query parameter to the value of the ~x-sort~
+  response header to retrieve the next page. The size of the page can
+  be set using the ~limit~ query parameter.  When ~limit~ is not
+  specified, the system default is used.
+
+  The endpoint utilizes two separate queries. The first query lazily
+  retrieves up to ~limit~ Vulnerability IDs that match the CPE Match
+  Strings. The second query then utilizes up to ~limit~ Vulnerability
+  IDs from the lazy seq to retreive and deliver the Vulnerabilities to
+  the end user. Both queries are sorted by ~id~ in ascending order to
+  support paging using the ~search_after~ query parameter. Due to this
+  design ~offset~, ~query~, and ~sort~ can not be supported.
+
+
+* Symbols Requiring Escapes
+  CPE Match Strings consist of 13 colon delimited components. A
+  component may have a ~:~ in it, which would require escaping.
+
+  The following systems are utilized by the endpoint, and have
+  different escaping conventions:
+  - National Vulnerability Database (the source of the data)
+  - URL Encoding (As encoded by the web browser)
+  - Elasticsearch Database
+  - Regular Expressions
+
+  To accomodate these differences, when providing a CPE that contains
+  a component with Symbols from the following table, the Escaped Name
+  must be substituted for the Symbol within the component.
+
+| Symbol | Escaped Name      |
+|--------+-------------------|
+| ~:~    | ~_COLON_~         |
+| ~(~    | ~_OPEN_PAREN_~    |
+| ~)~    | ~_CLOSED_PAREN_~  |
+| ~+~    | ~_PLUS_~          |
+| ~!~    | ~_BANG_~          |
+| ~/~    | ~_FORWARD_SLASH_~ |
+
+For example,
+~cpe:2.3:h:juniper:ex8200\\/vc_\\(xre\\):-:*:*:*:*:*:*:*~, must be
+passed into the endpoint as
+~cpe:2.3:h:juniper:ex8200_FORWARD_SLASH_vc__OPEN_PAREN_xre_CLOSED_PAREN_:-:*:*:*:*:*:*:*~

--- a/project.clj
+++ b/project.clj
@@ -49,6 +49,7 @@
                  [org.clojure/tools.cli "1.0.194"]
                  [pandect "0.6.1"]
                  [org.clojure/math.combinatorics "0.1.6"]
+                 [version-clj "2.0.1"]
 
                  ;; Trapperkeeper
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
@@ -59,6 +60,7 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
+
                  [threatgrid/ctim "1.1.4"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
@@ -143,7 +145,7 @@
                                   (:out (clojure.java.shell/sh
                                          "git" "symbolic-ref" "--short" "HEAD")))})}]
 
-  
+
   :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~trapperkeeper-version
                                    :classifier "test"]
                                   [puppetlabs/kitchensink ~trapperkeeper-version
@@ -254,7 +256,7 @@
             "init-properties" ^{:doc (str "create an initial `ctia.properties`"
                                           " using docker machine ip")}
             ["shell" "scripts/init-properties-for-docker.sh"]
-            
+
             ; circleci.test
             ;"test" ["run" "-m" "circleci.test/dir" :project/test-paths]
             "split-test" ["trampoline"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -1,10 +1,11 @@
 (ns ctia.entity.vulnerability
   (:require
+   [ctia.lib.compojure.api.core :refer [context GET routes]]
    [flanders.utils :as fu]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.relationship.graphql-schemas :as relationship]
    [ctia.entity.vulnerability.mapping :refer [vulnerability-mapping]]
-   [ctia.domain.entities :refer [default-realize-fn]]
+   [ctia.domain.entities :as ent]
    [ctia.schemas.graphql
     [sorting :as graphql-sorting]
     [flanders :as flanders]
@@ -23,7 +24,13 @@
    [schema-tools.core :as st]
    [schema.core :as s]
    [ctia.schemas.sorting :as sorting]
-   [ctia.schemas.graphql.ownership :as go]))
+   [ctia.schemas.graphql.ownership :as go]
+   [ring.swagger.schema :as swagger-schema]
+   [ctia.entity.vulnerability.cpe :as cpe]
+   [ctia.store :as ctia-store]
+   [clj-momo.lib.es.pagination :refer [default-limit]]
+   [ductile.document :as es-doc]
+   [ctim.schemas.vulnerability :as ctim-vulnerability-schema]))
 
 (def-acl-schema Vulnerability
   ws/Vulnerability
@@ -46,13 +53,14 @@
   (csu/optional-keys-schema StoredVulnerability))
 
 (def realize-vulnerability
-  (default-realize-fn "vulnerability" NewVulnerability StoredVulnerability))
+  (ent/default-realize-fn "vulnerability" NewVulnerability StoredVulnerability))
 
 (def-es-store VulnerabilityStore :vulnerability StoredVulnerability PartialStoredVulnerability)
 
 (def vulnerability-fields
   (concat sorting/base-entity-sort-fields
           sorting/sourcable-entity-sort-fields
+          sorting/describable-entity-sort-fields
           []))
 
 (def vulnerability-sort-fields
@@ -109,29 +117,88 @@
 (def vulnerability-enumerable-fields
   [:source])
 
+(defn build-query
+  [{:keys [part vendor product]}]
+  {:simple_query_string {:query (format "cpe\\:2.3\\:%s\\:%s\\:%s*"
+                                        part
+                                        (cpe/->simple-query-string-format vendor)
+                                        (cpe/->simple-query-string-format product))
+                         :flags "ESCAPE|PREFIX"
+                         :fields [:configurations.nodes.cpe_match.cpe23Uri
+                                  :configurations.nodes.children.cpe_match.cpe23Uri]}})
+
+(s/defn search-by-cpe-match-strings [{{:keys [get-store]} :StoreService
+                                      :as services} :- APIHandlerServices]
+  (context "/cpe_match_strings" []
+    (let [capabilities :search-vulnerability]
+      (GET "/" []
+        :return PartialVulnerabilityList
+        :query [{cpe23-match-strings :cpe23_match_strings limit :limit :as params}
+                (st/merge
+                 {:cpe23_match_strings (swagger-schema/describe [(s/conditional ctim-vulnerability-schema/formatted-cpe-23-string? s/Str)]
+                                                                "CPE 2.3 match strings to search by")
+                  (s/optional-key :search_after) (swagger-schema/describe [s/Str] "Pagination stateless cursor")
+                  (s/optional-key :limit) (swagger-schema/describe Long "Pagination Limit")}
+                 BaseEntityFilterParams
+                 SourcableEntityFilterParams
+                 VulnerabilityFieldsParam)]
+        :summary "List Vulnerabilities with configurations matching CPE 2.3 match strings"
+        :description (routes.common/capabilities->description capabilities)
+        :capabilities capabilities
+        :auth-identity identity
+        :identity-map identity-map
+        (let [{{:keys [conn index]} :state} (get-store :vulnerability)
+              cpe-matches (map cpe/->cpe-match cpe23-match-strings)
+              vulnerability-ids
+              (letfn
+                  [(list-vulnerability-ids [query-params]
+                     (lazy-seq
+                      (let [{:keys [data paging]}
+                            (es-doc/query conn
+                                          index
+                                          {:bool {:should (map build-query cpe-matches)}}
+                                          {}
+                                          (merge query-params {:fields [:configurations.nodes :id]
+                                                               :sort {:id :asc}}))
+                            ids (cpe/vulnerabilities->ids cpe-matches data)]
+                        (if-let [next-params (:next paging)]
+                          (concat ids (list-vulnerability-ids (merge query-params next-params)))
+                          ids))))]
+                (list-vulnerability-ids params))]
+          (-> (get-store :vulnerability)
+              (ctia-store/query-string-search (merge (routes.common/search-query :timestamp params)
+                                                     {:filter-map [[:id (take (or limit default-limit) vulnerability-ids)]]})
+                                              identity-map
+                                              (merge params {:sort {:id :asc}}))
+              (ent/page-with-long-id services)
+              ent/un-store-page
+              routes.common/paginated-ok))))))
+
 (s/defn vulnerability-routes [services :- APIHandlerServices]
-  (services->entity-crud-routes
-   services
-   {:entity :vulnerability
-    :new-schema NewVulnerability
-    :entity-schema Vulnerability
-    :get-schema PartialVulnerability
-    :get-params VulnerabilityGetParams
-    :list-schema PartialVulnerabilityList
-    :search-schema PartialVulnerabilityList
-    :external-id-q-params VulnerabilityByExternalIdQueryParams
-    :search-q-params VulnerabilitySearchParams
-    :new-spec :new-vulnerability/map
-    :realize-fn realize-vulnerability
-    :get-capabilities :read-vulnerability
-    :post-capabilities :create-vulnerability
-    :put-capabilities :create-vulnerability
-    :delete-capabilities :delete-vulnerability
-    :search-capabilities :search-vulnerability
-    :external-id-capabilities :read-vulnerability
-    :can-aggregate? true
-    :histogram-fields vulnerability-histogram-fields
-    :enumerable-fields vulnerability-enumerable-fields}))
+  (routes
+   (search-by-cpe-match-strings services)
+   (services->entity-crud-routes
+    services
+    {:entity :vulnerability
+     :new-schema NewVulnerability
+     :entity-schema Vulnerability
+     :get-schema PartialVulnerability
+     :get-params VulnerabilityGetParams
+     :list-schema PartialVulnerabilityList
+     :search-schema PartialVulnerabilityList
+     :external-id-q-params VulnerabilityByExternalIdQueryParams
+     :search-q-params VulnerabilitySearchParams
+     :new-spec :new-vulnerability/map
+     :realize-fn realize-vulnerability
+     :get-capabilities :read-vulnerability
+     :post-capabilities :create-vulnerability
+     :put-capabilities :create-vulnerability
+     :delete-capabilities :delete-vulnerability
+     :search-capabilities :search-vulnerability
+     :external-id-capabilities :read-vulnerability
+     :can-aggregate? true
+     :histogram-fields vulnerability-histogram-fields
+     :enumerable-fields vulnerability-enumerable-fields})))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/vulnerability/cpe.clj
+++ b/src/ctia/entity/vulnerability/cpe.clj
@@ -1,0 +1,173 @@
+(ns ctia.entity.vulnerability.cpe
+  (:require [clojure.string :as str]
+            [version-clj.core :as v]))
+
+(def escaped-name->literal
+  {"_COLON_" "\\:"
+   "_OPEN_PAREN_" "\\("
+   "_CLOSED_PAREN_" "\\)"
+   "_PLUS_" "\\+"
+   "_BANG_" "\\!"
+   "_FORWARD_SLASH_" "\\/"})
+
+(defn ->escaped-name
+  ""
+  [s]
+  (reduce (fn ->escaped-name-rf
+            [acc [escaped-name literal]]
+            (str/replace acc literal escaped-name))
+          s
+          escaped-name->literal))
+
+(defn ->simple-query-string-format
+  [s]
+  (reduce (fn ->simple-query-string-format-rf
+            [acc [escaped-name literal]]
+            (str/replace acc escaped-name (str "\\\\" literal)))
+          s
+          escaped-name->literal))
+
+(defn str->pattern
+  [s]
+  (-> s
+      (str/replace "*" ".*")
+      (str/replace "?" ".?")
+      re-pattern))
+
+(defn component-match?
+  [s1 s2]
+  (let [p1 (str->pattern s1)
+        p2 (str->pattern s2)]
+    (cond
+      (= s1 s2) true
+      (or (and (= s1 "-") (= s2 "*"))
+          (and (= s1 "*") (= s2 "-"))) true
+      (or (re-matches p1 s2) (re-matches p2 s1)) true
+      :else false)))
+
+(defn satisfies-interval?
+  [version
+   {:keys [version-start-including
+           version-start-excluding
+           version-end-including
+           version-end-excluding]}]
+
+  (letfn [(closed [] (and (left-closed) (right-closed)))
+          (open [] (and (left-open) (right-open)))
+          (left-closed-right-open [] (and (left-closed) (right-open)))
+          (left-open-right-closed [] (and (left-open) (right-closed)))
+          (left-closed [] (v/older-or-equal? version-start-including version))
+          (left-open [] (v/older? version-start-excluding version))
+          (right-closed [] (v/newer-or-equal? version-end-including version))
+          (right-open [] (v/newer? version-end-excluding version))]
+
+    (cond
+      (or (= version "*") (= version "-")) true
+      (and version-start-including version-end-including) (closed)
+      (and version-start-excluding version-end-excluding) (open)
+      (and version-start-including version-end-excluding) (left-closed-right-open)
+      (and version-start-excluding version-end-including) (left-open-right-closed)
+      version-start-including (left-closed)
+      version-start-excluding (left-open)
+      version-end-including (right-closed)
+      version-end-excluding (right-open)
+      :else true)))
+
+(defprotocol ICpeMatch
+  (match? [this CpeMatch]))
+
+(defrecord CpeMatch [part vendor product version version_update
+                     edition lang sw_edition target_sw
+                     target_hw other]
+  Object
+  (toString [_]
+    (format "cpe:2.3:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s:%s"
+            part vendor product version version_update
+            edition lang sw_edition target_sw
+            target_hw other))
+
+  ICpeMatch
+  (match? [_ CpeMatch]
+    (and (satisfies-interval? version CpeMatch)
+         (and CpeMatch
+              (component-match? part (:part CpeMatch))
+              (component-match? vendor (:vendor CpeMatch))
+              (component-match? product (:product CpeMatch))
+              (component-match? version (:version CpeMatch))
+              (component-match? version_update (:version_update CpeMatch))
+              (component-match? edition (:edition CpeMatch))
+              (component-match? lang (:lang CpeMatch))
+              (component-match? sw_edition (:sw_edition CpeMatch))
+              (component-match? target_sw (:target_sw CpeMatch))
+              (component-match? target_hw (:target_hw CpeMatch))
+              (component-match? other (:other CpeMatch))))))
+
+(defmethod print-method CpeMatch [v ^java.io.Writer w]
+  (.write w (str v)))
+
+(defn ->cpe-match
+  [s]
+  (apply ->CpeMatch
+         (-> s
+             ->escaped-name
+             (str/replace-first "cpe:2.3:" "")
+             (str/split #":"))))
+
+(defn apply-operator
+  [{:keys [negate operands operator result]}]
+  (case operator
+    "OR" (when (if negate
+                 (not (some identity operands))
+                 (some identity operands))
+           result)
+    "AND" (when (if negate
+                  (not (every? identity operands))
+                  (every? identity operands))
+            result)))
+
+(defn cpe_match->CpeMatch
+  [{:keys [versionStartIncluding
+           versionStartExcluding
+           versionEndIncluding
+           versionEndExcluding
+           cpe23Uri]}]
+  (cond-> (->cpe-match cpe23Uri)
+    versionStartIncluding (assoc :version-start-including versionStartIncluding)
+    versionStartExcluding (assoc :version-start-excluding versionStartExcluding)
+    versionEndIncluding (assoc :version-end-including versionEndIncluding)
+    versionEndExcluding (assoc :version-end-excluding versionEndExcluding)))
+
+(defn query-cpe-matches
+  [{:keys [cpe_match negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (for [CpeMatch (map cpe_match->CpeMatch cpe_match)]
+                               (some (fn match-uri? [x] (match? x CpeMatch))
+                                     cpes))
+                   :operator operator
+                   :result cpe_match}))
+
+(defn query-children
+  [{:keys [children negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (map (fn query-child [child]
+                                    (query-cpe-matches child cpes))
+                                  children)
+                   :operator operator
+                   :result children}))
+
+(defn query-node
+  [{:keys [children cpe_match] :as node} cpes]
+  (cond
+    (seq cpe_match) (query-cpe-matches node cpes)
+    (seq children) (query-children node cpes)))
+
+(defn vulnerabilities->ids
+  [cpes vulnerabilities]
+  (letfn [(query-vulnerability
+            [{{:keys [nodes]} :configurations
+              id :id}]
+            (when (seq (filter (fn [node]
+                                 (query-node node cpes))
+                               nodes))
+              id))]
+    (keep query-vulnerability vulnerabilities)))

--- a/src/ctia/entity/vulnerability/cpe_search.clj
+++ b/src/ctia/entity/vulnerability/cpe_search.clj
@@ -1,0 +1,53 @@
+(ns ctia.entity.vulnerability.cpe-search)
+
+(defn apply-operator
+  [{:keys [negate operands operator result]}]
+  (case operator
+    "OR" (when (if negate
+                 (not (some identity operands))
+                 (some identity operands))
+           result)
+    "AND" (when (if negate
+                  (not (every? identity operands))
+                  (every? identity operands))
+            result)))
+
+(defn query-cpe-matches
+  [{:keys [cpe_match negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (for [uri (map :cpe23Uri cpe_match)]
+                               (some #{uri} cpes))
+                   :operator operator
+                   :result cpe_match}))
+
+(defn query-children
+  [{:keys [children negate operator]} cpes]
+  (apply-operator {:negate negate
+                   :operands (map (fn query-child [child]
+                                    (query-cpe-matches child cpes))
+                                  children)
+                   :operator operator
+                   :result children}))
+
+(defn query-node
+  [{:keys [children cpe_match] :as node} cpes]
+  (cond
+    (seq cpe_match) (query-cpe-matches node cpes)
+    (seq children) (query-children node cpes)))
+
+(defn query-cve
+  [id nodes cpes]
+  (when (seq (keep (fn [node]
+                     (query-node node cpes))
+                   nodes))
+    id))
+
+(defn find-vulnerabilities
+  [cpes vulnerabilities]
+  (reduce (fn cpe-match-rf
+            [acc [id [{{:keys [nodes]} :configurations}]]]
+            (if-let [matching-id (query-cve id nodes cpes)]
+              (conj acc matching-id)
+              acc))
+          []
+          (group-by :id vulnerabilities)))

--- a/src/ctia/entity/vulnerability/mapping.clj
+++ b/src/ctia/entity/vulnerability/mapping.clj
@@ -75,7 +75,7 @@
 (def cpe-match
   {:properties
    {:vulnerable em/boolean-type
-    :cpe23uri em/token
+    :cpe23Uri em/token
     :versionStartIncluding em/token
     :versionEndIncluding em/token
     :versionStartExcluding em/token
@@ -86,8 +86,10 @@
    {:operator em/token
     :children {:properties
                {:operator em/token
-                :cpe_match cpe-match}}
-    :cpe_match cpe-match}})
+                :cpe_match cpe-match
+                :negate em/boolean-type}}
+    :cpe_match cpe-match
+    :negate em/boolean-type}})
 
 (def configurations
   {:properties

--- a/test/ctia/entity/vulnerability/cpe_test.clj
+++ b/test/ctia/entity/vulnerability/cpe_test.clj
@@ -1,0 +1,374 @@
+(ns ctia.entity.vulnerability.cpe-test
+  (:require
+   [clojure.test :refer :all]
+   [ctia.entity.vulnerability.cpe :as sut]))
+
+(def left-closed-right-open
+  {:configurations {:nodes [{:children [{:operator "OR",
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:o:juniper:advanced_threat_prevention:*:*:*:*:*:*:*:*"
+                                                      :versionStartIncluding "5.0.0"
+                                                      :versionEndExcluding "5.0.3"}]}
+                                        {:operator "OR",
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"}]}]
+                             :operator "AND"}]}
+   :id "vulnerability-left-closed-right-open"})
+
+(def single-configuration-no-children
+  {:configurations {:nodes [{:operator "OR",
+                             :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"}
+                                         {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"}
+                                         {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"}]}]}
+   :id "vulnerability-one"})
+
+(def single-configuration-with-children
+  {:configurations {:nodes [{:operator "AND"
+                             :children [{:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}]}
+                                        {:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:o:citrix:hypervisor:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:nutanix:ahv:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:o:vmware:vsphere:-:*:*:*:*:*:*:*"}]}]}]}
+   :id "vulnerability-two"})
+
+(def multiple-configurations
+  {:configurations {:nodes [{:operator "AND"
+                             :children
+                             [{:operator "OR"
+                               :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                           {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}]}
+                              {:operator "OR"
+                               :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"}]}]}
+                            {:operator "AND"
+                             :children [{:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}
+                                                     {:cpe23Uri "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"}]}
+                                        {:operator "OR"
+                                         :cpe_match [{:cpe23Uri "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"}]}]}]}
+   :id "vulnerability-three"})
+
+(deftest test-apply-operator
+  (testing "should return truthy"
+    (are [operator operands]
+        (sut/apply-operator {:negate false
+                             :operands operands
+                             :operator operator
+                             :result true})
+      "OR" [false false true]
+      "OR" [false true false]
+      "OR" [["ted"] nil "fred"]
+      "AND" [true true true]
+      "AND" [true true true 18]
+      "AND" [["ted"] true "fred" true]))
+
+  (testing "should return truthy"
+    (are [operator operands]
+        (sut/apply-operator {:negate true
+                             :operands operands
+                             :operator operator
+                             :result true})
+
+      "OR" [false false false]
+      "OR" [false false false]
+      "AND" [false false false]
+      "AND" [false false false]))
+
+  (testing "should return falsey"
+    (are [operator operands]
+        (not (sut/apply-operator {:negate true
+                                  :operands operands
+                                  :operator operator
+                                  :result true}))
+      "OR" [false false true]
+      "OR" [false true false]
+      "OR" [["ted"] nil "fred"]
+      "AND" [true true true]
+      "AND" [true true true 18]
+      "AND" [["ted"] true "fred" true]))
+
+  (testing "should return falsey"
+    (are [operator operands]
+        (not (sut/apply-operator {:operands operands
+                                  :operator operator
+                                  :result true}))
+      "OR" [false false false]
+      "OR" [false false false]
+      "AND" [false false false]
+      "AND" [false false false])))
+
+(deftest test-cpe-match
+  (let [or-cpe-match {:operator "OR",
+                      :cpe_match [{:cpe23Uri "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"}
+                                  {:cpe23Uri "cpe:2.3:o:microsoft:windows_10:1803:*:*:*:*:*:*:*"}]}
+        and-cpe-match {:operator "AND"
+                       :cpe_match [{:cpe23Uri "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"}
+                                   {:cpe23Uri "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"}]}]
+    (testing "OR CPEs should match"
+      (are [cpes] (sut/query-cpe-matches or-cpe-match (map sut/->cpe-match cpes))
+        ["cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows_10:1803:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:windows*:1803:*:*:*:*:*:*:*"]
+
+        ["cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))
+    (testing "OR CPEs should not match"
+      (are [cpes] (not (sut/query-cpe-matches or-cpe-match (map sut/->cpe-match cpes)))
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"]
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))
+    (testing "AND CPEs should match"
+      (are [cpes] (sut/query-cpe-matches and-cpe-match (map sut/->cpe-match cpes))
+        ["cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"
+         "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]))
+    (testing "AND CPEs should match"
+      (are [cpes] (sut/query-cpe-matches and-cpe-match (map sut/->cpe-match cpes))
+        ["cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"
+         "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"
+         "cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"]))
+    (testing "AND CPEs should not match"
+      (are [cpes] (not (sut/query-cpe-matches and-cpe-match (map sut/->cpe-match cpes)))
+        ["cpe:2.3:o:microsoft:fake-windows:-:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+         "cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"]))))
+
+(deftest test-vulnerability->ids
+  (is (= ["CVE-2021-0301"]
+         (sut/vulnerabilities->ids [(sut/->cpe-match "cpe:2.3:o:google:android:-:*:*:*:*:*:*:*")]
+                                   [{:id "CVE-2021-0301"
+                                     :configurations {:nodes [{:operator "OR",
+                                                               :cpe_match
+                                                               [{:vulnerable true,
+                                                                 :cpe23Uri "cpe:2.3:o:google:android:-:*:*:*:*:*:*:*"}]}]}}])))
+  (testing "CPEs should match these CVEs"
+    (are [cve cpes]
+        (= [(:id cve)] (sut/vulnerabilities->ids (map sut/->cpe-match cpes) [cve]))
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:-:*:*:*:*:*:*:*"
+                              "cpe:2.3:h:juniper:atp400:*:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:-:*:*:*:*:*:*:*"
+                              "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:5.0.0:*:*:*:*:*:*:*"
+                              "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:5.0.1:*:*:*:*:*:*:*"
+                              "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:5.0.2:*:*:*:*:*:*:*"
+                              "cpe:2.3:h:juniper:atp400:-:*:*:*:*:*:*:*"]
+      single-configuration-no-children ["cpe:2.3:o:microsoft:windows_10:1607:*:*:*:*:*:*:*"]
+      single-configuration-with-children ["cpe:2.3:a:nvidia:virtual_gpu_manager:*:*:*:*:*:*:*:*"
+                                          "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:microsoft:windows:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"]))
+  (testing "CPEs should not match these CVEs"
+    (are [cve cpes]
+        (empty? (sut/vulnerabilities->ids (map sut/->cpe-match cpes) [cve]))
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:4.9.18:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:5.0.3:*:*:*:*:*:*:*"]
+      left-closed-right-open ["cpe:2.3:o:juniper:advanced_threat_prevention:6.1.2:*:*:*:*:*:*:*"]
+      single-configuration-no-children ["cpe:2.3:o:fred:windows_server_2019:-:*:*:*:*:*:*:*"]
+      single-configuration-with-children ["cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:redhat:enterprise_linux_kernel-based_virtual_machine:-:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:android:android_kernel:-:*:*:*:*:*:*:*"]
+      multiple-configurations ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                               "cpe:2.3:o:openbsd:openbsd_kernel:-:*:*:*:*:*:*:*"]))
+  (testing "Should match vulnerability-one and vulnerability-three"
+    (is (= ["vulnerability-one"
+            "vulnerability-three"]
+           (sut/vulnerabilities->ids (map sut/->cpe-match
+                                          ["cpe:2.3:a:nvidia:gpu_driver:*:*:*:*:*:*:*:*"
+                                           "cpe:2.3:o:linux:linux_kernel:-:*:*:*:*:*:*:*"
+                                           "cpe:2.3:o:microsoft:windows_10:-:*:*:*:*:*:*:*"])
+                                     [single-configuration-no-children
+                                      single-configuration-with-children
+                                      multiple-configurations])))))
+
+(deftest test-str->pattern
+  (are [input expected] (testing input
+                          (is (= expected
+                                 (str (sut/str->pattern input))))
+                          true)
+    "gpu_driver*" "gpu_driver.*"
+    "*" ".*"
+    "gpu_*driver*" "gpu_.*driver.*"
+    "?gpu_*dri?ver" ".?gpu_.*dri.?ver"))
+
+(deftest test-component-match?
+  (are [source target] (testing (format "%s matches %s" source target)
+                         (is (sut/component-match? source target))
+                         true)
+    "-" "-"
+    "-" "*"
+    "*" "-"
+    "gpu_driver" "gpu_driver"
+    "*" "gpu_driver"
+    "gpu_driver" "*"
+    "*gpu_driver" "nvidia-gpu_driver"
+    "nvidia-gpu_driver" "*gpu_driver"
+    "gpu_driver*" "gpu_driver-nvidia"
+    "gpu_driver-nvidia" "gpu_driver*"
+    "?nvidia" "nvidia"
+    "?nvidia" "fnvidia"
+    "nvidia" "?nvidia"
+    "fnvidia" "?nvidia"
+    "nvidia" "nvidia?"
+    "nvidiaf" "nvidia?"
+    "nvidia?" "nvidia"
+    "nvidia?" "nvidiaf")
+  (are [source target] (testing (format "%s matches %s" source target)
+                         (is (not (sut/component-match? source target)))
+                         true)
+    "gpu_driver" "-"
+    "-" "gpu_driver"
+    "Microsoft" "Cisco"
+    "nvidia" "gpu_driver"
+    "*nvidia" "gpu_driver"
+    "gpu_driver" "*nvidia"
+    "?nvidia" "gpu_driver"
+    "gpu_driver" "?nvidia"
+    "nvidia?" "gpu_driver"
+    "gpu_driver?" "nvidia"
+    "gpu_driver*" "nvidia"))
+
+(deftest test-satisfies-interval?
+  (let [closed {:version-start-including "3.0.0"
+                :version-end-including "3.0.9"}
+        open {:version-start-excluding "3.0.0"
+              :version-end-excluding "3.0.9"}
+        left-closed-right-open {:version-start-including "3.0.0"
+                                :version-end-excluding "3.0.9"}
+        left-open-right-closed {:version-start-excluding "3.0.0"
+                                :version-end-including "3.0.9"}
+        left-closed {:version-start-including "3.0.0"}
+        left-open {:version-start-excluding "3.0.0"}
+        right-closed {:version-end-including "3.0.0"}
+        right-open {:version-end-excluding "3.0.0"}]
+    (are [x m] (testing (format "%s should satisfy closed interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.0" closed
+      "3.0.5" closed
+      "3.0.9" closed)
+    (are [x m] (testing (format "%s should not satisfy closed interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "2.0.9" closed
+      "4.0.0" closed)
+    (are [x m] (testing (format "%s should satisfy open interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.1" open
+      "3.0.5" open
+      "3.0.8" open)
+    (are [x m] (testing (format "%s should not satisfy open interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "3.0.0" open
+      "3.0.9" open)
+    (are [x m] (testing (format "%s should satisfy left-closed-right-open interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.0" left-closed-right-open
+      "3.0.5" left-closed-right-open
+      "3.0.8" left-closed-right-open)
+    (are [x m] (testing (format "%s should not satisfy left-closed-right-open interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "2.0.9" left-closed-right-open
+      "3.0.9" left-closed-right-open)
+    (are [x m] (testing (format "%s should satisfy left-open-right-closed interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.1" left-open-right-closed
+      "3.0.5" left-open-right-closed
+      "3.0.9" left-open-right-closed)
+    (are [x m] (testing (format "%s should not satisfy left-open-right-closed interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "3.0.0" left-open-right-closed
+      "4.0.0" left-open-right-closed)
+
+    (are [x m] (testing (format "%s should satisfy left-closed interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.0" left-closed
+      "3.0.5" left-closed
+      "57.0.32" left-closed)
+    (are [x m] (testing (format "%s should not satisfy left-closed interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "2.0.9" left-closed
+      "1.0.0" left-closed)
+    (are [x m] (testing (format "%s should satisfy left-open interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "3.0.1" left-open
+      "3.0.5" left-open
+      "57.0.32" left-open)
+    (are [x m] (testing (format "%s should not satisfy left-open interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "3.0.0" left-open
+      "1.0.0" left-open)
+    (are [x m] (testing (format "%s should satisfy right-closed interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "2.0.9" right-closed
+      "3.0.0" right-closed)
+    (are [x m] (testing (format "%s should not satisfy right-closed interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "3.0.1" right-closed
+      "3.0.2" right-closed)
+    (are [x m] (testing (format "%s should satisfy right-open interval %s" x m)
+                 (is (sut/satisfies-interval? x m))
+                 true)
+      "1.0.2" right-open
+      "2.0.9" right-open)
+    (are [x m] (testing (format "%s should not satisfy right-open interval %s" x m)
+                 (is (not (sut/satisfies-interval? x m)))
+                 true)
+      "3.0.0" right-open
+      "5.0.2" right-open)))
+
+(deftest test->escaped-name
+  (are [input expected] (testing input
+                          (is (= expected
+                                 (sut/->escaped-name input)))
+                          true)
+    "\\:" "_COLON_"
+
+    "cpe:2.3:a:wegoi:re-volt_2_\\:_multiplayer:1.1.4:*:*:*:*:android:*:*"
+    "cpe:2.3:a:wegoi:re-volt_2__COLON__multiplayer:1.1.4:*:*:*:*:android:*:*"
+
+    "cpe:2.3:o:rockwellautomation:slc5\\/01_1747-l5x_firmware:-:*:*:*:*:*:*:*"
+    "cpe:2.3:o:rockwellautomation:slc5_FORWARD_SLASH_01_1747-l5x_firmware:-:*:*:*:*:*:*:*"
+
+    "cpe:2.3:h:juniper:ex8200\\/vc_\\(xre\\):-:*:*:*:*:*:*:*"
+    "cpe:2.3:h:juniper:ex8200_FORWARD_SLASH_vc__OPEN_PAREN_xre_CLOSED_PAREN_:-:*:*:*:*:*:*:*"))
+
+(deftest test->simple-query-string-format
+  (are [input expected] (testing input
+                          (is (= expected
+                                 (sut/->simple-query-string-format input)))
+                          true)
+    "_COLON_" "\\\\\\:"
+
+    "cpe:2.3:a:wegoi:re-volt_2__COLON__multiplayer:1.1.4:*:*:*:*:android:*:*"
+    "cpe:2.3:a:wegoi:re-volt_2_\\\\\\:_multiplayer:1.1.4:*:*:*:*:android:*:*"
+
+    "cpe:2.3:o:rockwellautomation:slc5_FORWARD_SLASH_01_1747-l5x_firmware:-:*:*:*:*:*:*:*"
+    "cpe:2.3:o:rockwellautomation:slc5\\\\\\/01_1747-l5x_firmware:-:*:*:*:*:*:*:*"
+
+    "cpe:2.3:h:juniper:ex8200_FORWARD_SLASH_vc__OPEN_PAREN_xre_CLOSED_PAREN_:-:*:*:*:*:*:*:*"
+    "cpe:2.3:h:juniper:ex8200\\\\\\/vc_\\\\\\(xre\\\\\\):-:*:*:*:*:*:*:*"))


### PR DESCRIPTION
Progress toward #4744

    Epic threatgrid/iroh#4744

    Related threatgrid/iroh#4789

Add route to search for vulnerabilities configurations which match combinations of CPE Match Strings.

Proposed route:
GET /ctia/vulnerability/cpe_match_strings?cpe23_match_strings=[cpe_match_string]