### PR TITLE
Fix sightings gen test and enable casebook gen test for small inputs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 (def perforate-version "0.3.4")
 (def ring-version "1.8.0")
 (def schema-generators-version "0.1.3")
-(def test-check-version "1.0.0")
+(def test-check-version "1.1.0")
 (def test-chuck-version "0.2.10")
 (def trapperkeeper-version "3.1.0")
 
@@ -270,7 +270,9 @@
                           "run" "-m" "ctia.dev.split-tests/dir" :project/test-paths]
             "tests" ["with-profile" ~ci-profiles "run" "-m" "circleci.test"]
 
-            "ci-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test" ":no-gen"]
+            "ci-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test"
+                            ;; TEMPORARY just to validate iroh #4990
+                            ":all"]
             "cron-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test" ":all"]
             "all-ci-profiles" ["shell" "echo" ~(pr-str all-ci-profiles)]
             ;; warm deps cache for all permutations of the build

--- a/project.clj
+++ b/project.clj
@@ -270,9 +270,7 @@
                           "run" "-m" "ctia.dev.split-tests/dir" :project/test-paths]
             "tests" ["with-profile" ~ci-profiles "run" "-m" "circleci.test"]
 
-            "ci-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test"
-                            ;; TEMPORARY just to validate iroh #4990
-                            ":all"]
+            "ci-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test" ":no-gen"]
             "cron-run-tests" ["with-profile" ~ci-profiles "do" "clean," "javac," "split-test" ":all"]
             "all-ci-profiles" ["shell" "echo" ~(pr-str all-ci-profiles)]
             ;; warm deps cache for all permutations of the build

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -14,8 +14,7 @@
   esh/fixture-delete-store-indexes
   ;; The spec definitions below set all fields to be required
   ;; which we use to prove our ES mappings are complete
-  th/fixture-spec-validation
-  th/fixture-fast-gen)
+  th/fixture-spec-validation)
 
 (defspec ^:generative api-for-actor-routes-es-store
   prop/api-for-actor-routes)
@@ -59,6 +58,7 @@
   prop/api-for-judgement-routes)
 
 (defspec ^:generative api-for-sighting-routes-es-store
+;  {:seed 1616133759541}
   prop/api-for-sighting-routes)
 
 (defspec ^:generative api-for-identity-assertion-routes-es-store
@@ -75,5 +75,5 @@
 
 ;; TODO this test is disabled for now as this entity contains
 ;; data-table which triggers a StackOverflow Exception, find a wat to enable it again
-#_(defspec ^:disabled api-for-casebook-routes-es-store
-    prop/api-for-casebook-routes)
+(defspec ^:generative api-for-casebook-routes-es-store
+  prop/api-for-casebook-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -90,7 +90,7 @@
   (prop/api-for-weakness-routes
     100))
 
-(deftest ^:generative api-for-casebook-routes-es-store
+(deftest ^:disabled api-for-casebook-routes-es-store
   ;; TODO identify why this is slow
   (prop/api-for-casebook-routes
     {:max-size 1

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -77,5 +77,6 @@
 ;; data-table which triggers a StackOverflow Exception, find a wat to enable it again
 (defspec ^:generative api-for-casebook-routes-es-store
   ;; TODO this test consumes heap space at a high rate. 
-  {:num-tests 10}
+  {:max-size 1
+   :num-tests 1}
   prop/api-for-casebook-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -83,8 +83,9 @@
     100))
 
 (deftest ^:generative api-for-vulnerability-routes-es-store
+  ;; TODO why is this 4x slower than other entities?
   (prop/api-for-vulnerability-routes
-    100))
+    25))
 
 (deftest ^:generative api-for-weakness-routes-es-store
   (prop/api-for-weakness-routes

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -94,4 +94,4 @@
   ;; TODO identify why this is slow
   (prop/api-for-casebook-routes
     {:max-size 1
-     :num-tests 2}))
+     :num-tests 1}))

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -90,7 +90,7 @@
   (prop/api-for-weakness-routes
     100))
 
