### PR TITLE
Add client id to stored entities

### DIFF
--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -3,6 +3,7 @@
 
 (defprotocol IIdentity
   (authenticated? [this])
+  (client-id [this])
   (login [this])
   (groups [this])
   (allowed-capabilities [this])
@@ -11,6 +12,8 @@
 
 (defprotocol IAuth
   (identity-for-token [this token]))
+
+(def not-logged-client-id nil)
 
 (def not-logged-in-owner "Unknown")
 
@@ -22,6 +25,8 @@
   IIdentity
   (authenticated? [_]
     false)
+  (client-id [_]
+    not-logged-client-id)
   (login [_]
     not-logged-in-owner)
   (groups [_]
@@ -34,9 +39,14 @@
 
 (def denied-identity-singleton (->DeniedIdentity))
 
-(s/defn ident->map :- (s/maybe {:login (s/maybe s/Str)
-                                :groups (s/maybe [s/Str])})
+(s/defschema IdentityMap
+  {:client-id (s/maybe s/Str)
+   :login (s/maybe s/Str)
+   :groups (s/maybe [s/Str])})
+
+(s/defn ident->map :- (s/maybe IdentityMap)
   [ident]
   (when ident
     {:login (login ident)
-     :groups (groups ident)}))
+     :groups (groups ident)
+     :client-id (client-id ident)}))

