### PR TITLE
removes query_mode from search-query

### DIFF
--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -39,7 +39,7 @@
   {(s/optional-key :query) s/Str
 
    (s/optional-key :simple_query)
-   (describe s/Str "Query string for posting Simple Query String queries to ES")})
+   (describe s/Str "Query String with simple query format")})
 
 (s/defschema PagingParams
   "A schema defining the accepted paging and sorting related query parameters."

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -9,7 +9,7 @@
              [http-response :as http-res]
              [http-status :refer [ok]]]
             [ctia.schemas.search-agg :refer
-             [FullTextQueryMode MetricResult RangeQueryOpt SearchQuery]]
+             [MetricResult RangeQueryOpt SearchQuery]]
             [schema.core :as s]))
 
 (def search-options [:sort_by
@@ -38,8 +38,8 @@
 (s/defschema SearchableEntityParams
   {(s/optional-key :query) s/Str
 
-   (s/optional-key :query_mode)
-   (describe FullTextQueryMode "Elasticsearch Fulltext Query Mode. Defaults to query_string")})
+   (s/optional-key :simple_query)
+   (describe s/Str "Query string for posting Simple Query String queries to ES")})
 
 (s/defschema PagingParams
   "A schema defining the accepted paging and sorting related query parameters."

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -21,7 +21,7 @@
    {:query s/Str}
    (st/optional-keys
     {:query_mode       FullTextQueryMode
-     :fields           [(s/enum s/Keyword s/Str)]
+     :fields           [s/Str]
      :default_operator s/Str})))
 
 (s/defschema SearchQuery

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -13,11 +13,14 @@
   see: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
   {s/Keyword RangeQueryOpt})
 
+(s/defschema FullTextQueryMode
+  (s/enum :query_string :multi_match :simple_query_string))
+
 (s/defschema FullTextQuery
   (st/merge
    {:query s/Str}
    (st/optional-keys
-    {:simple_query     s/Str
+    {:query_mode       FullTextQueryMode
      :fields           [s/Str]
      :default_operator s/Str})))
 

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -13,14 +13,11 @@
   see: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html"
   {s/Keyword RangeQueryOpt})
 
-(s/defschema FullTextQueryMode
-  (s/enum :query_string :multi_match :simple_query_string))
-
 (s/defschema FullTextQuery
   (st/merge
    {:query s/Str}
    (st/optional-keys
-    {:query_mode       FullTextQueryMode
+    {:simple_query     s/Str
      :fields           [s/Str]
      :default_operator s/Str})))
 

--- a/src/ctia/schemas/search_agg.clj
+++ b/src/ctia/schemas/search_agg.clj
@@ -21,7 +21,7 @@
    {:query s/Str}
    (st/optional-keys
     {:query_mode       FullTextQueryMode
-     :fields           [s/Str]
+     :fields           [(s/enum s/Keyword s/Str)]
      :default_operator s/Str})))
 
 (s/defschema SearchQuery

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -454,14 +454,14 @@ It returns the documents with full hits meta data including the real index in wh
                                            ident
                                            get-in-config))))))
 
