### PR TITLE
remove clj-momo http helper

### DIFF
--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -35,7 +35,7 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (deep= expected-entity updated-casebook))))
+      (is (= expected-entity updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/observables :add on non existing casebook"
     (let [new-observables [{:type "ip" :value "42.42.42.42"}]
@@ -57,7 +57,7 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (deep= expected-entity
+      (is (= expected-entity
                  updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/observables :remove on non existing casebook"
@@ -80,7 +80,7 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (deep= expected-entity
+      (is (= expected-entity
                  updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/observables :replace"
@@ -93,7 +93,7 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (deep= expected-entity
+      (is (= expected-entity
                  updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/observables :replace on non existing casebook"
@@ -117,7 +117,7 @@
 
 
       (is (= 200 (:status response)))
-      (is (deep= expected-entity updated-casebook))))
+      (is (= expected-entity updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/texts :add on non existing casebook"
     (let [new-texts [{:type "some" :text "text"}]
@@ -138,7 +138,7 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (deep= expected-entity updated-casebook))))
+      (is (= expected-entity updated-casebook))))
 
   (testing "POST /ctia/casebook/:id/texts :remove on non existing casebook"
     (let [deleted-texts [{:type "some" :text "text"}]
@@ -218,7 +218,7 @@
                            :headers {"Authorization" "45c1f5e3f05d0"})
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (deep= (update casebook :bundle dissoc :malwares)
+        (is (= (update casebook :bundle dissoc :malwares)
                    (update updated-casebook :bundle dissoc :malwares)))
         (is (not (subset? (set (:malwares bundle-entities))
                           (set (-> updated-casebook :bundle :malwares)))))))
@@ -239,10 +239,10 @@
                            :headers {"Authorization" "45c1f5e3f05d0"})
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (deep= (update casebook :bundle dissoc :malwares)
+        (is (= (update casebook :bundle dissoc :malwares)
                    (update updated-casebook :bundle dissoc :malwares)))
         (is (= (:malwares bundle-entities)
-               (-> updated-casebook :bundle :malwares)))))
+               (-> updated-casebook :bundle :malwares set)))))
 
     (testing "POST /ctia/casebook/:id/bundle :replace on non existing casebook"
       (let [response (POST app
@@ -263,7 +263,7 @@
                             :headers {"Authorization" "45c1f5e3f05d0"}))
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (deep= expected-entity updated-casebook))
+        (is (= expected-entity updated-casebook))
 
         (testing "Adding an observable should work and update the schema_version"
           (testing "POST /ctia/casebook/:id/observables :add"
@@ -278,7 +278,7 @@
                                  :headers {"Authorization" "45c1f5e3f05d0"})
                   final-casebook (:parsed-body response)]
               (is (= 200 (:status response)))
-              (is (deep= expected-entity final-casebook)))))))))
+              (is (= expected-entity final-casebook)))))))))
 
 (deftest test-casebook-routes
   (test-for-each-store-with-app

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -108,8 +108,7 @@
     (testing "no Authorization"
       (let [{body :parsed-body status :status}
             (GET app
-                 (str "ctia/judgement/" (:short-id judgement-id))
-                 :accept :edn)]
+                 (str "ctia/judgement/" (:short-id judgement-id)))]
         (is (= 401 status))
         (is (= {:message "Only authenticated users allowed"
                 :error :not_authenticated}
@@ -119,7 +118,6 @@
       (let [{body :parsed-body status :status}
             (GET app
                  (str "ctia/judgement/" (:short-id judgement-id))
-                 :accept :edn
                  :headers {"Authorization" "1111111111111"})]
         (is (= 401 status))
         (is (= {:message "Only authenticated users allowed"
@@ -130,7 +128,6 @@
       (let [{body :parsed-body status :status}
             (GET app
                  (str "ctia/judgement/" (:short-id judgement-id))
-                 :accept :edn
                  :headers {"Authorization" "2222222222222"})]
         (is (= 403 status))
         (is (= {:message "Missing capability",
@@ -139,8 +136,7 @@
                 :error :missing_capability}
                body)))))
   (testing "POST /ctia/judgement/:id/expire revokes"
-    (let [fixed-now-str "2020-12-31T00:00:00.000Z"
-          fixed-now (tc/to-date fixed-now-str)]
+    (let [fixed-now (tc/to-date "2020-12-31")]
       (helpers/fixture-with-fixed-time
         fixed-now
         (fn []
@@ -156,7 +152,7 @@
                   :headers {"Authorization" "45c1f5e3f05d0"})]
             (is (= 200 (:status response))
                 "POST ctia/judgement/:id/expire succeeds")
-            (is (= fixed-now-str (:end_time valid_time))
+            (is (= fixed-now (:end_time valid_time))
                 ":valid_time correctly reset")
             (is (.endsWith reason (str " " expiry-reason))
                 (str ":reason correctly appended: " (pr-str reason))))))))
@@ -189,7 +185,6 @@
                                          "baruser"
                                          "bargroup"
                                          "user")
-
      (entity-crud-test
       (into sut/judgement-entity
             {:app app

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -6,21 +6,14 @@
             [ctia.entity.judgement :as sut]
             [ctia.entity.judgement.schemas
              :refer
-             [judgement-fields
-              judgement-sort-fields
-              judgement-enumerable-fields
-              judgement-histogram-fields]]
-            [ctia.test-helpers
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [GET POST]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [field-selection :refer [field-selection-tests]]
-             [http :refer [doc-id->rel-url]]
-             [pagination :refer [pagination-test]]
-             [store :refer [test-for-each-store-with-app]]]
+             [judgement-enumerable-fields judgement-histogram-fields]]
+            [ctia.test-helpers.access-control :refer [access-control-test]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers :refer [GET POST]]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.examples.judgements :as ex]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
@@ -246,13 +239,13 @@
                :disposition_name "Malicious"
                :source "test"
                :priority 100
-               :timestamp #inst "2042-01-01T00:00:00.000Z"
+               :timestamp "2042-01-01T00:00:00.000Z"
                :severity "High"
                :confidence "Low"
                :tlp "green"
                :schema_version schema-version
-               :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                            :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
+               :valid_time {:start_time "2016-02-11T00:40:48.212Zz"
+                            :end_time "2525-01-01T00:00:00.000Z"}}
               (dissoc judgement
                       :id
                       :groups ["foogroup"]
@@ -281,15 +274,15 @@
                  :disposition_name "Malicious"
                  :source "test"
                  :priority 100
-                 :timestamp #inst "2042-01-01T00:00:00.000Z"
+                 :timestamp "2042-01-01T00:00:00.000Z"
                  :severity "High"
                  :confidence "Low"
                  :tlp "green"
                  :schema_version schema-version
                  :owner "foouser"
                  :groups ["foogroup"]
-                 :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                              :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
+                 :valid_time {:start_time "2016-02-11T00:40:48.212Z"
+                              :end_time "2525-01-01T00:00:00.000Z"}}
                 (dissoc judgement
                         :id)))))
 