--- a/src/ctia/auth/allow_all.clj
+++ b/src/ctia/auth/allow_all.clj
@@ -1,6 +1,5 @@
 (ns ctia.auth.allow-all
-  (:require [clj-momo.lib.set :refer [as-set]]
-            [ctia.auth.capabilities :refer [all-capabilities]]
+  (:require [ctia.auth.capabilities :refer [all-capabilities]]
             [ctia.auth
              :refer [IIdentity IAuth]
              :as auth]
@@ -10,6 +9,8 @@
   IIdentity
   (authenticated? [_]
     true)
+  (client-id [_]
+    auth/not-logged-client-id)
   (login [_]
     auth/not-logged-in-owner)
   (groups [_]

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -26,6 +26,8 @@
   IIdentity
   (authenticated? [_]
     true)
+  (client-id [_]
+    auth/not-logged-client-id)
   (login [_]
     name)
   (groups [_]
@@ -41,6 +43,8 @@
   IIdentity
   (authenticated? [_]
     true)
+  (client-id [_]
+    auth/not-logged-client-id)
   (login [_]
     auth/not-logged-in-owner)
   (groups [_]

--- a/src/ctia/auth/threatgrid.clj
+++ b/src/ctia/auth/threatgrid.clj
@@ -28,6 +28,8 @@
   auth/IIdentity
   (authenticated? [_]
     true)
+  (client-id [_]
+    auth/not-logged-client-id)
   (login [_]
     login)
   (groups [_]

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -36,7 +36,7 @@
                     time/default-expire-date)}})
 
 (defn default-realize
-  [type-name Model new-object id ident-map prev-object services]
+  [{:keys [type-name Model new-object id ident-map prev-object services]}]
   (let [{{{:keys [get-in-config]} :ConfigService} :services} services
         {:keys [login groups client-id]} ident-map
         now (time/now)
@@ -48,9 +48,7 @@
                                 :schema_version schema-version
                                 :created (or (:created prev-object) now)
                                 :modified now
-                                :timestamp (or (:timestamp new-object)
-                                               (:timestamp prev-object)
-                                               now)
+                                :timestamp (or (:timestamp new-object) now)
                                 :tlp (:tlp new-object
                                            (:tlp prev-object (properties-default-tlp get-in-config)))})]
     (cond-> with-base-fields
@@ -80,7 +78,14 @@
       prev-object :- (s/maybe StoredModel)]
     (delayed/fn :- StoredModel
                 [services :- GraphQLRuntimeContext]
-                (default-realize type-name Model new-object id ident-map prev-object services)))))
+      (default-realize
+       {:type-name type-name
+        :Model Model
+        :new-object new-object
+        :id id
+        :ident-map ident-map
+        :prev-object prev-object
+        :services services})))))
 
 (s/defn short-id->long-id [id services :- HTTPShowServices]
   (id/short-id->long-id id #(get-http-show services)))

--- a/src/ctia/entity/feedback/schemas.clj
+++ b/src/ctia/entity/feedback/schemas.clj
@@ -1,6 +1,5 @@
 (ns ctia.entity.feedback.schemas
-  (:require [clj-momo.lib.time :as time]
-            [ctia.domain
+  (:require [ctia.domain
              [entities :refer [default-realize-fn]]]
             [ctia.schemas
              [core :refer [def-acl-schema def-stored-schema TempIDs]]

--- a/src/ctia/entity/judgement/schemas.clj
+++ b/src/ctia/entity/judgement/schemas.clj
@@ -1,5 +1,6 @@
 (ns ctia.entity.judgement.schemas
-  (:require [ctia.domain
+  (:require [ctia.auth :as auth]
+            [ctia.domain
              [entities :refer [default-realize-fn]]]
             [ctia.graphql.delayed :as delayed]
             [ctia.schemas
@@ -43,13 +44,12 @@
   (default-realize-fn "judgement" NewJudgement StoredJudgement))
 
 (s/defn realize-judgement :- (RealizeFnResult (with-error StoredJudgement))
-  ([new-judgement id tempids owner groups]
-   (realize-judgement new-judgement id tempids owner groups nil))
+  ([new-judgement id tempids ident-map]
+   (realize-judgement new-judgement id tempids ident-map nil))
   ([new-judgement :- NewJudgement
     id :- s/Str
     tempids :- (s/maybe TempIDs)
-    owner :- s/Str
-    groups :- [s/Str]
+    ident-map :- auth/IdentityMap
     prev-judgement :- (s/maybe StoredJudgement)]
   (delayed/fn :- (with-error StoredJudgement)
    [rt-ctx :- GraphQLRuntimeContext]
@@ -62,7 +62,7 @@
         (assoc new-judgement
                :disposition disposition
                :disposition_name disposition-name)
-        id tempids owner groups prev-judgement))
+        id tempids ident-map prev-judgement))
      (catch clojure.lang.ExceptionInfo e
        (let [{error-type :type} (ex-data e)]
          (if (= error-type :ctim.schemas.common/disposition-missing)

--- a/src/ctia/entity/sighting/schemas.clj
+++ b/src/ctia/entity/sighting/schemas.clj
@@ -1,16 +1,15 @@
 (ns ctia.entity.sighting.schemas
-  (:require [clj-momo.lib.time :as time]
-            [ctia.domain
-             [entities :refer [default-realize-fn]]]
+  (:require [ctia.domain.entities :refer [default-realize-fn]]
+            [ctia.auth :as auth]
             [ctia.graphql.delayed :as delayed]
-            [ctia.schemas
-             [core :refer [def-acl-schema
-                           def-stored-schema
-                           GraphQLRuntimeContext
-                           lift-realize-fn-with-context
-                           RealizeFnResult
-                           TempIDs]]
-             [sorting :as sorting]]
+            [ctia.schemas.core
+             :refer [def-acl-schema
+                     def-stored-schema
+                     GraphQLRuntimeContext
+                     lift-realize-fn-with-context
+                     RealizeFnResult
+                     TempIDs]]
+            [ctia.schemas.sorting :as sorting]
             [ctim.schemas.sighting :as ss]
             [flanders.utils :as fu]
             [schema-tools.core :as st]
@@ -40,13 +39,12 @@
   (default-realize-fn "sighting" NewSighting StoredSighting))
 
 (s/defn realize-sighting :- (RealizeFnResult StoredSighting)
-  ([new-sighting id tempids owner groups]
-   (realize-sighting new-sighting id tempids owner groups nil))
+  ([new-sighting id tempids ident-map]
+   (realize-sighting new-sighting id tempids ident-map nil))
   ([new-sighting :- NewSighting
     id :- s/Str
     tempids :- (s/maybe TempIDs)
-    owner :- s/Str
-    groups :- [s/Str]
+    ident-map :- auth/IdentityMap
     prev-sighting :- (s/maybe StoredSighting)]
   (delayed/fn :- StoredSighting
    [rt-ctx :- GraphQLRuntimeContext]
@@ -56,7 +54,7 @@
                           (:count prev-sighting 1))
            :confidence (:confidence new-sighting
                                     (:confidence prev-sighting "Unknown")))
-    id tempids owner groups prev-sighting))))
+    id tempids ident-map prev-sighting))))
 
 (def sighting-fields
   (concat sorting/default-entity-sort-fields

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -156,8 +156,7 @@
            tempids
            find-entity-id
            get-prev-entity] :as fm} :- FlowMap]
-  (let [login (auth/login identity)
-        groups (auth/groups identity)
+  (let [identity-map (auth/ident->map identity)
         realize-fn (lift-realize-fn-with-context
                      (:realize-fn fm)
                      {:services (APIHandlerServices->RealizeFnServices
@@ -174,20 +173,17 @@
                         :create (realize-fn entity
                                             entity-id
                                             tempids
-                                            login
-                                            groups)
+                                            identity-map)
                         :update (if-let [prev-entity (get-prev-entity entity-id)]
                                   (realize-fn entity
                                               entity-id
                                               tempids
-                                              login
-                                              groups
+                                              identity-map
                                               prev-entity)
                                   (realize-fn entity
                                               entity-id
                                               tempids
-                                              login
-                                              groups))
+                                              identity-map))
                         :delete entity)))))))
 
 (s/defn ^:private throw-validation-error

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -198,15 +198,8 @@
                       "ctia.migration.batch-size" s/Int
                       "ctia.migration.buffer-size" s/Int
 
-                      "ctia.store.asset" s/Str
-                      "ctia.store.asset-properties" s/Str
-                      "ctia.store.asset-mapping" s/Str
                       "ctia.store.bulk-refresh" Refresh
                       "ctia.store.bundle-refresh" Refresh
-
-                      "ctia.store.es.asset.indexname" s/Str
-                      "ctia.store.es.asset-properties.indexname" s/Str
-                      "ctia.store.es.asset-mapping.indexname" s/Str
 
                       "ctia.store.es.event.slicing.granularity"
                       (s/enum :minute :hour :day :week :month :year)})

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -60,6 +60,7 @@
    :owner s/Str
    :groups [s/Str]
    :created java.util.Date
+   (s/optional-key :client_id) s/Str
    (s/optional-key :modified) java.util.Date})
 
 (s/defschema RealizeFnServices
@@ -209,6 +210,7 @@
    (st/optional-keys
     {:authorized_users [Str]
      :authorized_groups [Str]
+     :client_id s/Str
      :owner s/Str
      :groups [s/Str]})))
 

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -72,7 +72,8 @@
    :source_uri token})
 
 (def stored-entity-mapping
-  {:owner token
+  {:client_id token
+   :owner token
    :groups token
    :authorized_users token
    :authorized_groups token

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -506,6 +506,7 @@
   (authenticated? [_] true)
   (login [_] login)
   (groups [_] groups)
+  (client-id [_] nil)
   (allowed-capabilities [_] #{})
   (capable? [_ _] true)
   (rate-limit-fn [_ _] false))

--- a/test/ctia/domain/entities_test.clj
+++ b/test/ctia/domain/entities_test.clj
@@ -13,15 +13,15 @@
                      {:access-control {:default-tlp "green"}}}}}}
         new-sighting-minimal (assoc (dissoc sighting-minimal :id)
                                     :source "create")
