### PR TITLE
configurable default sort

### DIFF
--- a/doc/properties.org
+++ b/doc/properties.org
@@ -312,10 +312,15 @@ Rate limit related configuration
 
   =actor=
   =attack-pattern=
+  =asset=
+  =asset-mapping=
+  =asset-properties=
   =campaign=
+  =casebook=
   =coa=
   =event=
   =data-table=
+  =feed=
   =feedback=
   =identity=
   =incident=
@@ -341,22 +346,24 @@ Rate limit related configuration
 Set ES Store implementation settings, 
 one can set defaults for all ES stores using =default= as entity
 
-| Property                                 | Description                                                          | Possible values            |
-|------------------------------------------+----------------------------------------------------------------------+----------------------------|
-| ctia.store.es.[entity].host              | ES instance host                                                     | string                     |
-| ctia.store.es.[entity].port              | ES instance port                                                     | port                       |
-| ctia.store.es.[entity].indexname         | ES index name to use                                                 | string                     |
-| ctia.store.es.[entity].refresh           | control when changes made by this request are made visible to search | string                     |
-| ctia.store.es.[entity].replicas          | how many replicas to setup at index creation                         | number                     |
-| ctia.store.es.[entity].shards            | how many shards to setup at index creation                           | number                     |
-| ctia.store.es.[entity].default_operator  | default operator for free text search                                | "AND" / "OR"               |
-| ctia.store.es.[entity].aliased           | should the index be aliased                                          | boolean                    |
-| ctia.store.es.[entity].rollover.max_docs | trigger rollover when store size exceeds that value                  | integer                    |
-| ctia.store.es.[entity].rollover.max_age  | trigger rollover when store age exceeds that period (ex: 2m, 1y)     | string                     |
-| ctia.store.es.[entity].version           | major version of used Elasticsearch                                  | integer                    |
-| ctia.store.es.[entity].update-mappings   | if true, automatically updates index mappings at startup             | boolean                    |
-| ctia.store.es.[entity].update-settings   | if true, automatically updates index settings at startup             | boolean                    |
-| ctia.store.es.[entity].auth              | authentication parameters for ES, see [[https://github.com/threatgrid/ductile][ductile documentation]]          | ductile.schemas/AuthParams |
+| Property                                 | Description                                                                        | Possible values            |
+|------------------------------------------+------------------------------------------------------------------------------------+----------------------------|
+| ctia.store.es.[entity].host              | ES instance host                                                                   | string                     |
+| ctia.store.es.[entity].port              | ES instance port                                                                   | port                       |
+| ctia.store.es.[entity].indexname         | ES index name to use                                                               | string                     |
+| ctia.store.es.[entity].refresh           | control when changes made by this request are made visible to search               | string                     |
+| ctia.store.es.[entity].replicas          | how many replicas to setup at index creation                                       | number                     |
+| ctia.store.es.[entity].shards            | how many shards to setup at index creation                                         | number                     |
+| ctia.store.es.[entity].default_operator  | default operator for free text search                                              | "AND" / "OR"               |
+| ctia.store.es.[entity].aliased           | should the index be aliased                                                        | boolean                    |
+| ctia.store.es.[entity].rollover.max_docs | trigger rollover when store size exceeds that value                                | integer                    |
+| ctia.store.es.[entity].rollover.max_age  | trigger rollover when store age exceeds that period (ex: 2m, 1y)                   | string                     |
+| ctia.store.es.[entity].version           | major version of used Elasticsearch                                                | integer                    |
+| ctia.store.es.[entity].update-mappings   | if true, automatically updates index mappings at startup                           | boolean                    |
+| ctia.store.es.[entity].refresh-mappings  | if true, automatically refreshes documents mappings at startup to index new fields | boolean                    |
+| ctia.store.es.[entity].update-settings   | if true, automatically updates index settings at startup                           | boolean                    |
+| ctia.store.es.[entity].auth              | authentication parameters for ES, see [[https://github.com/threatgrid/ductile][ductile documentation]]                        | ductile.schemas/AuthParams |
+| ctia.store.es.[entity].default-sort      | default sort parameter for search                                                  | string                     |
 
 ** Migration
 

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -72,6 +72,9 @@ ctia.store.es.default.version=5
 ctia.store.es.default.update-mappings=false
 ctia.store.es.default.update-settings=false
 ctia.store.es.default.refresh-mappings=false
+ctia.store.es.default.default-sort=timestamp,created,id
+ctia.store.es.event.default-sort=timestamp,id
+ctia.store.es.relationship.default-sort=created,id
 
 ctia.store.actor=es
 ctia.store.asset=es

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -40,6 +40,7 @@
    (str prefix store ".update-mappings")  s/Bool
    (str prefix store ".update-settings")  s/Bool
    (str prefix store ".refresh-mappings") s/Bool
+   (str prefix store ".default-sort") s/Str
    (str prefix store ".auth")  AuthParams})
 
 (s/defschema StorePropertiesSchema

--- a/test/ctia/entity/event_test.clj
+++ b/test/ctia/entity/event_test.clj
@@ -204,121 +204,121 @@
                                                (str "ctia/event/" event-id)
                                                :headers {"Authorization" "user1"})))))
 
