### PR TITLE
Reverts "redefine default search fields"

### DIFF
--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -106,23 +106,6 @@
    :valid_time.start_time
    :valid_time.end_time])
 
-(def searchable-fields
-  #{:id
-    :source
-    :actor_type
-    :confidence
-    :description
-    :identity.description
-    :identity.related_identities.identity
-    :identity.related_identities.information_source
-    :identity.related_identities.relationship
-    :intended_effect
-    :motivation
-    :planning_and_operational_support
-    :short_description
-    :sophistication
-    :title})
-
 (s/defn actor-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -145,8 +128,7 @@
     :external-id-capabilities :read-actor
     :can-aggregate?           true
     :histogram-fields         actor-histogram-fields
-    :enumerable-fields        actor-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        actor-enumerable-fields}))
 
 (def capabilities
   #{:create-actor

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -100,14 +100,6 @@
               asset_ref (:id entity))))
     (assoc entity :asset_ref asset_ref)))
 
-(def searchable-fields
-  #{:id
-    :source
-    :asset_type
-    :description
-    :short_description
-    :title})
-
 (s/defn asset-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -130,8 +122,7 @@
     :external-id-capabilities :read-asset
     :can-aggregate?           true
     :histogram-fields         asset-histogram-fields
-    :enumerable-fields        asset-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        asset-enumerable-fields}))
 
 (def capabilities
   #{:create-asset

--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -119,42 +119,30 @@
 
 (def asset-mapping-can-revoke? true)
 
-(def searchable-fields
-  #{:id
-    :source
-    :asset_ref
-    :asset_type
-    :confidence
-    :observable.type
-    :observable.value
-    :specificity
-    :stability})
-
 (s/defn asset-mapping-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
-   services
-   {:entity                   :asset-mapping
-    :new-schema               NewAssetMapping
-    :entity-schema            AssetMapping
-    :get-schema               PartialAssetMapping
-    :get-params               AssetMappingGetParams
-    :list-schema              PartialAssetMappingList
-    :search-schema            PartialAssetMappingList
-    :external-id-q-params     AssetMappingByExternalIdQueryParams
-    :search-q-params          AssetMappingSearchParams
-    :new-spec                 :new-asset-mapping/map
-    :realize-fn               realize-asset-mapping
-    :get-capabilities         :read-asset-mapping
-    :post-capabilities        :create-asset-mapping
-    :put-capabilities         :create-asset-mapping
-    :delete-capabilities      :delete-asset-mapping
-    :search-capabilities      :search-asset-mapping
-    :external-id-capabilities :read-asset-mapping
-    :can-aggregate?           true
-    :histogram-fields         asset-mapping-histogram-fields
-    :enumerable-fields        asset-mapping-enumerable-fields
-    :can-revoke?              asset-mapping-can-revoke?
-    :searchable-fields        searchable-fields}))
+    services
+    {:entity                   :asset-mapping
+     :new-schema               NewAssetMapping
+     :entity-schema            AssetMapping
+     :get-schema               PartialAssetMapping
+     :get-params               AssetMappingGetParams
+     :list-schema              PartialAssetMappingList
+     :search-schema            PartialAssetMappingList
+     :external-id-q-params     AssetMappingByExternalIdQueryParams
+     :search-q-params          AssetMappingSearchParams
+     :new-spec                 :new-asset-mapping/map
+     :realize-fn               realize-asset-mapping
+     :get-capabilities         :read-asset-mapping
+     :post-capabilities        :create-asset-mapping
+     :put-capabilities         :create-asset-mapping
+     :delete-capabilities      :delete-asset-mapping
+     :search-capabilities      :search-asset-mapping
+     :external-id-capabilities :read-asset-mapping
+     :can-aggregate?           true
+     :histogram-fields         asset-mapping-histogram-fields
+     :enumerable-fields        asset-mapping-enumerable-fields
+     :can-revoke?              asset-mapping-can-revoke?}))
 
 (def capabilities
   #{:create-asset-mapping

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -116,38 +116,30 @@
 
 (def asset-properties-can-revoke? true)
 
-(def searchable-fields
-  #{:id
-    :source
-    :asset_ref
-    :properties.name
-    :properties.value})
-
 (s/defn asset-properties-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
-   services
-   {:entity                   :asset-properties
-    :new-schema               NewAssetProperties
-    :entity-schema            AssetProperties
-    :get-schema               PartialAssetProperties
-    :get-params               AssetPropertiesGetParams
-    :list-schema              PartialAssetPropertiesList
-    :search-schema            PartialAssetPropertiesList
-    :external-id-q-params     AssetPropertiesByExternalIdQueryParams
-    :search-q-params          AssetPropertiesSearchParams
-    :new-spec                 :new-asset-properties/map
-    :realize-fn               realize-asset-properties
-    :get-capabilities         :read-asset-properties
-    :post-capabilities        :create-asset-properties
-    :put-capabilities         :create-asset-properties
-    :delete-capabilities      :delete-asset-properties
-    :search-capabilities      :search-asset-properties
-    :external-id-capabilities :read-asset-properties
-    :can-aggregate?           true
-    :histogram-fields         asset-properties-histogram-fields
-    :enumerable-fields        asset-properties-enumerable-fields
-    :can-revoke?              asset-properties-can-revoke?
-    :searchable-fields        searchable-fields}))
+    services
+    {:entity                   :asset-properties
+     :new-schema               NewAssetProperties
+     :entity-schema            AssetProperties
+     :get-schema               PartialAssetProperties
+     :get-params               AssetPropertiesGetParams
+     :list-schema              PartialAssetPropertiesList
+     :search-schema            PartialAssetPropertiesList
+     :external-id-q-params     AssetPropertiesByExternalIdQueryParams
+     :search-q-params          AssetPropertiesSearchParams
+     :new-spec                 :new-asset-properties/map
+     :realize-fn               realize-asset-properties
+     :get-capabilities         :read-asset-properties
+     :post-capabilities        :create-asset-properties
+     :put-capabilities         :create-asset-properties
+     :delete-capabilities      :delete-asset-properties
+     :search-capabilities      :search-asset-properties
+     :external-id-capabilities :read-asset-properties
+     :can-aggregate?           true
+     :histogram-fields         asset-properties-histogram-fields
+     :enumerable-fields        asset-properties-enumerable-fields
+     :can-revoke?              asset-properties-can-revoke?}))
 
 (def capabilities
   #{:create-asset-properties

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -90,19 +90,6 @@
 (def attack-pattern-histogram-fields
   [:timestamp])
 
-(def searchable-fields
-  #{:id
-    :source
-    :abstraction_level
-    :description
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
-    :short_description
-    :title
-    :x_mitre_contributors
-    :x_mitre_data_sources
-    :x_mitre_platforms})
-
 (s/defn attack-pattern-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -125,8 +112,7 @@
     :external-id-capabilities :read-attack-pattern
     :can-aggregate?           true
     :histogram-fields         attack-pattern-histogram-fields
-    :enumerable-fields        attack-pattern-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        attack-pattern-enumerable-fields}))
 
 (def AttackPatternType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -100,19 +100,6 @@
    routes.common/PagingParams
    CampaignFieldsParam))
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :activity.description
-    :campaign_type
-    :confidence
-    :intended_effect
-    :names
-    :short_description
-    :status
-    :title})
-
 (s/defn campaign-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -136,8 +123,7 @@
     :external-id-capabilities :read-campaign
     :can-aggregate?           true
     :histogram-fields         campaign-histogram-fields
-    :enumerable-fields        campaign-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        campaign-enumerable-fields}))
 
 (def capabilities
   #{:create-campaign

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -308,17 +308,6 @@
 (def casebook-histogram-fields
   [:timestamp])
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :observables.type
-    :observables.value
-    :short_description
-    :texts.text
-    :texts.type
-    :title})
-
 (s/defn casebook-routes [services :- APIHandlerServices]
   (routes
    (casebook-operation-routes services)
@@ -345,8 +334,7 @@
      :external-id-capabilities :read-casebook
      :hide-delete?             false
      :histogram-fields         casebook-histogram-fields
-     :enumerable-fields        casebook-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        casebook-enumerable-fields})))
 
 (def casebook-entity
   {:route-context         "/casebook"

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -109,41 +109,6 @@
    :cost
    :coa_type])
 
