### PR TITLE
install python-pip3 package, temporary disable test builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: clojure
 lein: 2.9.1
 dist: trusty
+python: 3
+
+addons:
+  apt:
+    update: true
+    packages:
+      - python3-pip
 
 branches:
   only:
@@ -79,22 +86,24 @@ matrix: #note: don't use "jobs:" introduces an extra build
     #     https://github.com/threatgrid/tenzin/blob/master/nextgen/saltstack/srv/salt/openjdk/defaults.yml
     # - IMPORTANT! Must include split build id's from in (range ${CTIA_NSPLITS}).
     #    Nothing ensures this is actually true, so make sure it is!
-    - stage: test
-      name: "JDK 11"
-      if: type = push
-      env: CTIA_THIS_SPLIT=0
-    - name: "JDK 11"
-      if: type = push
-      env: CTIA_THIS_SPLIT=1
-    - name: "JDK 11"
-      if: type = push
-      env: CTIA_THIS_SPLIT=2
-    - name: "JDK 11"
-      if: type = push
-      env: CTIA_THIS_SPLIT=3
-    - name: "JDK 11"
-      if: type = push
-      env: CTIA_THIS_SPLIT=4
+
+# TEMPORARY DISABLE
+#    - stage: test
+#      name: "JDK 11"
+#      if: type = push
+#      env: CTIA_THIS_SPLIT=0
+#    - name: "JDK 11"
+#      if: type = push
+#      env: CTIA_THIS_SPLIT=1
+#    - name: "JDK 11"
+#      if: type = push
+#      env: CTIA_THIS_SPLIT=2
+#    - name: "JDK 11"
+#      if: type = push
+#      env: CTIA_THIS_SPLIT=3
+#    - name: "JDK 11"
+#      if: type = push
+#      env: CTIA_THIS_SPLIT=4
 
     # Cron jobs:
     # ==========
@@ -103,18 +112,19 @@ matrix: #note: don't use "jobs:" introduces an extra build
     # - they repeat around the same time as initially started
     # - we deploy (also) during cron jobs in the 'deploy' stage
     # - generative tests are disabled and are instead run in Actions
-    - name: "JDK 11"
-      if: type = cron
-      env:
-        - CTIA_TEST_SUITE=ci
-        - CTIA_THIS_SPLIT=0
-        - CTIA_NSPLITS=2
-    - name: "JDK 11"
-      if: type = cron
-      env:
-        - CTIA_TEST_SUITE=ci
-        - CTIA_THIS_SPLIT=1
-        - CTIA_NSPLITS=2
+# TEMPORARY DISABLE
+#    - name: "JDK 11"
+#      if: type = cron
+#      env:
+#        - CTIA_TEST_SUITE=ci
+#        - CTIA_THIS_SPLIT=0
+#        - CTIA_NSPLITS=2
+#    - name: "JDK 11"
+#      if: type = cron
+#      env:
+#        - CTIA_TEST_SUITE=ci
+#        - CTIA_THIS_SPLIT=1
+#        - CTIA_NSPLITS=2
 
     # Deploy
     # ======
@@ -128,6 +138,13 @@ matrix: #note: don't use "jobs:" introduces an extra build
       after_script: ./build/build.sh
 
 before_install:
+
+    # check pip3
+    - which pip3    || echo 'which pip3 command failed.'
+    - export PATH=$HOME/.local/bin:$PATH
+    - pip3 install --user $(whoami) --upgrade pip # not pip3
+    - which pip3    || echo 'which pip3 command failed.'
+
     # upgrade shellcheck (https://github.com/koalaman/shellcheck#installing-a-pre-compiled-binary)
     - wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION?}/shellcheck-${SHELLCHECK_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
     - cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" "${BIN_DIR}"

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,7 +35,7 @@ function build-and-publish-package {
   if [ "${PKG_TYPE}" == "int" ]; then
     echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
     sudo docker pull zeronorth/owasp-5-job-runner
-    sudo docker run -v "${PWD}"/target/ctia.jar:/code/ctia.jar -e CYBRIC_API_KEY="${CYBRIC_API_KEY}" -e POLICY_ID=IUkmdVdkSjms9CjeWK-Peg -e WORKSPACE="${PWD}"/target -v /var/run/docker.sock:/var/run/docker.sock --name zeronorth zeronorth/integration:latest python3 cybric.py
+    sudo docker run -v "${PWD}"/target/ctia.jar:/code/ctia.jar -e CYBRIC_API_KEY="${CYBRIC_API_KEY}" -e POLICY_ID=IUkmdVdkSjms9CjeWK-Peg -e WORKSPACE="${PWD}"/target -v /var/run/docker.sock:/var/run/docker.sock --name zeronorth zeronorth/integration:latest python cybric.py
     echo "Waiting the ZeroNorth Vulnerability Scanner to finish..."
     while [[ -n $(docker ps -a --format "{{.ID}}" -f status=running -f ancestor=zeronorth/owasp-5-job-runner) ]]; do sleep 5; done
   fi


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/threatgrid/iroh/issues/5171

4th attempt of my side task :-), based on https://github.com/daggerok/pip3-travis/blob/master/trusty.travis.yml
After further investigation, pip3 requires to install `python-pip3` addon package.
I temporary disabled tests for a quicker iteration.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
