### PR TITLE
bulk patch routes

### DIFF
--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -1,9 +1,9 @@
 (ns ctia.bulk.routes
   (:require
-   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk delete-bulk get-bulk-max-size]]
-   [ctia.bulk.schemas :refer [Bulk BulkCreateRes BulkRefs NewBulk BulkActionsRefs]]
+   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk delete-bulk get-bulk-max-size patch-bulk]]
+   [ctia.bulk.schemas :as bulk.schemas]
    [ctia.http.routes.common :as common]
-   [ctia.lib.compojure.api.core :refer [GET POST DELETE routes]]
+   [ctia.lib.compojure.api.core :refer [GET POST DELETE PATCH routes]]
    [ctia.schemas.core :refer [APIHandlerServices Reference]]
    [ring.swagger.json-schema :refer [describe]]
    [ring.util.http-response :refer [bad-request ok]]
@@ -34,9 +34,9 @@
                          :create-vulnerability
                          :create-weakness}]
       (POST "/" []
-            :return (BulkCreateRes services)
+            :return (bulk.schemas/BulkCreateRes services)
             :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
-            :body [bulk (NewBulk services) {:description "a new Bulk object"}]
+            :body [bulk (bulk.schemas/NewBulk services) {:description "a new Bulk object"}]
             :summary "POST many new entities using a single HTTP call"
             :auth-identity login
             :description (common/capabilities->description capabilities)
@@ -73,7 +73,7 @@
                         :read-vulnerability
                         :read-weakness}]
      (GET "/" []
-          :return (s/maybe (Bulk services))
+          :return (s/maybe (bulk.schemas/Bulk services))
           :summary "GET many entities at once"
           :query-params [{actors              :- [Reference] []}
                          {asset_mappings      :- [Reference] []}
@@ -123,7 +123,19 @@
                               :vulnerabilities     vulnerabilities
                               :weaknesses          weaknesses}]
             (ok (fetch-bulk entities-map auth-identity services)))))
-
+    (let [capabilities (bulk.schemas/bulk-patch-capabilities services)]
+     (PATCH "/" []
+          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+          :summary "PATCH many entities at once"
+          :query-params [{wait_for :- (describe s/Bool "wait for patched entities to be available for search") nil}]
+          :body [bulk (bulk.schemas/BulkPatch services) {:description "a new Bulk Patch object"}]
+          :description (common/capabilities->description capabilities)
+          :capabilities capabilities
+          :auth-identity auth-identity
+          (ok (patch-bulk bulk
+                          auth-identity
+                          (common/wait_for->refresh wait_for)
+                          services))))
     (let [capabilities #{:delete-actor
                          :delete-asset
                          :delete-asset-mapping
@@ -147,10 +159,10 @@
                          :delete-vulnerability
                          :delete-weakness}]
      (DELETE "/" []
-          :return (s/maybe (BulkActionsRefs services))
+          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
           :summary "DELETE many entities at once"
-          :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
-          :body [bulk (BulkRefs services) {:description "a new Bulk Delete object"}]
+          :query-params [{wait_for :- (describe s/Bool "wait for deleted entities to not be available anymore for search") nil}]
+          :body [bulk (bulk.schemas/BulkRefs services) {:description "a new Bulk Delete object"}]
           :description (common/capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity auth-identity

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -39,6 +39,22 @@
   [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :schema))
 
+(defn bulk-patch-capabilities
+  [services]
+  (->> (get-entities services)
+       (map second)
+       (filter :can-patch?)
+       (map :patch-capabilities)
+       set))
+
+(s/defn BulkPatch :- (s/protocol s/Schema)
+  "Returns BulkUpdate schema without disabled entities and only entities that can be patched"
+  [services :- GetEntitiesServices]
+  (let [patchable-entities (into {}
+                                 (filter #(:can-patch? (second %)))
+                                 (get-entities services))]
+    (entities-bulk-schema patchable-entities :partial-schema)))
+
 (s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) [(s/maybe Reference)]))

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -304,5 +304,7 @@
    :es-mapping            incident-mapping
    :services->routes      (routes.common/reloadable-function incident-routes)
    :capabilities          capabilities
+   :can-patch?            true
+   :patch-capabilities    :create-incident
    :fields                incident-fields
    :sort-fields           incident-fields})

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -47,6 +47,7 @@
 (def handle-delete (crud/handle-delete :judgement))
 (def handle-list (crud/handle-find PartialStoredJudgement))
 (def handle-bulk-delete crud/bulk-delete)
+(def handle-bulk-update (crud/bulk-update StoredJudgement))
 (def handle-query-string-search (crud/handle-query-string-search PartialStoredJudgement))
 (def handle-query-string-count crud/handle-query-string-count)
 (def handle-aggregate crud/handle-aggregate)
@@ -114,6 +115,8 @@
     (handle-update state id judgement ident params))
   (bulk-delete [_ ids ident params]
     (handle-bulk-delete state ids ident params))
+  (bulk-update [_ docs ident params]
+    (handle-bulk-update state docs ident params))
   (list-records [_ filter-map ident params]
     (handle-list state filter-map ident params))
   (close [_] (close-connections! state))

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -123,6 +123,13 @@
     (update-fn state id $ ident params)
     (es-stored-sighting->stored-sighting $)))
 