-(def searchable-fields
-  #{:id
-    :source
-    :coa_type
-    :cost
-    :description
-    :efficacy
-    :impact
-    :objective
-    :open_c2_coa.action.type
-    :open_c2_coa.actuator.specifiers
-    :open_c2_coa.actuator.type
-    :open_c2_coa.id
-    :open_c2_coa.modifiers.additional_properties.context
-    :open_c2_coa.modifiers.destination
-    :open_c2_coa.modifiers.frequency
-    :open_c2_coa.modifiers.id
-    :open_c2_coa.modifiers.location
-    :open_c2_coa.modifiers.method
-    :open_c2_coa.modifiers.option
-    :open_c2_coa.modifiers.response
-    :open_c2_coa.modifiers.search
-    :open_c2_coa.modifiers.source
-    :open_c2_coa.target.specifiers
-    :open_c2_coa.target.type
-    :open_c2_coa.type
-    :related_COAs.COA_id
-    :related_COAs.confidence
-    :related_COAs.relationship
-    :related_COAs.source
-    :short_description
-    :stage
-    :structured_coa_type
-    :title})
-
 (s/defn coa-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -166,8 +131,7 @@
     :external-id-capabilities :read-coa
     :can-aggregate?           true
     :histogram-fields         coa-histogram-fields
-    :enumerable-fields        coa-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        coa-enumerable-fields}))
 
 (def capabilities
   #{:create-coa

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -50,6 +50,7 @@
    routes.common/PagingParams
    routes.common/BaseEntityFilterParams
    routes.common/SourcableEntityFilterParams
+   routes.common/SearchableEntityParams
    DataTableFieldsParam
    (st/optional-keys
     {:sort_by datatable-sort-fields})))

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -138,33 +138,27 @@
                  timeline (bucketize-events res get-in-config)]
              (ok timeline))))))
 
-(def searchable-fields
-  #{:id
-    :entity.id
-    :event_type})
-
 (s/defn event-routes [services :- APIHandlerServices]
   (routes
    (event-history-routes services)
    (services->entity-crud-routes
     services
-    {:tags                    ["Event"]
-     :entity                  :event
-     :entity-schema           Event
-     :get-schema              PartialEvent
-     :get-params              EventGetParams
-     :list-schema             PartialEventList
-     :search-schema           PartialEventList
-     :search-q-params         EventSearchParams
-     :get-capabilities        :read-event
-     :can-update?             false
-     :can-patch?              false
-     :can-post?               false
+    {:tags ["Event"]
+     :entity :event
+     :entity-schema Event
+     :get-schema PartialEvent
+     :get-params EventGetParams
+     :list-schema PartialEventList
+     :search-schema PartialEventList
+     :search-q-params EventSearchParams
+     :get-capabilities :read-event
+     :can-update? false
+     :can-patch? false
+     :can-post? false
      :can-get-by-external-id? false
-     :search-capabilities     :search-event
-     :delete-capabilities     #{:delete-event :developer}
-     :date-field              :timestamp
-     :searchable-fields       searchable-fields})))
+     :search-capabilities :search-event
+     :delete-capabilities #{:delete-event :developer}
+     :date-field :timestamp})))
 
 (def event-entity
   {:new-spec              map?

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -77,36 +77,28 @@
     :read-feedback
     :delete-feedback})
 
-(def searchable-fields
-  #{:id
-    :source
-    :entity_id
-    :feedback
-    :reason})
-
 (s/defn feedback-routes [services :- APIHandlerServices]
   (routes
    (feedback-by-entity-route services)
    (services->entity-crud-routes
     services
-    {:entity                   :feedback
-     :new-schema               fs/NewFeedback
-     :entity-schema            fs/Feedback
-     :get-schema               fs/PartialFeedback
-     :get-params               FeedbackGetParams
-     :list-schema              fs/PartialFeedbackList
-     :external-id-q-params     FeedbackByExternalIdQueryParams
-     :realize-fn               fs/realize-feedback
-     :get-capabilities         :read-feedback
-     :post-capabilities        :create-feedback
-     :put-capabilities         :create-feedback
-     :delete-capabilities      :delete-feedback
+    {:entity :feedback
+     :new-schema fs/NewFeedback
+     :entity-schema fs/Feedback
+     :get-schema fs/PartialFeedback
+     :get-params FeedbackGetParams
+     :list-schema fs/PartialFeedbackList
+     :external-id-q-params FeedbackByExternalIdQueryParams
+     :realize-fn fs/realize-feedback
+     :get-capabilities :read-feedback
+     :post-capabilities :create-feedback
+     :put-capabilities :create-feedback
+     :delete-capabilities :delete-feedback
      :external-id-capabilities :read-feedback
-     :spec                     :new-feedback/map
-     :can-search?              false
-     :enumerable-fields        []
-     :can-update?              false
-     :searchable-fields        searchable-fields})))
+     :spec :new-feedback/map
+     :can-search? false
+     :enumerable-fields []
+     :can-update? false})))
 
 (def feedback-entity
   {:route-context         "/feedback"

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -91,14 +91,6 @@
    routes.common/PagingParams
    IdentityAssertionFieldsParam))
 
-(def searchable-fields
-  #{:id
-    :source
-    :assertions.name
-    :assertions.value
-    :identity.observables.type
-    :identity.observables.value})
-
 (s/defn identity-assertion-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -120,8 +112,7 @@
     :external-id-capabilities :read-identity-assertion
     :can-aggregate?           true
     :enumerable-fields        identity-assertion-enumerable-fields
-    :histogram-fields         identity-assertion-histogram-fields
-    :searchable-fields        searchable-fields}))
+    :histogram-fields         identity-assertion-histogram-fields}))
 
 (def capabilities
   #{:create-identity-assertion

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -204,20 +204,6 @@
    routes.common/PagingParams
    IncidentFieldsParam))
 
