### PR TITLE
adds default searchable fields

### DIFF
--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -106,6 +106,23 @@
    :valid_time.start_time
    :valid_time.end_time])
 
+(def searchable-fields
+  #{:id
+    :source
+    :actor_type
+    :confidence
+    :description
+    :identity.description
+    :identity.related_identities.identity
+    :identity.related_identities.information_source
+    :identity.related_identities.relationship
+    :intended_effect
+    :motivation
+    :planning_and_operational_support
+    :short_description
+    :sophistication
+    :title})
+
 (s/defn actor-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -128,7 +145,8 @@
     :external-id-capabilities :read-actor
     :can-aggregate?           true
     :histogram-fields         actor-histogram-fields
-    :enumerable-fields        actor-enumerable-fields}))
+    :enumerable-fields        actor-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-actor

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -110,17 +110,8 @@
   #{:id
     :source
     :actor_type
-    :confidence
     :description
-    :identity.description
-    :identity.related_identities.identity
-    :identity.related_identities.information_source
-    :identity.related_identities.relationship
-    :intended_effect
-    :motivation
-    :planning_and_operational_support
     :short_description
-    :sophistication
     :title})
 
 (s/defn actor-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -100,6 +100,14 @@
               asset_ref (:id entity))))
     (assoc entity :asset_ref asset_ref)))
 
+(def searchable-fields
+  #{:id
+    :source
+    :asset_type
+    :description
+    :short_description
+    :title})
+
 (s/defn asset-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -122,7 +130,8 @@
     :external-id-capabilities :read-asset
     :can-aggregate?           true
     :histogram-fields         asset-histogram-fields
-    :enumerable-fields        asset-enumerable-fields}))
+    :enumerable-fields        asset-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-asset

--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -126,9 +126,7 @@
     :asset_type
     :confidence
     :observable.type
-    :observable.value
-    :specificity
-    :stability})
+    :observable.value})
 
 (s/defn asset-mapping-routes [services :- APIHandlerServices]
   (services->entity-crud-routes

--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -119,6 +119,17 @@
 
 (def asset-mapping-can-revoke? true)
 
+(def searchable-fields
+  #{:id
+    :source
+    :asset_ref
+    :asset_type
+    :confidence
+    :observable.type
+    :observable.value
+    :specificity
+    :stability})
+
 (s/defn asset-mapping-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
     services
@@ -142,7 +153,8 @@
      :can-aggregate?           true
      :histogram-fields         asset-mapping-histogram-fields
      :enumerable-fields        asset-mapping-enumerable-fields
-     :can-revoke?              asset-mapping-can-revoke?}))
+     :can-revoke?              asset-mapping-can-revoke?
+     :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-asset-mapping

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -116,6 +116,13 @@
 
 (def asset-properties-can-revoke? true)
 
+(def searchable-fields
+  #{:id
+    :source
+    :asset_ref
+    :properties.name
+    :properties.value})
+
 (s/defn asset-properties-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
     services
@@ -139,7 +146,8 @@
      :can-aggregate?           true
      :histogram-fields         asset-properties-histogram-fields
      :enumerable-fields        asset-properties-enumerable-fields
-     :can-revoke?              asset-properties-can-revoke?}))
+     :can-revoke?              asset-properties-can-revoke?
+     :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-asset-properties

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -90,6 +90,19 @@
 (def attack-pattern-histogram-fields
   [:timestamp])
 
+(def searchable-fields
+  #{:id
+    :source
+    :abstraction_level
+    :description
+    :kill_chain_phases.kill_chain_name
+    :kill_chain_phases.phase_name
+    :short_description
+    :title
+    :x_mitre_contributors
+    :x_mitre_data_sources
+    :x_mitre_platforms})
+
 (s/defn attack-pattern-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -112,7 +125,8 @@
     :external-id-capabilities :read-attack-pattern
     :can-aggregate?           true
     :histogram-fields         attack-pattern-histogram-fields
-    :enumerable-fields        attack-pattern-enumerable-fields}))
+    :enumerable-fields        attack-pattern-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def AttackPatternType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -93,15 +93,9 @@
 (def searchable-fields
   #{:id
     :source
-    :abstraction_level
     :description
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
     :short_description
-    :title
-    :x_mitre_contributors
-    :x_mitre_data_sources
-    :x_mitre_platforms})
+    :title})
 
 (s/defn attack-pattern-routes [services :- APIHandlerServices]
   (services->entity-crud-routes

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -104,13 +104,7 @@
   #{:id
     :source
     :description
-    :activity.description
-    :campaign_type
-    :confidence
-    :intended_effect
-    :names
     :short_description
-    :status
     :title})
 
 (s/defn campaign-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -100,6 +100,19 @@
    routes.common/PagingParams
    CampaignFieldsParam))
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :activity.description
+    :campaign_type
+    :confidence
+    :intended_effect
+    :names
+    :short_description
+    :status
+    :title})
+
 (s/defn campaign-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -123,7 +136,8 @@
     :external-id-capabilities :read-campaign
     :can-aggregate?           true
     :histogram-fields         campaign-histogram-fields
-    :enumerable-fields        campaign-enumerable-fields}))
+    :enumerable-fields        campaign-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-campaign

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -261,8 +261,6 @@
     :observables.type
     :observables.value
     :short_description
-    :texts.text
-    :texts.type
     :title})
 
 (s/defn casebook-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -254,6 +254,17 @@
 (def casebook-histogram-fields
   [:timestamp])
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :observables.type
+    :observables.value
+    :short_description
+    :texts.text
+    :texts.type
+    :title})
+
 (s/defn casebook-routes [services :- APIHandlerServices]
   (routes
    (casebook-operation-routes services)
@@ -280,7 +291,8 @@
      :external-id-capabilities :read-casebook
      :hide-delete?             false
      :histogram-fields         casebook-histogram-fields
-     :enumerable-fields        casebook-enumerable-fields})))
+     :enumerable-fields        casebook-enumerable-fields
+     :searchable-fields        searchable-fields})))
 
 (def casebook-entity
   {:route-context         "/casebook"

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -109,6 +109,41 @@
    :cost
    :coa_type])
 
