### PR TITLE
[POC DO NOT MERGE] high impact incident filter

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -1,8 +1,8 @@
 (ns ctia.entity.incident
   (:require [clj-momo.lib.clj-time.core :as time]
             [ctia.domain.entities :refer [default-realize-fn un-store with-long-id]]
-            [ctia.entity.incident.schemas :as is]
             [ctia.entity.incident.es-store :as i-store]
+            [ctia.entity.incident.schemas :as is]
             [ctia.flows.crud :as flows]
             [ctia.http.routes.common :as routes.common]
             [ctia.http.routes.crud :refer [services->entity-crud-routes]]

--- a/src/ctia/entity/incident/es_store.clj
+++ b/src/ctia/entity/incident/es_store.clj
@@ -1,0 +1,95 @@
+(ns ctia.entity.incident.es-store
+  (:require [ctia.entity.incident.schemas
+             :refer [PartialStoredIncident StoredIncident]]
+            [ctia.store :refer [IQueryStringSearchableStore IStore]]
+            [ctia.stores.es.mapping :as em]
+            [ctia.stores.es.store :refer [close-connections!]]
+            [ctia.stores.es.crud :as crud]
+            [schema.core :as s]
+            [ctia.schemas.search-agg :refer [SearchQuery]]))
+
+(def incident-mapping
+  {"incident"
+   {:dynamic false
+    :properties
+    (merge
+     em/base-entity-mapping
+     em/describable-entity-mapping
+     em/sourcable-entity-mapping
+     em/stored-entity-mapping
+     {:confidence em/token
+      :status em/token
+      :incident_time em/incident-time
+      :categories em/token
+      :discovery_method em/token
+      :intended_effect em/token
+      :assignees em/token
+      :promotion_method em/token})}})
+
+(def handle-create (crud/handle-create :incident StoredIncident))
+(def handle-update (crud/handle-update :incident StoredIncident))
+(def handle-read (crud/handle-read PartialStoredIncident))
+(def handle-delete (crud/handle-delete :incident))
+(def handle-list (crud/handle-find PartialStoredIncident))
+(def handle-bulk-delete crud/bulk-delete)
+(def handle-query-string-search (crud/handle-query-string-search PartialStoredIncident))
+(def handle-query-string-count crud/handle-query-string-count)
+(def handle-aggregate crud/handle-aggregate)
+(def handle-delete-search crud/handle-delete-search)
+
+(s/defn append-query-clause :- SearchQuery
+  [search-query  :- SearchQuery
+   str-lucene-clause :- s/Str]
+  (let [query (get-in search-query [:full-text :query])
+        lucene-query (cond->> str-lucene-clause
+                       query (str query " "))]
+    (assoc-in search-query [:full-text :query] lucene-query)))
+
+(s/defn prepare-impact :- SearchQuery
+  [conn-state
+   search-query :-  SearchQuery]
+  (let [get-in-config (get-in conn-state [:services :ConfigService :get-in-config])
+        high_impact_source (get-in-config [:ctia :incident :high-impact :source])
+        high_impact (get-in search-query [:filter-map :high_impact])]
+    (clojure.pprint/pprint get-in-config)
+    (cond-> search-query
+      (some? high_impact) (update :filter-map dissoc :high_impact)
+      (false? high_impact) (append-query-clause (format "-source:\"%s\"" high_impact_source))
+      (true? high_impact) (assoc-in [:filter-map :source] high_impact_source))))
+
+(defrecord IncidentStore [state]
+  IStore
+  (create-record [_ new-incidents ident params]
+    (handle-create state new-incidents ident params))
+  (read-record [_ id ident params]
+    (handle-read state id ident params))
+  (delete-record [_ id ident params]
+    (handle-delete state id ident params))
+  (update-record [_ id incident ident params]
+    (handle-update state id incident ident params))
+  (bulk-delete [_ ids ident params]
+    (handle-bulk-delete state ids ident params))
+  (list-records [_ filter-map ident params]
+    (handle-list state filter-map ident params))
+  (close [_] (close-connections! state))
+
+  IQueryStringSearchableStore
+  (query-string-search [_ search-query ident params]
+    (handle-query-string-search state
+                                (prepare-impact state search-query)
+                                ident
+                                params))
+  (query-string-count [_ search-query ident]
+    (handle-query-string-count state
+                               (prepare-impact state search-query)
+                               ident))
+  (aggregate [_ search-query agg-query ident]
+    (handle-aggregate state
+                      (prepare-impact state search-query)
+                      agg-query
+                      ident))
+  (delete-search [_ search-query ident params]
+    (handle-delete-search state
+                          (prepare-impact state search-query)
+                          ident
+                          params)))

--- a/src/ctia/entity/incident/graphql_schemas.clj
+++ b/src/ctia/entity/incident/graphql_schemas.clj
@@ -1,0 +1,37 @@
+(ns ctia.entity.incident.graphql-schemas
+  (:require [ctia.schemas.graphql.pagination :as pagination]
+            [ctim.schemas.incident :refer [Incident]]
+            [ctia.entity.incident.schemas :refer [incident-fields]]
+            [ctia.entity.feedback.graphql-schemas :as feedback]
+            [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
+            [ctia.schemas.graphql.flanders :as flanders]
+            [ctia.schemas.graphql.sorting :as graphql-sorting]
+            [flanders.utils :as fu]
+            [ctia.schemas.graphql.helpers :as g]
+            [ctia.schemas.graphql.ownership :as go]))
+
+
+(def IncidentType
+  (let [{:keys [fields name description]}
+        (flanders/->graphql
+         (fu/optionalize-all Incident)
+         {})]
+    (g/new-object
+     name
+     description
+     []
+     (merge fields
+            feedback/feedback-connection-field
+            relationship-graphql/relatable-entity-fields
+            go/graphql-ownership-fields))))
+
+(def IncidentConnectionType
+  (pagination/new-connection IncidentType))
+
+(def incident-order-arg
+  (graphql-sorting/order-by-arg
+   "IncidentOrder"
+   "incidents"
+   (into {}
+         (map (juxt graphql-sorting/sorting-kw->enum-name name)
+              incident-fields))))

--- a/src/ctia/entity/incident/graphql_schemas.clj
+++ b/src/ctia/entity/incident/graphql_schemas.clj
@@ -1,15 +1,14 @@
 (ns ctia.entity.incident.graphql-schemas
-  (:require [ctia.schemas.graphql.pagination :as pagination]
-            [ctim.schemas.incident :refer [Incident]]
+  (:require [ctia.entity.feedback.graphql-schemas :as feedback]
             [ctia.entity.incident.schemas :refer [incident-fields]]
-            [ctia.entity.feedback.graphql-schemas :as feedback]
             [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
             [ctia.schemas.graphql.flanders :as flanders]
-            [ctia.schemas.graphql.sorting :as graphql-sorting]
-            [flanders.utils :as fu]
             [ctia.schemas.graphql.helpers :as g]
-            [ctia.schemas.graphql.ownership :as go]))
-
+            [ctia.schemas.graphql.ownership :as go]
+            [ctia.schemas.graphql.pagination :as pagination]
+            [ctia.schemas.graphql.sorting :as graphql-sorting]
+            [ctim.schemas.incident :refer [Incident]]
+            [flanders.utils :as fu]))
 
 (def IncidentType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/incident/schemas.clj
+++ b/src/ctia/entity/incident/schemas.clj
@@ -1,0 +1,112 @@
+(ns ctia.entity.incident.schemas
+  (:require [ctia.schemas.core :refer [def-acl-schema def-stored-schema]]
+            [ctim.schemas.incident :as is]
+            [ctim.schemas.vocabularies :as vocs]
+            [ctia.http.routes.common :as routes.common]
+            [flanders.schema :as fs]
+            [flanders.utils :as fu]
+            [ctia.schemas.sorting
+             :refer
+             [default-entity-sort-fields
+              describable-entity-sort-fields
+              sourcable-entity-sort-fields]]
+            [schema-tools.core :as st]
+            [schema.core :as s]))
+
+(def-acl-schema Incident
+  is/Incident
+  "incident")
+
+(def-acl-schema PartialIncident
+  (fu/optionalize-all is/Incident)
+  "partial-incident")
+
+(s/defschema PartialIncidentList
+  [PartialIncident])
+
+(def-acl-schema NewIncident
+  is/NewIncident
+  "new-incident")
+
+(def-stored-schema StoredIncident Incident)
+
+(s/defschema PartialNewIncident
+  (st/optional-keys-schema NewIncident))
+
+(s/defschema PartialStoredIncident
+  (st/optional-keys-schema StoredIncident))
+
+
+(s/defschema IncidentStatus
+  (fs/->schema vocs/Status))
+
+(s/defschema IncidentStatusUpdate
+  {:status IncidentStatus})
+
+(def incident-fields
+  (concat default-entity-sort-fields
+          describable-entity-sort-fields
+          sourcable-entity-sort-fields
+          [:confidence
+           :status
+           :incident_time.opened
+           :incident_time.discovered
+           :incident_time.reported
+           :incident_time.remediated
+           :incident_time.closed
+           :incident_time.rejected
+           :discovery_method
+           :intended_effect
+           :assignees
+           :promotion_method]))
+
+(def incident-sort-fields
+  (apply s/enum incident-fields))
+
+(def incident-enumerable-fields
+  [:assignees
+   :categories
+   :confidence
+   :discovery_method
+   :intended_effect
+   :promotion_method
+   :source
+   :status
+   :title])
+
+(def incident-histogram-fields
+  [:timestamp
+   :incident_time.opened
+   :incident_time.discovered
+   :incident_time.reported
+   :incident_time.remediated
+   :incident_time.closed
+   :incident_time.rejected])
+
+(s/defschema IncidentFieldsParam
+  {(s/optional-key :fields) [incident-sort-fields]})
+
+(s/defschema IncidentSearchParams
+  (st/merge
+   routes.common/PagingParams
+   routes.common/BaseEntityFilterParams
+   routes.common/SourcableEntityFilterParams
+   routes.common/SearchableEntityParams
+   IncidentFieldsParam
+   (st/optional-keys
+    {:confidence       s/Str
+     :status           s/Str
+     :discovery_method s/Str
+     :intended_effect  s/Str
+     :categories       s/Str
+     :sort_by          incident-sort-fields
+     :assignees        s/Str
+     :promotion_method s/Str
+     :high_impact      s/Bool})))
+
+(def IncidentGetParams IncidentFieldsParam)
+
+(s/defschema IncidentByExternalIdQueryParams
+  (st/merge
+   routes.common/PagingParams
+   IncidentFieldsParam))

--- a/src/ctia/entity/incident/schemas.clj
+++ b/src/ctia/entity/incident/schemas.clj
@@ -1,15 +1,15 @@
 (ns ctia.entity.incident.schemas
-  (:require [ctia.schemas.core :refer [def-acl-schema def-stored-schema]]
-            [ctim.schemas.incident :as is]
-            [ctim.schemas.vocabularies :as vocs]
-            [ctia.http.routes.common :as routes.common]
-            [flanders.schema :as fs]
-            [flanders.utils :as fu]
+  (:require [ctia.http.routes.common :as routes.common]
+            [ctia.schemas.core :refer [def-acl-schema def-stored-schema]]
             [ctia.schemas.sorting
              :refer
              [default-entity-sort-fields
               describable-entity-sort-fields
               sourcable-entity-sort-fields]]
+            [ctim.schemas.incident :as is]
+            [ctim.schemas.vocabularies :as vocs]
+            [flanders.schema :as fs]
+            [flanders.utils :as fu]
             [schema-tools.core :as st]
             [schema.core :as s]))
 
@@ -35,7 +35,6 @@
 
 (s/defschema PartialStoredIncident
   (st/optional-keys-schema StoredIncident))
-
 
 (s/defschema IncidentStatus
   (fs/->schema vocs/Status))

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -7,7 +7,7 @@
    [ctia.entity.attack-pattern :as attack-pattern :refer [AttackPatternConnectionType AttackPatternType]]
    [ctia.entity.casebook :as casebook :refer [CasebookConnectionType CasebookType]]
    [ctia.entity.entities :as entities]
-   [ctia.entity.incident :as incident :refer [IncidentConnectionType IncidentType]]
+   [ctia.entity.incident.graphql-schemas :as incident :refer [IncidentConnectionType IncidentType]]
    [ctia.entity.indicator :as indicator :refer [IndicatorConnectionType IndicatorType]]
    [ctia.entity.investigation.graphql-schemas :as investigation :refer [InvestigationConnectionType InvestigationType]]
    [ctia.entity.judgement :as judgement :refer [JudgementConnectionType JudgementType]]

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -175,7 +175,9 @@
                       "ctia.hooks.before-delete" s/Str
                       "ctia.hooks.after-delete" s/Str
 
-                      "ctia.metrics.console.enabled" s/Bool
+                      "ctia.incident.high-impact.source" s/Str
+
+                     "ctia.metrics.console.enabled" s/Bool
                       "ctia.metrics.console.interval" s/Int
                       "ctia.metrics.jmx.enabled" s/Bool
                       "ctia.metrics.riemann.enabled" s/Bool
@@ -198,15 +200,8 @@
                       "ctia.migration.batch-size" s/Int
                       "ctia.migration.buffer-size" s/Int
 
-                      "ctia.store.asset" s/Str
-                      "ctia.store.asset-properties" s/Str
-                      "ctia.store.asset-mapping" s/Str
                       "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
-
-                      "ctia.store.es.asset.indexname" s/Str
-                      "ctia.store.es.asset-properties.indexname" s/Str
-                      "ctia.store.es.asset-mapping.indexname" s/Str
 
                       "ctia.store.es.event.slicing.granularity"
                       (s/enum :minute :hour :day :week :month :year)})

--- a/test/ctia/entity/incident/es_store_test.clj
+++ b/test/ctia/entity/incident/es_store_test.clj
@@ -1,0 +1,42 @@
+(ns ctia.entity.incident.es-store-test
+  (:require [ctia.entity.incident.es-store :as sut]
+            [clojure.test :refer [deftest is]]))
+
+
+(deftest append-query-clause-test
+  (is (= {:filter-map {:title "ho no..."}
+          :full-text {:query "source:-AMP"}}
+         (sut/append-query-clause {:filter-map {:title "ho no..."}}
+                                  "source:-AMP")))
+  (is (= {:filter-map {:title "ho no..."}
+          :full-text {:query "ransomware assignees:guigui"}}
+         (sut/append-query-clause {:filter-map {:title "ho no..."}
+                                   :full-text {:query "ransomware"}}
+                                  "assignees:guigui"))))
+
+(deftest prepare-impact
+  (let [fake-config #(get-in {:ctia {:incident {:high-impact {:source "fake source"}}}}
+                             %)
+        fake-conn-state {:services {:ConfigService {:get-in-config fake-config}}}]
+    (is (= {:filter-map {:title "ho no..."}
+            :full-text {:query "-source:\"fake source\""}}
+           (sut/prepare-impact fake-conn-state
+                               {:filter-map {:title "ho no..."
+                                             :high_impact false}})))
+    (is (= {:filter-map {:title "ho no..."
+                         :source "fake source"}}
+           (sut/prepare-impact fake-conn-state
+                               {:filter-map {:title "ho no..."
+                                             :high_impact true}})))
+
+    (is (= {:filter-map {:title "ho no..."
+                         :source "fake source"}
+            :full-text {:query "lucene"}}
+           (sut/prepare-impact fake-conn-state
+                               {:filter-map {:title "ho no..."
+                                             :high_impact true}
+                                :full-text {:query "lucene"}})))
+
+    (is (= {:filter-map {:title "ho no..."}}
+           (sut/prepare-impact fake-conn-state
+                               {:filter-map {:title "ho no..."}})))))

--- a/test/ctia/entity/incident/es_store_test.clj
+++ b/test/ctia/entity/incident/es_store_test.clj
@@ -3,35 +3,40 @@
             [clojure.test :refer [deftest is]]))
 
 
