### PR TITLE
Refresh mapping in mapping update

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
                  [threatgrid/flanders "0.1.23"]
                  [threatgrid/ctim "1.1.8"]
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.4.1"]
+                 [threatgrid/ductile "0.4.2"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -71,6 +71,7 @@ ctia.store.es.default.aliased=true
 ctia.store.es.default.version=5
 ctia.store.es.default.update-mappings=false
 ctia.store.es.default.update-settings=false
+ctia.store.es.default.refresh-mappings=false
 
 ctia.store.actor=es
 ctia.store.asset=es

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -39,6 +39,7 @@
    (str prefix store ".version") s/Num
    (str prefix store ".update-mappings")  s/Bool
    (str prefix store ".update-settings")  s/Bool
+   (str prefix store ".refresh-mappings") s/Bool
    (str prefix store ".auth")  AuthParams})
 
 (s/defschema StorePropertiesSchema

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -112,7 +112,7 @@
                                       [index] {}
                                       {:refresh "true"
                                        :conflicts "proceed"
-                                       :wait_for_completion true})
+                                       :wait_for_completion false})
     (catch clojure.lang.ExceptionInfo e
       (log/error "Cannot refresh mapping."
                  (assoc (ex-data e)

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -114,7 +114,7 @@
                                        :conflicts "proceed"
                                        :wait_for_completion true})
     (catch clojure.lang.ExceptionInfo e
-      (log/error "cannot refresh mapping."
+      (log/error "Cannot refresh mapping."
                  (assoc (ex-data e)
                         :conn conn
                         :mappings mappings))
@@ -138,8 +138,9 @@
       existing)))
 
 (defn update-index-state
-  [{{update-mappings? :update-mappings
-     update-settings? :update-settings}
+  [{{update-mappings?  :update-mappings
+     update-settings?  :update-settings
+     refresh-mappings? :refresh-mappings}
     :props
     :as conn-state}]
   (when update-mappings?
@@ -148,7 +149,9 @@
     ;; if it fails a System/exit is triggered because
     ;; this means that the mapping in invalid and thus
     ;; must not be propagated to the template that would accept it
-    (upsert-template! conn-state))
+    (upsert-template! conn-state)
+    (when refresh-mappings?
+      (refresh-mappings! conn-state)))
   (when update-settings?
     (update-settings! conn-state)))
 

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -23,6 +23,7 @@
             "ctia.store.es.malware.version" s/Num
             "ctia.store.es.malware.update-mappings" s/Bool
             "ctia.store.es.malware.update-settings" s/Bool
+            "ctia.store.es.malware.refresh-mappings" s/Bool
             "ctia.store.es.malware.timeout" s/Num
             "ctia.store.es.malware.auth" AuthParams}
            (sut/es-store-impl-properties "ctia.store.es." "malware")))
@@ -43,6 +44,7 @@
             "prefix.sighting.version" s/Num
             "prefix.sighting.update-mappings" s/Bool
             "prefix.sighting.update-settings" s/Bool
+            "prefix.sighting.refresh-mappings" s/Bool
             "prefix.sighting.timeout" s/Num
             "prefix.sighting.auth" AuthParams}
            (sut/es-store-impl-properties "prefix." "sighting")))))


### PR DESCRIPTION
Adds optional refresh-mapping during the init phase

> **Epic** #
> Close https://github.com/advthreat/iroh/issues/5793
> Related #


<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

ca29cf0b adds refresh-mappings property
813a2554 refresh-mappings! basic skeleton
2033f558 triggers refresh-mappings
7b120e37 origin/refresh_mapping_in_mapping_update_#5793 flip wait_for_completion