-(deftest ^:disabled api-for-casebook-routes-es-store
+(deftest ^:generative api-for-casebook-routes-es-store
   ;; TODO identify why this is slow
   (prop/api-for-casebook-routes
     {:max-size 1

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -16,65 +16,80 @@
   th/fixture-spec-validation)
 
 (deftest ^:generative api-for-actor-routes-es-store
-  (prop/api-for-actor-routes))
+  (prop/api-for-actor-routes
+    100))
 
 (deftest ^:generative api-for-asset-routes-es-store
-  (prop/api-for-asset-routes))
+  (prop/api-for-asset-routes
+    100))
 
 (deftest ^:generative api-for-asset-mapping-routes-es-store
-  (prop/api-for-asset-mapping-routes))
+  (prop/api-for-asset-mapping-routes
+    100))
 
 (deftest ^:generative api-for-asset-properties-routes-es-store
-  (prop/api-for-asset-properties-routes))
+  (prop/api-for-asset-properties-routes
+    100))
 (deftest ^:generative api-for-target-record-routes-es-store
-  (prop/api-for-target-record-routes))
+  (prop/api-for-target-record-routes
+    100))
 
 (deftest ^:generative api-for-attack-pattern-routes-es-store
-  (prop/api-for-attack-pattern-routes))
+  (prop/api-for-attack-pattern-routes
+    100))
 
 (deftest ^:generative api-for-campaign-routes-es-store
-  (prop/api-for-campaign-routes))
+  (prop/api-for-campaign-routes
+    100))
 
 (deftest ^:generative api-for-coa-routes-es-store
-  (prop/api-for-coa-routes))
+  (prop/api-for-coa-routes
+    100))
 
 (deftest ^:generative api-for-feedback-routes-es-store
-  (prop/api-for-feedback-routes))
+  (prop/api-for-feedback-routes
+    100))
 
 (deftest ^:generative api-for-incident-routes-es-store
-  (prop/api-for-incident-routes))
+  (prop/api-for-incident-routes
+    100))
 
 (deftest ^:generative api-for-indicator-routes-es-store
-  (prop/api-for-indicator-routes))
+  (prop/api-for-indicator-routes
+    100))
 
 (deftest ^:generative api-for-judgement-routes-es-store
-  (prop/api-for-judgement-routes))
+  (prop/api-for-judgement-routes
+    100))
 
 (deftest ^:generative api-for-malware-routes-es-store
-  (prop/api-for-malware-routes))
+  (prop/api-for-malware-routes
+    100))
 
 (deftest ^:generative api-for-relationship-routes-es-store
-  (prop/api-for-judgement-routes))
+  (prop/api-for-judgement-routes
+    100))
 
 (deftest ^:generative api-for-sighting-routes-es-store
-  (prop/api-for-sighting-routes))
+  (prop/api-for-sighting-routes
+    100))
 
 (deftest ^:generative api-for-identity-assertion-routes-es-store
-  (prop/api-for-identity-assertion-routes))
+  (prop/api-for-identity-assertion-routes
+    100))
 
 (deftest ^:generative api-for-tool-routes-es-store
-  (prop/api-for-tool-routes))
+  (prop/api-for-tool-routes
+    100))
 
 (deftest ^:generative api-for-vulnerability-routes-es-store
-  (prop/api-for-vulnerability-routes))
+  (prop/api-for-vulnerability-routes
+    100))
 
 (deftest ^:generative api-for-weakness-routes-es-store
-  (prop/api-for-weakness-routes))
+  (prop/api-for-weakness-routes
+    100))
 
 (deftest ^:generative api-for-casebook-routes-es-store
-  ;; FIXME examples are unexpectedly huge, especially given
-  ;; the smallest max-size. make them smaller and increase these
-  ;; parameters.
   (prop/api-for-casebook-routes
-    {:max-size 1
-     :num-tests 1}))
+    100))

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -91,5 +91,7 @@
     100))
 
 (deftest ^:generative api-for-casebook-routes-es-store
+  ;; TODO identify why this is slow
   (prop/api-for-casebook-routes
-    100))
+    {:max-size 1
+     :num-tests 2}))

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -58,7 +58,6 @@
   prop/api-for-judgement-routes)
 
 (defspec ^:generative api-for-sighting-routes-es-store
-;  {:seed 1616133759541}
   prop/api-for-sighting-routes)
 
 (defspec ^:generative api-for-identity-assertion-routes-es-store

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -76,4 +76,6 @@
 ;; TODO this test is disabled for now as this entity contains
 ;; data-table which triggers a StackOverflow Exception, find a wat to enable it again
 (defspec ^:generative api-for-casebook-routes-es-store
+  ;; TODO this test consumes heap space at a high rate. 
+  {:num-tests 10}
   prop/api-for-casebook-routes)

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -1,8 +1,7 @@
 (ns ctia.http.generative.es-store-spec
   (:require [clj-momo.test-helpers.core :as mth]
             [ctia.http.generative.properties :as prop]
-            [clojure.test :refer [use-fixtures]]
-            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test :refer [deftest use-fixtures]]
             [ctia.test-helpers.core :as th]
             [ctia.test-helpers.es :as esh]))
 
