### PR TITLE
Fix Wanderson nickname

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global codeowners
-* @gbuisson @yogsototh @msprunck @ereteog @frenchy64 @turbodog99 @rplevy @agzam @irinarenteria @bartuka
+* @gbuisson @yogsototh @msprunck @ereteog @frenchy64 @turbodog99 @rplevy @agzam @irinarenteria @wandersoncferreira


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/threatgrid/ctia/pull/1137

Wanderson nickname is @wandersoncferreira 

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