+(def searchable-fields
+  #{:id
+    :source
+    :coa_type
+    :cost
+    :description
+    :efficacy
+    :impact
+    :objective
+    :open_c2_coa.action.type
+    :open_c2_coa.actuator.specifiers
+    :open_c2_coa.actuator.type
+    :open_c2_coa.id
+    :open_c2_coa.modifiers.additional_properties.context
+    :open_c2_coa.modifiers.destination
+    :open_c2_coa.modifiers.frequency
+    :open_c2_coa.modifiers.id
+    :open_c2_coa.modifiers.location
+    :open_c2_coa.modifiers.method
+    :open_c2_coa.modifiers.option
+    :open_c2_coa.modifiers.response
+    :open_c2_coa.modifiers.search
+    :open_c2_coa.modifiers.source
+    :open_c2_coa.target.specifiers
+    :open_c2_coa.target.type
+    :open_c2_coa.type
+    :related_COAs.COA_id
+    :related_COAs.confidence
+    :related_COAs.relationship
+    :related_COAs.source
+    :short_description
+    :stage
+    :structured_coa_type
+    :title})
+
 (s/defn coa-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -131,7 +166,8 @@
     :external-id-capabilities :read-coa
     :can-aggregate?           true
     :histogram-fields         coa-histogram-fields
-    :enumerable-fields        coa-enumerable-fields}))
+    :enumerable-fields        coa-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-coa

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -112,36 +112,8 @@
 (def searchable-fields
   #{:id
     :source
-    :coa_type
-    :cost
     :description
-    :efficacy
-    :impact
-    :objective
-    :open_c2_coa.action.type
-    :open_c2_coa.actuator.specifiers
-    :open_c2_coa.actuator.type
-    :open_c2_coa.id
-    :open_c2_coa.modifiers.additional_properties.context
-    :open_c2_coa.modifiers.destination
-    :open_c2_coa.modifiers.frequency
-    :open_c2_coa.modifiers.id
-    :open_c2_coa.modifiers.location
-    :open_c2_coa.modifiers.method
-    :open_c2_coa.modifiers.option
-    :open_c2_coa.modifiers.response
-    :open_c2_coa.modifiers.search
-    :open_c2_coa.modifiers.source
-    :open_c2_coa.target.specifiers
-    :open_c2_coa.target.type
-    :open_c2_coa.type
-    :related_COAs.COA_id
-    :related_COAs.confidence
-    :related_COAs.relationship
-    :related_COAs.source
     :short_description
-    :stage
-    :structured_coa_type
     :title})
 
 (s/defn coa-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/data_table.clj
+++ b/src/ctia/entity/data_table.clj
@@ -50,7 +50,6 @@
    routes.common/PagingParams
    routes.common/BaseEntityFilterParams
    routes.common/SourcableEntityFilterParams
-   routes.common/SearchableEntityParams
    DataTableFieldsParam
    (st/optional-keys
     {:sort_by datatable-sort-fields})))

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -139,9 +139,7 @@
              (ok timeline))))))
 
 (def searchable-fields
-  #{:id
-    :entity.id
-    :event_type})
+  #{})
 
 (s/defn event-routes [services :- APIHandlerServices]
   (routes

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -138,27 +138,33 @@
                  timeline (bucketize-events res get-in-config)]
              (ok timeline))))))
 
+(def searchable-fields
+  #{:id
+    :entity.id
+    :event_type})
+
 (s/defn event-routes [services :- APIHandlerServices]
   (routes
    (event-history-routes services)
    (services->entity-crud-routes
     services
-    {:tags ["Event"]
-     :entity :event
-     :entity-schema Event
-     :get-schema PartialEvent
-     :get-params EventGetParams
-     :list-schema PartialEventList
-     :search-schema PartialEventList
-     :search-q-params EventSearchParams
-     :get-capabilities :read-event
-     :can-update? false
-     :can-patch? false
-     :can-post? false
+    {:tags                    ["Event"]
+     :entity                  :event
+     :entity-schema           Event
+     :get-schema              PartialEvent
+     :get-params              EventGetParams
+     :list-schema             PartialEventList
+     :search-schema           PartialEventList
+     :search-q-params         EventSearchParams
+     :get-capabilities        :read-event
+     :can-update?             false
+     :can-patch?              false
+     :can-post?               false
      :can-get-by-external-id? false
-     :search-capabilities :search-event
-     :delete-capabilities #{:delete-event :developer}
-     :date-field :timestamp})))
+     :search-capabilities     :search-event
+     :delete-capabilities     #{:delete-event :developer}
+     :date-field              :timestamp
+     :searchable-fields       searchable-fields})))
 
 (def event-entity
   {:new-spec              map?

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -77,28 +77,36 @@
     :read-feedback
     :delete-feedback})
 
+(def searchable-fields
+  #{:id
+    :source
+    :entity_id
+    :feedback
+    :reason})
+
 (s/defn feedback-routes [services :- APIHandlerServices]
   (routes
    (feedback-by-entity-route services)
    (services->entity-crud-routes
     services
-    {:entity :feedback
-     :new-schema fs/NewFeedback
-     :entity-schema fs/Feedback
-     :get-schema fs/PartialFeedback
-     :get-params FeedbackGetParams
-     :list-schema fs/PartialFeedbackList
-     :external-id-q-params FeedbackByExternalIdQueryParams
-     :realize-fn fs/realize-feedback
-     :get-capabilities :read-feedback
-     :post-capabilities :create-feedback
-     :put-capabilities :create-feedback
-     :delete-capabilities :delete-feedback
+    {:entity                   :feedback
+     :new-schema               fs/NewFeedback
+     :entity-schema            fs/Feedback
+     :get-schema               fs/PartialFeedback
+     :get-params               FeedbackGetParams
+     :list-schema              fs/PartialFeedbackList
+     :external-id-q-params     FeedbackByExternalIdQueryParams
+     :realize-fn               fs/realize-feedback
+     :get-capabilities         :read-feedback
+     :post-capabilities        :create-feedback
+     :put-capabilities         :create-feedback
+     :delete-capabilities      :delete-feedback
      :external-id-capabilities :read-feedback
-     :spec :new-feedback/map
-     :can-search? false
-     :enumerable-fields []
-     :can-update? false})))
+     :spec                     :new-feedback/map
+     :can-search?              false
+     :enumerable-fields        []
+     :can-update?              false
+     :searchable-fields        searchable-fields})))
 
 (def feedback-entity
   {:route-context         "/feedback"

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -91,6 +91,14 @@
    routes.common/PagingParams
    IdentityAssertionFieldsParam))
 