@@ -16,66 +15,66 @@
   ;; which we use to prove our ES mappings are complete
   th/fixture-spec-validation)
 
-(defspec ^:generative api-for-actor-routes-es-store
-  prop/api-for-actor-routes)
+(deftest ^:generative api-for-actor-routes-es-store
+  (prop/api-for-actor-routes))
 
-(defspec ^:generative api-for-asset-routes-es-store
-  prop/api-for-asset-routes)
+(deftest ^:generative api-for-asset-routes-es-store
+  (prop/api-for-asset-routes))
 
-(defspec ^:generative api-for-asset-mapping-routes-es-store
-  prop/api-for-asset-mapping-routes)
+(deftest ^:generative api-for-asset-mapping-routes-es-store
+  (prop/api-for-asset-mapping-routes))
 
-(defspec ^:generative api-for-asset-properties-routes-es-store
-  prop/api-for-asset-properties-routes)
-(defspec ^:generative api-for-target-record-routes-es-store
-  prop/api-for-target-record-routes)
+(deftest ^:generative api-for-asset-properties-routes-es-store
+  (prop/api-for-asset-properties-routes))
+(deftest ^:generative api-for-target-record-routes-es-store
+  (prop/api-for-target-record-routes))
 
-(defspec ^:generative api-for-attack-pattern-routes-es-store
-  prop/api-for-attack-pattern-routes)
+(deftest ^:generative api-for-attack-pattern-routes-es-store
+  (prop/api-for-attack-pattern-routes))
 
-(defspec ^:generative api-for-campaign-routes-es-store
-  prop/api-for-campaign-routes)
+(deftest ^:generative api-for-campaign-routes-es-store
+  (prop/api-for-campaign-routes))
 
-(defspec ^:generative api-for-coa-routes-es-store
-  prop/api-for-coa-routes)
+(deftest ^:generative api-for-coa-routes-es-store
+  (prop/api-for-coa-routes))
 
-(defspec ^:generative api-for-feedback-routes-es-store
-  prop/api-for-feedback-routes)
+(deftest ^:generative api-for-feedback-routes-es-store
+  (prop/api-for-feedback-routes))
 
-(defspec ^:generative api-for-incident-routes-es-store
-  prop/api-for-incident-routes)
+(deftest ^:generative api-for-incident-routes-es-store
+  (prop/api-for-incident-routes))
 
-(defspec ^:generative api-for-indicator-routes-es-store
-  prop/api-for-indicator-routes)
+(deftest ^:generative api-for-indicator-routes-es-store
+  (prop/api-for-indicator-routes))
 
-(defspec ^:generative api-for-judgement-routes-es-store
-  prop/api-for-judgement-routes)
+(deftest ^:generative api-for-judgement-routes-es-store
+  (prop/api-for-judgement-routes))
 
-(defspec ^:generative api-for-malware-routes-es-store
-  prop/api-for-malware-routes)
+(deftest ^:generative api-for-malware-routes-es-store
+  (prop/api-for-malware-routes))
 
-(defspec ^:generative api-for-relationship-routes-es-store
-  prop/api-for-judgement-routes)
+(deftest ^:generative api-for-relationship-routes-es-store
+  (prop/api-for-judgement-routes))
 
-(defspec ^:generative api-for-sighting-routes-es-store
-  prop/api-for-sighting-routes)
+(deftest ^:generative api-for-sighting-routes-es-store
+  (prop/api-for-sighting-routes))
 
