### PR TITLE
Issue-4744: Include `query-params` in CPE search

### DIFF
--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -147,8 +147,9 @@
          (ctia-store/query-string-search store
                                          {:full-text {:query (build-configurations-query cpe-matches)}}
                                          identity-map
-                                         {:fields [:configurations.nodes :id]
-                                          :sort {:id :asc}})
+                                         (merge {:fields [:configurations.nodes :id]
+                                                 :sort {:id :asc}}
+                                                query-params))
          ids (cpe/vulnerabilities->ids cpe-matches data)]
      (if-let [next-params (:next paging)]
        (concat ids (vulnerability-ids-affected-by-cpe-matches {:cpe-matches cpe-matches


### PR DESCRIPTION
> **Epic** threatgrid/iroh#4744

> Related #1077 

`query-params` were not being passed into the CPE Search. This PR also resolves paging problems that resulted from not including `query-params`.