### PR TITLE
Extend FeaturesService

### DIFF
--- a/dev/ctia/dev/split_tests.clj
+++ b/dev/ctia/dev/split_tests.clj
@@ -204,7 +204,7 @@
                                              "\nOut:\n" out
                                              "\nErr:\n" err)
                                         {:res res}))))
-          timeout-seconds 120
+          timeout-seconds 240
           exit-if-too-long (str "if [[ " timeout-seconds " -le $SECONDS ]]; then "
                                 "  echo \"timeout during connection attempt (waited ${SECONDS} seconds)\"; "
                                 "  exit 1; "

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -31,8 +31,8 @@
 
 (s/defn get-entities :- [s/Any]
   "Returns list of enabled entities"
-  [{{:keys [enabled?]} :FeaturesService} :- GetEntitiesServices]
-  (->> (entities/all-entities) (filter (fn [[k _]] (enabled? k)))))
+  [{{:keys [entity-enabled?]} :FeaturesService} :- GetEntitiesServices]
+  (->> (entities/all-entities) (filter (fn [[k _]] (entity-enabled? k)))))
 
 (s/defn Bulk :- (s/protocol s/Schema)
   "Returns Bulk schema without disabled entities"

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -78,10 +78,10 @@
 
 (s/defn prep-bundle-schema :- s/Any
   "Remove keys of disabled entities from Bundle schema"
-  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  [{{:keys [entity-enabled?]} :FeaturesService} :- APIHandlerServices]
   (->> (entities/all-entities)
        keys
-       (remove enabled?)
+       (remove entity-enabled?)
        (mapcat entity->bundle-keys)
        (apply st/dissoc NewBundle)))
 

--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -57,16 +57,3 @@
        (contains? x key)
        (not x)))))
 
