### PR TITLE
use python 3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: clojure
 lein: 2.9.1
 dist: trusty
+python: 3.6.1
 
 branches:
   only:


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

We should try travis build with python 3.
Python 2.7 will not work soon:
https://github.com/pypa/pypi-support/issues/978

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->