+(def searchable-fields
+  #{:id
+    :source
+    :assertions.name
+    :assertions.value
+    :identity.observables.type
+    :identity.observables.value})
+
 (s/defn identity-assertion-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -112,7 +120,8 @@
     :external-id-capabilities :read-identity-assertion
     :can-aggregate?           true
     :enumerable-fields        identity-assertion-enumerable-fields
-    :histogram-fields         identity-assertion-histogram-fields}))
+    :histogram-fields         identity-assertion-histogram-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-identity-assertion

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -212,6 +212,20 @@
    routes.common/PagingParams
    IncidentFieldsParam))
 
+(def searchable-fields
+  #{:description
+    :source
+    :id
+    :assignees
+    :categories
+    :confidence
+    :discovery_method
+    :intended_effect
+    :promotion_method
+    :short_description
+    :status
+    :title})
+
 (s/defn incident-routes [services :- APIHandlerServices]
   (routes
    (incident-additional-routes services)
@@ -239,7 +253,8 @@
      :search-capabilities      :search-incident
      :external-id-capabilities :read-incident
      :histogram-fields         incident-histogram-fields
-     :enumerable-fields        incident-enumerable-fields})))
+     :enumerable-fields        incident-enumerable-fields
+     :searchable-fields        searchable-fields})))
 
 (def IncidentType
   (let [{:keys [fields name description]}

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -139,6 +139,22 @@
 (s/defschema IndicatorsByExternalIdQueryParams
   IndicatorsListQueryParams)
 
+(def searchable-fields
+  #{:id
+    :source
+    :confidence
+    :description
+    :indicator_type
+    :kill_chain_phases.kill_chain_name
+    :kill_chain_phases.phase_name
+    :likely_impact
+    :producer
+    :severity
+    :short_description
+    :tags
+    :test_mechanisms
+    :title})
+
 (s/defn indicator-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -161,7 +177,8 @@
     :external-id-capabilities :read-indicator
     :can-aggregate?           true
     :histogram-fields         indicator-histogram-fields
-    :enumerable-fields        indicator-enumerable-fields}))
+    :enumerable-fields        indicator-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:read-indicator

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -142,17 +142,8 @@
 (def searchable-fields
   #{:id
     :source
-    :confidence
     :description
-    :indicator_type
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
-    :likely_impact
-    :producer
-    :severity
     :short_description
-    :tags
-    :test_mechanisms
     :title})
 
 (s/defn indicator-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -73,6 +73,19 @@
 (def investigation-histogram-fields
   [:timestamp])
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :investigated_observables
+    :object_ids
+    :short_description
+    :targets.observables.type
+    :targets.observables.value
+    :targets.os
+    :targets.type
+    :title})
+
 (s/defn investigation-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -95,7 +108,8 @@
     :external-id-capabilities :read-investigation
     :can-aggregate?           true
     :histogram-fields         investigation-histogram-fields
-    :enumerable-fields        investigation-enumerable-fields}))
+    :enumerable-fields        investigation-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:read-investigation

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -78,12 +78,7 @@
     :source
     :description
     :investigated_observables
-    :object_ids
     :short_description
-    :targets.observables.type
-    :targets.observables.value
-    :targets.os
-    :targets.type
     :title})
 
 (s/defn investigation-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -107,28 +107,39 @@
                                                        (update :reason str " " reason)))
                            :wait_for wait_for}))))
 
+(def searchable-fields
+  #{:id
+    :source
+    :confidence
+    :disposition_name
+    :observable.type
+    :observable.value
+    :reason
+    :severity})
+
 (s/defn judgement-routes [services :- APIHandlerServices]
-  (let [entity-crud-config {:entity :judgement
-                            :new-schema js/NewJudgement
-                            :entity-schema js/Judgement
-                            :get-schema js/PartialJudgement
-                            :get-params JudgementGetParams
-                            :list-schema js/PartialJudgementList
-                            :search-schema js/PartialJudgementList
-                            :external-id-q-params JudgementsByExternalIdQueryParams
-                            :search-q-params JudgementSearchParams
-                            :new-spec :new-judgement/map
-                            :realize-fn js/realize-judgement
-                            :get-capabilities :read-judgement
-                            :post-capabilities :create-judgement
-                            :put-capabilities #{:create-judgement :developer}
-                            :delete-capabilities :delete-judgement
-                            :search-capabilities :search-judgement
+  (let [entity-crud-config {:entity                   :judgement
+                            :new-schema               js/NewJudgement
+                            :entity-schema            js/Judgement
+                            :get-schema               js/PartialJudgement
+                            :get-params               JudgementGetParams
+                            :list-schema              js/PartialJudgementList
+                            :search-schema            js/PartialJudgementList
+                            :external-id-q-params     JudgementsByExternalIdQueryParams
+                            :search-q-params          JudgementSearchParams
+                            :new-spec                 :new-judgement/map
+                            :realize-fn               js/realize-judgement
+                            :get-capabilities         :read-judgement
+                            :post-capabilities        :create-judgement
+                            :put-capabilities         #{:create-judgement :developer}
+                            :delete-capabilities      :delete-judgement
+                            :search-capabilities      :search-judgement
                             :external-id-capabilities :read-judgement
-                            :can-update? true
-                            :can-aggregate? true
-                            :histogram-fields js/judgement-histogram-fields
-                            :enumerable-fields js/judgement-enumerable-fields}]
+                            :can-update?              true
+                            :can-aggregate?           true
+                            :histogram-fields         js/judgement-histogram-fields
+                            :enumerable-fields        js/judgement-enumerable-fields
+                            :searchable-fields        searchable-fields}]
     (routes
       (services->entity-crud-routes
         services

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -110,12 +110,9 @@
 (def searchable-fields
   #{:id
     :source
-    :confidence
     :disposition_name
-    :observable.type
     :observable.value
-    :reason
-    :severity})
+    :reason})
 
 (s/defn judgement-routes [services :- APIHandlerServices]
   (let [entity-crud-config {:entity                   :judgement

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -124,6 +124,18 @@
 (def MalwareConnectionType
   (pagination/new-connection MalwareType))
 
+(def searchable-fields
+  #{:id
+    :source
+    :abstraction_level
+    :description
+    :kill_chain_phases.kill_chain_name
+    :kill_chain_phases.phase_name
+    :labels
+    :short_description
+    :title
+    :x_mitre_aliases})
+
 (s/defn malware-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -146,7 +158,8 @@
     :external-id-capabilities :read-malware
     :can-aggregate?           true
     :histogram-fields         malware-histogram-fields
-    :enumerable-fields        malware-enumerable-fields}))
+    :enumerable-fields        malware-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def malware-entity
   {:route-context         "/malware"

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -127,7 +127,6 @@
 (def searchable-fields
   #{:id
     :source
-    :abstraction_level
     :description
     :kill_chain_phases.kill_chain_name
     :kill_chain_phases.phase_name

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -206,10 +206,7 @@
   #{:id
     :source
     :description
-    :relationship_type
     :short_description
-    :source_ref
-    :target_ref
     :title})
 
 (s/defn relationship-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -202,6 +202,16 @@
   [:source
    :relationship_type])
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :relationship_type
+    :short_description
+    :source_ref
+    :target_ref
+    :title})
+
 (s/defn relationship-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -224,7 +234,8 @@
     :external-id-capabilities :read-relationship
     :can-aggregate?           true
     :histogram-fields         relationship-histogram-fields
-    :enumerable-fields        relationship-enumerable-fields}))
+    :enumerable-fields        relationship-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-relationship

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -46,29 +46,10 @@
 (def searchable-fields
   #{:id
     :source
-    :confidence
     :description
-    :observables.type
     :observables.value
-    :relations.origin
-    :relations.origin_uri
-    :relations.related.type
-    :relations.related.value
-    :relations.relation
-    :relations.source.type
-    :relations.source.value
-    :resolution
-    :sensor
-    :sensor_coordinates.observables.type
-    :sensor_coordinates.observables.value
-    :sensor_coordinates.os
-    :sensor_coordinates.type
-    :severity
     :short_description
-    :targets.observables.type
     :targets.observables.value
-    :targets.os
-    :targets.type
     :title})
 
 (s/defn sighting-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -43,6 +43,34 @@
    routes.common/PagingParams
    SightingFieldsParam))
 
