### PR TITLE
try pip3 and python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,8 +129,6 @@ matrix: #note: don't use "jobs:" introduces an extra build
 
 before_install:
     # upgrade shellcheck (https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary)
-    - sudo apt-get update
-    - sudo apt-get install python3
     - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
     - cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" "${BIN_DIR}"
     - shellcheck --version

--- a/build/build.sh
+++ b/build/build.sh
@@ -26,7 +26,7 @@ function build-and-publish-package {
   fi
 
   ARTIFACT_NAME="${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:8}.jar"
-  ( set -x && pip install --upgrade --user awscli )
+  ( set -x && pip3 install --upgrade --user awscli )
   export PATH=$PATH:$HOME/.local/bin
   ( set -x && aws s3 cp ./target/ctia.jar s3://${ARTIFACTS_BUCKET}/artifacts/ctia/"${ARTIFACT_NAME}" --sse aws:kms --sse-kms-key-id alias/kms-s3 )
 
@@ -35,7 +35,7 @@ function build-and-publish-package {
   if [ "${PKG_TYPE}" == "int" ]; then
     echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
     sudo docker pull zeronorth/owasp-5-job-runner
-    sudo docker run -v "${PWD}"/target/ctia.jar:/code/ctia.jar -e CYBRIC_API_KEY="${CYBRIC_API_KEY}" -e POLICY_ID=IUkmdVdkSjms9CjeWK-Peg -e WORKSPACE="${PWD}"/target -v /var/run/docker.sock:/var/run/docker.sock --name zeronorth zeronorth/integration:latest python cybric.py
+    sudo docker run -v "${PWD}"/target/ctia.jar:/code/ctia.jar -e CYBRIC_API_KEY="${CYBRIC_API_KEY}" -e POLICY_ID=IUkmdVdkSjms9CjeWK-Peg -e WORKSPACE="${PWD}"/target -v /var/run/docker.sock:/var/run/docker.sock --name zeronorth zeronorth/integration:latest python3 cybric.py
     echo "Waiting the ZeroNorth Vulnerability Scanner to finish..."
     while [[ -n $(docker ps -a --format "{{.ID}}" -f status=running -f ancestor=zeronorth/owasp-5-job-runner) ]]; do sleep 5; done
   fi


### PR DESCRIPTION

> Related #https://github.com/threatgrid/iroh/issues/5171

The [trusty build environment has python 3 installed](https://docs.travis-ci.com/user/reference/trusty/#python-images) but 2.7 is default.
This PR tries to call `pip3` and `python3`