-(def searchable-fields
-  #{:description
-    :source
-    :id
-    :assignees
-    :categories
-    :confidence
-    :discovery_method
-    :intended_effect
-    :promotion_method
-    :short_description
-    :status
-    :title})
-
 (s/defn incident-routes [services :- APIHandlerServices]
   (routes
    (incident-additional-routes services)
@@ -245,8 +231,7 @@
      :search-capabilities      :search-incident
      :external-id-capabilities :read-incident
      :histogram-fields         incident-histogram-fields
-     :enumerable-fields        incident-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        incident-enumerable-fields})))
 
 (def IncidentType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -139,22 +139,6 @@
 (s/defschema IndicatorsByExternalIdQueryParams
   IndicatorsListQueryParams)
 
-(def searchable-fields
-  #{:id
-    :source
-    :confidence
-    :description
-    :indicator_type
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
-    :likely_impact
-    :producer
-    :severity
-    :short_description
-    :tags
-    :test_mechanisms
-    :title})
-
 (s/defn indicator-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -177,8 +161,7 @@
     :external-id-capabilities :read-indicator
     :can-aggregate?           true
     :histogram-fields         indicator-histogram-fields
-    :enumerable-fields        indicator-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        indicator-enumerable-fields}))
 
 (def capabilities
   #{:read-indicator

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -73,19 +73,6 @@
 (def investigation-histogram-fields
   [:timestamp])
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :investigated_observables
-    :object_ids
-    :short_description
-    :targets.observables.type
-    :targets.observables.value
-    :targets.os
-    :targets.type
-    :title})
-
 (s/defn investigation-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -108,8 +95,7 @@
     :external-id-capabilities :read-investigation
     :can-aggregate?           true
     :histogram-fields         investigation-histogram-fields
-    :enumerable-fields        investigation-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        investigation-enumerable-fields}))
 
 (def capabilities
   #{:read-investigation

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -1,14 +1,16 @@
 (ns ctia.entity.judgement
   (:require
+   [clj-momo.lib.clj-time.core :as time]
+   [compojure.api.resource :refer [resource]]
+   [ctia.domain.entities :refer [un-store with-long-id]]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.judgement.es-store :as j-store]
    [ctia.entity.judgement.schemas :as js]
    [ctia.entity.relationship.graphql-schemas :as relationship]
+   [ctia.flows.crud :as flows]
    [ctia.http.routes.common :as routes.common]
-   [ctia.http.routes.crud
-    :refer
-    [capitalize-entity revoke-request services->entity-crud-routes]]
-   [ctia.lib.compojure.api.core :refer [POST routes]]
+   [ctia.http.routes.crud :refer [capitalize-entity revoke-request services->entity-crud-routes]]
+   [ctia.lib.compojure.api.core :refer [context POST routes]]
    [ctia.schemas.core :refer [APIHandlerServices Entity]]
    [ctia.schemas.graphql.flanders :as f]
    [ctia.schemas.graphql.helpers :as g]
@@ -19,6 +21,7 @@
    [ctim.schemas.judgement :as judgement]
    [flanders.utils :as fu]
    [ring.swagger.schema :refer [describe]]
+   [ring.util.http-response :refer [not-found ok]]
    [schema-tools.core :as st]
    [schema.core :as s]))
 
@@ -103,40 +106,29 @@
                                                    (-> entity
                                                        (update :reason str " " reason)))
                            :wait_for wait_for}))))
-(def searchable-fields
-  #{:id
-    :source
-    :confidence
-    :disposition_name
-    :observable.type
-    :observable.value
-    :reason
-    :severity})
 
 (s/defn judgement-routes [services :- APIHandlerServices]
-  (let [entity-crud-config
-        {:entity                   :judgement
-         :new-schema               js/NewJudgement
-         :entity-schema            js/Judgement
-         :get-schema               js/PartialJudgement
-         :get-params               JudgementGetParams
-         :list-schema              js/PartialJudgementList
-         :search-schema            js/PartialJudgementList
-         :external-id-q-params     JudgementsByExternalIdQueryParams
-         :search-q-params          JudgementSearchParams
-         :new-spec                 :new-judgement/map
-         :realize-fn               js/realize-judgement
-         :get-capabilities         :read-judgement
-         :post-capabilities        :create-judgement
-         :put-capabilities         #{:create-judgement :developer}
-         :delete-capabilities      :delete-judgement
-         :search-capabilities      :search-judgement
-         :external-id-capabilities :read-judgement
-         :can-update?              true
-         :can-aggregate?           true
-         :histogram-fields         js/judgement-histogram-fields
-         :enumerable-fields        js/judgement-enumerable-fields
-         :searchable-fields        searchable-fields}]
+  (let [entity-crud-config {:entity :judgement
+                            :new-schema js/NewJudgement
+                            :entity-schema js/Judgement
+                            :get-schema js/PartialJudgement
+                            :get-params JudgementGetParams
+                            :list-schema js/PartialJudgementList
+                            :search-schema js/PartialJudgementList
+                            :external-id-q-params JudgementsByExternalIdQueryParams
+                            :search-q-params JudgementSearchParams
+                            :new-spec :new-judgement/map
+                            :realize-fn js/realize-judgement
+                            :get-capabilities :read-judgement
+                            :post-capabilities :create-judgement
+                            :put-capabilities #{:create-judgement :developer}
+                            :delete-capabilities :delete-judgement
+                            :search-capabilities :search-judgement
+                            :external-id-capabilities :read-judgement
+                            :can-update? true
+                            :can-aggregate? true
+                            :histogram-fields js/judgement-histogram-fields
+                            :enumerable-fields js/judgement-enumerable-fields}]
     (routes
       (services->entity-crud-routes
         services
@@ -179,21 +171,21 @@
   (pagination/new-connection JudgementType))
 
 (s/def judgement-entity :- Entity
-  {:route-context         "/judgement"
-   :tags                  ["Judgement"]
-   :entity                :judgement
-   :plural                :judgements
-   :new-spec              :new-judgement/map
-   :schema                js/Judgement
-   :partial-schema        js/PartialJudgement
-   :partial-list-schema   js/PartialJudgementList
-   :new-schema            js/NewJudgement
-   :stored-schema         js/StoredJudgement
+  {:route-context "/judgement"
+   :tags ["Judgement"]
+   :entity :judgement
+   :plural :judgements
+   :new-spec :new-judgement/map
+   :schema js/Judgement
+   :partial-schema js/PartialJudgement
+   :partial-list-schema js/PartialJudgementList
+   :new-schema js/NewJudgement
+   :stored-schema js/StoredJudgement
    :partial-stored-schema js/PartialStoredJudgement
-   :realize-fn            js/realize-judgement
-   :es-store              j-store/->JudgementStore
-   :es-mapping            j-store/judgement-mapping-def
-   :services->routes      (routes.common/reloadable-function judgement-routes)
-   :capabilities          capabilities
-   :fields                js/judgement-fields
-   :sort-fields           js/judgement-sort-fields})
+   :realize-fn js/realize-judgement
+   :es-store j-store/->JudgementStore
+   :es-mapping j-store/judgement-mapping-def
+   :services->routes (routes.common/reloadable-function judgement-routes)
+   :capabilities capabilities
+   :fields js/judgement-fields
+   :sort-fields js/judgement-sort-fields})

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -124,18 +124,6 @@
 (def MalwareConnectionType
   (pagination/new-connection MalwareType))
 
-(def searchable-fields
-  #{:id
-    :source
-    :abstraction_level
-    :description
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
-    :labels
-    :short_description
-    :title
-    :x_mitre_aliases})
-
 (s/defn malware-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -158,8 +146,7 @@
     :external-id-capabilities :read-malware
     :can-aggregate?           true
     :histogram-fields         malware-histogram-fields
-    :enumerable-fields        malware-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        malware-enumerable-fields}))
 
 (def malware-entity
   {:route-context         "/malware"

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -202,16 +202,6 @@
   [:source
    :relationship_type])
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :relationship_type
-    :short_description
-    :source_ref
-    :target_ref
-    :title})
-
 (s/defn relationship-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -234,8 +224,7 @@
     :external-id-capabilities :read-relationship
     :can-aggregate?           true
     :histogram-fields         relationship-histogram-fields
-    :enumerable-fields        relationship-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        relationship-enumerable-fields}))
 
 (def capabilities
   #{:create-relationship

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -43,34 +43,6 @@
    routes.common/PagingParams
    SightingFieldsParam))
 
