### PR TITLE
fix random index name clean

### DIFF
--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -66,11 +66,11 @@
                                    :as services} :- ESConnServices]
   (let [{:keys [conn index]} (es-init/init-store-conn
                               (es-init/get-store-properties entity get-in-config)
-                              services)]
+                              services)
+        index-wildcard (str index "*")]
     (when conn
-      (doto (str index "*")
-        #(es-index/delete! conn %)
-        #(es-index/delete-template! conn %)))))
+        (es-index/delete! conn index-wildcard)
+        (es-index/delete-template! conn index-wildcard))))
 
 (defn fixture-purge-event-indices-and-templates
   "walk through all producers and delete their indices and templates"
@@ -207,7 +207,7 @@
            :_id _id)))
 
 (defn load-bulk
-  ([conn docs] (load-bulk conn docs "true"))
+  ([conn docs] (load-bulk conn docs "wait_for"))
   ([{:keys [version] :as conn} docs refresh?]
    (es-doc/bulk-create-doc conn
                            (cond->> docs


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

When using `fixture-ctia-with-app` we generate random indices to avoid collision between tests. 
We always had trailing indices in our local clusters since, I thought that it was due to failing tests, but indeed the cleaning was not triggered at all.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

