### PR TITLE
renames DateRange query to correspond to ES DSL

### DIFF
--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -115,7 +115,7 @@
    (let [filter-map (apply dissoc search-params filter-map-search-options)
          date-range (make-date-range-fn from to)]
      (cond-> {}
-       (seq date-range) (assoc-in [:date-range date-field] date-range)
+       (seq date-range) (assoc-in [:range date-field] date-range)
        (seq filter-map) (assoc :filter-map filter-map)
        query (assoc :query-string query)))))
 
@@ -123,10 +123,10 @@
   [result
    agg-type
    aggregate-on
-   {:keys [date-range query-string filter-map]} :- SearchQuery]
+   {:keys [range query-string filter-map]} :- SearchQuery]
   (let [nested-fields (map keyword
                             (str/split (name aggregate-on) #"\."))
-        {from :gte to :lt} (-> date-range first val)
+        {from :gte to :lt} (-> range first val)
         filters (cond-> {:from from :to to}
                   (seq filter-map) (into filter-map)
                   (seq query-string) (assoc :query-string query-string))]

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -8,7 +8,7 @@
              [codec :as codec]
              [http-response :as http-res]
              [http-status :refer [ok]]]
-            [ctia.schemas.search-agg :refer [DateRangeQueryOpt SearchQuery MetricResult]]
+            [ctia.schemas.search-agg :refer [RangeQueryOpt SearchQuery MetricResult]]
             [schema.core :as s]))
 
 (def search-options [:sort_by
@@ -101,7 +101,7 @@
   ([date-field search-params]
    (search-query date-field
                  search-params
-                 (s/fn :- DateRangeQueryOpt
+                 (s/fn :- RangeQueryOpt
                    [from :- (s/maybe s/Inst)
                     to :- (s/maybe s/Inst)]
                    (cond-> {}
@@ -109,7 +109,7 @@
                      to (assoc :lt to)))))
   ([date-field
     {:keys [query from to] :as search-params}
-    make-date-range-fn :- (s/=> DateRangeQueryOpt
+    make-date-range-fn :- (s/=> RangeQueryOpt
                                 (s/named (s/maybe s/Inst) 'from)
                                 (s/named (s/maybe s/Inst) 'to))]
    (let [filter-map (apply dissoc search-params filter-map-search-options)

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -1,23 +1,25 @@
 (ns ctia.schemas.search-agg
-  (:require [schema.core :as s]
-            [schema-tools.core :as st]))
+  (:require
+   [schema.core :as s]
+   [schema-tools.core :as st]))
 
-(s/defschema DateRangeQueryOpt
+(s/defschema RangeQueryOpt
   (st/optional-keys
     {:gte s/Inst
      :lt s/Inst}))
 
-(s/defschema DateRange
-  "Date range query, includes lowerfrom and excludes to"
-  {s/Keyword DateRangeQueryOpt})
+(s/defschema RangeQuery
+  "Corresponds to Range Query of Elasticsearch Query DSL.
+  see: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
+  {s/Keyword RangeQueryOpt})
 
 (s/defschema SearchQuery
   "components of a search query:
    - query-string: free text search, with lucene syntax enabled"
   (st/optional-keys
-   {:query-string s/Str
+   {:query-string s/Str         ;; TODO change as described: https://github.com/threatgrid/iroh/issues/4959#issuecomment-810815287
     :filter-map {s/Keyword s/Any}
-    :date-range DateRange}))
+    :range RangeQuery}))
 
 (s/defschema AggType
   "supported aggregation types"

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -19,7 +19,7 @@
   (st/optional-keys
    {:query-string s/Str         ;; TODO change as described: https://github.com/threatgrid/iroh/issues/4959#issuecomment-810815287
     :filter-map {s/Keyword s/Any}
-    :range RangeQuery}))
+    :date-range RangeQuery}))
 
 (s/defschema AggType
   "supported aggregation types"

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -19,7 +19,7 @@
   (st/optional-keys
    {:query-string s/Str         ;; TODO change as described: https://github.com/threatgrid/iroh/issues/4959#issuecomment-810815287
     :filter-map {s/Keyword s/Any}
-    :date-range RangeQuery}))
+    :range RangeQuery}))
 
 (s/defschema AggType
   "supported aggregation types"

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -318,20 +318,20 @@ It returns the documents with full hits meta data including the real index in wh
 (s/defn make-search-query
   [{{:keys [default_operator]} :props
     {{:keys [get-in-config]} :ConfigService} :services} :- ESConnState
-   {:keys [query-string filter-map date-range]} :- SearchQuery
+   {:keys [query-string filter-map range]} :- SearchQuery
    ident]
   (let [es-query-string {:query_string (into {:query query-string}
                                              (when default_operator
                                                {:default_operator default_operator}))}
-        date-range-query (when date-range
-                           {:range date-range})
+        date-range-query (when range
+                           {:range range})
         filter-terms (-> (ensure-document-id-in-map filter-map)
                          q/prepare-terms)]
     {:bool
      {:filter
       (cond-> [(find-restriction-query-part ident get-in-config)]
         (seq filter-map) (into filter-terms)
-        (seq date-range) (conj date-range-query)
+        (seq range) (conj date-range-query)
         (seq query-string) (conj es-query-string))}}))
 
 (defn handle-query-string-search

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -40,22 +40,21 @@
           to #inst "2020-06-01"]
       (is (= {:query-string "bad-domain"}
              (sut/search-query :created {:query "bad-domain"})))
-      (is (= {:date-range {:created
-                           {:gte from
-                            :lt to}}}
+      (is (= {:range {:created
+                      {:gte from
+                       :lt  to}}}
              (sut/search-query :created {:from from
                                          :to to})))
-
-      (is (= {:date-range {:timestamp
-                           {:gte from
-                            :lt to}}}
+      (is (= {:range {:timestamp
+                      {:gte from
+                       :lt  to}}}
              (sut/search-query :timestamp {:from from
                                            :to to})))
-      (is (= {:date-range {:created
-                           {:lt to}}}
+      (is (= {:range {:created
+                      {:lt to}}}
              (sut/search-query :created {:to to})))
-      (is (= {:date-range {:created
-                           {:gte from}}}
+      (is (= {:range {:created
+                      {:gte from}}}
              (sut/search-query :created {:from from})))
       (is (= {:filter-map {:title "firefox exploit"
                            :disposition 2}}
@@ -77,9 +76,9 @@
                                          :sort_by "disposition"
                                          :sort_order :desc})))
       (is (= {:query-string "bad-domain"
-              :date-range {:created
-                           {:gte from
-                            :lt to}}
+              :range {:created
+                      {:gte from
+                       :lt to}}
               :filter-map {:title "firefox exploit"
                            :disposition 2}}
              (sut/search-query :created {:query "bad-domain"
@@ -91,9 +90,9 @@
                                          :sort_by "disposition"
                                          :sort_order :desc})))
       (testing "make-date-range-fn should be properly called"
-        (is (= {:date-range {:timestamp
-                             {:gte #inst "2050-01-01"
-                              :lt #inst "2100-01-01"}}}
+        (is (= {:range {:timestamp
+                        {:gte #inst "2050-01-01"
+                         :lt  #inst "2100-01-01"}}}
                 (sut/search-query :timestamp
                                   {:from from
                                    :to to}
@@ -124,7 +123,7 @@
              (sut/format-agg-result cardinality
                                     :cardinality
                                     "observable.type"
-                                    {:date-range
+                                    {:range
                                      {:timestamp {:gte from
                                                   :lt to}}
                                      :query-string "baddomain*"
@@ -139,7 +138,7 @@
              (sut/format-agg-result cardinality
                                     :cardinality
                                     "observable.type"
-                                    {:date-range
+                                    {:range
                                      {:timestamp {:gte from
                                                   :lt to}}
                                      :filter-map {:field1 "value1"
@@ -153,7 +152,7 @@
              (sut/format-agg-result topn
                                     :topn
                                     "status"
-                                    {:date-range
+                                    {:range
                                      {:timestamp {:gte from
                                                   :lt to}}
                                      :query-string "android"})))
@@ -164,7 +163,7 @@
              (sut/format-agg-result histogram
                                     :histogram
                                     "timestamp"
-                                    {:date-range
+                                    {:range
                                      {:incident_time.closed
                                       {:gte from
                                        :lt to}}}))))))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -264,7 +264,7 @@
            (is (= {:bool {:filter [simple-access-ctrl-query
                                    es-date-range]}}
                   (sut/make-search-query es-conn-state
-                                         {:date-range date-range}
+                                         {:range date-range}
                                          ident)))
            (is (= {:bool {:filter (into
                                    [simple-access-ctrl-query]
@@ -277,7 +277,7 @@
                                       (into [es-date-range es-query-string-AND]))}}
                   (sut/make-search-query es-conn-state
                                          {:query-string query-string
-                                          :date-range date-range
+                                          :range date-range
                                           :filter-map filter-map}
                                          ident))))))))))
 
@@ -406,7 +406,7 @@
                   (count-helper {:query-string query-string})))
            (is (= (count (concat high-t1-title1
                                  medium-t1-title1))
-                  (count (:data (search-helper {:date-range date-range}
+                  (count (:data (search-helper {:range date-range}
                                                {})))))
            (is (= (count (concat high-t1-title1
                                  high-t2-title2))
@@ -415,12 +415,12 @@
                   (count-helper {:filter-map filter-map})))
            (is (= (count high-t1-title1)
                   (count (:data (search-helper {:query-string query-string
-                                                :date-range date-range
+                                                :range date-range
                                                 :filter-map filter-map}
                                                {})))
 
                   (count-helper {:query-string query-string
-                                 :date-range date-range
+                                 :range date-range
                                  :filter-map filter-map}))))
          (testing "Properly handle search params"
            (let [search-page-0 (search-helper {:query-string query-string}


### PR DESCRIPTION
The name should reflect the features of Elasticsearch Range query
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#range-query-ex-request

<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close https://github.com/threatgrid/iroh/issues/5075
> Related #


No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

157b9167 rename :date-range key
c40463db trying to leave the key as is
cd1b4948 renames DateRange query to correspond to ES DSL