-(def searchable-fields
-  #{:id
-    :source
-    :confidence
-    :description
-    :observables.type
-    :observables.value
-    :relations.origin
-    :relations.origin_uri
-    :relations.related.type
-    :relations.related.value
-    :relations.relation
-    :relations.source.type
-    :relations.source.value
-    :resolution
-    :sensor
-    :sensor_coordinates.observables.type
-    :sensor_coordinates.observables.value
-    :sensor_coordinates.os
-    :sensor_coordinates.type
-    :severity
-    :short_description
-    :targets.observables.type
-    :targets.observables.value
-    :targets.os
-    :targets.type
-    :title})
-
 (s/defn sighting-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -93,8 +65,7 @@
     :search-capabilities      :search-sighting
     :can-aggregate?           true
     :histogram-fields         ss/sighting-histogram-fields
-    :enumerable-fields        ss/sighting-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        ss/sighting-enumerable-fields}))
 
 (def capabilities
   #{:create-sighting

--- a/src/ctia/entity/target_record.clj
+++ b/src/ctia/entity/target_record.clj
@@ -103,18 +103,6 @@
    :targets.observed_time.start_time
    :targets.observed_time.end_time])
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :short_description
-    :targets.observables.type
-    :targets.observables.value
-    :targets.os
-    :targets.sensor
-    :targets.type
-    :title})
-
 (s/defn target-record-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -137,8 +125,7 @@
     :external-id-capabilities :read-target-record
     :can-aggregate?           true
     :histogram-fields         target-record-histogram-fields
-    :enumerable-fields        target-record-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        target-record-enumerable-fields}))
 
 (def capabilities
   #{:create-target-record

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -69,17 +69,6 @@
     :delete-tool
     :search-tool})
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
-    :labels
-    :short_description
-    :title
-    :x_mitre_aliases})
-
 (s/defn tool-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -102,8 +91,7 @@
     :external-id-capabilities :read-tool
     :can-aggregate?           true
     :histogram-fields         tool-histogram-fields
-    :enumerable-fields        tool-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        tool-enumerable-fields}))
 
 (def tool-entity
   {:route-context         "/tool"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -203,15 +203,6 @@
               ent/un-store-page
               routes.common/paginated-ok))))))
 
-(def searchable-fields
-  #{:id
-    :source
-    :description
-    :configurations.nodes.children.cpe_match.cpe23Uri
-    :configurations.nodes.cpe_match.cpe23Uri
-    :short_description
-    :title})
-
 (s/defn vulnerability-routes [services :- APIHandlerServices]
   (routes
    (search-by-cpe-match-strings services)
@@ -236,8 +227,7 @@
      :external-id-capabilities :read-vulnerability
      :can-aggregate?           true
      :histogram-fields         vulnerability-histogram-fields
-     :enumerable-fields        vulnerability-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        vulnerability-enumerable-fields})))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -130,58 +130,6 @@
    :technologies.name
    :technologies.prevalence])
 
-(def searchable-fields
-  #{:id
-    :source
-    :paradigms.name
-    :description
-    :technologies.name
-    :background_details
-    :abstraction_level
-    :languages.name
-    :architectures.prevalence
-    :common_consequences.scopes
-    :alternate_terms.term
-    :detection_methods.method
-    :architectures.name
-    :operating_systems.version
-    :potential_mitigations.effectiveness_notes
-    :likelihood
-    :potential_mitigations.effectiveness
-    :paradigms.prevalence
-    :languages.prevalence
-    :modes_of_introduction.phase
-    :external_references.source_name
-    :external_ids
-    :short_description
-    :common_consequences.likelihood
-    :notes.note
-    :title
-    :operating_systems.name
-    :operating_systems.cpe_id
-    :functional_areas
-    :notes.type
-    :operating_systems.prevalence
-    :structure
-    :external_references.description
-    :technologies.prevalence
-    :external_references.hashes
-    :affected_resources
-    :potential_mitigations.phases
-    :alternate_terms.description
-    :external_references.external_id
-    :potential_mitigations.strategy
-    :detection_methods.effectiveness_notes
-    :architectures.class
-    :languages.class
-    :potential_mitigations.description
-    :common_consequences.note
-    :detection_methods.effectiveness
-    :common_consequences.impacts
-    :operating_systems.class
-    :modes_of_introduction.note
-    :detection_methods.description})
-
 (s/defn weakness-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -204,8 +152,7 @@
     :external-id-capabilities :read-weakness
     :can-aggregate?           true
     :histogram-fields         weakness-histogram-fields
-    :enumerable-fields        weakness-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        weakness-enumerable-fields}))
 
 (def capabilities
   #{:create-weakness

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -1,20 +1,16 @@
 (ns ctia.http.routes.common
-  (:require
-   [clj-http.headers :refer [canonicalize]]
-   [clj-momo.lib.clj-time.core :as t]
-   [clojure.set :as set]
-   [clojure.string :as str]
-   [ctia.schemas.search-agg
-    :refer
-    [FullTextQueryMode MetricResult RangeQueryOpt RawSearchParams SearchQuery]]
-   [ctia.schemas.sorting :as sorting]
-   [ctia.schemas.utils :as csu]
-   [ring.swagger.schema :refer [describe]]
-   [ring.util.codec :as codec]
-   [ring.util.http-response :as http-res]
-   [ring.util.http-status :refer [ok]]
-   [schema-tools.core :as st]
-   [schema.core :as s]))
+  (:require [clj-http.headers :refer [canonicalize]]
+            [clojure.string :as str]
+            [ctia.schemas.sorting :as sorting]
+            [ring.swagger.schema :refer [describe]]
+            [clj-momo.lib.clj-time.core :as t]
+            [ring.util
+             [codec :as codec]
+             [http-response :as http-res]
+             [http-status :refer [ok]]]
+            [ctia.schemas.search-agg :refer
+             [FullTextQueryMode MetricResult RangeQueryOpt SearchQuery]]
+            [schema.core :as s]))
 
 (def search-options [:sort_by
                      :sort_order
@@ -53,32 +49,6 @@
    (s/optional-key :offset) (describe Long "Pagination Offset")
    (s/optional-key :search_after) (describe [s/Str] "Pagination stateless cursor")
    (s/optional-key :limit) (describe Long "Pagination Limit")})
