### PR TITLE
Improves error message of asset_ref resolution

### DIFF
--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.asset-mapping
   (:require
    [ctia.domain.entities :as entities]
+   [ctia.entity.asset :as asset]
    [ctia.flows.schemas :refer [with-error]]
    [ctia.graphql.delayed :as delayed]
    [ctia.http.routes.common :as routes.common]
@@ -50,20 +51,10 @@
    id tempids & rest-args]
   (delayed/fn :- (with-error StoredAssetMapping)
               [rt-ctx :- GraphQLRuntimeContext]
-              (let [set-ref (fn [m]
-                              (if (schemas/transient-id? asset_ref)
-                                (if-let [new-ref (get tempids asset_ref)]
-                                  (assoc m :asset_ref new-ref)
-                                  (assoc m :error
-                                         (format
-                                          (str "Cannot resolve asset_ref for transient ID: %s, in AssetMapping %s."
-                                               "Maybe the associated Asset is missing in the Bundle?")
-                                          asset_ref (:id m))))
-                                (assoc m :asset_ref asset_ref)))]
-                (-> asset-mapping-default-realize
-                    (schemas/lift-realize-fn-with-context rt-ctx)
-                    (apply new-entity id tempids rest-args)
-                    (set-ref)))))
+              (-> asset-mapping-default-realize
+                  (schemas/lift-realize-fn-with-context rt-ctx)
+                  (apply new-entity id tempids rest-args)
+                  (asset/set-asset-ref tempids))))
 
 (def asset-mapping-mapping
   {"asset-mapping"

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -1,18 +1,45 @@
 (ns ctia.entity.asset-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.test :refer [deftest is are join-fixtures testing use-fixtures]]
-            [ctia.entity.asset :as sut]
-            [ctia.test-helpers.aggregate :as aggregate]
-            [ctia.test-helpers.auth :as auth]
-            [ctia.test-helpers.core :as helpers]
-            [ctia.test-helpers.crud :refer [entity-crud-test]]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-            [ctia.test-helpers.http :as http]
-            [ctia.test-helpers.store :as store]
-            [ctim.examples.assets :refer [new-asset-minimal new-asset-maximal]]))
+  (:require
+   [clj-momo.test-helpers.core :as mth]
+   [clojure.test :refer [deftest is are join-fixtures testing use-fixtures]]
+   [ctia.entity.asset :as asset]
+   [ctia.test-helpers.aggregate :as aggregate]
+   [ctia.test-helpers.auth :as auth]
+   [ctia.test-helpers.core :as helpers]
+   [ctia.test-helpers.crud :refer [entity-crud-test]]
+   [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+   [ctia.test-helpers.http :as http]
+   [ctia.test-helpers.store :as store]
+   [ctim.examples.assets :refer [new-asset-minimal new-asset-maximal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
+
+(deftest set-asset-ref-test
+  (testing "with proper tempids, transient asset_ref gets resolved"
+    (let [entity  {:asset_ref "transient:asset-1"
+                   :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}
+          tempids {"transient:asset-1" "http://non-transient-asset-id"}]
+      (is (= {:asset_ref "http://non-transient-asset-id"
+              :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}
+             (asset/set-asset-ref entity tempids)))))
+  (testing "with no asset_ref in tempids, it returns entity with :error"
+    (let [entity {:asset_ref "transient:asset-1"
+                  :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}
+          tempids {}]
+     (is (contains? (asset/set-asset-ref entity tempids) :error))))
+  (testing "if asset_ref is a non-transient ID, returns normal entity"
+    (let [entity {:asset_ref "http://non-transient-asset-id"
+                  :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}]
+      (is (= {:asset_ref "http://non-transient-asset-id",
+              :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}
+             (asset/set-asset-ref entity {})))
+      (is (= {:asset_ref "http://non-transient-asset-id",
+              :id        "asset-mapping-91bf8d35-648a-4965-af2c-e1c3d48a14b2"}
+             (asset/set-asset-ref
+              entity
+              {"http://non-transient-asset-id" "http://different-asset-id"}))
+          "it shouldn't try to renew non-transient asset_ref, even when tempids has it"))))
 
 (defn additional-tests [app asset-id asset-sample]
   (testing "GET /ctia/asset/search"
@@ -35,7 +62,7 @@
      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" auth/all-capabilities)
      (whoami-helpers/set-whoami-response app http/api-key "foouser" "foogroup" "user")
      (entity-crud-test
-      (into sut/asset-entity
+      (into asset/asset-entity
             {:app              app
              :example          new-asset-maximal
              :invalid-tests?   true
@@ -47,8 +74,8 @@
 
 (deftest asset-metric-routes-test
   (aggregate/test-metric-routes
-   (into sut/asset-entity
+   (into asset/asset-entity
          {:plural            :assets
           :entity-minimal    new-asset-minimal
-          :enumerable-fields sut/asset-enumerable-fields
-          :date-fields       sut/asset-histogram-fields})))
+          :enumerable-fields asset/asset-enumerable-fields
+          :date-fields       asset/asset-histogram-fields})))


### PR DESCRIPTION
During AssetMapping/AssetProperties resolution, when it cannot resolve an
asset_ref with a transientID, it throws an ambiguous message.

This PR is to make it less ambiguous.

> **Epic** #
> Close #https://github.com/threatgrid/iroh/issues/5132
> Related #1089

<a name="qa">[§](#qa)</a> QA
============================

QA instructions are the same as in: https://github.com/threatgrid/ctia/pull/1089

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

ad517508 * origin/improve_asset_ref_resolution_errmsg__#iroh/5132 refactor set-asset-ref and add tests
c7ca53fc * 1110 improves error message of asset_ref resolution