### PR TITLE
Issue-1106: promotion_method in Incident entity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.5"]
+                 [threatgrid/ctim "1.1.6"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.3.0"]
 

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -149,7 +149,8 @@
       :categories em/token
       :discovery_method em/token
       :intended_effect em/token
-      :assignees em/token})}})
+      :assignees em/token
+      :promotion_method em/token})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
 
@@ -167,7 +168,8 @@
            :incident_time.rejected
            :discovery_method
            :intended_effect
-           :assignees]))
+           :assignees
+           :promotion_method]))
 
 (def incident-sort-fields
   (apply s/enum incident-fields))
@@ -205,7 +207,8 @@
      :intended_effect s/Str
      :categories s/Str
      :sort_by incident-sort-fields
-     :assignees s/Str})))
+     :assignees s/Str
+     :promotion_method s/Str})))
 
 (def IncidentGetParams IncidentFieldsParam)
 

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -103,4 +103,5 @@ fragment incidentFields on Incident {
   owner
   groups
   assignees
+  promotion_method
 }


### PR DESCRIPTION
Adds support for the new `promotion_method` field being added in
CTIM.

> Related # https://github.com/threatgrid/ctim/issues/338
> Related # https://github.com/threatgrid/response/issues/625

Describe your PR for reviewers.

This PR adds the promotion_method field to the incident entity. It is optional and
can have a value of either `manual` or `automatic`.

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

Positive case - no errors expected
1. POST an incident with a promotion_method of `manual`
2. Note the id
3. GET the incident by id

Negative case - errors expected
1. POST an incident with a promotion_method of `securex`

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: one-line description for internal eyes only.
Adds promotion_method to incident model
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