@@ -316,15 +309,15 @@
                :disposition_name "Unknown"
                :source "test"
                :priority 100
-               :timestamp #inst "2042-01-01T00:00:00.000Z"
+               :timestamp "2042-01-01T00:00:00.000Z"
                :severity "High"
                :confidence "Low"
                :tlp "green"
                :owner "foouser"
                :groups ["foogroup"]
                :schema_version schema-version
-               :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
-                            :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
+               :valid_time {:start_time "2016-02-11T00:40:48.212Z"
+                            :end_time "2525-01-01T00:00:00.000Z"}}
               (dissoc judgement
                       :id)))))
 
@@ -354,7 +347,7 @@
                            :priority 100
                            :severity "High"
                            :confidence "Low"
-                           :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"}}}
+                           :valid_time {:start_time "2016-02-11T00:40:48.212Z"}}}
               judgement))))
 
      (testing "POST a judgement with mismatched disposition/disposition_name"
@@ -382,7 +375,7 @@
                              :priority 100
                              :severity "High"
                              :confidence "Low"
-                             :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"}}}
+                             :valid_time {:start_time "2016-02-11T00:40:48.212Z"}}}
                 judgement)))))))
 
 (deftest test-judgement-routes-access-control

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -1,6 +1,5 @@
 (ns ctia.flows.crud-test
   (:require [clj-momo.lib.map :refer [deep-merge-with]]
-            [clj-momo.test-helpers.core]
             [clojure.test :refer [deftest testing is]]
             [ctia.auth.threatgrid :refer [map->Identity]]
             [ctia.flows.crud :as flows.crud]
@@ -9,29 +8,29 @@
 (deftest deep-merge-with-add-colls-test
   (let [fixture {:foo {:bar ["one" "two" "three"]
                        :lorem ["ipsum" "dolor"]}}]
-    (is (deep= {:foo {:bar ["one" "two" "three" "four"]
-                      :lorem ["ipsum" "dolor"]}}
-               (deep-merge-with coll/add-colls
-                                fixture
-                                {:foo {:bar ["four"]}})))))
+    (is (= {:foo {:bar ["one" "two" "three" "four"]
+                  :lorem ["ipsum" "dolor"]}}
+           (deep-merge-with coll/add-colls
+                            fixture
+                            {:foo {:bar ["four"]}})))))
 
 (deftest deep-merge-with-remove-colls-test
   (let [fixture {:foo {:bar #{"one" "two" "three"}
                        :lorem ["ipsum" "dolor"]}}]
-    (is (deep= {:foo {:bar #{"one" "three"}
-                      :lorem ["ipsum" "dolor"]}}
-               (deep-merge-with coll/remove-colls
-                                fixture
-                                {:foo {:bar ["two"]}})))))
+    (is (= {:foo {:bar #{"one" "three"}
+                  :lorem ["ipsum" "dolor"]}}
+           (deep-merge-with coll/remove-colls
+                            fixture
+                            {:foo {:bar ["two"]}})))))
 
 (deftest deep-merge-with-replace-colls-test
   (let [fixture {:foo {:bar {:foo {:bar ["something" "or" "something" "else"]}}
                        :lorem ["ipsum" "dolor"]}}]
-    (is (deep= {:foo {:bar {:foo {:bar ["else"]}}
-                      :lorem ["ipsum" "dolor"]}}
-               (deep-merge-with coll/replace-colls
-                                fixture
-                                {:foo  {:bar {:foo {:bar #{"else"}}}}})))))
+    (is (= {:foo {:bar {:foo {:bar ["else"]}}
+                  :lorem ["ipsum" "dolor"]}}
+           (deep-merge-with coll/replace-colls
+                            fixture
+                            {:foo  {:bar {:foo {:bar #{"else"}}}}})))))
 
 (deftest preserve-errors-test
   (testing "with enveloped result"

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -33,7 +33,6 @@
 
           judgement-id
           (id/long-id->id (:id judgement))]
-      (clojure.pprint/pprint judgement)
       (is (= 201 status))
       (is (=
            {:type "judgement"
@@ -45,13 +44,13 @@
             :tlp "green"
             :schema_version schema-version
             :priority 100
-            :timestamp "2042-01-01T00:00:00.000Z"
+            :timestamp #inst "2042-01-01T00:00:00.000Z"
             :severity "High"
             :confidence "Low"
             :groups ["Administrators"]
             :owner "Unknown"
-            :valid_time {:start_time "2016-02-11T00:00:00.000Z"
-                         :end_time "2016-03-11T00:00:00.000Z"}}
+            :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
+                         :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
            (dissoc judgement :id)))
 
       (testing "GET /ctia/judgement"
@@ -71,11 +70,11 @@
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100
-                :timestamp "2042-01-01T00:00:00.000Z"
+                :timestamp #inst "2042-01-01T00:00:00.000Z"
                 :severity "High"
                 :confidence "Low"
                 :groups ["Administrators"]
                 :owner "Unknown"
-                :valid_time {:start_time "2016-02-11T00:00:00.000Z"
-                             :end_time "2016-03-11T00:00:00.000Z"}}
+                :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
+                             :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
                get-judgement)))))))

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -1,6 +1,5 @@
 (ns ctia.http.handler.allow-all-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [ctia.domain.entities :refer [schema-version]]
+  (:require [ctia.domain.entities :refer [schema-version]]
             [ctia.test-helpers
              [core :as helpers :refer [POST GET]]
              [es :as es-helpers]]
@@ -34,8 +33,9 @@
 
           judgement-id
           (id/long-id->id (:id judgement))]
+      (clojure.pprint/pprint judgement)
       (is (= 201 status))
-      (is (deep=
+      (is (=
            {:type "judgement"
             :observable {:value "1.2.3.4"
                          :type "ip"}
@@ -45,13 +45,13 @@
             :tlp "green"
             :schema_version schema-version
             :priority 100
-            :timestamp #inst "2042-01-01T00:00:00.000Z"
+            :timestamp "2042-01-01T00:00:00.000Z"
             :severity "High"
             :confidence "Low"
             :groups ["Administrators"]
             :owner "Unknown"
-            :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
-                         :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
+            :valid_time {:start_time "2016-02-11T00:00:00.000Z"
+                         :end_time "2016-03-11T00:00:00.000Z"}}
            (dissoc judgement :id)))
 
       (testing "GET /ctia/judgement"
@@ -60,7 +60,7 @@
               (GET app
                    (str "ctia/judgement/" (:short-id judgement-id)))]
           (is (= 200 status))
-          (is (deep=
+          (is (=
                {:id (:id judgement)
                 :type "judgement"
                 :observable {:value "1.2.3.4"
@@ -71,11 +71,11 @@
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100
-                :timestamp #inst "2042-01-01T00:00:00.000Z"
+                :timestamp "2042-01-01T00:00:00.000Z"
                 :severity "High"
                 :confidence "Low"
                 :groups ["Administrators"]
                 :owner "Unknown"
-                :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
-                             :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
+                :valid_time {:start_time "2016-02-11T00:00:00.000Z"
+                             :end_time "2016-03-11T00:00:00.000Z"}}
                get-judgement)))))))

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -1,6 +1,5 @@
 (ns ctia.http.handler.static-auth-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [ctia.domain.entities :refer [schema-version]]
+  (:require [ctia.domain.entities :refer [schema-version]]
             [ctia.test-helpers
              [core :as helpers :refer [POST GET]]
              [es :as es-helpers]]
@@ -73,7 +72,7 @@
                    (str "ctia/judgement/" (:short-id judgement-id))
                    :headers {"Authorization" "tearbending"})]
           (is (= 200 status))
-          (is (deep=
+          (is (=
                {:id (:id judgement)
                 :type "judgement"
                 :observable {:value "1.2.3.4"
@@ -81,7 +80,7 @@
                 :disposition 2
                 :disposition_name "Malicious"
                 :source "test"
-                :timestamp #inst "2042-01-01T00:00:00.000Z"
+                :timestamp "2042-01-01T00:00:00.000Z"
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100
@@ -89,8 +88,8 @@
                 :confidence "Low"
                 :groups ["kitara"]
                 :owner "kitara"
-                :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
-                             :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
+                :valid_time {:start_time "2016-02-11T00:00:00.000Z"
+                             :end_time "2016-03-11T00:00:00.000Z"}}
                get-judgement)))
         (testing "fails with any key"
           (let [{status :status}

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -80,7 +80,7 @@
                 :disposition 2
                 :disposition_name "Malicious"
                 :source "test"
-                :timestamp "2042-01-01T00:00:00.000Z"
+                :timestamp #inst "2042-01-01T00:00:00.000Z"
                 :tlp "green"
                 :schema_version schema-version
                 :priority 100
@@ -88,8 +88,8 @@
                 :confidence "Low"
                 :groups ["kitara"]
                 :owner "kitara"
-                :valid_time {:start_time "2016-02-11T00:00:00.000Z"
-                             :end_time "2016-03-11T00:00:00.000Z"}}
+                :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
+                             :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
                get-judgement)))
         (testing "fails with any key"
           (let [{status :status}

--- a/test/ctia/http/routes/pagination_test.clj
+++ b/test/ctia/http/routes/pagination_test.clj
@@ -1,13 +1,11 @@
 (ns ctia.http.routes.pagination-test
-  (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [clojure.spec.alpha :as cs]
             [clojure.spec.gen.alpha :as csg]
             [clojure.test :refer [deftest testing use-fixtures]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]
             [ctia.auth.capabilities :refer [all-capabilities]]
-            [ctia.entity.target-record :refer [target-record-fields]]
             [ctia.properties :as p]
             [ctia.entity.entities :as entities]
             [ctia.entity.feed-test :refer [new-feed-maximal]]
@@ -15,19 +13,19 @@
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.field-selection :as field-selection]
             [ctia.test-helpers
-             [core :as helpers :refer [url-id]]
-             [http :as http :refer [app->HTTPShowServices assert-post]]
+             [core :as helpers :refer [url-id assert-post]]
+             [http :as http :refer [app->HTTPShowServices]]
              [pagination :as pagination
               :refer [pagination-test
                       pagination-test-no-sort]]
              [store :as store :refer [test-for-each-store-with-app]]]
             [ctim.domain.id :as id]
-            [ctim.examples.target-records :refer [new-target-record-maximal]]
+            [schema.test :refer [validate-schemas]]
             [schema.core :as s]
             [schema-tools.core :as st]))
 
 (use-fixtures :once
-  mth/fixture-schema-validation
+  validate-schemas
   helpers/fixture-allow-all-auth
   whoami-helpers/fixture-server)
 
@@ -191,7 +189,7 @@
                           sort)
            _ (assert (= 3 (count test-cases))
                      (mapv first test-cases))]
-       (doseq [[entity {:keys [fields plural endpoint new-maximal snake-plural sort-fields]} :as test-case] test-cases]
+       (doseq [[entity {:keys [fields endpoint new-maximal snake-plural sort-fields]} :as test-case] test-cases]
          ;; progress reporting for slow test
          (println (str "Testing pagination: " entity))
          ;; ensure good coverage via non-default fields
@@ -227,10 +225,11 @@
        {;; :seed ...
         :num-tests 5}
        [;; note: may check same entity multiple times
-        [entity {:keys [fields plural endpoint new-maximal snake-plural sort-fields]}] (-> (pagination+field-selection-test-cases)
-                                                                                           sort
-                                                                                           gen/elements
-                                                                                           gen/no-shrink)
+        [entity {:keys [fields plural endpoint new-maximal snake-plural sort-fields]}]
+        (-> (pagination+field-selection-test-cases)
+            sort
+            gen/elements
+            gen/no-shrink)
         sample-size (gen/large-integer* {:min 30 :max 345})]
        ;; progress reporting for slow test
        (println (str "Testing pagination: " entity))

--- a/test/ctia/lib/collection_test.clj
+++ b/test/ctia/lib/collection_test.clj
@@ -1,19 +1,18 @@
 (ns ctia.lib.collection-test
   (:require [ctia.lib.collection :as sut]
-            [clj-momo.test-helpers.core] ;; deep=
             [clojure.test :refer [deftest is]]))
 
 (deftest add-colls-test
   (let [input [#{:a :b} [:c :d] nil [:e]]]
-    (is (deep= #{:a :b :c :d :e}
-               (apply sut/add-colls input)))))
+    (is (= #{:a :b :c :d :e}
+           (apply sut/add-colls input)))))
 
 (deftest remove-colls-test
   (let [input [[:a :b :c :d :e] #{:c :d} [:e] nil]]
-    (is (deep= [:a :b]
-               (apply sut/remove-colls input)))))
+    (is (= [:a :b]
+           (apply sut/remove-colls input)))))
 
 (deftest replace-colls-test
   (let [input [#{:a :b} [:c :d] nil [:e :f]]]
-    (is (deep= #{:e :f}
-               (apply sut/replace-colls input)))))
+    (is ( #{:e :f}
+         (apply sut/replace-colls input)))))

--- a/test/ctia/lib/collection_test.clj
+++ b/test/ctia/lib/collection_test.clj
@@ -14,5 +14,5 @@
 
 (deftest replace-colls-test
   (let [input [#{:a :b} [:c :d] nil [:e :f]]]
-    (is ( #{:e :f}
-         (apply sut/replace-colls input)))))
+    (is (= #{:e :f}
+           (apply sut/replace-colls input)))))

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -300,7 +300,8 @@
 
             (when revoke-tests?
               (testing (format "POST /ctia/%s/:id/expire revokes" entity-str)
-                (let [fixed-now (-> "2020-12-31" tc/from-string tc/to-date)]
+                (let [fixed-now-str "2020-12-31T00:00:00.000Z"
+                      fixed-now (tc/to-date fixed-now-str)]
                   (helpers/fixture-with-fixed-time
                    fixed-now
                    (fn []
@@ -312,7 +313,7 @@
                                              [:query-params revoke-tests-extra-query-params]))]
                        (is (= 200 (:status response))
                            (format "POST %s/:id/expire succeeds" entity-str))
-                       (is (= fixed-now (-> response :parsed-body :valid_time :end_time))
+                       (is (= fixed-now-str (-> response :parsed-body :valid_time :end_time))
                            ":valid_time properly reset")))))))
 
             ;; execute entity custom tests before deleting the fixture

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -300,8 +300,7 @@
 
             (when revoke-tests?
               (testing (format "POST /ctia/%s/:id/expire revokes" entity-str)
-                (let [fixed-now-str "2020-12-31T00:00:00.000Z"
-                      fixed-now (tc/to-date fixed-now-str)]
+                (let [fixed-now (tc/to-date  "2020-12-31")]
                   (helpers/fixture-with-fixed-time
                    fixed-now
                    (fn []
@@ -313,7 +312,7 @@
                                              [:query-params revoke-tests-extra-query-params]))]
                        (is (= 200 (:status response))
                            (format "POST %s/:id/expire succeeds" entity-str))
-                       (is (= fixed-now-str (-> response :parsed-body :valid_time :end_time))
+                       (is (= fixed-now (-> response :parsed-body :valid_time :end_time))
                            ":valid_time properly reset")))))))
 
             ;; execute entity custom tests before deleting the fixture

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -2,6 +2,8 @@
   (:refer-clojure :exclude [get])
   (:require
    [clojure.string :as string]
+   [clojure.pprint :refer [pprint]]
+   [clojure.edn :as edn]
    [cheshire.core :as json]
    [ctia.schemas.core :refer [APIHandlerServices HTTPShowServices]]
    [ctia.schemas.utils :as csu]
@@ -21,23 +23,54 @@
       (.getBytes)
       (ByteArrayInputStream.)))
 
+(defn content-type? [expected-str]
+  (fn [test-str]
+    (if (some? test-str)
+      (string/includes? (name test-str) expected-str)
+      false)))
+(def json? (content-type? "json"))
+(def edn? (content-type? "edn"))
+
+(defn parse-body
+  [{{content-type "Content-Type"} :headers
+    body :body
+    :as resp}]
+  (try
+    (cond
+      (edn? content-type) (edn/read-string body)
+      (json? content-type) (json/parse-string body)
+      :else body)
+    (catch Exception e
+      (binding [*out* *err*]
+        (println "------- BODY ----------")
+        (pprint body)
+        (println "------- EXCEPTION ----------")
+        (pprint e)))))
+
+(defn with-parsed-body
+  [{:keys [body] :as response}]
+  ;; assoc parsed-body for backward compatibiity
+  (assoc response
+         :parsed-body
+         (if (string? body)
+           (parse-body response)
+           body)))
+
 (defn encode-body
   [body]
   (string->input-stream
    (json/generate-string body)))
 
-(defn get [path port & {:as options}]
+(defn get [path port & {:as opts}]
   (let [options
         (merge {:as :json
                 :throw-exceptions false
                 :socket-timeout 10000
                 :conn-timeout 10000}
-               options)
-
+               opts)
         response
         (client/get (local-url path port) options)]
-    ;; assoc parsed-body for backward compatibiity
-    (assoc response :parsed-body (:body response))))
+    (with-parsed-body response)))
 
 (defn post [path port & {:as opts}]
   (let [{:keys [body] :as options}
@@ -51,15 +84,14 @@
         (client/post (local-url path port)
                    (-> options
                        (cond-> body (update :body encode-body))))]
-    ;; assoc parsed-body for backward compatibiity
-    (assoc response :parsed-body (:body response))))
+    (with-parsed-body response)))
 
-(defn delete [path port & {:as options}]
+(defn delete [path port & {:as opts}]
   (client/delete (local-url path port)
-               (merge {:throw-exceptions false}
-                      options)))
+                 (merge {:throw-exceptions false}
+                        opts)))
 
-(defn put [path port & {:as options}]
+(defn put [path port & {:as opts}]
   (let [{:keys [body]
          :as options}
         (merge {:content-type :json
@@ -67,16 +99,15 @@
                 :throw-exceptions false
                 :socket-timeout 10000
                 :conn-timeout 10000}
-               options)
+               opts)
 
         response
         (client/put (local-url path port)
                   (-> options
                       (cond-> body (update :body encode-body))))]
-    ;; assoc parsed-body for backward compatibiity
-    (assoc response :parsed-body (:body response))))
+    (with-parsed-body response)))
 
-(defn patch [path port & {:as options}]
+(defn patch [path port & {:as opts}]
   (let [{:keys [body]
          :as options}
         (merge {:content-type :json
@@ -84,14 +115,12 @@
                 :throw-exceptions false
                 :socket-timeout 10000
                 :conn-timeout 10000}
-               options)
-
+               opts)
         response
         (client/patch (local-url path port)
                     (-> options
                         (cond-> body (update :body encode-body))))]
-    (assoc response :parsed-body (:body response))))
-
+    (with-parsed-body response)))
 
 (defn with-port-fn
   "Helper to compose a fn that knows how to lookup an HTTP port with

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -40,11 +40,11 @@
 
 (defn encode-body
   [body content-type]
-;;  (string->input-stream
+  (string->input-stream
    (cond
      (edn? content-type) (pr-str body)
      (json? content-type) (json/generate-string body)
-     :else body))
+     :else body)))
 
 (def base-opts
   {:accept :edn

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -53,13 +53,17 @@
    :socket-timeout 10000
    :conn-timeout 10000})
 