+(def searchable-fields
+  #{:id
+    :source
+    :confidence
+    :description
+    :observables.type
+    :observables.value
+    :relations.origin
+    :relations.origin_uri
+    :relations.related.type
+    :relations.related.value
+    :relations.relation
+    :relations.source.type
+    :relations.source.value
+    :resolution
+    :sensor
+    :sensor_coordinates.observables.type
+    :sensor_coordinates.observables.value
+    :sensor_coordinates.os
+    :sensor_coordinates.type
+    :severity
+    :short_description
+    :targets.observables.type
+    :targets.observables.value
+    :targets.os
+    :targets.type
+    :title})
+
 (s/defn sighting-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -65,7 +93,8 @@
     :search-capabilities      :search-sighting
     :can-aggregate?           true
     :histogram-fields         ss/sighting-histogram-fields
-    :enumerable-fields        ss/sighting-enumerable-fields}))
+    :enumerable-fields        ss/sighting-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-sighting

--- a/src/ctia/entity/target_record.clj
+++ b/src/ctia/entity/target_record.clj
@@ -108,11 +108,7 @@
     :source
     :description
     :short_description
-    :targets.observables.type
     :targets.observables.value
-    :targets.os
-    :targets.sensor
-    :targets.type
     :title})
 
 (s/defn target-record-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/target_record.clj
+++ b/src/ctia/entity/target_record.clj
@@ -103,6 +103,18 @@
    :targets.observed_time.start_time
    :targets.observed_time.end_time])
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :short_description
+    :targets.observables.type
+    :targets.observables.value
+    :targets.os
+    :targets.sensor
+    :targets.type
+    :title})
+
 (s/defn target-record-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -125,7 +137,8 @@
     :external-id-capabilities :read-target-record
     :can-aggregate?           true
     :histogram-fields         target-record-histogram-fields
-    :enumerable-fields        target-record-enumerable-fields}))
+    :enumerable-fields        target-record-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-target-record

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -69,6 +69,17 @@
     :delete-tool
     :search-tool})
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :kill_chain_phases.kill_chain_name
+    :kill_chain_phases.phase_name
+    :labels
+    :short_description
+    :title
+    :x_mitre_aliases})
+
 (s/defn tool-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -91,7 +102,8 @@
     :external-id-capabilities :read-tool
     :can-aggregate?           true
     :histogram-fields         tool-histogram-fields
-    :enumerable-fields        tool-enumerable-fields}))
+    :enumerable-fields        tool-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def tool-entity
   {:route-context         "/tool"

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -73,12 +73,9 @@
   #{:id
     :source
     :description
-    :kill_chain_phases.kill_chain_name
-    :kill_chain_phases.phase_name
     :labels
     :short_description
-    :title
-    :x_mitre_aliases})
+    :title})
 
 (s/defn tool-routes [services :- APIHandlerServices]
   (services->entity-crud-routes

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -203,6 +203,15 @@
               ent/un-store-page
               routes.common/paginated-ok))))))
 
+(def searchable-fields
+  #{:id
+    :source
+    :description
+    :configurations.nodes.children.cpe_match.cpe23Uri
+    :configurations.nodes.cpe_match.cpe23Uri
+    :short_description
+    :title})
+
 (s/defn vulnerability-routes [services :- APIHandlerServices]
   (routes
    (search-by-cpe-match-strings services)
@@ -227,7 +236,8 @@
      :external-id-capabilities :read-vulnerability
      :can-aggregate?           true
      :histogram-fields         vulnerability-histogram-fields
-     :enumerable-fields        vulnerability-enumerable-fields})))
+     :enumerable-fields        vulnerability-enumerable-fields
+     :searchable-fields        searchable-fields})))
 
 (def capabilities
   #{:create-vulnerability

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -207,8 +207,6 @@
   #{:id
     :source
     :description
-    :configurations.nodes.children.cpe_match.cpe23Uri
-    :configurations.nodes.cpe_match.cpe23Uri
     :short_description
     :title})
 

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -130,6 +130,58 @@
    :technologies.name
    :technologies.prevalence])
 