-
-(s/defn prep-es-fields-schema :- (s/protocol s/Schema)
-  "Conjoins Elasticsearch fields parameter into search-q-params schema"
-  [{:keys [search-q-params
-           searchable-fields] :as entity-crud-config}]
-  (let [default-fields-schema (->>
-                               searchable-fields
-                               (map name)
-                               (apply s/enum))]
-    (if (seq searchable-fields)
-     (st/merge
-      search-q-params
-      {;; We cannot name the parameter :fields, because we already have :fields (part
-       ;; of search-q-params). That key is to select a subsets of fields of the
-       ;; retrieved document and it gets passed to the `_source` parameter of
-       ;; Elasticsearch. For more: www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html
-       (s/optional-key :search_fields)
-       (describe [default-fields-schema] "'fields' key of Elasticsearch Fulltext Query.")})
-     search-q-params)))
-
-(s/defn enforce-search-fields
-  "Guarantees that ES fields parameter always passed to ES instance"
-  [{:keys [search_fields] :as query-params}
-   searchable-fields]
-  (cond-> query-params
-    (not (seq search_fields)) (assoc :search_fields (mapv name searchable-fields))))
 
 (def paging-param-keys
   "A list of the paging and sorting related parameters, we can use

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -1,42 +1,43 @@
 (ns ctia.http.routes.crud
-  (:require [clj-momo.lib.clj-time.core :as time]
-            [clojure.string :as str]
-            [ctia.domain.entities
-             :refer
-             [page-with-long-id un-store un-store-page with-long-id]]
-            [ctia.flows.crud :as flows]
-            [ctia.http.routes.common
-             :as routes.common
-             :refer [capabilities->description
-                     coerce-date-range
-                     created
-                     format-agg-result
-                     paginated-ok
-                     search-options
-                     search-query
-                     wait_for->refresh]]
-            [ctia.lib.compojure.api.core
-             :refer
-             [context DELETE GET PATCH POST PUT routes]]
-            [ctia.schemas.core :refer [APIHandlerServices DelayedRoutes]]
-            [ctia.schemas.search-agg
-             :refer
-             [CardinalityParams HistogramParams MetricResult TopnParams]]
-            [ctia.store
-             :refer
-             [aggregate
-              create-record
-              delete-record
-              delete-search
-              list-records
-              query-string-count
-              query-string-search
-              read-record
-              update-record]]
-            [ring.swagger.schema :refer [describe]]
-            [ring.util.http-response :refer [forbidden no-content not-found ok]]
-            [schema-tools.core :as st]
-            [schema.core :as s]))
+  (:require
+   [clj-momo.lib.clj-time.core :as time]
+   [clojure.string :as str]
+   [ctia.domain.entities
+    :refer
+    [page-with-long-id
+     un-store
+     un-store-page
+     with-long-id]]
+   [ctia.flows.crud :as flows]
+   [ctia.http.middleware.auth]
+   [ctia.http.routes.common :refer [capabilities->description
+                                    created
+                                    paginated-ok
+                                    search-options
+                                    wait_for->refresh
+                                    search-query
+                                    coerce-date-range
+                                    format-agg-result]]
+   [ctia.lib.compojure.api.core :refer [context DELETE GET POST PUT PATCH routes]]
+   [ctia.schemas.core :refer [APIHandlerServices DelayedRoutes]]
+   [ctia.schemas.search-agg :refer [HistogramParams
+                                    CardinalityParams
+                                    TopnParams
+                                    MetricResult]]
+   [ctia.store :refer [query-string-search
+                       query-string-count
+                       aggregate
+                       create-record
+                       delete-record
+                       read-record
+                       update-record
+                       list-records
+                       delete-search]]
+   [ring.swagger.schema :refer [describe]]
+   [ring.util.http-response :refer [no-content not-found ok forbidden]]
+   [schema-tools.core :as st]
+   [schema.core :as s]
+   [ctia.http.routes.common :as routes.common]))
 
 (s/defn capitalize-entity [entity :- (s/pred simple-keyword?)]
   (-> entity name str/capitalize))
@@ -148,22 +149,28 @@
            can-get-by-external-id?
            date-field
            histogram-fields
-           enumerable-fields
-           searchable-fields]
-    :or {hide-delete?            false
-         can-post?               true
-         can-update?             true
-         can-patch?              false
-         can-search?             true
-         can-aggregate?          false
+           enumerable-fields]
+    :or {hide-delete? false
+         can-post? true
+         can-update? true
+         can-patch? false
+         can-search? true
+         can-aggregate? false
          can-get-by-external-id? true
-         date-field              :created
-         histogram-fields        [:created]}
+         date-field :created
+         histogram-fields [:created]}
     :as entity-crud-config}]
  (s/fn [{{:keys [get-store]} :StoreService
          :as services} :- APIHandlerServices]
   (let [capitalized (capitalize-entity entity)
-        search-q-params* (routes.common/prep-es-fields-schema entity-crud-config)
+        search-q-params* (st/merge
+                          search-q-params
+                          {;; We cannot name the parameter :fields, because we already have :fields (part
+                           ;; of search-q-params). That key is to select a subsets of fields of the
+                           ;; retrieved document and it gets passed to the `_source` parameter of
+                           ;; Elasticsearch. For more: www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html
+                           (s/optional-key :search_fields)
+                           (describe (st/get-in search-q-params [:fields]) "'fields' key of Elasticsearch Fulltext Query.")})
         search-filters (st/dissoc search-q-params
                                   :sort_by
                                   :sort_order
@@ -323,17 +330,14 @@
              :description (capabilities->description search-capabilities)
              :capabilities search-capabilities
              :query [params search-q-params*]
-             (let [params* (routes.common/enforce-search-fields
-                            params
-                            searchable-fields)]
-              (-> (get-store entity)
-                  (query-string-search
-                   (search-query date-field params*)
+             (-> (get-store entity)
+                 (query-string-search
+                   (search-query date-field params)
                    identity-map
-                   (select-keys params* search-options))
-                  (page-with-long-id services)
-                  un-store-page
-                  paginated-ok)))
+                   (select-keys params search-options))
+                 (page-with-long-id services)
+                 un-store-page
+                 paginated-ok))
            (GET "/count" []
              :return s/Int
              :summary (format "Count %s matching a Lucene/ES query string and field filters" capitalized)

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -178,27 +178,27 @@
 
 (s/defschema Entity
   (st/merge
-   {:entity                s/Keyword
-    :plural                s/Keyword
-    :new-spec              (s/either s/Keyword s/Any)
-    :schema                (s/protocol s/Schema)
-    :partial-schema        (s/protocol s/Schema)
-    :partial-list-schema   (s/protocol s/Schema)
-    :stored-schema         (s/protocol s/Schema)
+   {:entity s/Keyword
+    :plural s/Keyword
+    :new-spec (s/either s/Keyword s/Any)
+    :schema (s/protocol s/Schema)
+    :partial-schema (s/protocol s/Schema)
+    :partial-list-schema (s/protocol s/Schema)
+    :stored-schema (s/protocol s/Schema)
     :partial-stored-schema (s/protocol s/Schema)
-    :es-store              s/Any
-    :es-mapping            {s/Any s/Any}}
+    :es-store s/Any
+    :es-mapping {s/Any s/Any}}
    (st/optional-keys
-    {:fields            [Field]
-     :sort-fields       [Field]
-     :new-schema        (s/protocol s/Schema)
-     :route-context     s/Str
-     :services->routes  DelayedRoutes
-     :tags              [s/Str]
-     :capabilities      #{s/Keyword}
-     :no-bulk?          s/Bool
-     :no-api?           s/Bool
-     :realize-fn        RealizeFn})))
+    {:fields [Field]
+     :sort-fields [Field]
+     :new-schema (s/protocol s/Schema)
+     :route-context s/Str
+     :services->routes DelayedRoutes
+     :tags [s/Str]
+     :capabilities #{s/Keyword}
+     :no-bulk? s/Bool
+     :no-api? s/Bool
+     :realize-fn RealizeFn})))
 
 (s/defschema OpenCTIMSchemaVersion
   {(s/optional-key :schema_version) s/Str})

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -24,23 +24,9 @@
      :fields           [s/Str]
      :default_operator s/Str})))
 