-                    (is (= [{:owner "user1",
-                             :groups ["group1"],
-                             :timestamp #inst "2042-01-01T00:00:00.000-00:00",
-                             :tlp "amber"
-                             :entity
-                             {:description "my description",
-                              :schema_version ctim-schema-version,
-                              :type "incident",
-                              :created "2042-01-01T00:00:00.000Z",
-                              :modified "2042-01-01T00:00:00.000Z",
-                              :timestamp "2042-01-01T00:00:00.000Z",
-                              :incident_time {:opened "2042-01-01T00:00:00.000Z"},
-                              :status "Open",
-                              :id
-                              (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
-                                      port),
-                              :tlp "amber",
+                    (is (= #{{:owner "user1",
                               :groups ["group1"],
-                              :confidence "High",
-                              :owner "user1"},
-                             :id
-                             (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111113"
-                                     port),
-                             :type "event",
-                             :event_type :record-created}
-                            {:owner "user2",
-                             :groups ["group1"],
-                             :timestamp #inst "2042-01-02T00:00:00.000-00:00",
-                             :tlp "amber"
-                             :entity
-                             {:description "changed description",
-                              :schema_version ctim-schema-version,
-                              :type "incident",
-                              :created "2042-01-01T00:00:00.000Z",
-                              :modified "2042-01-02T00:00:00.000Z",
-                              :timestamp "2042-01-01T00:00:00.000Z",
-                              :incident_time {:opened "2042-01-01T00:00:00.000Z"},
-                              :status "Open",
+                              :timestamp #inst "2042-01-01T00:00:00.000-00:00",
+                              :tlp "amber"
+                              :entity
+                              {:description "my description",
+                               :schema_version ctim-schema-version,
+                               :type "incident",
+                               :created "2042-01-01T00:00:00.000Z",
+                               :modified "2042-01-01T00:00:00.000Z",
+                               :timestamp "2042-01-01T00:00:00.000Z",
+                               :incident_time {:opened "2042-01-01T00:00:00.000Z"},
+                               :status "Open",
+                               :id
+                               (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                                       port),
+                               :tlp "amber",
+                               :groups ["group1"],
+                               :confidence "High",
+                               :owner "user1"},
                               :id
-                              (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                              (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111113"
                                       port),
-                              :tlp "amber",
+                              :type "event",
+                              :event_type :record-created}
+                             {:owner "user2",
                               :groups ["group1"],
-                              :confidence "High",
-                              :owner "user1"},
-                             :id
-                             (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111116"
-                                     port),
-                             :type "event",
-                             :event_type :record-updated,
-                             :fields
-                             [{:field :description,
-                               :action "modified",
-                               :change
-                               {:before "my description",
-                                :after "changed description"}}
-                              {:field :modified,
-                               :action "modified",
-                               :change
-                               {:before "2042-01-01T00:00:00.000Z",
-                                :after "2042-01-02T00:00:00.000Z"}}]}
-                            {:owner "user1",
-                             :groups ["group1"],
-                             :timestamp #inst "2042-01-01T00:00:00.000-00:00",
-                             :tlp "amber"
-                             :entity
-                             {:schema_version ctim-schema-version,
-                              :target_ref
-                              (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
-                                      port),
-                              :type "relationship",
-                              :created "2042-01-01T00:00:00.000Z",
-                              :modified "2042-01-01T00:00:00.000Z",
-                              :timestamp "2042-01-01T00:00:00.000Z",
-                              :source_ref
-                              (format "http://localhost:%s/ctia/casebook/casebook-00000000-0000-0000-0000-111111111117"
-                                      port),
+                              :timestamp #inst "2042-01-02T00:00:00.000-00:00",
+                              :tlp "amber"
+                              :entity
+                              {:description "changed description",
+                               :schema_version ctim-schema-version,
+                               :type "incident",
+                               :created "2042-01-01T00:00:00.000Z",
+                               :modified "2042-01-02T00:00:00.000Z",
+                               :timestamp "2042-01-01T00:00:00.000Z",
+                               :incident_time {:opened "2042-01-01T00:00:00.000Z"},
+                               :status "Open",
+                               :id
+                               (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                                       port),
+                               :tlp "amber",
+                               :groups ["group1"],
+                               :confidence "High",
+                               :owner "user1"},
                               :id
-                              (format "http://localhost:%s/ctia/relationship/relationship-00000000-0000-0000-0000-111111111119"
+                              (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111116"
                                       port),
-                              :tlp "amber",
+                              :type "event",
+                              :event_type :record-updated,
+                              :fields
+                              [{:field :description,
+                                :action "modified",
+                                :change
+                                {:before "my description",
+                                 :after "changed description"}}
+                               {:field :modified,
+                                :action "modified",
+                                :change
+                                {:before "2042-01-01T00:00:00.000Z",
+                                 :after "2042-01-02T00:00:00.000Z"}}]}
+                             {:owner "user1",
                               :groups ["group1"],
-                              :owner "user1",
-                              :relationship_type "related-to"},
-                             :id
-                             (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111120"
-                                     port),
-                             :type "event",
-                             :event_type :record-created}
-                            {:owner "user2",
-                             :groups ["group1"],
-                             :timestamp #inst "2042-01-01T00:00:00.000-00:00",
-                             :tlp "amber"
-                             :entity
-                             {:description "changed description",
-                              :schema_version ctim-schema-version,
-                              :type "incident",
-                              :created "2042-01-01T00:00:00.000Z",
-                              :modified "2042-01-02T00:00:00.000Z",
-                              :timestamp "2042-01-01T00:00:00.000Z",
-                              :incident_time {:opened "2042-01-01T00:00:00.000Z"},
-                              :status "Open",
+                              :timestamp #inst "2042-01-01T00:00:00.000-00:00",
+                              :tlp "amber"
+                              :entity
+                              {:schema_version ctim-schema-version,
+                               :target_ref
+                               (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                                       port),
+                               :type "relationship",
+                               :created "2042-01-01T00:00:00.000Z",
+                               :modified "2042-01-01T00:00:00.000Z",
+                               :timestamp "2042-01-01T00:00:00.000Z",
+                               :source_ref
+                               (format "http://localhost:%s/ctia/casebook/casebook-00000000-0000-0000-0000-111111111117"
+                                       port),
+                               :id
+                               (format "http://localhost:%s/ctia/relationship/relationship-00000000-0000-0000-0000-111111111119"
+                                       port),
+                               :tlp "amber",
+                               :groups ["group1"],
+                               :owner "user1",
+                               :relationship_type "related-to"},
                               :id
-                              (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                              (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111120"
                                       port),
-                              :tlp "amber",
+                              :type "event",
+                              :event_type :record-created}
+                             {:owner "user2",
                               :groups ["group1"],
-                              :confidence "High",
-                              :owner "user1"},
-                             :id
-                             (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111121"
-                                     port),
-                             :type "event",
-                             :event_type :record-deleted}]
-                           results)))))))))))))
+                              :timestamp #inst "2042-01-01T00:00:00.000-00:00",
+                              :tlp "amber"
+                              :entity
+                              {:description "changed description",
+                               :schema_version ctim-schema-version,
+                               :type "incident",
+                               :created "2042-01-01T00:00:00.000Z",
+                               :modified "2042-01-02T00:00:00.000Z",
+                               :timestamp "2042-01-01T00:00:00.000Z",
+                               :incident_time {:opened "2042-01-01T00:00:00.000Z"},
+                               :status "Open",
+                               :id
+                               (format "http://localhost:%s/ctia/incident/incident-00000000-0000-0000-0000-111111111112"
+                                       port),
+                               :tlp "amber",
+                               :groups ["group1"],
+                               :confidence "High",
+                               :owner "user1"},
+                              :id
+                              (format "http://localhost:%s/ctia/event/event-00000000-0000-0000-0000-111111111121"
+                                      port),
+                              :type "event",
+                              :event_type :record-deleted}}
+                           (set results))))))))))))))
 
 (defn get-event [owner event_type timestamp]
   {:owner owner

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -186,15 +186,6 @@
                              judgements))
                    (set (map :observable
                              (:judgements valid-response-body)))))