-(defspec ^:generative api-for-identity-assertion-routes-es-store
-  prop/api-for-identity-assertion-routes)
+(deftest ^:generative api-for-identity-assertion-routes-es-store
+  (prop/api-for-identity-assertion-routes))
 
-(defspec ^:generative api-for-tool-routes-es-store
-  prop/api-for-tool-routes)
+(deftest ^:generative api-for-tool-routes-es-store
+  (prop/api-for-tool-routes))
 
-(defspec ^:generative api-for-vulnerability-routes-es-store
-  prop/api-for-vulnerability-routes)
+(deftest ^:generative api-for-vulnerability-routes-es-store
+  (prop/api-for-vulnerability-routes))
 
-(defspec ^:generative api-for-weakness-routes-es-store
-  prop/api-for-weakness-routes)
+(deftest ^:generative api-for-weakness-routes-es-store
+  (prop/api-for-weakness-routes))
 
-(defspec ^:generative api-for-casebook-routes-es-store
+(deftest ^:generative api-for-casebook-routes-es-store
   ;; FIXME examples are unexpectedly huge, especially given
   ;; the smallest max-size. make them smaller and increase these
   ;; parameters.
-  {:max-size 1
-   :num-tests 1}
-  prop/api-for-casebook-routes)
+  (prop/api-for-casebook-routes
+    {:max-size 1
+     :num-tests 1}))

--- a/test/ctia/http/generative/es_store_spec.clj
+++ b/test/ctia/http/generative/es_store_spec.clj
@@ -73,10 +73,10 @@
 (defspec ^:generative api-for-weakness-routes-es-store
   prop/api-for-weakness-routes)
 
-;; TODO this test is disabled for now as this entity contains
-;; data-table which triggers a StackOverflow Exception, find a wat to enable it again
 (defspec ^:generative api-for-casebook-routes-es-store
-  ;; TODO this test consumes heap space at a high rate. 
+  ;; FIXME examples are unexpectedly huge, especially given
+  ;; the smallest max-size. make them smaller and increase these
+  ;; parameters.
   {:max-size 1
    :num-tests 1}
   prop/api-for-casebook-routes)

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -43,8 +43,8 @@
              [utils :as fu]]))
 
 (defn check-differences-in-common-key-paths
-  "More detailed error messages when large sequentials or sets
-  are unexpectedly not equal."
+  "Like (apply common= (vals id->m)) but
+  with more specific error messages."
   [id->m]
   {:pre [(seq id->m)]}
   (let [id->m-at-path (fn [key-path]
@@ -133,17 +133,6 @@
          [NewCasebook "max-new-casebook"]]]
   (fs/->spec (fu/require-all entity)
              kw-ns))
-
-(comment
-  (-> (into {} (filter (fn [[k]] (.contains (str k) "max-new-sighting"))) (clojure.spec.alpha/registry))
-      clojure.pprint/pprint)
-  (-> (into {} (filter (fn [[k]] (.contains (str k) "max-new-casebook"))) (clojure.spec.alpha/registry))
-      sort
-      clojure.pprint/pprint)
-  (-> (into {} (filter (fn [[k]] (.contains (str k) "data-table"))) (clojure.spec.alpha/registry))
-      sort
-      clojure.pprint/pprint)
-  )
 
 (defn spec-gen [kw-ns]
   (tcg/fmap #(dissoc % :id)

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -51,7 +51,10 @@
                (map #(into all0 (frequencies %)))
                (apply merge-with -)))))
 
-(defn check-differences-in-common-key-paths! [id->m]
+(defn check-differences-in-common-key-paths!
+  "More detailed error messages when large sequentials or sets
+  are unexpectedly not equal."
+  [id->m]
   {:pre [(seq id->m)]}
   (when-not (apply common= (vals id->m))
     (throw
@@ -99,467 +102,55 @@
                                                         d}))))]))
                   different-common-key-paths)))}))))
 