+(def searchable-fields
+  #{:id
+    :source
+    :paradigms.name
+    :description
+    :technologies.name
+    :background_details
+    :abstraction_level
+    :languages.name
+    :architectures.prevalence
+    :common_consequences.scopes
+    :alternate_terms.term
+    :detection_methods.method
+    :architectures.name
+    :operating_systems.version
+    :potential_mitigations.effectiveness_notes
+    :likelihood
+    :potential_mitigations.effectiveness
+    :paradigms.prevalence
+    :languages.prevalence
+    :modes_of_introduction.phase
+    :external_references.source_name
+    :external_ids
+    :short_description
+    :common_consequences.likelihood
+    :notes.note
+    :title
+    :operating_systems.name
+    :operating_systems.cpe_id
+    :functional_areas
+    :notes.type
+    :operating_systems.prevalence
+    :structure
+    :external_references.description
+    :technologies.prevalence
+    :external_references.hashes
+    :affected_resources
+    :potential_mitigations.phases
+    :alternate_terms.description
+    :external_references.external_id
+    :potential_mitigations.strategy
+    :detection_methods.effectiveness_notes
+    :architectures.class
+    :languages.class
+    :potential_mitigations.description
+    :common_consequences.note
+    :detection_methods.effectiveness
+    :common_consequences.impacts
+    :operating_systems.class
+    :modes_of_introduction.note
+    :detection_methods.description})
+
 (s/defn weakness-routes [services :- APIHandlerServices]
   (services->entity-crud-routes
    services
@@ -152,7 +204,8 @@
     :external-id-capabilities :read-weakness
     :can-aggregate?           true
     :histogram-fields         weakness-histogram-fields
-    :enumerable-fields        weakness-enumerable-fields}))
+    :enumerable-fields        weakness-enumerable-fields
+    :searchable-fields        searchable-fields}))
 
 (def capabilities
   #{:create-weakness

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -133,54 +133,9 @@
 (def searchable-fields
   #{:id
     :source
-    :paradigms.name
     :description
-    :technologies.name
-    :background_details
-    :abstraction_level
-    :languages.name
-    :architectures.prevalence
-    :common_consequences.scopes
-    :alternate_terms.term
-    :detection_methods.method
-    :architectures.name
-    :operating_systems.version
-    :potential_mitigations.effectiveness_notes
-    :likelihood
-    :potential_mitigations.effectiveness
-    :paradigms.prevalence
-    :languages.prevalence
-    :modes_of_introduction.phase
-    :external_references.source_name
-    :external_ids
     :short_description
-    :common_consequences.likelihood
-    :notes.note
-    :title
-    :operating_systems.name
-    :operating_systems.cpe_id
-    :functional_areas
-    :notes.type
-    :operating_systems.prevalence
-    :structure
-    :external_references.description
-    :technologies.prevalence
-    :external_references.hashes
-    :affected_resources
-    :potential_mitigations.phases
-    :alternate_terms.description
-    :external_references.external_id
-    :potential_mitigations.strategy
-    :detection_methods.effectiveness_notes
-    :architectures.class
-    :languages.class
-    :potential_mitigations.description
-    :common_consequences.note
-    :detection_methods.effectiveness
-    :common_consequences.impacts
-    :operating_systems.class
-    :modes_of_introduction.note
-    :detection_methods.description})
+    :title})
 
 (s/defn weakness-routes [services :- APIHandlerServices]
   (services->entity-crud-routes

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -196,14 +196,7 @@
  (s/fn [{{:keys [get-store]} :StoreService
          :as services} :- APIHandlerServices]
   (let [capitalized (capitalize-entity entity)
-        search-q-params* (st/merge
-                          search-q-params
-                          {;; We cannot name the parameter :fields, because we already have :fields (part
-                           ;; of search-q-params). That key is to select a subsets of fields of the
-                           ;; retrieved document and it gets passed to the `_source` parameter of
-                           ;; Elasticsearch. For more: www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html
-                           (s/optional-key :search_fields)
-                           (describe (st/get-in search-q-params [:fields]) "'fields' key of Elasticsearch Fulltext Query.")})
+        search-q-params* (routes.common/prep-es-fields-schema entity-crud-config)
         search-filters (st/dissoc search-q-params
                                   :sort_by
                                   :sort_order

--- a/src/ctia/schemas/utils.clj
+++ b/src/ctia/schemas/utils.clj
@@ -193,3 +193,29 @@
                       {:missing-keys missing-keys
                        :res res})))
     res))
+
+(s/defn contains-key? :- s/Bool
+  "Returns true if schema contains key at the given path.
+   Example:
+    (contains-key? Sighting [:sensor_coordinates :observables :type]) => true"
+  [schema :- (s/protocol s/Schema)
+   path :- [s/Keyword]]
+  (let [any-schema? (fn [s]
+                      (and (map? s)
+                           (instance? schema.core.AnythingSchema (ffirst s))))
+        full-path   (reduce
+                     (fn [track n]
+                       (let [cur (st/get-in schema track)]
+                         (cond
+                           (any-schema? cur) track ;; if {Any _} - don't go deeper
+                           (map? cur)        (conj track n)
+                           (vector? cur)     (conj track 0 n)
+
+                           :else track)))
+                     []
+                     path)
+        val (st/get-in schema full-path)]
+    (or (any-schema? val)
+        (and (some? val)
+             (= (count (remove number? full-path))
+                (count path))))))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -454,6 +454,12 @@ It returns the documents with full hits meta data including the real index in wh
                                            ident
                                            get-in-config))))))
 
+(defn- rename-search-fields [fields]
+  (let [search-fields-mapping {"source" "source.text"}]
+    (when fields
+      {:fields
+       (mapv (comp #(get search-fields-mapping % %) name) fields)})))
+
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [full-text-terms :- [FullTextQuery]
    default-operator]
@@ -466,8 +472,7 @@ It returns the documents with full hits meta data including the real index in wh
                                     (when (and default-operator
                                                (not= query_mode :multi_match))
                                       {:default_operator default-operator})
-                                    (when fields
-                                      {:fields (mapv name fields)})))))]
+                                    (rename-search-fields fields)))))]
     (mapv term->es-query-part full-text-terms)))
 
 (s/defn make-search-query :- {s/Keyword s/Any}

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -454,12 +454,6 @@ It returns the documents with full hits meta data including the real index in wh
                                            ident
                                            get-in-config))))))
 