+(def bulk-update-fn (crud/bulk-update ESStoredSighting))
+
+(s/defn handle-bulk-update
+  [state realized-docs ident es-params]
+  (let [es-stored-docs (map stored-sighting->es-stored-sighting realized-docs)]
+    (bulk-update-fn state es-stored-docs ident es-params)))
+
 (def handle-delete (crud/handle-delete :sighting))
 
 (s/defn es-paginated-list->paginated-list
@@ -166,6 +173,8 @@
     (handle-list state filter-map ident params))
   (bulk-delete [_ ids ident params]
     (handle-bulk-delete state ids ident params))
+  (bulk-update [_ docs ident params]
+    (handle-bulk-update state docs ident params))
   (close [_] (close-connections! state))
   ISightingStore
   (list-sightings-by-observables [_ observables ident params]

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -199,7 +199,9 @@
      :capabilities #{s/Keyword}
      :no-bulk? s/Bool
      :no-api? s/Bool
-     :realize-fn RealizeFn})))
+     :realize-fn RealizeFn
+     :can-patch? s/Bool
+     :patch-capabilities  s/Keyword})))
 
 (s/defschema OpenCTIMSchemaVersion
   {(s/optional-key :schema_version) s/Str})

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -8,6 +8,7 @@
   (update-record [this id record ident params])
   (delete-record [this id ident params])
   (bulk-delete [this ids ident params])
+  (bulk-update [this records ident params])
   (list-records [this filtermap ident params])
   (close [this]))
 

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -42,6 +42,9 @@
        ~(symbol "state") id# ident# params#))
      (~(symbol "bulk-delete") [_# ids# ident# params#]
       (crud/bulk-delete ~(symbol "state") ids# ident# params#))
+     (~(symbol "bulk-update") [_# docs# ident# params#]
+      ((crud/bulk-update ~stored-schema)
+       ~(symbol "state") docs# ident# params#))
      (~(symbol "list-records") [_# filter-map# ident# params#]
       ((crud/handle-find ~partial-stored-schema)
        ~(symbol "state") filter-map# ident# params#))

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -4,7 +4,6 @@
             [ctia.bundle.core :as sut]
             [ctia.domain.entities :refer [with-long-id]]
             [ctia.flows.crud :refer [make-id]]
-            [clojure.test :as t :refer [deftest use-fixtures are is testing]]
             [ctia.test-helpers.core :as h]
             [ctia.test-helpers.http :refer [app->HTTPShowServices]]
             [ctia.test-helpers.es :as es-helpers]))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -21,6 +21,7 @@
                                     whoami-helpers/fixture-server]))
 
 (defn partial-operations-tests [app incident-id incident]
+  (println "incident id :" incident-id)
   (let [fixed-now (t/internal-now)]
     (helpers/fixture-with-fixed-time
      fixed-now
@@ -29,8 +30,7 @@
          (let [response (PATCH app
                                (str "ctia/incident/" (:short-id incident-id))
                                :body {:incident_time {}}
-                               :headers {"Authorization" "45c1f5e3f05d0"})
-               updated-incident (:parsed-body response)]
+                               :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 200 (:status response)))))
 
        (testing "POST /ctia/incident/:id/status Open"
@@ -40,6 +40,7 @@
                               :body new-status
                               :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
+           (is (= (:id incident) (:id updated-incident)))
            (is (= 200 (:status response)))
            (is (= "Open" (:status updated-incident)))
            (is (get-in updated-incident [:incident_time :opened]))

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -2,20 +2,17 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [deftest join-fixtures use-fixtures]]
             [ctia.entity.sighting :as sut]
-            [ctia.entity.sighting.schemas :refer [sighting-sort-fields
-                                                  sighting-fields
-                                                  sighting-enumerable-fields
-                                                  sighting-histogram-fields
-                                                  NewSighting]]
-            [ctia.test-helpers
-             [access-control :refer [access-control-test]]
-             [auth :refer [all-capabilities]]
-             [core :as helpers :refer [POST-bulk]]
-             [crud :refer [entity-crud-test]]
-             [aggregate :refer [test-metric-routes]]
-             [fake-whoami-service :as whoami-helpers]
-             [http :refer [api-key]]
-             [store :refer [test-for-each-store-with-app]]]
+            [ctia.entity.sighting.schemas
+             :refer
+             [sighting-enumerable-fields sighting-histogram-fields]]
+            [ctia.test-helpers.access-control :refer [access-control-test]]
+            [ctia.test-helpers.aggregate :refer [test-metric-routes]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers]
+            [ctia.test-helpers.crud :refer [entity-crud-test]]
+            [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.http :refer [api-key]]
+            [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
             [ctim.examples.sightings
              :refer
              [new-sighting-maximal new-sighting-minimal]]))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #https://github.com/advthreat/iroh/issues/2249

The PR implements bulk patch routes and most of the logic of bulk update.

<a name="qa">[§](#qa)</a> QA
============================


1. create 3 incidents and note their ids 
2. `PATCH /ctia/bulk`
``` javascript
{
  "incidents":
    [{"id": "incident-id-1", "source": "patched"},
     {"id": "incident-id-2", "source": "patched"},
     {"id": "incident-id-2", "source": "patched"}]
}
```
3. bulk export these patched incidents and check they are actually updated
4. check that update events are created for these incidents.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: bulk patch route in CTIA
```