-(comment
- (def diff-data
-   {:differences
-    '([[:data :rows]
-      {:just-with-path
-       {:new-entity
-        {:data
-         {:rows
-          [[nil
-            nil
-            nil
-            nil
-            [:R/G]
-            {}
-            nil
-            nil
-            #uuid "98eb5bb8-96b2-400f-b631-a30879eebd80"]
-           [nil [:j 0N "" \* 0N K/Q]]
-           [#{}
-            nil
-            nil
-            #{}
-            nil
-            ()
-            {}
-            #{}
-            [I 0 ""]
-            #{}
-            nil
-            nil
-            ()
-            #{}
-            #{}
-            ()
-            nil
-            ()]
-           [()
-            nil
-            nil
-            #{}
-            [\l A]
-            []
-            [#uuid "9ba5bd1d-50f8-47ab-96bb-086bedbae36c"]]
-           [nil [] () #{} [""] () {}]
-           [nil]
-           [() nil nil #{}]
-           [nil
-            nil
-            #{}
-            [0N]
-            ()
-            nil
-            nil
-            ()
-            {}
-            #{}
-            nil
-            #{}
-            nil
-            {}
-            nil
-            ()
-            nil
-            nil]
-           [#{}
-            nil
-            #{}
-            nil
-            nil
-            nil
-            nil
-            nil
-            nil
-            nil
-            ()
-            nil
-            nil
-            ()
-            :D/n
-            nil
-            {}]
-           [!
-            #{}
-            nil
-            nil
-            {}
-            #{}
-            nil
-            ["" 0 B/a]
-            [""]
-            ()
-            {}
-            ()
-            nil
-            #{}
-            nil
-            [\V
-             #uuid "4eb6c3b3-2b36-4cf1-8b5a-e7536c8e8e62"
-             \"
-             #uuid "99b3a577-3f90-4df7-afc0-3a687b5066cb"]
-            nil
-            nil
-            nil]
-           [nil {} nil {} nil]
-           [nil {} nil #{} [0] () #{} nil nil nil]
-           [{}
-            [\s]
-            nil
-            nil
-            nil
-            nil
-            nil
-            {}
-            {}
-            {}
-            nil
-            []
-            ()
-            nil
-            []
-            nil
-            nil
-            nil
-            ()
-            ()]
-[nil [] nil nil nil [0 B/U :*/l] {}]
-[nil {} nil {} #{} () [] {} #{} nil [k/+] nil nil nil nil]
-[nil
- nil
- nil
- #{}
- ()
- []
- nil
- nil
- #{}
- #{}
- nil
- nil
- ()
- nil
- {}
- nil
- nil]
-[[true] nil nil nil {} () nil nil () nil () nil]
-[{}]]}},
-:post-entity
-{:data
- {:rows
-  [[nil
-    nil
-    nil
-    nil
-    [:R/G]
-    {}
-    nil
-    nil
-    #uuid "98eb5bb8-96b2-400f-b631-a30879eebd80"]
-   [nil [:j 0N "" \* 0N K/Q]]
-   [#{}
-    nil
-    nil
-    #{}
-    nil
-    ()
-    {}
-    #{}
-    [I 0 ""]
-    #{}
-    nil
-    nil
-    ()
-    #{}
-    #{}
-    ()
-    nil
-    ()]
-   [()
-    nil
-    nil
-    #{}
-    [\l A]
-    []
-    [#uuid "9ba5bd1d-50f8-47ab-96bb-086bedbae36c"]]
-   [nil [] () #{} [""] () {}]
-   [nil]
-   [() nil nil #{}]
-   [nil
-    nil
-    #{}
-    [0N]
-    ()
-    nil
-    nil
-    ()
-    {}
-    #{}
-    nil
-    #{}
-    nil
-    {}
-    nil
-    ()
-    nil
-    nil]
-   [#{}
-    nil
-    #{}
-    nil
-    nil
-    nil
-    nil
-    nil
-    nil
-    nil
-    ()
-    nil
-    nil
-    ()
-    :D/n
-    nil
-         {}]
-        [!
-         #{}
-         nil
-         nil
-         {}
-         #{}
-         nil
-         ["" 0 B/a]
-         [""]
-         ()
-         {}
-         ()
-         nil
-         #{}
-         nil
-         [\V
-          #uuid "4eb6c3b3-2b36-4cf1-8b5a-e7536c8e8e62"
-          \"
-          #uuid "99b3a577-3f90-4df7-afc0-3a687b5066cb"]
-         nil
-         nil
-         nil]
-        [nil {} nil {} nil]
-        [nil {} nil #{} [0] () #{} nil nil nil]
-        [{}
-         [\s]
-         nil
-         nil
-         nil
-         nil
-         nil
-         {}
-         {}
-         {}
-         nil
-         []
-         ()
-         nil
-         []
-         nil
-         nil
-         nil
-         ()
-         ()]
-        [nil [] nil nil nil [0 B/U :*/l] {}]
-        [nil {} nil {} #{} () [] {} #{} nil [k/+] nil nil nil nil]
-        [nil
-         nil
-         nil
-         #{}
-         ()
-         []
-         nil
-         nil
-         #{}
-         #{}
-         nil
-         nil
-         ()
-         nil
-         {}
-         nil
-         nil]
-        [[true] nil nil nil {} () nil nil () nil () nil]
-        [{}]]}},
-     :get-entity
-     {:data
-      {:rows
-       [[nil
-         nil
-         nil
-         nil
-         ["R/G"]
-         {}
-         nil
-         nil
-         "98eb5bb8-96b2-400f-b631-a30879eebd80"]
-        [nil ["j" 0 "" "*" 0 "K/Q"]]
-        [[]
-         nil
-         nil
-         []
-         nil
-         []
-         {}
-         []
-         ["I" 0 ""]
-         []
-         nil
-         nil
-         []
-         []
-         []
-         []
-         nil
-         []]
-        [[]
-         nil
-         nil
-         []
-         ["l" "A"]
-         []
-         ["9ba5bd1d-50f8-47ab-96bb-086bedbae36c"]]
-        [nil [] [] [] [""] [] {}]
-        [nil]
-        [[] nil nil []]
-        [nil
-         nil
-         []
-         [0]
-         []
-         nil
-         nil
-         []
-         {}
-         []
-         nil
-         []
-         nil
-         {}
-         nil
-         []
-         nil
-         nil]
-        [[]
-         nil
-         []
-         nil
-         nil
-         nil
-         nil
-         nil
-         nil
-         nil
-         []
-         nil
-         nil
-         []
-         "D/n"
-         nil
-         {}]
-        ["!"
-         []
-         nil
-         nil
-         {}
-         []
-         nil
-         ["" 0 "B/a"]
-         [""]
-         []
-         {}
-         []
-         nil
-         []
-         nil
-         ["V"
-          "4eb6c3b3-2b36-4cf1-8b5a-e7536c8e8e62"
-          "\""
-          "99b3a577-3f90-4df7-afc0-3a687b5066cb"]
-         nil
-         nil
-         nil]
-        [nil {} nil {} nil]
-        [nil {} nil [] [0] [] [] nil nil nil]
-        [{}
-         ["s"]
-         nil
-         nil
-         nil
-         nil
-         nil
-         {}
-         {}
-         {}
-         nil
-         []
-         []
-         nil
-         []
-         nil
-         nil
-         nil
-         []
-         []]
-        [nil [] nil nil nil [0 "B/U" "*/l"] {}]
-        [nil {} nil {} [] [] [] {} [] nil ["k/+"] nil nil nil nil]
-        [nil nil nil [] [] [] nil nil [] [] nil nil [] nil {} nil nil]
-        [[true] nil nil nil {} [] nil nil [] nil [] nil]
-        [{}]]}}}}])})
+(defn new-entity-workarounds
+  "Returns a massaged new-entity that works around
+  unresolved problems in the generators."
+  [new-entity model-type]
+  (let [;; sets seem to get coerced to vectors in rows after a GET
+        rows-workaround #(walk/postwalk
+                           (fn [v]
+                             (if (set? v)
+                               (vec v)
+                               v))
+                           %)
+        sighting-workaround #(cond-> %
+                               (:data %) (update-in [:data :rows] rows-workaround))
+        datatable-workaround #(-> %
+                                  ;; these are huge for some reason
+                                  (assoc :rows ())
+                                  (dissoc :row_count))]
+    (case model-type
+      ;; FIXME data table generator needs refinement and/or behavior needs investigation:
+      ;; https://github.com/threatgrid/ctim/blob/9fff33b81c705c649ad8ea8d9331fa091102f121/src/ctim/schemas/sighting.cljc#L34
+      ;; - :row_count and :rows should probably agree.
+      ;; - unclear if sets are allowed as Datum in a row. they get coerced to vectors
+      ;;   when using GET.
+      ;;   - eg., for sighting with {:data {:rows [[[] #{}]]}} in {new,post}-entity,
+      ;;     get-entity is {:data {:rows [[[] []]]}}
+      ;;     - to reproduce, remove this workaround and run 
+      ;;        lein test :only ctia.http.generative.es-store-spec/api-for-sighting-routes-es-store
+      ;;       with {:seed 1616133759541}
+      ;;       - shrunk args: [{:description "", :schema_version "1.1.3", :revision 0, :relations [], :sensor_coordinates {:type "endpoint.sensor", :observables [], :os ""}, :observables [], :type "sighting", :source "", :external_ids [], :targets [], :short_description "", :title "", :resolution "", :internal false, :external_references [], :source_uri "http://0/", :language "", :count 0, :severity "Medium", :tlp "white", :timestamp #inst "2010-01-01T00:00:00.000-00:00", :confidence "Medium", :observed_time {:start_time #inst "2017-01-01T00:00:00.000-00:00", :end_time #inst "2017-01-01T00:00:00.000-00:00"}, :sensor "endpoint.sensor", :data {:columns [], :rows [[[:A]]], :row_count 0}}]
+      (sighting) (sighting-workaround new-entity)
+      (casebook) (cond-> new-entity
+                   (get-in new-entity [:bundle :data_tables])
+                   (update-in [:bundle :data_tables]
+                              #(into #{}
+                                     (map datatable-workaround)
+                                     %))
 
-  (map (fn [[path {:keys [just-with-path]}]]
-         (let [] path))
-       (:differences diff-data))
-  )
+                   (get-in new-entity [:bundle :sightings])
+                   (update-in [:bundle :sightings]
+                              #(into #{}
+                                     (map sighting-workaround)
+                                     %)))
+      new-entity)))
 
 (defn api-for-route [model-type entity-gen]
   (for-all
     [new-entity entity-gen]
     (let [app (helpers/get-current-app)
-          ;; sets seem to get coerced to vectors in rows after a GET
-          rows-workaround #(walk/postwalk
-                             (fn [v]
-                               (if (set? v)
-                                 (vec v)
-                                 v))
-                             %)
-          sighting-workaround #(cond-> %
-                                 (:data %) (update-in [:data :rows] rows-workaround))
-          datatable-workaround #(-> %
-                                    ;; these are huge for some reason
-                                    (assoc :rows ())
-                                    (dissoc :row_count))
-          new-entity (case model-type
-                       ;; FIXME data table generator needs refinement and/or behavior needs investigation:
-                       ;; https://github.com/threatgrid/ctim/blob/9fff33b81c705c649ad8ea8d9331fa091102f121/src/ctim/schemas/sighting.cljc#L34
-                       ;; - :row_count and :rows should probably agree.
-                       ;; - unclear if sets are allowed as Datum in a row. they get coerced to vectors
-                       ;;   when using GET.
-                       ;;   - eg., for sighting with {:data {:rows [[[] #{}]]}} in {new,post}-entity,
-                       ;;     get-entity is {:data {:rows [[[] []]]}}
-                       ;;     - to reproduce, remove this workaround and run 
-                       ;;        lein test :only ctia.http.generative.es-store-spec/api-for-sighting-routes-es-store
-                       ;;       with {:seed 1616133759541}
-                       ;;       - shrunk args: [{:description "", :schema_version "1.1.3", :revision 0, :relations [], :sensor_coordinates {:type "endpoint.sensor", :observables [], :os ""}, :observables [], :type "sighting", :source "", :external_ids [], :targets [], :short_description "", :title "", :resolution "", :internal false, :external_references [], :source_uri "http://0/", :language "", :count 0, :severity "Medium", :tlp "white", :timestamp #inst "2010-01-01T00:00:00.000-00:00", :confidence "Medium", :observed_time {:start_time #inst "2017-01-01T00:00:00.000-00:00", :end_time #inst "2017-01-01T00:00:00.000-00:00"}, :sensor "endpoint.sensor", :data {:columns [], :rows [[[:A]]], :row_count 0}}]
-                       (sighting) (sighting-workaround new-entity)
-                       (casebook) (cond-> new-entity
-                                    (get-in new-entity [:bundle :data_tables])
-                                    (update-in [:bundle :data_tables]
-                                               #(into #{}
-                                                      (map datatable-workaround)
-                                                      %))
-
-                                    (get-in new-entity [:bundle :sightings])
-                                    (update-in [:bundle :sightings]
-                                               #(into #{}
-                                                      (map sighting-workaround)
-                                                      %)))
-                       new-entity)
+          new-entity (new-entity-workarounds new-entity model-type)
 
           {post-status :status
            {id :id

--- a/test/ctia/http/generative/properties.clj
+++ b/test/ctia/http/generative/properties.clj
@@ -149,7 +149,8 @@
   (tcg/fmap #(dissoc % :id)
             (cs/gen (keyword kw-ns "map")
                     (let [;; override data-table Datum, originally `any?` which is
-                          ;; a documented underapproximation.
+                          ;; a documented underapproximation and generates huge examples
+                          ;; which don't end up round-tripping via GET anyway.
                           gen-datum (constantly tcg/string-ascii)]
                       {:max-new-casebook.bundle.sightings.set-of.data.rows.seq-of/seq-of gen-datum
                        :max-new-casebook.bundle.data_tables.set-of.rows.seq-of/seq-of gen-datum

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -440,10 +440,6 @@
 (defn fixture-max-spec [node-to-spec ns]
   (fixture-spec (fu/require-all node-to-spec) ns))
 
-(defn fixture-fast-gen [t]
-  (with-redefs [gen/vector cgc/vector]
-    (t)))
-
 (s/defn make-id
   "Make a long style ID using CTIA code (eg with a random UUID).
   Returns an ID object."


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close https://github.com/threatgrid/iroh/issues/4990
Close https://github.com/threatgrid/iroh/issues/4445

Reviewers: please ignore whitespace changes.

This PR refactors our routing generative tests to be more debuggable, and using that scaffolding fixes the recently-enabled sighting test that's been failing in cron (that has always failed AFAICT). Also, upgrades the casebook test from `:disabled` to `:generative` with very small inputs.

Normally, these tests only run during cron, but I temporarily used `split-test :all` in CI to build commits for this PR. All commits before [`revert :no-gen`](https://github.com/threatgrid/ctia/pull/1101/commits/16835d2aaa0d3f8e7c9e6c558024504057e6df58) in this PR are run with `split-test :all`. For example, the commit just before it [`adjust`](https://github.com/threatgrid/ctia/pull/1101/commits/9768db72467842f3c26793673b077bb5910ca9a9) runs these tests in the [first split](https://github.com/threatgrid/ctia/runs/2170236692):

```
Testing ctia.http.generative.es-store-spec
   48s for ctia.http.generative.es-store-spec/api-for-coa-routes-es-store.
   39s for ctia.http.generative.es-store-spec/api-for-relationship-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-identity-assertion-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-tool-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-malware-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-asset-mapping-routes-es-store.
   37s for ctia.http.generative.es-store-spec/api-for-incident-routes-es-store.
   37s for ctia.http.generative.es-store-spec/api-for-actor-routes-es-store.
   43s for ctia.http.generative.es-store-spec/api-for-sighting-routes-es-store.
   37s for ctia.http.generative.es-store-spec/api-for-attack-pattern-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-asset-properties-routes-es-store.
   37s for ctia.http.generative.es-store-spec/api-for-asset-routes-es-store.
   49s for ctia.http.generative.es-store-spec/api-for-vulnerability-routes-es-store.
   38s for ctia.http.generative.es-store-spec/api-for-campaign-routes-es-store.
   39s for ctia.http.generative.es-store-spec/api-for-indicator-routes-es-store.
   39s for ctia.http.generative.es-store-spec/api-for-target-record-routes-es-store.
   36s for ctia.http.generative.es-store-spec/api-for-judgement-routes-es-store.
   36s for ctia.http.generative.es-store-spec/api-for-feedback-routes-es-store.
   44s for ctia.http.generative.es-store-spec/api-for-weakness-routes-es-store.
    5s for ctia.http.generative.es-store-spec/api-for-casebook-routes-es-store.

758s for ctia.http.generative.es-store-spec

Ran 20 tests containing 554 assertions.
0 failures, 0 errors.
```

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Fix sightings gen test and enable casebook gen test for small inputs
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