-(deftest append-query-clause-test
+(deftest append-query-clausse-test
   (is (= {:filter-map {:title "ho no..."}
           :full-text {:query "source:-AMP"}}
-         (sut/append-query-clause {:filter-map {:title "ho no..."}}
-                                  "source:-AMP")))
+         (sut/append-query-clauses {:filter-map {:title "ho no..."}}
+                                   ["source:-AMP"])))
   (is (= {:filter-map {:title "ho no..."}
-          :full-text {:query "ransomware assignees:guigui"}}
-         (sut/append-query-clause {:filter-map {:title "ho no..."}
-                                   :full-text {:query "ransomware"}}
-                                  "assignees:guigui"))))
+          :full-text {:query "(assignees:guigui) AND (ransomware)"}}
+         (sut/append-query-clauses {:filter-map {:title "ho no..."}
+                                    :full-text {:query "ransomware"}}
+                                   ["assignees:guigui"])))
+  (is (= {:filter-map {:title "ho no..."}
+          :full-text {:query "(assignees:guigui OR source:-amp) AND (ransomware)"}}
+         (sut/append-query-clauses {:filter-map {:title "ho no..."}
+                                    :full-text {:query "ransomware"}}
+                                   ["assignees:guigui" "source:-amp"]))))
 
 (deftest prepare-impact
-  (let [fake-config #(get-in {:ctia {:incident {:high-impact {:source "fake source"}}}}
+  (let [sources "source1,source2"
+        fake-config #(get-in {:ctia {:incident {:high-impact {:source sources}}}}
                              %)
         fake-conn-state {:services {:ConfigService {:get-in-config fake-config}}}]
     (is (= {:filter-map {:title "ho no..."}
-            :full-text {:query "-source:\"fake source\""}}
+            :full-text {:query "-source:\"source1\" OR -source:\"source2\""}}
            (sut/prepare-impact fake-conn-state
                                {:filter-map {:title "ho no..."
                                              :high_impact false}})))
-    (is (= {:filter-map {:title "ho no..."
-                         :source "fake source"}}
+    (is (= {:filter-map {:title "ho no..."}
+            :full-text {:query "source:\"source1\" OR source:\"source2\""}}
            (sut/prepare-impact fake-conn-state
                                {:filter-map {:title "ho no..."
                                              :high_impact true}})))
 
-    (is (= {:filter-map {:title "ho no..."
-                         :source "fake source"}
-            :full-text {:query "lucene"}}
+    (is (= {:filter-map {:title "ho no..."}
+            :full-text {:query "(source:\"source1\" OR source:\"source2\") AND (lucene)"}}
            (sut/prepare-impact fake-conn-state
                                {:filter-map {:title "ho no..."
                                              :high_impact true}

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -81,14 +81,21 @@
                                "ctia/incident"
                                :body (assoc incident :source "ngfw")
                                :headers {"Authorization" "45c1f5e3f05d0"}))
-        high-impact (:parsed-body
-                     (POST app
-                           "ctia/incident?wait_for=true"
-                           :body (assoc new-incident-minimal
-                                        :source "secure endpoint")
-                           :headers {"Authorization" "45c1f5e3f05d0"}))
+        high-impact-1 (:parsed-body
+                       (POST app
+                             "ctia/incident"
+                             :body (assoc new-incident-minimal
+                                          :source "highsource")
+                             :headers {"Authorization" "45c1f5e3f05d0"}))
+        high-impact-2 (:parsed-body
+                       (POST app
+                             "ctia/incident?wait_for=true"
+                             :body (assoc new-incident-minimal
+                                          :source "ao")
+                             :headers {"Authorization" "45c1f5e3f05d0"}))
         _ (assert (map? not-high-impact))
-        _ (assert (map? high-impact))
+        _ (assert (map? high-impact-1))
+        _ (assert (map? high-impact-2))
         test-fn (fn [{:keys [msg high-impact? expected-entities]}]
                   (testing msg
                     (let [path (cond-> "ctia/incident/search"
@@ -102,13 +109,13 @@
                              (set found-ids))))))
         test-plan [{:msg "Only high impact incidents shall be returned when high_impact is true"
                     :high-impact? true
-                    :expected-entities [high-impact]}
+                    :expected-entities [high-impact-1 high-impact-2]}
                    {:msg "Only non high impact incidents shall be returned when high_impact is false"
                     :high-impact? false
                     :expected-entities [not-high-impact]}
                    {:msg "The impact of an incident is ignored by default"
                     :high-impact? nil
-                    :expected-entities [high-impact not-high-impact]}]]
+                    :expected-entities [high-impact-1 high-impact-2 not-high-impact]}]]
     (doseq [test-case test-plan]
       (test-fn test-case))))
 
@@ -119,7 +126,7 @@
 
 (deftest test-incident-crud-routes
   (helpers/with-properties
-    ["ctia.incident.high-impact.source" "secure endpoint"]
+    ["ctia.incident.high-impact.source" "highsource,ao"]
     (test-for-each-store-with-app
      (fn [app]
        (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -1,26 +1,25 @@
 (ns ctia.entity.incident-test
-  (:require [clj-momo.lib.clj-time
-             [coerce :as tc]
-             [core :as t]]
+  (:require [clj-momo.lib.clj-time.coerce :as tc]
+            [clj-momo.lib.clj-time.core :as t]
             [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [ctia.entity.incident :as sut]
-            [ctia.test-helpers
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [PATCH POST]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [store :refer [test-for-each-store-with-app]]]
+            [ctia.entity.incident.schemas
+             :refer [incident-enumerable-fields incident-histogram-fields]]
+            [ctia.test-helpers.access-control :refer [access-control-test]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers :refer [PATCH POST GET]]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.examples.incidents
-             :refer
-             [new-incident-maximal new-incident-minimal]]))
+             :refer [new-incident-maximal new-incident-minimal]]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
 
-(defn partial-operations-tests [app incident-id incident]
+(defn partial-operations-tests [app incident-id]
   (let [fixed-now (t/internal-now)]
     (helpers/fixture-with-fixed-time
      fixed-now
@@ -29,8 +28,7 @@
          (let [response (PATCH app
                                (str "ctia/incident/" (:short-id incident-id))
                                :body {:incident_time {}}
-                               :headers {"Authorization" "45c1f5e3f05d0"})
-               updated-incident (:parsed-body response)]
+                               :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 200 (:status response)))))
 
        (testing "POST /ctia/incident/:id/status Open"
@@ -40,6 +38,7 @@
                               :body new-status
                               :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
+           (clojure.pprint/pprint response)
            (is (= 200 (:status response)))
            (is (= "Open" (:status updated-incident)))
            (is (get-in updated-incident [:incident_time :opened]))
@@ -75,24 +74,69 @@
            (is (= (get-in updated-incident [:incident_time :remediated])
                   (tc/to-date fixed-now)))))))))
 
+(defn test-high-impact-incident
+  [app incident]
+  (let [not-high-impact (:parsed-body
+                         (POST app
+                               "ctia/incident"
+                               :body (assoc incident :source "ngfw")
+                               :headers {"Authorization" "45c1f5e3f05d0"}))
+        high-impact (:parsed-body
+                     (POST app
+                           "ctia/incident?wait_for=true"
+                           :body (assoc new-incident-minimal
+                                        :source "secure endpoint")
+                           :headers {"Authorization" "45c1f5e3f05d0"}))
+        _ (assert (map? not-high-impact))
+        _ (assert (map? high-impact))
+        test-fn (fn [{:keys [msg high-impact? expected-entities]}]
+                  (testing msg
+                    (let [path (cond-> "ctia/incident/search"
+                                 (some? high-impact?) (str "?high_impact=" high-impact?))
+                          search-res (GET app
+                                          path
+                                          :headers {"Authorization" "45c1f5e3f05d0"})
+                          found-ids (->> search-res :parsed-body (map :id))]
+                      (is (= 200 (:status search-res)))
+                      (is (= (set (map :id expected-entities))
+                             (set found-ids))))))
+        test-plan [{:msg "Only high impact incidents shall be returned when high_impact is true"
+                    :high-impact? true
+                    :expected-entities [high-impact]}
+                   {:msg "Only non high impact incidents shall be returned when high_impact is false"
+                    :high-impact? false
+                    :expected-entities [not-high-impact]}
+                   {:msg "The impact of an incident is ignored by default"
+                    :high-impact? nil
+                    :expected-entities [high-impact not-high-impact]}]]
+    (doseq [test-case test-plan]
+      (test-fn test-case))))
+
+(defn crud-additional-tests
+  [app incident-id incident]
+  (partial-operations-tests app incident-id)
+  (test-high-impact-incident app incident))
+
 (deftest test-incident-crud-routes
-  (test-for-each-store-with-app
-   (fn [app]
-     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-     (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
-     (let [parameters (into sut/incident-entity
-                            {:app app
-                             :patch-tests? true
-                             :example new-incident-maximal
-                             :headers {:Authorization "45c1f5e3f05d0"}
-                             :additional-tests partial-operations-tests})]
-       (entity-crud-test parameters)))))
+  (helpers/with-properties
+    ["ctia.incident.high-impact.source" "secure endpoint"]
+    (test-for-each-store-with-app
+     (fn [app]
+       (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+       (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
+       (let [parameters (into sut/incident-entity
+                              {:app app
+                               :patch-tests? true
+                               :example new-incident-maximal
+                               :headers {:Authorization "45c1f5e3f05d0"}
+                               :additional-tests crud-additional-tests})]
+         (entity-crud-test parameters))))))
 
 (deftest test-incident-metric-routes
   (test-metric-routes (into sut/incident-entity
                             {:entity-minimal new-incident-minimal
-                             :enumerable-fields sut/incident-enumerable-fields
-                             :date-fields sut/incident-histogram-fields})))
+                             :enumerable-fields incident-enumerable-fields
+                             :date-fields incident-histogram-fields})))
 
 (deftest test-incident-routes-access-control
   (access-control-test "incident"

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -1,6 +1,9 @@
 (ns ctia.http.routes.graphql.incident-test
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.entity.incident.schemas :refer [incident-fields]]
+            [ctia.entity.feedback.schemas :refer [feedback-fields]]
+            [ctia.entity.relationship.schemas :refer [relationship-fields]]
             [ctia.test-helpers
              [auth :refer [all-capabilities]]
              [core :as helpers]
@@ -127,7 +130,7 @@
                 graphql-queries
                 {:id incident-1-id}
                 [:incident :relationships]
-                ctia.entity.relationship.schemas/relationship-fields)))
+                relationship-fields)))
 
            (testing "feedbacks connection"
              (gh/connection-test app
@@ -145,7 +148,7 @@
                 graphql-queries
                 {:id incident-1-id}
                 [:incident :feedbacks]
-                ctia.entity.feedback.schemas/feedback-fields))))
+                feedback-fields))))
          (testing "incidents query"
            (testing "incidents connection"
              (gh/connection-test app
@@ -164,7 +167,7 @@
                 graphql-queries
                 {:query "*"}
                 [:incidents]
-                ctia.entity.incident/incident-fields)))
+                incident-fields)))
 
            (testing "query argument"
              (let [{:keys [data errors status]}

--- a/test/ctia/task/migration/migrations_test.clj
+++ b/test/ctia/task/migration/migrations_test.clj
@@ -1,6 +1,6 @@
 (ns ctia.task.migration.migrations-test
   (:require [clojure.test :refer [deftest is]]
-            [ctia.entity.incident :refer [StoredIncident]]
+            [ctia.entity.incident.schemas :refer [StoredIncident]]
             [ctia.task.migration.migrations :as sut]
             [schema.core :as s]))
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** https://github.com/threatgrid/response/issues/837
> Related https://github.com/advthreat/iroh/issues/5633
> Related https://github.com/advthreat/iroh/issues/5685

This PR implements the last definition of high impact incidents: incidents which come from secure endpoint.
It adds a `high_impact` parameter to the incident search params. When added it modifies the query to filter on the right source value.
Since the processing of this parameter is specific to the incidents, it's processing is done at the store level. Then we implement a dedicated store for incident.
I split incident in store and schema. The non refacto changes are:
- incident store, [ctia.entity.incident.es-store](https://github.com/threatgrid/ctia/pull/1145/files#diff-b90613956baca1c05ec12a9fd21ee3a0cc56dd437de90565864064d6cee8bc47)
- incident store tests, [ctia.entity.incident.es-store-test](https://github.com/threatgrid/ctia/pull/1145/files#diff-bac4023f7516a485c8d958f0549782db892d40d44dd301a38cf4cda5863cd107)
- incident additional search tests, [ctia.entity.incident-test](https://github.com/threatgrid/ctia/pull/1145/files#diff-13536891658e3f88756e547592bfab86d330fe3638956456d02439e9feba34bf)

<a name="qa">[§](#qa)</a> QA
============================

1. create incidents with the `source` value `secure endpoint` and incidents with other `source` values (e.g. `ngfw`, `stealthwatch`).
2. `GET /ctia/incident/search` without any parameter returns all incidents.
3. `GET /ctia/incident/search?high_impact=true` returns only incidents with `source` value EQUAL TO `secure endpoint`.
4. `GET /ctia/incident/search?high_impact=false` returns only incidents with `source` value DIFFERENT FROM `secure endpoint`.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: high impact incident filter in CTIA
```