-            (testing "using \"_doc\" as default sort by value makes this test fail."
-              (with-redefs [sut/fetch-limit 19
-                            es.crud/default-sort-field "_doc"] ;; _doc is unique per shard, but not per index
-                (is (< (-> (client/get feed-view-url
-                                       {:as :json})
-                           :body
-                           :judgements
-                           count)
-                       (count judgements)))))
 
             ;;teardown
             (is (= 200

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -1,8 +1,7 @@
 (ns ctia.properties-test
   (:require [ctia.properties :as sut]
-            [ductile.schemas :refer [AuthParams]]
+            [ductile.schemas :refer [AuthParams Refresh]]
             [clojure.test :refer [deftest is testing]]
-            [ductile.schemas :refer [Refresh]]
             [schema.core :as s]))
 
 (deftest es-store-impl-properties-test
@@ -24,6 +23,7 @@
             "ctia.store.es.malware.update-mappings" s/Bool
             "ctia.store.es.malware.update-settings" s/Bool
             "ctia.store.es.malware.refresh-mappings" s/Bool
+            "ctia.store.es.malware.default-sort" s/Str
             "ctia.store.es.malware.timeout" s/Num
             "ctia.store.es.malware.auth" AuthParams}
            (sut/es-store-impl-properties "ctia.store.es." "malware")))
