### PR TITLE
renames asset-intel scope -> asset

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -4,7 +4,7 @@ ctia.auth.type=allow-all
 ctia.auth.threatgrid.cache=true
 ctia.auth.entities.scope=private-intel
 ctia.auth.casebook.scope=casebook
-ctia.auth.assets.scope=asset-intel
+ctia.auth.assets.scope=asset
 
 ctia.access-control.min-tlp green
 ctia.access-control.default-tlp green

--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -63,7 +63,7 @@
                               "casebook"))
 
 (defn assets-root-scope [get-in-config]
-  (get-in-config [:ctia :auth :assets :scope] "asset-intel"))
+  (get-in-config [:ctia :auth :assets :scope] "asset"))
 
 (defn claim-prefix [get-in-config]
   (get-in-config [:ctia :http :jwt :claim-prefix]
@@ -111,7 +111,7 @@
    (:access scope-repr)))
 
 (defn gen-assets-capabilities
-  "Generate capabilities for the root-scope 'asset-intel'."
+  "Generate capabilities for the root-scope 'asset'."
   [scope-repr]
   (->> [:asset :asset-mapping :asset-properties :target-record]
        (select-keys (all-entities))

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -42,7 +42,7 @@
 (deftest assets-scope-test
   (testing "Assets scope and capabilities"
     (helpers/with-properties ["ctia.auth.entities.scope" "global-intel"
-                              "ctia.auth.assets.scope" "asset-intel"]
+                              "ctia.auth.assets.scope" "asset"]
       (helpers/fixture-ctia-with-app
        (fn [app]
          (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
@@ -63,7 +63,7 @@
     (are [root-scope-fn def-val] (= def-val (root-scope-fn get-in-config))
       sut/entity-root-scope   "private-intel"
       sut/casebook-root-scope "casebook"
-      sut/assets-root-scope   "asset-intel")
+      sut/assets-root-scope   "asset")
     (is (= #{:search-casebook :create-casebook :list-casebooks :read-casebook
              :delete-casebook}
            (sut/scope-to-capabilities (sut/casebook-root-scope get-in-config) get-in-config))


### PR DESCRIPTION
Adjust Asset-scope name to match the name based on: https://github.com/threatgrid/iroh/pull/5248

> Related https://github.com/threatgrid/ctia/pull/1078

No QA is needed. QA Instructions covered in #1078