-        realized-create (sut/default-realize "sighting"
-                                             ss/NewSighting
-                                             new-sighting-minimal
-                                             "sighting-id-1"
-                                             {:login "g2"
-                                              :groups ["iroh-services"]
-                                              :client-id "ireaux"}
-                                             nil
-                                             services)]
+        realized-create (sut/default-realize {:type-name "sighting"
+                                              :Model ss/NewSighting
+                                              :new-object new-sighting-minimal
+                                              :id "sighting-id-1"
+                                              :ident-map {:login "g2"
+                                                          :groups ["iroh-services"]
+                                                          :client-id "ireaux"}
+                                              :prev-object nil
+                                              :services services})]
     (testing "realized fn without previous object shall initiate all stored field"
       (is-submap? new-sighting-minimal realized-create)
       (is-submap? {:client_id "ireaux",
@@ -40,15 +40,15 @@
     (testing "realized fn with a previous object shall preserve previous stored field and update modified"
       (let [new-sighting-maximal (assoc (dissoc sighting-maximal :id)
                                         :source "update")
-            realized-update (sut/default-realize "sighting"
-                                                 ss/NewSighting
-                                                 new-sighting-maximal
-                                                 "sighting-id-2"
-                                                 {:login "update-login"
-                                                  :groups ["update-group"]
-                                                  :client-id "iroh"}
-                                                 realized-create
-                                                 services)]
+            realized-update (sut/default-realize {:type-name "sighting"
+                                                  :Model ss/NewSighting
+                                                  :new-object new-sighting-maximal
+                                                  :id "sighting-id-2"
+                                                  :ident-map {:login "update-login"
+                                                              :groups ["update-group"]
+                                                              :client-id "iroh"}
+                                                  :prev-object realized-create
+                                                  :services services})]
         (is-submap? new-sighting-maximal realized-update)
         (is-submap? {:client_id "ireaux",
                      :schema_version "1.1.3",

--- a/test/ctia/domain/entities_test.clj
+++ b/test/ctia/domain/entities_test.clj
@@ -1,0 +1,67 @@
+(ns ctia.domain.entities-test
+  (:require [ctia.domain.entities :as sut]
+            [ctim.examples.sightings :refer [sighting-minimal sighting-maximal]]
+            [ctia.entity.sighting.schemas :as ss]
+            [ctia.test-helpers.collections :refer [is-submap?]]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest simple-default-realize
+  (let [services {:services
+                  {:ConfigService
+                   {:get-in-config
+                    {:ctia
+                     {:access-control {:default-tlp "green"}}}}}}
+        new-sighting-minimal (assoc (dissoc sighting-minimal :id)
+                                    :source "create")
+        realized-create (sut/default-realize "sighting"
+                                             ss/NewSighting
+                                             new-sighting-minimal
+                                             "sighting-id-1"
+                                             {:login "g2"
+                                              :groups ["iroh-services"]
+                                              :client-id "ireaux"}
+                                             nil
+                                             services)]
+    (testing "realized fn without previous object shall initiate all stored field"
+      (is-submap? new-sighting-minimal realized-create)
+      (is-submap? {:client_id "ireaux",
+                   :schema_version "1.1.3",
+                   :type "sighting",
+                   :id "sighting-id-1",
+                   :tlp "green",
+                   :groups ["iroh-services"],
+                   :owner "g2"}
+                  realized-create)
+      (is (some? (:created realized-create)))
+      (is (= (:modified realized-create)
+             (:created realized-create)
+             (:timestamp realized-create))))
+
+    (testing "realized fn with a previous object shall preserve previous stored field and update modified"
+      (let [new-sighting-maximal (assoc (dissoc sighting-maximal :id)
+                                        :source "update")
+            realized-update (sut/default-realize "sighting"
+                                                 ss/NewSighting
+                                                 new-sighting-maximal
+                                                 "sighting-id-2"
+                                                 {:login "update-login"
+                                                  :groups ["update-group"]
+                                                  :client-id "iroh"}
+                                                 realized-create
+                                                 services)]
+        (is-submap? new-sighting-maximal realized-update)
+        (is-submap? {:client_id "ireaux",
+                     :schema_version "1.1.3",
+                     :type "sighting",
+                     :id "sighting-id-2",
+                     :tlp "amber",
+                     :groups ["iroh-services"],
+                     :owner "g2"}
+                    realized-update)
+        (is (some? (:created realized-update)))
+        (is (some? (:modified realized-update)))
+        (is (not= (:modified realized-update)
+                  (:created realized-update)))
+        (is (= (:created realized-update)
+               (:created realized-create)
+               (:timestamp realized-create)))))))

--- a/test/ctia/http/middleware/ratelimit_test.clj
+++ b/test/ctia/http/middleware/ratelimit_test.clj
@@ -17,6 +17,7 @@
   (authenticated? [_] true)
   (login [_] "user")
   (groups [_] groups)
+  (client-id [_] nil)
   (allowed-capabilities [_] #{})
   (capable? [_ _] true)
   (rate-limit-fn [_ limit-fn] (when limited? limit-fn)))

--- a/test/ctia/test_helpers/collections.clj
+++ b/test/ctia/test_helpers/collections.clj
@@ -1,0 +1,6 @@
+(ns ctia.test-helpers.collections
+  (:require [clojure.test :refer [is]]))
+
+(defn is-submap? [a b]
+  (let [selected (select-keys b (keys a))]
+    (is (= a selected))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** https://github.com/advthreat/iroh/issues/5710
> Related https://github.com/advthreat/iroh/issues/5714

- add client-id to Identity protocol and accordingly update jwt auth.
- add client-id to StoredEntity model and update realize entity fns.

<a name="qa">[§](#qa)</a> QA
============================

1. Create 2 IROH clients
2. Create an incident with jwt created with each client
==> check that created incidents contain the field `client-id` with the value of corresponding client.
3. for earch client: `GET /ctia/incident/search?query=client_id:{client_id}`
==> check that each response only return the incident created with corresponding client id

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: In CTIA, each newly created entity contains now the client-id. .
```