@@ -45,6 +45,7 @@
             "prefix.sighting.update-mappings" s/Bool
             "prefix.sighting.update-settings" s/Bool
             "prefix.sighting.refresh-mappings" s/Bool
+            "prefix.sighting.default-sort" s/Str
             "prefix.sighting.timeout" s/Num
             "prefix.sighting.auth" AuthParams}
            (sut/es-store-impl-properties "prefix." "sighting")))))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -778,3 +778,24 @@
          (is (= expected-delete-result
                 (-> (update-in delete-res [:errors :not-found] set)
                     (update :deleted set)))))))))
+
+(deftest with-default-sort-field-test
+  (let [test-cases [{:msg "Use default hardcoded value when sort_by is not defined and no default sort is configured"
+                     :expected {:sort_by "_doc,id"}
+                     :es-params {}
+                     :props  {}}
+                    {:msg "Always use es-params sort_by when provided"
+                     :expected {:sort_by "title"}
+                     :es-params {:sort_by "title"}
+                     :props  {:default-sort "id"}}
+                    {:msg "Always use es-params sort_by when provided"
+                     :expected {:sort_by "title"}
+                     :es-params {:sort_by "title"}
+                     :props  {}}
+                    {:msg "When sort_by is not provided, use configured default-sort"
+                     :expected {:sort_by "id"}
+                     :es-params {}
+                     :props  {:default-sort "id"}}]]
+    (doseq [{:keys [msg expected es-params props]} test-cases]
+      (is (= expected (sut/with-default-sort-field es-params props))
+          msg))))

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -100,6 +100,9 @@
                       "ctia.store.es.default.version" 5
                       "ctia.store.es.default.auth" {:type :basic-auth
                                                     :params {:user "elastic" :pwd "ductile"}}
+                      "ctia.store.es.default.default-sort" "timestamp,created,id"
+                      "ctia.store.es.event.default-sort" "timestamp,id"
+                      "ctia.store.es.relationship.default-sort" "created,id"
                       "ctia.store.es.actor.indexname" "ctia_actor"
                       "ctia.store.es.actor.default_operator" "OR"
                       "ctia.store.es.asset.indexname" "ctia_assets"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/advthreat/iroh/issues/5891

This PR introduces a configurable default sort for searching.
I could not reproduce the issue locally, but for some reason the sorting on `_doc` is inconsistent even if we also sort by id as a second sort element (which [previously fixed inconsistency for feeds](https://github.com/threatgrid/ctia/pull/993)).
My intuition is that it happens when different replicas or primary shards are hit. During the migration, we turn off the replication for performance reason and then turn on the replication at the end. It's very likely that a parallelization during the replication do not ensure that the `_doc` values are preserved across replicas. I could not replicate this behavior.

<a name="qa">[§](#qa)</a> QA
============================

- For each of these entity types: sighting, relationship, indicator, event
search 10 times without any filter and limit 3 and check that the returned entities and their order is always the same:
`GET /ctia/<entity>/search?limit=3`

- You can optionally generalize/automate this test for all entities.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: fix CTIA default sort.
```