-(defn- rename-search-fields [fields]
-  (let [search-fields-mapping {"source" "source.text"}]
-    (when fields
-      {:fields
-       (mapv (comp #(get search-fields-mapping % %) name) fields)})))
-
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [full-text-terms :- [FullTextQuery]
    default-operator]
@@ -472,7 +466,8 @@ It returns the documents with full hits meta data including the real index in wh
                                     (when (and default-operator
                                                (not= query_mode :multi_match))
                                       {:default_operator default-operator})
-                                    (rename-search-fields fields)))))]
+                                    (when fields
+                                      {:fields (mapv name fields)})))))]
     (mapv term->es-query-part full-text-terms)))
 
 (s/defn make-search-query :- {s/Keyword s/Any}

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -43,9 +43,6 @@
   (assoc text
          :fields {:whole token}))
 
-(def searchable-token
-  (assoc token :fields {:text text}))
-
 (def external-reference
   {:properties
    {:source_name token
@@ -71,7 +68,7 @@
    :description text})
 
 (def sourcable-entity-mapping
-  {:source searchable-token
+  {:source token
    :source_uri token})
 
 (def stored-entity-mapping

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -43,6 +43,9 @@
   (assoc text
          :fields {:whole token}))
 
+(def searchable-token
+  (assoc token :fields {:text text}))
+
 (def external-reference
   {:properties
    {:source_name token
@@ -68,7 +71,7 @@
    :description text})
 
 (def sourcable-entity-mapping
-  {:source token
+  {:source searchable-token
    :source_uri token})
 
 (def stored-entity-mapping

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -206,6 +206,27 @@
        :bundle-gen       bundle-gen
        :check            check-fn}])
 
+   (let [bundle-gen (->> :incidents
+                         bundle-gen-for
+                         (gen/fmap
+                          (fn [bundle]
+                            (update
+                             bundle :incidents
+                             (fn [incidents]
+                               (utils/update-items
+                                incidents
+                                #(assoc % :title "fried eggs")))))))
+         check-fn   (fn [_ _ _ res]
+                      (is (seq (get-in res [:parsed-body :errors :search_fields]))))]
+     [{:test-description "passing non-existing fields shouldn't be allowed"
+       :query-params     {:query "*", :search_fields ["bad-field"]}
+       :bundle-gen       bundle-gen
+       :check            check-fn}
+      {:test-description "passing legit entity, albeit non-searchable fields still not allowed"
+       :query-params     {:query "*", :search_fields ["incident_time.discovered"]}
+       :bundle-gen       bundle-gen
+       :check            check-fn}])
+
    ;; TODO: Re-enable after solving https://github.com/threatgrid/ctia/pull/1152#pullrequestreview-780638906
    #_(let [expected {:title  "intrusion event 3:19187:7 incident"
                      :source "ngfw_ips_event_service"}

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -1,12 +1,13 @@
 (ns ctia.http.generative.fulltext-search-test
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures join-fixtures]]
+   [clojure.test :refer [deftest testing is are use-fixtures join-fixtures]]
    [clojure.test.check.generators :as gen]
    [ctia.auth.capabilities :as capabilities]
    [ctia.auth.threatgrid :refer [map->Identity]]
    [ctia.bundle.core :as bundle]
    [ctia.http.generative.properties :as prop]
    [ctia.lib.utils :as utils]
+   [ctia.store :as store]
    [ctia.test-helpers.core :as helpers]
    [ctia.test-helpers.es :as es-helpers]
    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
@@ -203,7 +204,25 @@
                           :query         "(fried eggs eggplant) OR (fried eggs potato)"
                           :search_fields ["title"]}
        :bundle-gen       bundle-gen
-       :check            check-fn}])))
+       :check            check-fn}])
+
+   ;; TODO: Re-enable after solving https://github.com/threatgrid/ctia/pull/1152#pullrequestreview-780638906
+   #_(let [expected {:title  "intrusion event 3:19187:7 incident"
+                     :source "ngfw_ips_event_service"}
+           bundle (gen/fmap
+                   (fn [bndl]
+                     (update bndl :incidents
+                             (fn [items]
+                               (utils/update-items items #(merge % expected)))))
+                   (bundle-gen-for :incidents))
+           check-fn (fn [_ _ _ res]
+                      (is (= expected
+                             (-> res :parsed-body first (select-keys [:source :title])))))]
+       [{:test-description "searching in mixed fields indexed as pure text and keyword"
+         :query-params     {:query "the intrusion event 3\\:19187\\:7 incident"
+                            :search_fields ["title" "source"]}
+         :bundle-gen       bundle
+         :check            check-fn}])))
 
 (defn test-search-case
   [app
@@ -241,3 +260,82 @@
       (doseq [test-case (if-let [cases (seq (filter :only (test-cases)))]
                           cases (test-cases))]
         (test-search-case app test-case))))))