-(s/defschema RawSearchParams
-  (st/optional-keys
-   {:query         s/Str
-    :search_fields [s/Str]
-    :query_mode    (->> FullTextQueryMode
-                        vals first (map name)
-                        (apply s/enum))
-    :limit         s/Int
-    :sort_by       s/Any
-    :from          s/Any
-    :to            s/Any
-    :id            s/Str
-    :tags          s/Any}))
-
 (s/defschema SearchQuery
   "components of a search query:
-   - query-string: free text search"
+   - query-string: free text search, with lucene syntax enabled"
   (st/optional-keys
    {:filter-map   {s/Keyword s/Any}
     :range        RangeQuery

--- a/src/ctia/schemas/utils.clj
+++ b/src/ctia/schemas/utils.clj
@@ -193,29 +193,3 @@
                       {:missing-keys missing-keys
                        :res res})))
     res))
-
-(s/defn contains-key? :- s/Bool
-  "Returns true if schema contains key at the given path.
-   Example:
-    (contains-key? Sighting [:sensor_coordinates :observables :type]) => true"
-  [schema :- (s/protocol s/Schema)
-   path :- [s/Keyword]]
-  (let [any-schema? (fn [s]
-                      (and (map? s)
-                           (instance? schema.core.AnythingSchema (ffirst s))))
-        full-path   (reduce
-                     (fn [track n]
-                       (let [cur (st/get-in schema track)]
-                         (cond
-                           (any-schema? cur) track ;; if {Any _} - don't go deeper
-                           (map? cur)        (conj track n)
-                           (vector? cur)     (conj track 0 n)
-
-                           :else track)))
-                     []
-                     path)
-        val (st/get-in schema full-path)]
-    (or (any-schema? val)
-        (and (some? val)
-             (= (count (remove number? full-path))
-                (count path))))))

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -4,12 +4,15 @@
    [clojure.test.check.generators :as gen]
    [ctia.auth.capabilities :as capabilities]
    [ctia.auth.threatgrid :refer [map->Identity]]
+   [ctia.bundle.core :as bundle]
+   [ctia.http.generative.properties :as prop]
    [ctia.lib.utils :as utils]
    [ctia.test-helpers.core :as helpers]
    [ctia.test-helpers.es :as es-helpers]
    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
-   [ctia.test-helpers.fixtures :as fixt]
    [ctia.test-helpers.search :as th.search]
+   [ctim.examples.bundles :refer [bundle-maximal]]
+   [ctim.schemas.bundle :as bundle.schema]
    [ductile.index :as es-index]
    [puppetlabs.trapperkeeper.app :as app]))
 
@@ -19,55 +22,82 @@
 
 (use-fixtures :once (join-fixtures [es-helpers/fixture-properties:es-store
                                     whoami-helpers/fixture-server]))
