### PR TITLE
incident severity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.8-SNAPSHOT"]
+                 [threatgrid/ctim "1.1.8"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.1"]
 

--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
                  [prismatic/schema "1.1.12"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.6"]
+                 [threatgrid/ctim "1.1.8-SNAPSHOT"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.1"]
 

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -137,7 +137,8 @@
       :discovery_method em/token
       :intended_effect em/token
       :assignees em/token
-      :promotion_method em/token})}})
+      :promotion_method em/token
+      :severity em/token})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
 
@@ -156,7 +157,8 @@
            :discovery_method
            :intended_effect
            :assignees
-           :promotion_method]))
+           :promotion_method
+           :severity]))
 
 (def incident-sort-fields
   (apply s/enum incident-fields))
@@ -170,7 +172,8 @@
    :promotion_method
    :source
    :status
-   :title])
+   :title
+   :severity])
 
 (def incident-histogram-fields
   [:timestamp
@@ -199,7 +202,8 @@
      :categories       s/Str
      :sort_by          incident-sort-fields
      :assignees        s/Str
-     :promotion_method s/Str})))
+     :promotion_method s/Str
+     :severity s/Str})))
 
 (def IncidentGetParams IncidentFieldsParam)
 

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -104,4 +104,5 @@ fragment incidentFields on Incident {
   groups
   assignees
   promotion_method
+  severity
 }


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #https://github.com/advthreat/iroh/issues/5710
> **Related** #https://github.com/advthreat/iroh/issues/5684

This PR adds `severity` field to incident.

<a name="qa">[§](#qa)</a> QA
============================

1. `POST /ctia/incident` with body:
``` javascript
{
  "incident_time": {
    "opened": "2016-02-11T00:40:48.212Z"
  },
  "status": "Open",
  "schema_version": "c/ctim-schema-version",
  "confidence": "High",
  "severity": "Critical",
  "source": "pr1149"
}
```
2. `GET /ctia/incident/search?severity=Critical&source=pr1149`
=> check that only the previously created incident is returned.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: added severity to incidents.
```