+(defn with-parsed-body
+  [response]
+  ;; assoc parsed-body for backward compatibiity
+  (assoc response :parsed-body (parse-body response)))
+
 (defn get [path port & {:as opts}]
   (let [options (merge base-opts opts)
         response
         (http/get (local-url path port)
                   options)]
-  ;; assoc parsed-body for backward compatibiity
-    (assoc response :parsed-body (parse-body response))))
+    (with-parsed-body response)))
 
 (defn post [path port & {:as opts}]
   (let [{:keys [body content-type]
@@ -70,7 +74,7 @@
         (http/post (local-url path port)
                    (-> options
                        (cond-> body (assoc :body (encode-body body content-type)))))]
-    (assoc response :parsed-body (parse-body response))))
+    (with-parsed-body response)))
 
 (defn delete [path port & {:as opts}]
   (http/delete (local-url path port)
@@ -86,7 +90,7 @@
         (http/put (local-url path port)
                   (-> options
                       (cond-> body (assoc :body (encode-body body content-type)))))]
-    (assoc response :parsed-body (parse-body response))))
+    (with-parsed-body response)))
 
 (defn patch [path port & {:as opts}]
   (let [{:keys [body content-type]
@@ -97,7 +101,7 @@
         (http/patch (local-url path port)
                     (-> options
                         (cond-> body (assoc :body (encode-body body content-type)))))]
-    (assoc response :parsed-body (parse-body response))))
+    (with-parsed-body response)))
 
 (defn with-port-fn
   "Helper to compose a fn that knows how to lookup an HTTP port with


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/5385

I experienced similar issues related to large bodies in test submitted not only to ES but also to CTIA test server.
This PR internalizes the clj-momo test-helper and transforms the string body into an input stream to avoid http chuncks issue with big bodies while testing. 
In the path to get rid of `clj-momo` this PR also removes unnecessary use of `deep=` and custom schema validation.


<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