-(s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
+(s/defn ^:always-validate refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [full-text-terms :- [FullTextQuery]
    default-operator]
-  (let [term->es-query-part (fn [{:keys [simple_query] :as x}]
+  (let [term->es-query-part (fn [{:keys [simple_query query_mode] :as x}]
                               (hash-map
-                               (if simple_query :simple_query_string :query_string)
+                               (if simple_query :simple_query_string query_mode)
                                (-> x
-                                   (dissoc :simple_query)
+                                   (dissoc :simple_query :query_mode)
                                    (merge
                                     (when default-operator
                                       {:default_operator default-operator})))))]

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -457,15 +457,14 @@ It returns the documents with full hits meta data including the real index in wh
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [full-text-terms :- [FullTextQuery]
    default-operator]
-  (let [term->es-query-part (fn [{:keys [query_mode] :as x}]
+  (let [term->es-query-part (fn [{:keys [simple_query] :as x}]
                               (hash-map
-                               ;; if no :query-mode specified, use the default
-                               (or query_mode :query_string)
-                               (merge
-                                (dissoc x :query_mode)
-                                (when (and default-operator
-                                           (not= :multi_match query_mode))
-                                  {:default_operator default-operator}))))]
+                               (if simple_query :simple_query_string :query_string)
+                               (-> x
+                                   (dissoc :simple_query)
+                                   (merge
+                                    (when default-operator
+                                      {:default_operator default-operator})))))]
     (mapv term->es-query-part full-text-terms)))
 
 (s/defn make-search-query :- {s/Keyword s/Any}

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -457,14 +457,11 @@ It returns the documents with full hits meta data including the real index in wh
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [full-text-terms :- [FullTextQuery]
    default-operator]
-  (let [term->es-query-part (fn [{:keys [simple_query
-                                         query_mode
-                                         fields] :as text-query}]
+  (let [term->es-query-part (fn [{:keys [query_mode fields] :as text-query}]
                               (hash-map
-                               (if simple_query :simple_query_string
-                                   (or query_mode :query_string))
+                               (or query_mode :query_string)
                                (-> text-query
-                                   (dissoc :simple_query :query_mode)
+                                   (dissoc :query_mode)
                                    (merge
                                     (when (and default-operator
                                                (not= query_mode :multi_match))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -459,11 +459,11 @@ It returns the documents with full hits meta data including the real index in wh
    default-operator]
   (let [term->es-query-part (fn [{:keys [simple_query
                                          query_mode
-                                         fields] :as x}]
+                                         fields] :as text-query}]
                               (hash-map
                                (if simple_query :simple_query_string
                                    (or query_mode :query_string))
-                               (-> x
+                               (-> text-query
                                    (dissoc :simple_query :query_mode)
                                    (merge
                                     (when (and default-operator

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -211,5 +211,6 @@
     (fn [app]
       (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (capabilities/all-capabilities))
       (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
-      (doseq [test-case (test-cases)]
+      (doseq [test-case (if-let [cases (seq (filter :only (test-cases)))]
+                          cases (test-cases))]
         (test-search-case app test-case))))))

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -190,9 +190,9 @@
                      (bundle-gen-for :incidents))
          check-fn   (fn [_ _ _ res]
                       (let [matching (->> res :parsed-body)]
-                      (is (= 2 (count matching)))
-                      (= #{"fried eggs eggplant" "fried eggs potato"}
-                         (->> matching (map :title) set))))]
+                        (is (= 2 (count matching)))
+                        (= #{"fried eggs eggplant" "fried eggs potato"}
+                           (->> matching (map :title) set))))]
      [{:test-description "simple_query_string"
        :query-params     {:simple_query  "\"fried eggs\" +(eggplant | potato) -frittata"
                           :search_fields ["title"]}
@@ -225,9 +225,9 @@
     (doseq [plural ent-keys]
       (let [entity (ffirst (helpers/plural-key->entity plural))
             search-res (th.search/search-raw app entity query-params)]
-       (testing test-description (check test-case plural bundle search-res))
-       (th.search/delete-search app entity {:query "*"
-                                            :REALLY_DELETE_ALL_THESE_ENTITIES true})))))
+        (testing test-description (check test-case plural bundle search-res))
+        (th.search/delete-search app entity {:query "*"
+                                             :REALLY_DELETE_ALL_THESE_ENTITIES true})))))
 
 (deftest fulltext-search-test
   (es-helpers/for-each-es-version

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -82,8 +82,7 @@
 (defn test-cases []
   (concat
    [{:test-description "Returns all the records when the wildcard used"
-     :query-params     {:query_mode "query_string"
-                        :query      "*"}
+     :query-params     {:query "*"}
      :bundle-gen       (bundle-gen-for :incidents :assets)
      :check            (fn [_ entity bundle res]
                          (is (= (-> res :parsed-body count)
@@ -104,29 +103,24 @@
                                         (filter #(-> % :title (= "nunc porta vulputate tellus"))))]
                       (is (= 3 (count matching)) test-description)))]
      [{:test-description "Multiple records with the same value in a given field. Lucene syntax"
-       :query-params     {:query_mode "query_string"
-                          :query      "title:nunc porta vulputate tellus"}
+       :query-params     {:query "title:nunc porta vulputate tellus"}
        :bundle-gen       bundle
        :check            check-fn}
       {:test-description "Multiple records with the same value in a given field set in search_fields"
-       :query-params     {:query_mode      "query_string"
-                          :query           "nunc porta vulputate tellus"
+       :query-params     {:query "nunc porta vulputate tellus"
                           :search_fields ["title"]}
        :bundle-gen       bundle
        :check            check-fn}
       {:test-description "Querying for non-existing value should yield no results. Lucene syntax."
-       :query-params     {:query_mode "query_string"
-                          :query      "title:0e1c9f6a-c3ac-4fd5-982e-4981f86df07a"}
+       :query-params     {:query "title:0e1c9f6a-c3ac-4fd5-982e-4981f86df07a"}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (zero? (-> res :parsed-body count))))}
       {:test-description "Querying for non-existing field with wildcard should yield no results. Lucene syntax."
-       :query-params     {:query_mode "query_string"
-                          :query      "74f93781-f370-46ea-bd53-3193db379e41:*"}
+       :query-params     {:query "74f93781-f370-46ea-bd53-3193db379e41:*"}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (empty? (-> res :parsed-body))))}
       {:test-description "Querying for non-existing field with wildcard should fail the schema validation. search_fields"
-       :query-params     {:query_mode      "query_string"
-                          :query           "*"
+       :query-params     {:query "*"
                           :search_fields ["512b8dce-0423-4e9a-aa63-d3c3b91eb8d8"]}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (= 400 (-> res :status))))}])
@@ -150,15 +144,13 @@
                                        (-> % :title (= "title of test incident"))))))]
      [{:test-description (str "Should NOT return anything, because query field is missing."
                               "Asking for multiple things in the query, but not providing all the fields.")
-       :query-params     {:query_mode      "query_string"
-                          :query           "(title of test incident) AND (Log Review)"
+       :query-params     {:query "(title of test incident) AND (Log Review)"
                           :search_fields ["title"]}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res] (is (nil? (get-fields res))))}
 
       {:test-description "Should return an entity where multiple fields match"
-       :query-params     {:query_mode      "query_string"
-                          :query           "\"title of test incident\" AND \"Log Review\""
+       :query-params     {:query "\"title of test incident\" AND \"Log Review\""
                           :search_fields ["title" "discovery_method"]}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res]
@@ -166,8 +158,7 @@
                            (is (get-fields res)))}])
 
    [{:test-description "multi_match - looking for the same value in different fields in multiple records"
-     :query-params     {:query_mode      "multi_match"
-                        :query           "bibendum"
+     :query-params     {:query "bibendum"
                         :search_fields ["assignees" "title"]}
      :bundle-gen       (gen/fmap
                         (fn [bundle]

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -85,6 +85,28 @@
                                          :fields      ["title"]
                                          :sort_by     "disposition"
                                          :sort_order  :desc})))
+      (is (= {:full-text [{:query "lucene", :query_mode :query_string}
+                          {:query "simple", :query_mode :simple_query_string}]
+              :filter-map {:title "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:query "lucene"
+                                         :simple_query "simple"
+                                         :disposition 2
+                                         :title "firefox exploit"
+                                         :fields ["title"]
+                                         :sort_by "disposition"
+                                         :sort_order :desc}))
+          "query and simple_query can be both submitted and accepted")
+      (is (= {:full-text  [{:query "simple", :query_mode :simple_query_string}]
+              :filter-map {:title       "firefox exploit"
+                           :disposition 2}}
+             (sut/search-query :created {:simple_query "simple"
+                                         :disposition  2
+                                         :title        "firefox exploit"
+                                         :fields       ["title"]
+                                         :sort_by      "disposition"
+                                         :sort_order   :desc}))
+          "simple_query can be the only full text search")
       (testing "make-date-range-fn should be properly called"
         (is (= {:range {:timestamp
                         {:gte #inst "2050-01-01"

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -85,27 +85,33 @@
                                          :fields      ["title"]
                                          :sort_by     "disposition"
                                          :sort_order  :desc})))
-      (is (= {:full-text [{:query "lucene", :query_mode :query_string}
-                          {:query "simple", :query_mode :simple_query_string}]
+      (is (= {:full-text [{:query      "lucene"
+                           :query_mode :query_string
+                           :fields     ["title"]}
+                          {:query      "simple"
+                           :query_mode :simple_query_string
+                           :fields     ["title"]}]
               :filter-map {:title "firefox exploit"
                            :disposition 2}}
              (sut/search-query :created {:query "lucene"
                                          :simple_query "simple"
                                          :disposition 2
                                          :title "firefox exploit"
-                                         :fields ["title"]
+                                         :search_fields ["title"]
                                          :sort_by "disposition"
                                          :sort_order :desc}))
           "query and simple_query can be both submitted and accepted")
-      (is (= {:full-text  [{:query "simple", :query_mode :simple_query_string}]
+      (is (= {:full-text  [{:query "simple"
+                            :query_mode :simple_query_string
+                            :fields ["title"]}]
               :filter-map {:title       "firefox exploit"
                            :disposition 2}}
-             (sut/search-query :created {:simple_query "simple"
-                                         :disposition  2
-                                         :title        "firefox exploit"
-                                         :fields       ["title"]
-                                         :sort_by      "disposition"
-                                         :sort_order   :desc}))
+             (sut/search-query :created {:simple_query  "simple"
+                                         :disposition   2
+                                         :title         "firefox exploit"
+                                         :search_fields ["title"]
+                                         :sort_by       "disposition"
+                                         :sort_order    :desc}))
           "simple_query can be the only full text search")
       (testing "make-date-range-fn should be properly called"
         (is (= {:range {:timestamp

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -22,6 +22,36 @@
 (use-fixtures :each
   es-helpers/fixture-properties:es-store)
 
+(deftest refine-full-text-query-parts-test
+  (testing "refine-full-text-query-parts with different queries"
+   (are [queries res] (is (= res (sut/refine-full-text-query-parts queries nil)))
+     [{:query "foo"}]                                  [{:query_string {:query "foo"}}]
+
+     [{:query "foo" :query_mode :simple_query_string}] [{:simple_query_string {:query "foo"}}]
+
+     [{:query "foo" :query_mode :simple_query_string}
+      {:query "bar"}]                                  [{:simple_query_string {:query "foo"}}
+                                                        {:query_string {:query "bar"}}]))
+  (testing "refine-full-text-query-parts schema"
+    (s/with-fn-validation
+      (is (thrown-with-msg?
+           Exception #"does not match schema"
+           (sut/refine-full-text-query-parts
+            [{:query "foo" :query_mode :unknown}] nil)))
+      (is (thrown-with-msg?
+           Exception #"does not match schema"
+           (sut/refine-full-text-query-parts
+            [{}] nil)))))
+  (testing "refine-full-text-query-parts default operator"
+    (is (= [{:query_string {:query "foo" :default_operator "and"}}]
+         (sut/refine-full-text-query-parts
+          [{:query "foo"}]
+          "and")))
+    (is (= [{:multi_match {:query "foo"}}]
+           (sut/refine-full-text-query-parts
+            [{:query "foo" :query_mode :multi_match}]
+            "and")) "no default_operator with mutli_match")))
+
 (deftest ensure-document-id-in-map-test
   (is (= {:id '("actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7")}
          (sut/ensure-document-id-in-map

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -301,14 +301,12 @@
                                    {:simple_query_string {:query "*"
                                                           :default_operator "AND"}}]}}
                   (sut/make-search-query es-conn-state
-                                         {:full-text [{:query      query-string
-                                                       :query_mode :simple_query_string}]}
+                                         {:full-text [{:simple_query query-string}]}
                                          ident)))
            (is (= {:bool {:filter [simple-access-ctrl-query
                                    {:multi_match {:query "*"}}]}}
                   (sut/make-search-query es-conn-state
-                                         {:full-text [{:query      query-string
-                                                       :query_mode :multi_match}]}
+                                         {:full-text [{:query query-string}]}
                                          ident))
                "multi_match queries don't support default_operator")
            (is (= {:bool {:filter (-> [simple-access-ctrl-query]
@@ -326,10 +324,8 @@
                                                    :default_operator "AND"}}]}}
                   (sut/make-search-query
                    es-conn-state
-                   {:full-text [{:query "simple"
-                                 :query_mode :simple_query_string}
-                                {:query "lucene"
-                                 :query_mode :query_string}]}
+                   {:full-text [{:simple_query "simple"}
+                                {:query "lucene"}]}
                    ident))))))))))
 
 (deftest make-aggregation-test

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -25,13 +25,13 @@
 (deftest refine-full-text-query-parts-test
   (testing "refine-full-text-query-parts with different queries"
    (are [queries res] (is (= res (sut/refine-full-text-query-parts queries nil)))
-     [{:query "foo"}]                                  [{:query_string {:query "foo"}}]
+     [{:query "foo"}] [{:query_string {:query "foo"}}]
 
      [{:query "foo" :query_mode :simple_query_string}] [{:simple_query_string {:query "foo"}}]
 
      [{:query "foo" :query_mode :simple_query_string}
-      {:query "bar"}]                                  [{:simple_query_string {:query "foo"}}
-                                                        {:query_string {:query "bar"}}]))
+      {:query "bar"}] [{:simple_query_string {:query "foo"}}
+                       {:query_string {:query "bar"}}]))
   (testing "refine-full-text-query-parts schema"
     (s/with-fn-validation
       (is (thrown-with-msg?
@@ -50,7 +50,14 @@
     (is (= [{:multi_match {:query "foo"}}]
            (sut/refine-full-text-query-parts
             [{:query "foo" :query_mode :multi_match}]
-            "and")) "no default_operator with mutli_match")))
+            "and")) "no default_operator with mutli_match"))
+  (testing "refine-full-text-query-parts with fields"
+    (is (= [{:query_string {:query            "foo"
+                            :default_operator "and"
+                            :fields           ["title" "description"]}}]
+           (sut/refine-full-text-query-parts
+            [{:query "foo" :fields ["title" "description"]}]
+            "and")))))
 
 (deftest ensure-document-id-in-map-test
   (is (= {:id '("actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7")}

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -301,12 +301,14 @@
                                    {:simple_query_string {:query "*"
                                                           :default_operator "AND"}}]}}
                   (sut/make-search-query es-conn-state
-                                         {:full-text [{:simple_query query-string}]}
+                                         {:full-text [{:query      query-string
+                                                       :query_mode :simple_query_string}]}
                                          ident)))
            (is (= {:bool {:filter [simple-access-ctrl-query
                                    {:multi_match {:query "*"}}]}}
                   (sut/make-search-query es-conn-state
-                                         {:full-text [{:query query-string}]}
+                                         {:full-text [{:query      query-string
+                                                       :query_mode :multi_match}]}
                                          ident))
                "multi_match queries don't support default_operator")
            (is (= {:bool {:filter (-> [simple-access-ctrl-query]
@@ -324,8 +326,10 @@
                                                    :default_operator "AND"}}]}}
                   (sut/make-search-query
                    es-conn-state
-                   {:full-text [{:simple_query "simple"}
-                                {:query "lucene"}]}
+                   {:full-text [{:query "simple"
+                                 :query_mode :simple_query_string}
+                                {:query "lucene"
+                                 :query_mode :query_string}]}
                    ident))))))))))
 
 (deftest make-aggregation-test


### PR DESCRIPTION
Removes the `search_mode` parameter in the API and exposes `simple_query`

<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close https://github.com/advthreat/iroh/issues/5679
> Related #

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

This PR exposes `simple_query` parameter (in addition to the existing `query`) for search routes. We need to ensure there's no regression with existing search facilities and also make sure that `simple_query` type of queries do work.

1. Create three different Incidents with titles:
"Ice Cream Gelato"
"Ice Cream Sorbet"
"Ice Cream Yogurt"
2. Search incidents: `ctia/incident/search?query=Ice%20Cream` (where `query="Ice Cream"`), expected to return all three Incidents
3. Search incidents: `/ctia/incident/search?simple_query=%22Ice%20Cream%22%20%2B(Gelato%7CSorbet)` (where `simple_query="Ice Cream" +(Gelato|Sorbet)`), expected to return only the first two.
4. Search incidents: `/ctia/incident/search?query=(%22Ice%20Cream%20Gelato%22)%20OR%20(%22Ice%20Cream%20Sorbet%22)` (where `query=("Ice Cream Gelato") OR ("Ice Cream Sorbet")`), expected to return only the first two.
5. Search incidents: `search?search_fields=title&query=Ice%20Cream%20Gelato&simple_query=(Yogurt%7CSorbet)`
(where `query=Ice Cream Gelato`, `simple_query=(Yogurt|Sorbet))`, expected to return all three.


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

65709e47 removes query_mode from search-query
ebb678a2 adjust schemas, remove FullTextQueryMode
d2d50567 refactor. build query without query_mode
1e95f903 adjust tests
3ec14849 adjusting tests
4f3db8b5 temporarily always-validate
1d8ea297 revert changes in crud_test
5dca73f3 add :only to full-text-search-test
c2b392c3 a couple of additional tests
3fc823af change swagger description
de1bb32d revert schema change
0f5bf0f2 more meaningful var name
4c9e439f bugfix: refine-full-text-query-parts
4026b422 fixes the test
4fe93a8f fmt: fix indentation
6e16af36 origin/remove__query_mode__parameter__#5679 adds a test case