-(defn- bulk-gen-for
-  "Generator for a bulk of entities that contains only given entity keys
-  Example: (gen/generate (bulk-gen-for :assets :actors))"
+
+(def bundle-entity-field-names
+  "extracted non-essential Bundle keys"
+  (->>
+   bundle.schema/objects-entries
+   (into bundle.schema/references-entries)
+   (mapcat #(-> % :key :values))
+   (set)))
+
+(defn- entities-gen
+  "Generator for a map where each k/v represents entity-type/list of entities (of
+  that type)"
   [& entity-keys]
-  (let [examples (->> (-> (fixt/bundle 10 :maximal)
-                          (select-keys entity-keys))
-                      (reduce-kv
-                       (fn [a k v]
-                         ;; remove IDs
-                         (assoc a k (apply utils/update-items v (repeat #(dissoc % :id)))))
-                       {}))]
-    (gen/return examples)))
+  (let [gens (map
+              (fn [e]
+                (-> (->> e
+                         helpers/plural-key->entity
+                         ffirst
+                         name
+                         (str "max-new-")
+                         prop/spec-gen
+                         ;; remove IDs so it can be used it in Bundle import
+                         (gen/fmap #(dissoc % :id)))
+                    (gen/vector 5 11)))
+              entity-keys)]
+    (gen/bind
+     (apply gen/tuple gens)
+     (fn [entity-maps]
+       (gen/return
+        (zipmap entity-keys entity-maps))))))
 
-;; Every single query gets tested with its own set of generated Bulk data.
-;; These tests are not meant to test relations between entitites, that is why
-;; we're not using Bundle, but Bulk.
-;;
-;; After the query gets sent, the response results
-;; are passed into :check function, together with the test-case map, entity key
-;; and the original Bulk data
-(defn test-cases
-  "Returns vector of test cases, where each map represents:
+(defn- bundle-gen-for
+  "Generator for a bundle that contains only given entity key(s)
+  Example: (gen/generate (bundle-gen-for :assets :actors))"
+  [& entity-keys]
+  (gen/let [bundle (->
+                    bundle-maximal
+                    (dissoc :id)
+                    gen/return
+                    (gen/bind
+                     (fn [bundle]
+                       ;; To generate a bundle that contains only given entity(ies), we're gonna need
+                       ;; to generate a complete bundle and remove all other keys from it
+                       (let [bundle-keys-to-remove (apply
+                                                    disj bundle-entity-field-names
+                                                    entity-keys)
+                             new-bundle            (apply
+                                                    dissoc
+                                                    bundle
+                                                    bundle-keys-to-remove)]
+                         (gen/return new-bundle)))))
+            entities (apply entities-gen entity-keys)]
+    (merge bundle entities)))
 
-  - a recipe for generating data
-  - a query
-  - a way to verify the response data
-
-  Test checker function (that would use this) is responsible for generating and
-  importing the data into the ES cluster, and then query and verify the
-  results"
-  []
+;; Every single query gets tested with its own set of generated Bundle
+;; data. After the query gets sent, the response results are passed into :check
+;; function, together with the test-case map, entity key and the Bundle data
+(defn test-cases []
   (concat
    [{:test-description "Returns all the records when the wildcard used"
      :query-params     {:query_mode "query_string"
                         :query      "*"}
-     :bulk-gen         (bulk-gen-for :incidents :assets)
-     :check            (fn [_ entity examples res]
+     :bundle-gen       (bundle-gen-for :incidents :assets)
+     :check            (fn [_ entity bundle res]
                          (is (= (-> res :parsed-body count)
-                                (-> examples (get entity) count))))}]
-   (let [bulk     (gen/fmap
-                   (fn [examples]
+                                (-> bundle (get entity) count))))}]
+   (let [bundle   (gen/fmap
+                   (fn [bundle]
                      (update
-                      examples :incidents
+                      bundle :incidents
                       (fn [incidents]
                         (apply
                          utils/update-items incidents
                          ;; update first 3 records, leave the rest unchanged
                          (repeat 3 #(assoc % :title "nunc porta vulputate tellus"))))))
-                   (bulk-gen-for :incidents))
+                   (bundle-gen-for :incidents))
          check-fn (fn [{:keys [test-description]} _ _ res]
                     (let [matching (->> res
                                         :parsed-body
@@ -76,43 +106,43 @@
      [{:test-description "Multiple records with the same value in a given field. Lucene syntax"
        :query-params     {:query_mode "query_string"
                           :query      "title:nunc porta vulputate tellus"}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            check-fn}
       {:test-description "Multiple records with the same value in a given field set in search_fields"
-       :query-params     {:query_mode    "query_string"
-                          :query         "nunc porta vulputate tellus"
+       :query-params     {:query_mode      "query_string"
+                          :query           "nunc porta vulputate tellus"
                           :search_fields ["title"]}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            check-fn}
       {:test-description "Querying for non-existing value should yield no results. Lucene syntax."
        :query-params     {:query_mode "query_string"
                           :query      "title:0e1c9f6a-c3ac-4fd5-982e-4981f86df07a"}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (zero? (-> res :parsed-body count))))}
       {:test-description "Querying for non-existing field with wildcard should yield no results. Lucene syntax."
        :query-params     {:query_mode "query_string"
                           :query      "74f93781-f370-46ea-bd53-3193db379e41:*"}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (empty? (-> res :parsed-body))))}
       {:test-description "Querying for non-existing field with wildcard should fail the schema validation. search_fields"
-       :query-params     {:query_mode    "query_string"
-                          :query         "*"
+       :query-params     {:query_mode      "query_string"
+                          :query           "*"
                           :search_fields ["512b8dce-0423-4e9a-aa63-d3c3b91eb8d8"]}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (= 400 (-> res :status))))}])
 
    ;; Test `AND` (set two different fields that contain the same word in the same entity)
-   (let [bulk       (gen/fmap
-                     (fn [examples]
-                       (update
-                        examples :incidents
-                        (fn [incidents]
-                          (utils/update-items
-                           incidents
-                           ;; update only the first, leave the rest unchanged
-                           #(assoc % :discovery_method "Log Review"
-                                   :title "title of test incident")))))
-                     (bulk-gen-for :incidents))
+   (let [bundle        (gen/fmap
+                        (fn [bundle]
+                          (update
+                           bundle :incidents
+                           (fn [incidents]
+                             (utils/update-items
+                              incidents
+                              ;; update only the first, leave the rest unchanged
+                              #(assoc % :discovery_method "Log Review"
+                                      :title "title of test incident")))))
+                        (bundle-gen-for :incidents))
          get-fields (fn [res]
                       (->> res
                            :parsed-body
@@ -120,113 +150,66 @@
                                        (-> % :title (= "title of test incident"))))))]
      [{:test-description (str "Should NOT return anything, because query field is missing."
                               "Asking for multiple things in the query, but not providing all the fields.")
-       :query-params     {:query_mode    "query_string"
-                          :query         "(title of test incident) AND (Log Review)"
+       :query-params     {:query_mode      "query_string"
+                          :query           "(title of test incident) AND (Log Review)"
                           :search_fields ["title"]}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (nil? (get-fields res))))}
 
       {:test-description "Should return an entity where multiple fields match"
-       :query-params     {:query_mode    "query_string"
-                          :query         "\"title of test incident\" AND \"Log Review\""
+       :query-params     {:query_mode      "query_string"
+                          :query           "\"title of test incident\" AND \"Log Review\""
                           :search_fields ["title" "discovery_method"]}
-       :bulk-gen         bulk
+       :bundle-gen       bundle
        :check            (fn [_ _ _ res]
                            (is (= 1 (-> res :parsed-body count)))
                            (is (get-fields res)))}])
 
    [{:test-description "multi_match - looking for the same value in different fields in multiple records"
-     :query-params     {:query_mode    "multi_match"
-                        :query         "bibendum"
+     :query-params     {:query_mode      "multi_match"
+                        :query           "bibendum"
                         :search_fields ["assignees" "title"]}
-     :bulk-gen         (gen/fmap
-                        (fn [examples]
+     :bundle-gen       (gen/fmap
+                        (fn [bundle]
                           (update
-                           examples :incidents
+                           bundle :incidents
                            (fn [incidents]
                              (apply
                               utils/update-items incidents
                               (repeat 3 ;; update first 3, leave the rest unchanged
                                       #(assoc % :title "Etiam vel neque bibendum dignissim"
                                               :assignees ["bibendum"]))))))
-                        (bulk-gen-for :incidents))
+                        (bundle-gen-for :incidents))
      :check            (fn [_ _ _ res]
                          (let [matching (->> res
                                              :parsed-body
                                              (filter #(and (-> % :assignees (= ["bibendum"]))
                                                            (-> % :title (= "Etiam vel neque bibendum dignissim")))))]
-                           (is (= 3 (count matching)))))}]
-
-   [{:test-description "searching for non-existing fields, returns errors"
-     :query-params     {:query         "*"
-                        :search_fields ["donec_retium_posuere_tellus"
-                                        "proin_neque_massa"]}
-     :bulk-gen         (bulk-gen-for :incidents)
-     :check            (fn [_ _ _ res]
-                         (is (= 400 (:status res))))}
-    {:test-description "searching for non-existing values, returns nothing"
-     :query-params     {:query "nullam tempus nulla posuere pellentesque dapibus suscipit ligula"}
-     :bulk-gen         (bulk-gen-for :incidents)
-     :check            (fn [_ _ _ res]
-                         (is (-> res :parsed-body empty?)))}]
-   [(let [bulk (gen/fmap (fn [examples]
-                           (update examples :assets
-                                   (fn [incidents]
-                                     (apply utils/update-items incidents
-                                            [;; update only the first record, leave the rest unchanged
-                                             #(assoc % :short_description "first incident"
-                                                     :title "Lorem Ipsum Test Incident"
-                                                     :tlp "white")]))))
-                         (bulk-gen-for :assets))]
-      {:test-description "searching within fields that don't contain the pattern, shall not return any results"
-       :query-params     {:query         "first Ipsum"
-                          :search_fields ["description"]}
-       :bulk-gen         bulk
-       :check            (fn [_ _ _ res] (is (-> res :parsed-body empty?)))}
-
-      {:test-description "searching in default fields that contain the pattern, yields results"
-       :query-params     {:query "\"first\" \"Ipsum\""}
-       :bulk-gen         bulk
-       :check            (fn [_ _ _ unparsed]
-                           (let [res (-> unparsed :parsed-body)]
-                             (is (= 1 (count res)))
-                             (is "first incident" (-> res first :short_description))
-                             (is "Lorem Ipsum Test Incident" (-> res first :title))))}
-      {:test-description (str "searching in non-default search fields that "
-                              "contain the pattern, shall not return any results")
-       :query-params     {:query "white"}
-       :bulk-gen         bulk
-       :check            (fn [_ _ _ res] (is (-> res :parsed-body empty?)))}
-
-      {:test-description "searching in a nested default field, yields results"
-       :query-params     {:query "\"lacinia purus\""}
-       :bulk-gen         (gen/fmap (fn [examples]
-                                     (update examples :sightings
-                                             (fn [sightings]
-                                               (apply utils/update-items sightings
-                                                      [;; update only the first record, leave the rest unchanged
-                                                       #(assoc-in % [:observables 0 :value] "lacinia purus")]))))
-                                   (bulk-gen-for :sightings))
-       :check            (fn [_ _ _ unparsed]
-                           (let [res (-> unparsed :parsed-body)]
-                            (is (= 1 (count res)))
-                            (is (-> res first :observables first :value (= "lacinia purus")))))})]))
+                           (is (= 3 (count matching)))))}]))
 
 (defn test-search-case
-  [app test-case]
-  (let [{:keys [query-params
-                bulk-gen
-                check
-                test-description]} test-case
-        examples (gen/generate bulk-gen)
-        ent-keys (keys examples)]
-    (helpers/POST-bulk app examples)
+  [app
+   {:keys [query-params
+           bundle-gen
+           check
+           test-description] :as test-case}]
+  (let [services (app/service-graph app)
+        bundle   (gen/generate bundle-gen)
+        ent-keys (->> bundle
+                      keys
+                      (filter (partial contains? bundle-entity-field-names)))]
+    (bundle/import-bundle
+     bundle
+     nil    ;; external-key-prefixes
+     login
+     services)
+
     (doseq [plural ent-keys]
-      (let [entity     (ffirst (helpers/plural-key->entity plural))
+      (let [entity (ffirst (helpers/plural-key->entity plural))
             search-res (th.search/search-raw app entity query-params)]
-        (testing test-description (check test-case plural examples search-res))
-        (th.search/delete-search app entity {:query "*"
-                                             :REALLY_DELETE_ALL_THESE_ENTITIES true})))))
+       (testing test-description (check test-case plural bundle search-res))
+       (th.search/delete-search app entity {:query "*"
+                                            :REALLY_DELETE_ALL_THESE_ENTITIES true})))))
 
 (deftest fulltext-search-test
   (es-helpers/for-each-es-version

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -1,20 +1,17 @@
 (ns ctia.http.routes.common-test
   (:require [clj-momo.test-helpers.core :as mth]
-            [clojure.set :as set]
-            [clojure.string :as string]
-            [clojure.test :refer [are deftest is testing use-fixtures]]
+            [clojure.instant :as inst]
+            [clojure.test :refer [are is deftest testing use-fixtures]]
             [ctia.auth.capabilities :refer [all-capabilities]]
-            [ctia.entity.incident :as incident]
+            [ctia.entity.incident :refer [incident-entity]]
             [ctia.http.routes.common :as sut]
-            [ctia.schemas.utils :as csu]
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.crud :refer [crud-wait-for-test]]
-            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.http :as http]
             [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctim.examples.incidents :refer [new-incident-maximal]]
-            [puppetlabs.trapperkeeper.app :as app]
-            [schema-tools.core :as st]
-            [schema.core :as s]))
+            [puppetlabs.trapperkeeper.app :as app]))
 
 (use-fixtures :once
               mth/fixture-schema-validation
@@ -36,88 +33,6 @@
       (is (= {:gte from
               :lt to}
              (sut/coerce-date-range from to))))))
-
-(deftest prep-es-fields-schema-test
-  (let [enum->set (fn [enum-schema]
-                    (->> enum-schema ffirst (apply hash-map) :vs))]
-    (are [fields result]
-        (is (= result
-               (some-> (sut/prep-es-fields-schema
-                        {:search-q-params   incident/IncidentSearchParams
-                         :searchable-fields fields})
-                       (st/get-in [:search_fields])
-                       enum->set))
-            (format "when %s passed, %s expected" fields result))
-      #{:foo :bar} #{"foo" "bar"}
-      #{:foo}      #{"foo"}
-      nil          nil))
-  (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
-    (is (= incident/IncidentSearchParams
-           (sut/prep-es-fields-schema  {:search-q-params incident/IncidentSearchParams})
-           (sut/prep-es-fields-schema  {:search-q-params   incident/IncidentSearchParams
-                                        :searchable-fields #{}})))))
-
-(deftest enforce-search-fields-test
-  (is (= {:search_fields ["foo" "foo-bar"]}
-         (sut/enforce-search-fields {} [:foo :foo-bar]))
-      "a query without search_fields forcibly gets some")
-  (is (= {:search_fields ["zap" "zop"]}
-         (sut/enforce-search-fields
-          {:search_fields ["zap" "zop"]}
-          [:foo :foo-bar]))
-      "a query with :search_fields retains search_fields")
-  (is (= {:search_fields []}
-         (sut/enforce-search-fields nil nil))
-      "a query without search_fields, adds the key"))
-
-(defn- entity-schema+searchable-fields
-  "Traverses through existing entities and grabs `schema` and
-  `searchable-fields` (if any) for each.
-  Returns a map where k/v pair is an entity key and a nested map with :schema
-  and :searchable-fields."
-  []
-  ;; get the entities loaded in 'ctia.entity.entities
-  ;; figure out the values of 'searchable-fields and 'schema
-  (let [vars (ns-map 'ctia.entity.entities)
-        ns-keys (->> vars keys (filter #(string/ends-with? % "-entity")))
-        namespaces (->> ns-keys
-                        (map #(some->> % (get vars)
-                                       symbol
-                                       find-var
-                                       meta
-                                       :ns))
-                        (zipmap
-                         (map (comp keyword #(string/replace % "-entity" ""))
-                              ns-keys)))
-        pluck (fn [ns var] (some->> var
-                                    (str ns "/")
-                                    symbol
-                                    resolve
-                                    deref))
-        pluck-searchable-fields (fn [entity-key]
-                                  (pluck
-                                   (get namespaces entity-key)
-                                   "searchable-fields"))
-        pluck-schema (fn [entity-key]
-                       (-> (get namespaces entity-key)
-                           (pluck (str (name entity-key) "-entity"))
-                           :schema))]
-    (zipmap
-     (keys namespaces)
-     (map
-      #(hash-map :searchable-fields (pluck-searchable-fields %)
-                 :schema (pluck-schema %))
-      (keys namespaces)))))
-
-(deftest searchable-fields-test
-  (testing "make sure :searchable-fields of an entity always points to existing key in the schema"
-    (doseq [[entity {:keys [searchable-fields schema]}] (entity-schema+searchable-fields)]
-      (when (seq searchable-fields)
-        (doseq [sf   searchable-fields
-                :let [path (->> (string/split (name sf) #"\.")
-                                (map keyword))]]
-          (is (csu/contains-key? schema path)
-              (format "%s contains %s key" entity (name sf))))))))
 
 (deftest search-query-test
   (with-redefs [sut/now (constantly #inst "2020-12-31")]
@@ -280,7 +195,7 @@
       (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
       (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
       (let [{{:keys [get-in-config]} :ConfigService} (app/service-graph app)
-            {:keys [entity] :as parameters} (into incident/incident-entity
+            {:keys [entity] :as parameters} (into incident-entity
                                                   {:app app
                                                    :example new-incident-maximal
                                                    :headers {:Authorization "45c1f5e3f05d0"}})

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -47,13 +47,12 @@
          :query-params query-params)))
 
 (defn search-text
-  [app entity text & [query-params]]
-  (search-raw app entity (merge {:query text}
-                                query-params)))
+  [app entity text]
+  (search-raw app entity {:query text}))
 
 (defn search-ids
-  [app entity query & [query-params]]
-  (->> (search-text app entity query query-params)
+  [app entity query]
+  (->> (search-text app entity query)
        :parsed-body
        (map :id)
        set))
@@ -153,7 +152,7 @@
       (is (empty? (search-ids app entity "wor"))))
 
     ;; test stop word filtering
-    (is (= matched-ids (search-ids app entity "the word" {:search_fields ["description"]}))
+    (is (= matched-ids (search-ids app entity "the word"))
         "\"the\" is not in text but should be filtered out from query as a stop word")
     (is (empty? (search-ids app entity "description:\"property that attack\""))
         "search_quote analyzer in describabble fields shall preserve stop words")
@@ -190,7 +189,8 @@
       (if (= "AND" default_operator)
         (is (= matched-ids found-ids-escaped)
             "escaping reserved characters should avoid parsing errors and preserve behavior of AND")
-        (is (set/subset? found-ids-escaped matched-ids)
+        (is (set/subset? (set/union matched-ids unmatched-ids)
+                         found-ids-escaped)
             ;; OR could match other test documents matching "http"
             "escaping reserved characters should avoid parsing errors and preserve behavior of OR"))
       (is (= matched-ids


### PR DESCRIPTION
We have found a few issues with ES5 and decided for now to revert
https://github.com/threatgrid/ctia/pull/1127

<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #
> Related #

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