-(comment
-
-  (require '[ctia.test-helpers.core :as th])
-
-  (th/with-properties
-    ["ctia.features.disable" "asset,actor,sighting"
-     "ctia.feature-flags" "experimental_ratio:35, bubble-gum:50"]
-    (th/fixture-ctia-with-app
-     (fn [app]
-       (let [{:keys [feature-flags]} (th/get-service-map app :FeaturesService)]
-         (println (feature-flags))))))
-
-  )

--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -13,7 +13,7 @@
   would not be visible in Swagger console."
   (feature-flags [this]
     "Returns all feature flags defined in the config")
-  (enabled? [this key]
+  (entity-enabled? [this key]
     "Returns `true` unless entity key is marked as Disabled in properties config"))
 
 (tk/defservice features-service
@@ -21,7 +21,7 @@
   [[:ConfigService get-in-config]]
   (feature-flags [this]
     (get-in-config [:ctia :features]))
-  (enabled?
+  (entity-enabled?
    [this key]
    (when (-> (entities/all-entities)
              keys

--- a/src/ctia/graphql/schemas.clj
+++ b/src/ctia/graphql/schemas.clj
@@ -174,10 +174,10 @@
       keyword))
 
 (defn- disabled-entities
-  [{{:keys [enabled?]} :FeaturesService}]
+  [{{:keys [entity-enabled?]} :FeaturesService}]
   (->> (entities/all-entities)
        keys
-       (filter #(not (enabled? %)))))
+       (filter #(not (entity-enabled? %)))))
 
 (defn- entities+plural-forms
   "Gets map of entity keys with their plural forms."

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -116,7 +116,7 @@
    :compojure.api.exception/default ex/default-error-handler})
 
 (s/defn api-tags
-  [{{:keys [enabled?]} :FeaturesService} :- APIHandlerServices]
+  [{{:keys [entity-enabled?]} :FeaturesService} :- APIHandlerServices]
   (->>
    [[:actor               "Actor"               "Actor operations"]
     [:asset               "Asset"               "Asset operations"]
@@ -148,7 +148,7 @@
     [:verdict             "Verdict"             "Verdict operations"]
     [:version             "Version"             "Version Information"]]
    (keep (fn [[k n desc]]
-          (when (enabled? k)
+          (when (entity-enabled? k)
             {:name n :description desc})))))
 
 (defn apply-oauth2-swagger-conf
@@ -185,10 +185,10 @@
                     :flow flow}))))
 
 (defn- mark-disabled-entities
-  [{{:keys [enabled?]} :FeaturesService}
+  [{{:keys [entity-enabled?]} :FeaturesService}
    {:keys [entity] :as entity-map}]
   (cond-> entity-map
-    (not (enabled? entity)) (assoc :no-api? true)))
+    (not (entity-enabled? entity)) (assoc :no-api? true)))
 
 (defn make-text-plain-format-encoder
   "Make a simple format encoder for the text/plain

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -205,6 +205,7 @@
                       "ctia.store.es.event.slicing.granularity"
                       (s/enum :minute :hour :day :week :month :year)})
    (st/optional-keys {"ctia.versions.config" s/Str})
+   (st/optional-keys {"ctia.feature-flags" s/Str})
    (st/optional-keys {"ctia.features.disable" (s/constrained s/Str #(not (re-find #"\s" %)))})))
 
 (def configurable-properties

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -40,8 +40,8 @@
                                             (s/=> graphql.schema.GraphQLType))}
     :IEncryption                     {:encrypt (s/=> s/Any s/Any)
                                       :decrypt (s/=> s/Any s/Any)}
-    :FeaturesService                 {:enabled?      (s/=> s/Bool s/Keyword)
-                                      :feature-flags (s/=> [s/Str])}}))
+    :FeaturesService                 {:entity-enabled? (s/=> s/Bool s/Keyword)
+                                      :feature-flags   (s/=> [s/Str])}}))
 
 (s/defschema HTTPShowServices
   (-> APIHandlerServices
@@ -320,7 +320,7 @@
   "vocab.observable-type-id")
 
 (s/defschema GetEntitiesServices
-  {:FeaturesService {:enabled? (s/=> s/Bool s/Keyword)
+  {:FeaturesService {:entity-enabled? (s/=> s/Bool s/Keyword)
                      s/Keyword s/Any}
    s/Keyword        s/Any})
 

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -434,7 +434,7 @@
                             :asset_properties_refs #{"http://ex.tld/ctia/asset-properties/asset-properties-5023697b-3857-4652-9b53-ccda297f9c3e"}
                             :target_record_refs    #{"http://ex.tld/ctia/target-record/target-record-5023697b-3857-4652-9b53-ccda297f9c3e"}
                             :target_records        (set-of target-record-maximal)}
-          api-handler-svcs {:FeaturesService {:enabled? #(contains? selected-keys %)}}]
+          api-handler-svcs {:FeaturesService {:entity-enabled? #(contains? selected-keys %)}}]
       (s/set-fn-validation! false)    ;; otherwise it fails for incomplete APIHandlerServices passed into `prep-bundle-schema`
       (is (map? (s/validate (bundle.routes/prep-bundle-schema api-handler-svcs) fake-bundle)))
       (is (thrown? Exception

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -11,13 +11,13 @@
     (th/with-properties ["ctia.features.disable" "asset,actor,sighting"]
       (th/fixture-ctia-with-app
        (fn [app]
-         (let [{:keys [enabled?]} (th/get-service-map app :FeaturesService)]
+         (let [{:keys [entity-enabled?]} (th/get-service-map app :FeaturesService)]
            (testing "Asset, Actor and Sighting are disabled"
-             (is (not-any? enabled? [:asset :actor :sighting])))
+             (is (not-any? entity-enabled? [:asset :actor :sighting])))
            (testing "Incident, Indicator entities are enabled"
-             (is (every? enabled? [:incident :indicator])))
+             (is (every? entity-enabled? [:incident :indicator])))
            (testing "It should not return `true` for non-existing entity keys"
-             (is (not (enabled? :lorem-ipsum))))))))))
+             (is (not (entity-enabled? :lorem-ipsum))))))))))
 
 (deftest routes-for-disabled-entities-test
   (let [try-route (fn [app entity]

--- a/test/ctia/features_service_test.clj
+++ b/test/ctia/features_service_test.clj
@@ -17,7 +17,22 @@
            (testing "Incident, Indicator entities are enabled"
              (is (every? entity-enabled? [:incident :indicator])))
            (testing "It should not return `true` for non-existing entity keys"
-             (is (not (entity-enabled? :lorem-ipsum))))))))))
+             (is (not (entity-enabled? :lorem-ipsum)))))))))
+  (testing "FeaturesService feature flagging methods"
+    (th/with-properties ["ctia.feature-flags"
+                         "star:proxima-centauri, distance:4.246,evo-stage:red_dwarf"]
+      (th/fixture-ctia-with-app
+       (fn [app]
+         (let [{:keys [flag-value feature-flags]} (th/get-service-map app :FeaturesService)]
+           (testing "feature flags"
+             (is (= {:star "proxima-centauri"
+                     :evo-stage "red_dwarf"
+                     :distance "4.246"}
+                    (feature-flags)))
+             (is (= (flag-value :star) "proxima-centauri"))
+             (is (= (flag-value :evo-stage) "red_dwarf"))
+             (is (= (flag-value :distance) "4.246"))
+             (is (= (flag-value :no-flag-like-dat) nil)))))))))
 
 (deftest routes-for-disabled-entities-test
   (let [try-route (fn [app entity]

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -524,7 +524,7 @@
   (-> app
       app/service-graph
       (csu/select-service-subgraph
-        {:FeaturesService #{:enabled?}})))
+        {:FeaturesService #{:entity-enabled?}})))
 
 (defn plural-key->entity
   "Returns entity map for given plural form of the entity key"


### PR DESCRIPTION
Need to extend FeaturesService to handle feature flags.

`ctia.features-service/FeaturesService` in addition to disabling entities (`[:ctia :features]` key) now can handle arbitrary feature flags.

e.g., `ctia.feature-flags=easter-egg:on, experimental-ratio:42`

Ideally, it would be nice if `[:ctia :features]` could be modified to also handle feature flags, but since the key already used on various environments for disabling entities, changing the logic that handles it would be risky. 
Therefore I had to add a new key.
Also, to minimize confusion I renamed `enabled?` method to `entity-enabled?`.

> **Epic** https://github.com/advthreat/iroh/issues/5929
> Close #
> Related https://github.com/advthreat/iroh/issues/5953

<a name="qa">[§](#qa)</a> QA
============================

no QA required

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

0aa8f9f7 disambiguates `FeaturesService::enabled?`, renames to `entity-enabled?`
34e26d5b try increasing timeout time for docker
a95863d2 extends FeaturesService to handle feature flags
655e4041 adds a simple test case