+
+;; For the time being (before we fully migrate to ES7), we need to test the behavior
+;; of searching in multiple heterogeneous types of fields, i.e., when some fields are
+;; mapped to 'text' and others to 'keyword'.
+;;
+;; Since at the moment we cannot implement a workaround in the API because that would
+;; require updating mappings on the live, production data, we'd have to test this by
+;; directly sending queries into ES, bypassing the CTIA routes.
+(deftest mixed-fields-text-and-keyword-multi-match
+  (es-helpers/for-each-es-version
+   "Mixed fields text and keyword multimatch"
+   [5 7]
+   #(es-index/delete! % "ctia_*")
+   (helpers/fixture-ctia-with-app
+    (fn [app]
+      (let [{{:keys [get-store]} :StoreService :as services} (app/service-graph app)
+
+            incidents-store (get-store :incident)
+
+            expected {:title  "intrusion event 3:19187:7 incident"
+                      :source "ngfw_ips_event_service"}
+            bundle   (->>
+                      :incidents
+                      bundle-gen-for
+                      (gen/fmap
+                       (fn [bndl]
+                         (update bndl :incidents
+                                 (fn [items]
+                                   (utils/update-items items #(merge % expected))))))
+                      gen/generate)
+
+            _ (bundle/import-bundle
+               bundle
+               nil    ;; external-key-prefixes
+               login services)
+
+            ignore-ks  [:created :groups :id :incident_time :modified :owner :timestamp]]
+        (are [desc query check-fn] (let [res (-> incidents-store
+                                                 (store/query-string-search
+                                                  (merge query {:default_operator "AND"})
+                                                  login {})
+                                                 :data)]
+                                     (testing (str "query: " query)
+                                       (is (check-fn res) desc)))
+          "base query matches expected data"
+          {:full-text [{:query "intrusion event 3\\:19187\\:7 incident"}]}
+          (fn [res]
+            (and
+             (= 1 (count res))
+             (-> res first
+                 (select-keys (keys expected))
+                 (= expected))))
+
+          "querying all, matches generated incidents, minus selected fields in each entity"
+          {:full-text [{:query "*"}]}
+          (fn [res]
+            (let [norm (fn [data] (->> data (map #(apply dissoc % ignore-ks)) set))]
+              (= (-> bundle :incidents norm)
+                 (-> res norm))))
+
+          "using 'title' and 'source' fields + a stop word"
+          {:full-text [{:query "that intrusion event 3\\:19187\\:7 incident"}]
+           :fields ["title" "source"]}
+          (fn [res]
+            (and
+             (= 1 (count res))
+             (-> res first
+                 (select-keys (keys expected))
+                 (= expected))))
+
+          "using double-quotes at the end of the query"
+          {:full-text [{:query "intrusion event 3\\:19187\\:7 incident \"\""}]
+           :fields ["title" "source"]}
+          (fn [res]
+            (and
+             (= 1 (count res))
+             (-> res first
+                 (select-keys (keys expected))
+                 (= expected))))))))))

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -2,14 +2,15 @@
   (:require [clj-momo.test-helpers.core :as mth]
             [clojure.test :refer [are is deftest testing use-fixtures]]
             [ctia.auth.capabilities :refer [all-capabilities]]
-            [ctia.entity.incident :refer [incident-entity]]
+            [ctia.entity.incident :as incident :refer [incident-entity]]
             [ctia.http.routes.common :as sut]
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.crud :refer [crud-wait-for-test]]
-            [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
+            [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
             [ctim.examples.incidents :refer [new-incident-maximal]]
-            [puppetlabs.trapperkeeper.app :as app]))
+            [puppetlabs.trapperkeeper.app :as app]
+            [schema-tools.core :as st]))
 
 (use-fixtures :once
               mth/fixture-schema-validation
@@ -31,6 +32,26 @@
       (is (= {:gte from
               :lt to}
              (sut/coerce-date-range from to))))))
+
+(deftest prep-es-fields-schema-test
+  (let [enum->set (fn [enum-schema]
+                    (->> enum-schema ffirst (apply hash-map) :vs))]
+    (are [fields result]
+        (is (= result
+               (some-> (sut/prep-es-fields-schema
+                        {:search-q-params   incident/IncidentSearchParams
+                         :searchable-fields fields})
+                       (st/get-in [:search_fields])
+                       enum->set))
+            (format "when %s passed, %s expected" fields result))
+      #{:foo :bar} #{"foo" "bar"}
+      #{:foo}      #{"foo"}
+      nil          nil))
+  (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
+    (is (= incident/IncidentSearchParams
+           (sut/prep-es-fields-schema  {:search-q-params incident/IncidentSearchParams})
+           (sut/prep-es-fields-schema  {:search-q-params   incident/IncidentSearchParams
+                                        :searchable-fields #{}})))))
 
 (deftest search-query-test
   (with-redefs [sut/now (constantly #inst "2020-12-31")]


### PR DESCRIPTION
Adds searchable-fields in all searchable entities. Users allowed to use subset of those fields with search queries.

> **Epic** https://github.com/advthreat/iroh/issues/5929
> Close https://github.com/advthreat/iroh/issues/5938
> Related #



<a name="qa">[§](#qa)</a> QA
============================

*QA plan for this ticket should be very similar to one in: https://github.com/threatgrid/ctia/pull/1109 Mostly, we need to make sure there's no regression and the search works as before.*

*We encourage you to think of various query strategies and send as many different queries as possible. Saturate the test cases to flush out things that we may have missed. The following outline is an example of a few different queries.*

Naturally, you're going to need some data to query against it. You can use Bundle Import to create a few entities. 

- Mark your entities with some unique group name, e.g., the following examples set the value of `source` field for every entity to be `pr1155`

- Whenever you need to re-run the tests, it's probably desirable to remove any existing entities, to avoid confusion:

```http
DELETE http://ctia-instance/ctia/incident/search?source=pr1155&query=*&REALLY_DELETE_ALL_THESE_ENTITIES=true

DELETE http://ctia-instance/ctia/actor/search?source=pr1155&query=*&REALLY_DELETE_ALL_THESE_ENTITIES=true
```

- Make sure you don't have any records for entities you're about to test. The following queries should return 0.

```http
GET http://ctia-instance/ctia/incident/search/count&source=pr1155

GET http://ctia-instance/ctia/actor/search/count&source=pr1155
```

### Import a bundle
    
<details>
    <summary>
    Use bundle import to create some entities, the following example bundle contains three incidents, and a single actor:
   </summary>

```
POST http://ctia-instance/ctia/bundle/import
Content-type: application/json

{
    "timestamp": "2016-02-11T00:40:48Z",
    "incidents": [
        {
            "confidence": "High",
            "timestamp": "2016-02-11T00:40:48Z",
            "tlp": "green",
            "language": "language",
            "status": "Open",
            "categories": [
                "Denial of Service",
                "Improper Usage"
            ],
            "intended_effect": "Extortion",
            "source_uri": "http://example.com/incident-one",
            "discovery_method": "Log Review",
            "external_references": [],
            "incident_time": {
                "reported": "2016-02-11T00:40:48Z",
                "remediated": "2016-02-11T00:40:48Z",
                "rejected": "2016-02-11T00:40:48Z",
                "opened": "2016-02-11T00:40:48Z",
                "discovered": "2016-02-11T00:40:48Z",
                "closed": "2016-02-11T00:40:48Z"
            },
            "title": "Lorem Ipsum Test Incident",
            "short_description": "first incident",
            "external_ids": [],
            "source": "pr1155",
            "type": "incident",
            "revision": 1,
            "schema_version": "1.1.3",
            "assignees": [],
            "description": "description of first incident"
        },
        {
            "confidence": "High",
            "timestamp": "2016-02-11T00:40:48Z",
            "tlp": "green",
            "language": "language",
            "status": "Open",
            "categories": [
                "Denial of Service",
                "Improper Usage"
            ],
            "intended_effect": "Extortion",
            "source_uri": "http://example.com/incident-two",
            "discovery_method": "Log Review",
            "external_references": [],
            "incident_time": {
                "reported": "2016-02-11T00:40:48Z",
                "remediated": "2016-02-11T00:40:48Z",
                "rejected": "2016-02-11T00:40:48Z",
                "opened": "2016-02-11T00:40:48Z",
                "discovered": "2016-02-11T00:40:48Z",
                "closed": "2016-02-11T00:40:48Z"
            },
            "title": "Lorem Ipsum Test Incident dos",
            "short_description": "incident numero dos",
            "external_ids": [],
            "source": "pr1155",
            "type": "incident",
            "revision": 1,
            "schema_version": "1.1.3",
            "assignees": [],
            "description": "second incident"
        },
        {
            "confidence": "High",
            "timestamp": "2016-02-11T00:40:48Z",
            "tlp": "green",
            "language": "language",
            "status": "Open",
            "categories": [
                "Denial of Service",
                "Improper Usage"
            ],
            "intended_effect": "Extortion",
            "source_uri": "http://example.com/incident-three",
            "discovery_method": "Log Review",
            "external_references": [],
            "incident_time": {
                "reported": "2016-02-11T00:40:48Z",
                "remediated": "2016-02-11T00:40:48Z",
                "rejected": "2016-02-11T00:40:48Z",
                "opened": "2016-02-11T00:40:48Z",
                "discovered": "2016-02-11T00:40:48Z",
                "closed": "2016-02-11T00:40:48Z"
            },
            "title": "incident numero three",
            "short_description": "incident numero tres",
            "external_ids": [],
            "source": "pr1155",
            "type": "incident",
            "revision": 1,
            "schema_version": "1.1.3",
            "assignees": [],
            "description": "third incident"
        }
    ],
    "actors": [
        {
            "description" : "Legion Of Doom",
            "motivation" : "Ego",
            "valid_time" : {
                "start_time" : "2016-02-11T00:40:48Z",
                "end_time" : "2016-07-11T00:40:48Z"
            },
            "identity" : {
                "description" : "LOD identity",
                "related_identities" : [ ]
            },
            "sophistication" : "Innovator",
            "schema_version" : "1.0",
            "revision" : 1,
            "planning_and_operational_support" : "MUHS 9th Hour",
            "type" : "actor",
            "source": "pr1155",
            "external_ids" : [ ],
            "short_description" : "founded by the hacker Lex Luthor",
            "title" : "LOD Group",
            "external_references" : [ ],
            "source_uri" : "http://example.com/actors/legion-of-doom",
            "intended_effect" : "Fraud",
            "actor_type" : "Hacker",
            "language" : "language",
            "tlp" : "green",
            "timestamp" : "2016-02-11T00:40:48Z",
            "confidence" : "High"
        }],
    "tlp": "green",
    "language": "language",
    "source_uri": "http://example.com",
    "title": "title",
    "short_description": "bundle",
    "source": "source",
    "revision": 1,
    "schema_version": "1.1.3",
    "valid_time": {
        "start_time": "2016-05-11T00:40:48Z",
        "end_time": "2016-07-11T00:40:48Z"
    },
    "description": "incidents to test"
}
```

</details>

- After the Import, check the number of imported entities

```http
GET http://ctia-instance/ctia/incident/search/count?source=pr1155
```
Expected: 3

```http
GET http://ctia-instance/ctia/actor/search/count?source=pr1155
```
Expected: 1

### Now you're ready to test some queries

#### 1. Query for non-existing values

```http
GET http://ctia-instance/ctia/actor/search?source=pr1155&query=lorem_ipsum_suspendisse_potenti
```

Expected: empty list

#### 2. Query including non-existing fields

Even though the following query is expected to succeed:
```http
GET http://ctia-instance/ctia/actor/search?source=pr1155&query=LOD
```

This next one is expected to fail
```http
GET http://ctia-instance/ctia/actor/search?source=pr1155&query=LOD&search_fields=some_strange_field
```

Expected: Error - search field is not a subset of allowed fields. The error message would be a schema validation error, basically saying that the given search_field is not one of:

"id, source, actor_type, confidence, description, identity.description, identity.related_identities.identity, identity.related_identities.information_source, identity.related_identities.relationship, intended_effect, motivation, planning_and_operational_support, short_description, sophistication, title"

These are the allowed searchable fields for the Actor entity (they vary for different entities)

#### 3. Search for Incidents that have specific values in specified fields

The following query should return nothing:

```http
GET http://ctia-instance/ctia/incident/search?source=pr1155&query=first%20Ipsum&search_fields=description
```

However, if we add the `title` field (without changing the query), it should find the record

```http
GET http://ctia-instance/ctia/incident/search?source=pr1155&query=first%20Ipsum&search_fields=description&search_fields=title
```

#### 4. Looking for the same value in different fields in multiple records

The next query returns two incidents, because two incidents have "numero" in their `short_description` fields

```http
GET http://ctia-instance/ctia/incident/search?source=pr1155&query=numero
```

#### 5. Now, if we want to match a record with "numero" in multiple fields, we still can use Lucene syntax, like so:

  This query `short_description:numero AND title:numero` should return only a single incident
  
```http
GET http://ctia-instance/ctia/incident/search?source=pr1155&query=short_description%3Anumero%20AND%20title%3Anumero
```

But changing the query slightly: `short_description:numero OR title:numero`, again gets both incidents
  
```http
GET http://ctia-instance/ctia/incident/search?source=pr1155&query=short_description%3Anumero%20OR%20title%3Anumero
```


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

30e48cec limit number of searchable-fields
a03d582d adds test cases for non-searchable fields
0473f7a8 reverts some files - bad rebase
260fb003 test: adds searchable-fields-test
8b54c834 remove introducing searchable-token
e5bfa8ab removes a test introduced in other branch
57277647 test: adds prep-es-fields-schema-test
52cf04df ns cleanup & minimizing refers
529c4966 prep-es-fields-schema
ce0ef9de adds default searchable fields
6936fbfd temporarily puts away mixed fields test
9cb9c6b3 source -> source.text at search
