### PR TITLE
adds rename-search-fields fn

### DIFF
--- a/doc/searchable-fields-qa.md
+++ b/doc/searchable-fields-qa.md
@@ -1,0 +1,335 @@
+# QA instructions for [advthreat/iroh#5929 reactivate default fields + search-token rewrite](https://github.com/advthreat/iroh/issues/5929)
+
+*Due to the extended nature of this document, it was decided to keep it in a file instead of the PR description header*
+
+## Mechanics of the search improvements
+
+The whole kit & caboodle has begun with this [ticket](https://github.com/advthreat/response/issues/573). While trying to improve the search, we've encountered a few things. First, we've found that simply allowing other search modes (beside Lucene) breaks our previous [workflows](https://github.com/advthreat/iroh/issues/5597). Later we discovered that we couldn't search mixing different types of fields, i.e., keywords and text.
+
+Keywords usually are used for structured content such as IDs, email addresses, hostnames, status codes, zip codes, tags, etc. So we use them quite a lot. We also use text fields. And when searching for data, specifying fields, mixing keywords and text fields sometimes just doesn't work.
+
+Take this Elasticsearch query example:
+
+    {
+        "query_string": {
+            "query": "the intrusion event 3\\:19187\\:7 incident",
+            "default_operator": "AND",
+            "fields": ["title", "source"]
+        }
+    }
+
+Let's imagine we have an Incident with the title: "incident" and source: "intrusion event 3:19187:7". Even though the search phrase contains "the", the search engine should ignore it - it's a stop word. But the query above doesn't work. And the reason is that `title` and `source` are mapped to store different types of values.
+
+So why do we have to specify which fields to include in the search now? We never had to do that before. Older versions of ES could use [_all](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping-all-field.html) option, which forces ES to search in every field, treating every field like text. However, that approach requires extra CPU cycles; it is slow and less accurate. Most importantly, this option is deprecated and no longer available in the new versions. And we're currently undergoing migration to Elasticsearch v7.
+
+So we have to specify the fields. But we cannot break existing API functionality. Just like before, we don't force clients to instruct API which fields to use - if no `search-fields` specified, we quietly "inject" default fields. Each entity has a different set of "default searchable fields". And the search would be performed **only** on those fields. That is the set of allowed fields for searching.
+
+But, that still doesn't solve the problem of mixed types of fields. 
+
+We're solving that using the "nested fields" feature. Going back to the example above, `source` is a keyword, and `title` is a type of text, and thus they cannot be used together in the same query. But we can add a sub-field to `source`, of text type. Would then that query work? Well, then you'd have to specify that sub-field in the query, like so: `"fields": ["title", "source.text"]`. But we don't need to burden the user with these pesky details. We can do that translation ourselves. So, what the API does - for every field that is a keyword and has a sub-field of type text, it would automatically change the query, so the search is performed using the text sub-field. You send a request with: `"fields": ["title", "source"]` - internally it gets translated to: `"fields": ["title", "source.text"]`.
+
+Is that all? Well, not quite.
+Actually, in order for that to work, just adding a sub-field is not enough. We can add it now, but that change would not affect all the existing data. So, what do we do? We have to refresh the mapping for all our existing records. Basically, we need to tell ES: "Hey, we've changed the way how the records get stored; Could you now re-index existing records, please?"
+
+And that is an intimidating task - it's too much data to process. That is why we need to test everything thoroughly before enabling all these things in production.
+
+We have added a couple of feature flags (in addition to existing config properties) to turn things on and off quickly if something goes awry.
+
+The first config flag you need to know is:
+
+`ctia.store.es.default.refresh-mappings` - when set to true, it would queue the mapping update at the initialization phase when the server starts.
+
+`ctia.feature-flags` - is a new way of setting arbitrary feature flags. It can take multiple comma-separated values. Right now, we have: `enforce-search-fields` and `translate-searchable-fields`
+
+so they can be set like this, e.g.,
+
+    ctia.feature-flags=enforce-search-fields:true, translate-searchable-fields:false
+
+`enforce-search-fields` - when set to true, and if the user has not indicated which fields to include in the search, CTIA would explicitly perform the search using default searchable fields (again, each entity has its own set of those fields).
+
+`translate-searchable-fields` - when set to "true", does the automatic translation and sends the query with the correct sub-field, i.e., "source" gets sent as "source.text"
+
+## Regressions to watch for
+
+### Queries that end with double quotes
+
+Apparently, some systems today could append an empty string to the end of the query. We shouldn't break that:
+[advthreat/iroh#5597 Search behavior changed for Ribbon case/incident queries](https://github.com/advthreat/iroh/issues/5597)
+
+### Make sure Lucene syntax still works
+
+We recently added a simple query format for searching things, but we need to confirm that search still works for queries like: `description:Incident AND title:Injection`
+
+## Sample data for testing
+
+It helps to have some data to test the search. You can use `Bulk Import` to create a few unrelated entities; or `Bundle Import` if you want to test entities linked to each other, e.g., `Asset` and `AssetMapping`.
+
+It is a good strategy to set some property of these test subjects to something unique to eliminate ambiguous results. You can set `source` of every entity to be something like: `dec3_2021`
+
+<details>
+<summary>
+Here's an example with a single Actor and three Incident entities
+</summary>
+
+```json
+{
+    "actors": [
+        {
+            "confidence": "High",
+            "timestamp": "2016-02-11T00:40:48Z",
+            "tlp": "green",
+            "language": "language",
+            "actor_type": "Hacker",
+            "intended_effect": "Fraud",
+            "source_uri": "http://example.com/actors/legion-of-doom",
+            "external_references": [],
+            "title": "LOD Group",
+            "short_description": "founded by the hacker Lex Luthor",
+            "external_ids": [],
+            "source": "dec3_2021",
+            "type": "actor",
+            "planning_and_operational_support": "MUHS 9th Hour",
+            "revision": 1,
+            "schema_version": "1.0",
+            "sophistication": "Innovator",
+            "identity": {
+                "related_identities": [],
+                "description": "LOD identity"
+            },
+            "valid_time": {
+                "end_time": "2016-07-11T00:40:48Z",
+                "start_time": "2016-02-11T00:40:48Z"
+            },
+            "motivation": "Ego",
+            "description": "Legion Of Doom"
+        }
+    ],
+    "incidents": [
+        {
+            "description": "description of first incident",
+            "assignees": [],
+            "schema_version": "1.1.3",
+            "revision": 1,
+            "type": "incident",
+            "source": "dec3_2021",
+            "external_ids": [],
+            "short_description": "first incident",
+            "title": "Lorem Ipsum Test Incident",
+            "incident_time": {
+                "closed": "2016-02-11T00:40:48Z",
+                "discovered": "2016-02-11T00:40:48Z",
+                "opened": "2016-02-11T00:40:48Z",
+                "rejected": "2016-02-11T00:40:48Z",
+                "remediated": "2016-02-11T00:40:48Z",
+                "reported": "2016-02-11T00:40:48Z"
+            },
+            "external_references": [],
+            "discovery_method": "Log Review",
+            "source_uri": "http://example.com/incident-one",
+            "intended_effect": "Extortion",
+            "categories": [
+                "Denial of Service",
+                "Improper Usage"
+            ],
+            "status": "Open",
+            "language": "language",
+            "tlp": "green",
+            "timestamp": "2016-02-11T00:40:48Z",
+            "confidence": "High"
+        },
+        {
+            "description": "second incident",
+            "assignees": [],
+            "schema_version": "1.1.3",
+            "revision": 1,
+            "type": "incident",
+            "source": "dec3_2021",
+            "external_ids": [],
+            "short_description": "incident numero dos",
+            "title": "Lorem Ipsum Test Incident dos",
+            "incident_time": {
+                "closed": "2016-02-11T00:40:48Z",
+                "discovered": "2016-02-11T00:40:48Z",
+                "opened": "2016-02-11T00:40:48Z",
+                "rejected": "2016-02-11T00:40:48Z",
+                "remediated": "2016-02-11T00:40:48Z",
+                "reported": "2016-02-11T00:40:48Z"
+            },
+            "external_references": [],
+            "discovery_method": "Log Review",
+            "source_uri": "http://example.com/incident-two",
+            "intended_effect": "Extortion",
+            "categories": [
+                "Denial of Service",
+                "Improper Usage"
+            ],
+            "status": "Open",
+            "language": "language",
+            "tlp": "green",
+            "timestamp": "2016-02-11T00:40:48Z",
+            "confidence": "High"
+        },
+        {
+            "description": "third incident",
+            "assignees": [],
+            "schema_version": "1.1.3",
+            "revision": 1,
+            "type": "incident",
+            "source": "dec3_2021",
+            "external_ids": [],
+            "short_description": "incident numero tres",
+            "title": "incident numero three",
+            "incident_time": {
+                "closed": "2016-02-11T00:40:48Z",
+                "discovered": "2016-02-11T00:40:48Z",
+                "opened": "2016-02-11T00:40:48Z",
+                "rejected": "2016-02-11T00:40:48Z",
+                "remediated": "2016-02-11T00:40:48Z",
+                "reported": "2016-02-11T00:40:48Z"
+            },
+            "external_references": [],
+            "discovery_method": "Log Review",
+            "source_uri": "http://example.com/incident-three",
+            "intended_effect": "Extortion",
+            "categories": [
+                "Denial of Service",
+                "Improper Usage"
+            ],
+            "status": "Open",
+            "language": "language",
+            "tlp": "green",
+            "timestamp": "2016-02-11T00:40:48Z",
+            "confidence": "High"
+        }
+    ]
+}
+```
+
+</details>
+
+You can POST it using Bulk Import route to create these entities.
+
+## Testing
+
+We suggest exploring various ways to query, frequently changing the shape of data, and trying different queries. Saturate test cases to flush out any bugs. What's listed below is an outline with a few examples of what to test. These examples assume you're using the test data above.
+
+### Query for non-existing values
+
+Send a search query with a bogus text
+
+GET http://private.intel.int.iroh.site/ctia/actor/search?source=dec3_2021&query=lorem_ipsum_suspendisse_potenti
+
+**Expected**: empty list/no results
+
+### Query including non-existing fields
+
+Even though the following query should work:
+
+GET http://private.intel.int.iroh.site/ctia/actor/search?source=dec3_2021&query=LOD
+
+This next one is expected to fail:
+
+GET http://private.intel.int.iroh.site/ctia/actor/search?source=dec3_2021&query=LOD&search_fields=some_strange_field
+
+**Expected:** Error like this or similar:
+
+```json
+{
+  "errors": {
+    "search_fields": [
+      "(not (#{\"id\" \"short_description\" \"title\" \"source\" \"actor_type\" \"description\"} \"some_strange_field\"))"
+    ]
+  }
+}
+```
+
+### Search for Incidents that have specific values in specified fields
+
+The following query yields nothing (even though there is an Incident with the description containing "first", it doesn't include "Ipsum"):
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=first%20Ipsum&search_fields=description
+
+However, if we add the title field (without changing the query), it should find the matching record:
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=first%20Ipsum&search_fields=description&search_fields=title
+
+**Expected:** A single Incident
+
+### Looking for the same value in different fields in multiple records
+
+Both next queries return two incidents because two incidents have "numero" in their short_description fields:
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=numero&search_fields=short_description
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=numero
+
+**Expected:** Two Incidents
+
+Now, if we want to match a record with "numero" in multiple fields, we still can use Lucene syntax, like so:
+
+This query `short_description:numero AND title:numero` should return only a single incident
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=short_description%3Anumero%20AND%20title%3Anumero
+
+**Expected:** Single Incident
+
+But changing the query slightly: `short_description:numero OR title:numero` once again, gets both incidents:
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=short_description%3Anumero%20OR%20title%3Anumero
+
+**Expected:** Two incidents
+
+### Testing mixed types of fields
+
+Now, here's an interesting bit coming up for which I think all that explanation of the search mechanics felt necessary.
+Let's try a query where:
+
+- Two different types of fields involved, 
+- And the query contains a stop word
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&query=the%20Lorem&search_fields=title&search_fields=source
+
+Do you see? The query has "the", and yields no results. Remove "the", and it would return two Incidents. But the point is - it has to work with "the". "The" is a stopword, and Elasticsearch should ignore it. And in fact - it does. But because now we're mixing two different types of fields - keyword and text, nothing comes up.
+
+Now, let's set this property: `ctia.feature-flags=translate-searchable-fields:true` and restart the server
+
+After that, sending the same query again should work.
+
+**Expected:** Two incidents
+
+You should also try other stopwords: "a", "is", "are", etc.
+
+### Testing mapping update
+
+This one is a bit tricky. It requires you to find some data (and that's important) that has existed before this version of CTIA. Any data that's created in this version of CTIA, including the data above, would work *(unless it's deliberately imported via a previous version of CTIA)*. But you need to find data that existed before and query it similarly as shown in the previous section.
+
+You need to find an entity and send a mixed fields request. First, send a wide-range query ("query=*"); From the result, pick an element and using the information in the "title", send a query, and don't forget to include "source" field and a stopword. *'source' is a good field to use here because it is for sure mapped as keyword*
+Most likely, that attempt would yield nothing. Then you should set:
+
+    ctia.store.es.default.refresh-mappings=true
+    
+Restart the server, and try again. And this time, your query should work.
+
+### Testing of enforcing search fields
+
+If you try this query:
+
+GET http://private.intel.int.iroh.site/ctia/incident/search?source=dec3_2021&simple_query=second%7Cextortion
+
+It should return all three Incidents because the query says: "get everything that contains 'second' or 'extortion'" *('%7C' part of the query is encoded "or" operator - "|")*. And you can see from the results, `intended_effect` field of every Incident indeed is set to "extortion".
+
+Now, set the feature flags like this:
+
+    ctia.feature-flags=translate-searchable-fields:true,enforce-search-fields:true
+    
+Restart the server, and try sending the same query again. It should return only a single Incident.
+Why is that? The reason is that `enforce-search-fields:true`, when there are no `search_fields` specified, "injects" default fields, and default searchable fields for Incident entity do not include "intended_effect" field *TODO: add a link to ctia.entity.incident/searchable-fields*, and thus it would be ignored.
+
+**Expected:** Only the second Incident
+
+### Testing queries that end with quotes
+
+That previously mentioned issue: [Search behavior changed](https://github.com/advthreat/iroh/issues/5597), where we accidentally broke the search and had to revert the changes. Let's make sure we're not reintroducing it again:
+
+GET http://localhost:3000/ctia/incident/search?source=dec3_2021&query=the%20%22dos%22+%22%22&search_fields=title
+
+**Expected:** Single incident with the title : "Lorem Ipsum Test Incident dos"

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -136,8 +136,7 @@
     :external-id-capabilities :read-actor
     :can-aggregate?           true
     :histogram-fields         actor-histogram-fields
-    :enumerable-fields        actor-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        actor-enumerable-fields}))
 
 (def capabilities
   #{:create-actor
@@ -163,4 +162,5 @@
    :services->routes      (routes.common/reloadable-function actor-routes)
    :capabilities          capabilities
    :fields                actor-fields
-   :sort-fields           actor-fields})
+   :sort-fields           actor-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/asset.clj
+++ b/src/ctia/entity/asset.clj
@@ -130,8 +130,7 @@
     :external-id-capabilities :read-asset
     :can-aggregate?           true
     :histogram-fields         asset-histogram-fields
-    :enumerable-fields        asset-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        asset-enumerable-fields}))
 
 (def capabilities
   #{:create-asset
@@ -157,4 +156,5 @@
    :services->routes      (routes.common/reloadable-function asset-routes)
    :capabilities          capabilities
    :fields                asset-fields
-   :sort-fields           asset-fields})
+   :sort-fields           asset-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -150,8 +150,7 @@
      :can-aggregate?           true
      :histogram-fields         asset-mapping-histogram-fields
      :enumerable-fields        asset-mapping-enumerable-fields
-     :can-revoke?              asset-mapping-can-revoke?
-     :searchable-fields        searchable-fields}))
+     :can-revoke?              asset-mapping-can-revoke?}))
 
 (def capabilities
   #{:create-asset-mapping
@@ -178,4 +177,5 @@
                             asset-mapping-routes)
    :capabilities          capabilities
    :fields                asset-mapping-fields
-   :sort-fields           asset-mapping-fields})
+   :sort-fields           asset-mapping-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/asset_mapping.clj
+++ b/src/ctia/entity/asset_mapping.clj
@@ -125,7 +125,6 @@
     :asset_ref
     :asset_type
     :confidence
-    :observable.type
     :observable.value})
 
 (s/defn asset-mapping-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -146,8 +146,7 @@
      :can-aggregate?           true
      :histogram-fields         asset-properties-histogram-fields
      :enumerable-fields        asset-properties-enumerable-fields
-     :can-revoke?              asset-properties-can-revoke?
-     :searchable-fields        searchable-fields}))
+     :can-revoke?              asset-properties-can-revoke?}))
 
 (def capabilities
   #{:create-asset-properties
@@ -174,4 +173,5 @@
                             asset-properties-routes)
    :capabilities          capabilities
    :fields                asset-properties-fields
-   :sort-fields           asset-properties-fields})
+   :sort-fields           asset-properties-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/asset_properties.clj
+++ b/src/ctia/entity/asset_properties.clj
@@ -45,7 +45,7 @@
   {:type "object"
    :properties
    {:name  em/token
-    :value em/token}})
+    :value em/searchable-token}})
 
 (s/defn realize-asset-properties
   :- (RealizeFnResult (with-error StoredAssetProperties))

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -119,8 +119,7 @@
     :external-id-capabilities :read-attack-pattern
     :can-aggregate?           true
     :histogram-fields         attack-pattern-histogram-fields
-    :enumerable-fields        attack-pattern-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        attack-pattern-enumerable-fields}))
 
 (def AttackPatternType
   (let [{:keys [fields name description]}
@@ -171,4 +170,5 @@
    :services->routes      (routes.common/reloadable-function attack-pattern-routes)
    :capabilities          capabilities
    :fields                attack-pattern-fields
-   :sort-fields           attack-pattern-fields})
+   :sort-fields           attack-pattern-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/campaign.clj
+++ b/src/ctia/entity/campaign.clj
@@ -130,8 +130,7 @@
     :external-id-capabilities :read-campaign
     :can-aggregate?           true
     :histogram-fields         campaign-histogram-fields
-    :enumerable-fields        campaign-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        campaign-enumerable-fields}))
 
 (def capabilities
   #{:create-campaign
@@ -157,4 +156,5 @@
    :services->routes      (routes.common/reloadable-function campaign-routes)
    :capabilities          capabilities
    :fields                campaign-fields
-   :sort-fields           campaign-fields})
+   :sort-fields           campaign-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -288,8 +288,7 @@
      :external-id-capabilities :read-casebook
      :hide-delete?             false
      :histogram-fields         casebook-histogram-fields
-     :enumerable-fields        casebook-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        casebook-enumerable-fields})))
 
 (def casebook-entity
   {:route-context         "/casebook"
@@ -309,4 +308,5 @@
    :services->routes      (routes.common/reloadable-function casebook-routes)
    :capabilities          casebook-capabilities
    :fields                casebook-fields
-   :sort-fields           casebook-fields})
+   :sort-fields           casebook-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -258,7 +258,6 @@
   #{:id
     :source
     :description
-    :observables.type
     :observables.value
     :short_description
     :title})

--- a/src/ctia/entity/coa.clj
+++ b/src/ctia/entity/coa.clj
@@ -138,8 +138,7 @@
     :external-id-capabilities :read-coa
     :can-aggregate?           true
     :histogram-fields         coa-histogram-fields
-    :enumerable-fields        coa-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        coa-enumerable-fields}))
 
 (def capabilities
   #{:create-coa
@@ -165,4 +164,5 @@
    :services->routes      (routes.common/reloadable-function coa-routes)
    :capabilities          capabilities
    :fields                coa-fields
-   :sort-fields           coa-fields})
+   :sort-fields           coa-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -161,8 +161,7 @@
      :can-get-by-external-id? false
      :search-capabilities     :search-event
      :delete-capabilities     #{:delete-event :developer}
-     :date-field              :timestamp
-     :searchable-fields       searchable-fields})))
+     :date-field              :timestamp})))
 
 (def event-entity
   {:new-spec              map?
@@ -179,4 +178,5 @@
    :es-store              ->EventStore
    :es-mapping            event-mapping
    :services->routes      (routes.common/reloadable-function
-                           event-routes)})
+                           event-routes)
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -19,7 +19,7 @@
      em/base-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:entity_id em/token
+     {:entity_id em/searchable-token
       :feedback em/integer-type
       :reason em/sortable-text})}})
 

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -105,8 +105,7 @@
      :spec                     :new-feedback/map
      :can-search?              false
      :enumerable-fields        []
-     :can-update?              false
-     :searchable-fields        searchable-fields})))
+     :can-update?              false})))
 
 (def feedback-entity
   {:route-context         "/feedback"
@@ -127,4 +126,5 @@
                            feedback-routes)
    :capabilities          capabilities
    :fields                fs/feedback-fields
-   :sort-fields           fs/feedback-fields})
+   :sort-fields           fs/feedback-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/identity_assertion.clj
+++ b/src/ctia/entity/identity_assertion.clj
@@ -120,8 +120,7 @@
     :external-id-capabilities :read-identity-assertion
     :can-aggregate?           true
     :enumerable-fields        identity-assertion-enumerable-fields
-    :histogram-fields         identity-assertion-histogram-fields
-    :searchable-fields        searchable-fields}))
+    :histogram-fields         identity-assertion-histogram-fields}))
 
 (def capabilities
   #{:create-identity-assertion
@@ -147,4 +146,5 @@
    :services->routes      (routes.common/reloadable-function identity-assertion-routes)
    :capabilities          capabilities
    :fields                identity-assertion-fields
-   :sort-fields           identity-assertion-fields})
+   :sort-fields           identity-assertion-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -130,15 +130,15 @@
      em/describable-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:confidence       em/searchable-token
+     {:confidence       em/token
       :status           em/token
       :incident_time    em/incident-time
-      :categories       em/searchable-token
-      :discovery_method em/searchable-token
-      :intended_effect  em/searchable-token
-      :assignees        em/searchable-token
-      :promotion_method em/searchable-token
-      :severity         em/searchable-token})}})
+      :categories       em/token
+      :discovery_method em/token
+      :intended_effect  em/token
+      :assignees        em/token
+      :promotion_method em/token
+      :severity         em/token})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
 
@@ -216,14 +216,7 @@
   #{:description
     :source
     :id
-    :assignees
-    :categories
-    :confidence
-    :discovery_method
-    :intended_effect
-    :promotion_method
     :short_description
-    :status
     :title})
 
 (s/defn incident-routes [services :- APIHandlerServices]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -246,8 +246,7 @@
      :search-capabilities      :search-incident
      :external-id-capabilities :read-incident
      :histogram-fields         incident-histogram-fields
-     :enumerable-fields        incident-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        incident-enumerable-fields})))
 
 (def IncidentType
   (let [{:keys [fields name description]}
@@ -300,4 +299,5 @@
    :can-patch?            true
    :patch-capabilities    :create-incident
    :fields                incident-fields
-   :sort-fields           incident-fields})
+   :sort-fields           incident-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -130,15 +130,15 @@
      em/describable-entity-mapping
      em/sourcable-entity-mapping
      em/stored-entity-mapping
-     {:confidence em/token
-      :status em/token
-      :incident_time em/incident-time
-      :categories em/token
-      :discovery_method em/token
-      :intended_effect em/token
-      :assignees em/token
-      :promotion_method em/token
-      :severity em/token})}})
+     {:confidence       em/searchable-token
+      :status           em/token
+      :incident_time    em/incident-time
+      :categories       em/searchable-token
+      :discovery_method em/searchable-token
+      :intended_effect  em/searchable-token
+      :assignees        em/searchable-token
+      :promotion_method em/searchable-token
+      :severity         em/searchable-token})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
 

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -168,8 +168,7 @@
     :external-id-capabilities :read-indicator
     :can-aggregate?           true
     :histogram-fields         indicator-histogram-fields
-    :enumerable-fields        indicator-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        indicator-enumerable-fields}))
 
 (def capabilities
   #{:read-indicator
@@ -219,4 +218,5 @@
    :services->routes      (routes.common/reloadable-function indicator-routes)
    :capabilities          capabilities
    :fields                indicator-fields
-   :sort-fields           indicator-fields})
+   :sort-fields           indicator-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/investigation.clj
+++ b/src/ctia/entity/investigation.clj
@@ -103,8 +103,7 @@
     :external-id-capabilities :read-investigation
     :can-aggregate?           true
     :histogram-fields         investigation-histogram-fields
-    :enumerable-fields        investigation-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        investigation-enumerable-fields}))
 
 (def capabilities
   #{:read-investigation
@@ -131,4 +130,5 @@
    :services->routes      (routes.common/reloadable-function investigation-routes)
    :capabilities          capabilities
    :fields                investigation-fields
-   :sort-fields           investigation-fields})
+   :sort-fields           investigation-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -135,8 +135,7 @@
                             :can-update?              true
                             :can-aggregate?           true
                             :histogram-fields         js/judgement-histogram-fields
-                            :enumerable-fields        js/judgement-enumerable-fields
-                            :searchable-fields        searchable-fields}]
+                            :enumerable-fields        js/judgement-enumerable-fields}]
     (routes
       (services->entity-crud-routes
         services
@@ -196,4 +195,5 @@
    :services->routes (routes.common/reloadable-function judgement-routes)
    :capabilities capabilities
    :fields js/judgement-fields
-   :sort-fields js/judgement-sort-fields})
+   :sort-fields js/judgement-sort-fields
+   :searchable-fields searchable-fields})

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -157,8 +157,7 @@
     :external-id-capabilities :read-malware
     :can-aggregate?           true
     :histogram-fields         malware-histogram-fields
-    :enumerable-fields        malware-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        malware-enumerable-fields}))
 
 (def malware-entity
   {:route-context         "/malware"
@@ -178,4 +177,5 @@
    :services->routes      (routes.common/reloadable-function malware-routes)
    :capabilities          capabilities
    :fields                malware-fields
-   :sort-fields           malware-fields})
+   :sort-fields           malware-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -51,9 +51,9 @@
      em/sourcable-entity-mapping
      em/describable-entity-mapping
      em/stored-entity-mapping
-     {:labels            em/token
+     {:labels            em/searchable-token
       :kill_chain_phases em/kill-chain-phase
-      :x_mitre_aliases   em/token
+      :x_mitre_aliases   em/searchable-token
       :abstraction_level em/token})}})
 
 (def-es-store MalwareStore :malware StoredMalware PartialStoredMalware)

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -231,8 +231,7 @@
     :external-id-capabilities :read-relationship
     :can-aggregate?           true
     :histogram-fields         relationship-histogram-fields
-    :enumerable-fields        relationship-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        relationship-enumerable-fields}))
 
 (def capabilities
   #{:create-relationship
@@ -259,4 +258,5 @@
    :services->routes      (routes.common/reloadable-function relationship-routes)
    :capabilities          capabilities
    :fields                relationship-fields
-   :sort-fields           relationship-fields})
+   :sort-fields           relationship-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/sighting.clj
+++ b/src/ctia/entity/sighting.clj
@@ -74,8 +74,7 @@
     :search-capabilities      :search-sighting
     :can-aggregate?           true
     :histogram-fields         ss/sighting-histogram-fields
-    :enumerable-fields        ss/sighting-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        ss/sighting-enumerable-fields}))
 
 (def capabilities
   #{:create-sighting
@@ -102,4 +101,5 @@
    :services->routes      (routes.common/reloadable-function sighting-routes)
    :capabilities          capabilities
    :fields                ss/sighting-fields
-   :sort-fields           ss/sighting-sort-fields})
+   :sort-fields           ss/sighting-sort-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/target_record.clj
+++ b/src/ctia/entity/target_record.clj
@@ -133,8 +133,7 @@
     :external-id-capabilities :read-target-record
     :can-aggregate?           true
     :histogram-fields         target-record-histogram-fields
-    :enumerable-fields        target-record-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        target-record-enumerable-fields}))
 
 (def capabilities
   #{:create-target-record
@@ -158,7 +157,8 @@
    :es-store              ->TargetRecordStore
    :es-mapping            target-record-mapping
    :services->routes      (routes.common/reloadable-function
-                            target-record-routes)
+                           target-record-routes)
    :capabilities          capabilities
    :fields                target-record-fields
-   :sort-fields           target-record-fields})
+   :sort-fields           target-record-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/tool.clj
+++ b/src/ctia/entity/tool.clj
@@ -99,8 +99,7 @@
     :external-id-capabilities :read-tool
     :can-aggregate?           true
     :histogram-fields         tool-histogram-fields
-    :enumerable-fields        tool-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        tool-enumerable-fields}))
 
 (def tool-entity
   {:route-context         "/tool"
@@ -120,4 +119,5 @@
    :services->routes      (routes.common/reloadable-function tool-routes)
    :capabilities          capabilities
    :fields                ts/tool-fields
-   :sort-fields           ts/tool-fields})
+   :sort-fields           ts/tool-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -234,8 +234,7 @@
      :external-id-capabilities :read-vulnerability
      :can-aggregate?           true
      :histogram-fields         vulnerability-histogram-fields
-     :enumerable-fields        vulnerability-enumerable-fields
-     :searchable-fields        searchable-fields})))
+     :enumerable-fields        vulnerability-enumerable-fields})))
 
 (def capabilities
   #{:create-vulnerability
@@ -261,4 +260,5 @@
    :services->routes      (routes.common/reloadable-function vulnerability-routes)
    :capabilities          capabilities
    :fields                vulnerability-fields
-   :sort-fields           vulnerability-fields})
+   :sort-fields           vulnerability-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -159,8 +159,7 @@
     :external-id-capabilities :read-weakness
     :can-aggregate?           true
     :histogram-fields         weakness-histogram-fields
-    :enumerable-fields        weakness-enumerable-fields
-    :searchable-fields        searchable-fields}))
+    :enumerable-fields        weakness-enumerable-fields}))
 
 (def capabilities
   #{:create-weakness
@@ -186,4 +185,5 @@
    :services->routes      (routes.common/reloadable-function weakness-routes)
    :capabilities          capabilities
    :fields                weakness-fields
-   :sort-fields           weakness-fields})
+   :sort-fields           weakness-fields
+   :searchable-fields     searchable-fields})

--- a/src/ctia/http/routes/common.clj
+++ b/src/ctia/http/routes/common.clj
@@ -53,9 +53,10 @@
 
 (s/defn prep-es-fields-schema :- (s/protocol s/Schema)
   "Conjoins Elasticsearch fields parameter into search-q-params schema"
-  [{:keys [search-q-params
-           searchable-fields] :as _entity-crud-config}]
-  (let [default-fields-schema (->> searchable-fields
+  [{{:keys [get-store]} :StoreService}
+   {:keys [search-q-params entity] :as _entity-crud-config}]
+  (let [searchable-fields (-> entity get-store :state :searchable-fields)
+        default-fields-schema (->> searchable-fields
                                    (map name)
                                    (apply s/enum))]
     (if (seq searchable-fields)
@@ -68,14 +69,6 @@
         (s/optional-key :search_fields)
         (describe [default-fields-schema] "'fields' key of Elasticsearch Fulltext Query.")})
       search-q-params)))
-
-(s/defn enforce-search-fields
-  "Guarantees that ES fields parameter always passed to ES instance"
-  [{:keys [search_fields] :as query-params}
-   searchable-fields]
-  (cond-> query-params
-    (empty? search_fields)
-    (assoc :search_fields (mapv name searchable-fields))))
 
 (def paging-param-keys
   "A list of the paging and sorting related parameters, we can use

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -41,7 +41,7 @@
     :IEncryption                     {:encrypt (s/=> s/Any s/Any)
                                       :decrypt (s/=> s/Any s/Any)}
     :FeaturesService                 {:entity-enabled? (s/=> s/Bool s/Keyword)
-                                      :feature-flags   (s/=> [s/Str])}}))
+                                      :feature-flags (s/=> [s/Str])}}))
 
 (s/defschema HTTPShowServices
   (-> APIHandlerServices
@@ -201,7 +201,8 @@
      :no-api? s/Bool
      :realize-fn RealizeFn
      :can-patch? s/Bool
-     :patch-capabilities  s/Keyword})))
+     :patch-capabilities s/Keyword
+     :searchable-fields #{s/Keyword}})))
 
 (s/defschema OpenCTIMSchemaVersion
   {(s/optional-key :schema_version) s/Str})

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -1,21 +1,21 @@
 (ns ctia.stores.es.crud
-  (:require [clojure.set :as set]
-            [clojure.string :as string]
-            [clojure.tools.logging :as log]
-            [ctia.domain.access-control
-             :refer
-             [acl-fields allow-read? allow-write? restricted-read?]]
-            [ctia.lib.pagination :refer [list-response-schema]]
-            [ctia.schemas.search-agg
-             :refer [AggQuery CardinalityQuery HistogramQuery SearchQuery TopnQuery FullTextQuery]]
-            [ctia.stores.es.query :refer [find-restriction-query-part]]
-            [ctia.stores.es.schemas :refer [ESConnState]]
-            [ductile.document :as ductile.doc]
-            [ductile.query :as q]
-            [ring.swagger.coerce :as sc]
-            [schema-tools.core :as st]
-            [schema.coerce :as c]
-            [schema.core :as s]))
+  (:require
+   [clojure.set :as set]
+   [clojure.string :as string]
+   [clojure.tools.logging :as log]
+   [ctia.domain.access-control :as ac
+    :refer [allow-read? allow-write? restricted-read?]]
+   [ctia.lib.pagination :refer [list-response-schema]]
+   [ctia.schemas.search-agg
+    :refer [AggQuery CardinalityQuery HistogramQuery SearchQuery TopnQuery]]
+   [ctia.stores.es.query :as es.query]
+   [ctia.stores.es.schemas :refer [ESConnState]]
+   [ductile.document :as ductile.doc]
+   [ductile.query :as q]
+   [ring.swagger.coerce :as sc]
+   [schema-tools.core :as st]
+   [schema.coerce :as c]
+   [schema.core :as s]))
 
 (defn make-es-read-params
   "Prepare ES Params for read operations, setting the _source field
@@ -24,7 +24,7 @@
     :as es-params}]
   (if (coll? fields)
     (-> es-params
-        (assoc :_source (concat fields acl-fields))
+        (assoc :_source (concat fields ac/acl-fields))
         (dissoc :fields))
     es-params))
 
@@ -37,7 +37,7 @@
   document ID, if it's a document ID already, it will just return
   that."
   [id]
-  (let [[_orig docid] (re-matches #".*?([^/]+)\z" id) ]
+  (let [[_orig docid] (re-matches #".*?([^/]+)\z" id)]
     docid))
 
 (defn ensure-document-id-in-map
@@ -225,13 +225,6 @@ It returns the documents with full hits meta data including the real index in wh
     :_index s/Str
     :status s/Int
     :result s/Str}))
-
-(s/defschema ESQFullTextQuery
-  (st/merge
-   {:query s/Str}
-   (st/optional-keys
-    {:default_operator s/Str
-     :fields [s/Str]})))
 
 ;; TODO move it to ductile
 (s/defschema ESBulkRes
@@ -434,7 +427,7 @@ It returns the documents with full hits meta data including the real index in wh
        es-params]
       (let [filter-val (cond-> (q/prepare-terms all-of)
                          (restricted-read? ident)
-                         (conj (find-restriction-query-part ident get-in-config)))
+                         (conj (es.query/find-restriction-query-part ident get-in-config)))
 
             query_string  {:query_string {:query query}}
             bool-params (cond-> {:filter filter-val}
@@ -453,54 +446,26 @@ It returns the documents with full hits meta data including the real index in wh
                                            access-control-filter-list
                                            ident
                                            get-in-config))))))
-(s/defn rename-search-fields :- (s/maybe {s/Keyword [s/Str]})
-  "Automatically translates keyword fields to use underlying text field.
-
-   ES doesn't like when different types of tokens get used in the same query. To deal with
-   that, we create a nested field of type 'text', see:
-   `ctia.stores.es.mapping/searchable-token`. This should be opaque - caller shouldn't
-   have to explicitly instruct API to direct query to the nested field."
-  [fields :- (s/maybe [s/Any])]
-  (let [search-fields-mapping {"source" "source.text"}]
-    (when fields
-      {:fields
-       (mapv (comp #(get search-fields-mapping % %) name) fields)})))
-
-(s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
-  [full-text-terms :- [FullTextQuery]
-   default-operator]
-  (let [term->es-query-part (fn [{:keys [query_mode fields] :as text-query}]
-                              (hash-map
-                               (or query_mode :query_string)
-                               (-> text-query
-                                   (dissoc :query_mode)
-                                   (merge
-                                    (when (and default-operator
-                                               (not= query_mode :multi_match))
-                                      {:default_operator default-operator})
-                                    (rename-search-fields fields)))))]
-    (mapv term->es-query-part full-text-terms)))
 
 (s/defn make-search-query :- {s/Keyword s/Any}
   "Translate SearchQuery map into ES Query DSL map"
-  [{{:keys [default_operator]} :props
-    {{:keys [get-in-config]} :ConfigService} :services} :- ESConnState
-   {:keys [filter-map
-           range
-           full-text]} :- SearchQuery
+  [es-conn-state :- ESConnState
+   search-query :- SearchQuery
    ident]
-  (let [range-query (when range
+  (let [{:keys [services]} es-conn-state
+        {{:keys [get-in-config]} :ConfigService} services
+        {:keys [filter-map range full-text]} search-query
+        range-query (when range
                       {:range range})
         filter-terms (-> (ensure-document-id-in-map filter-map)
                          q/prepare-terms)]
     {:bool
      {:filter
-      (cond-> [(find-restriction-query-part ident get-in-config)]
+      (cond-> [(es.query/find-restriction-query-part ident get-in-config)]
         (seq filter-map) (into filter-terms)
         (seq range)      (conj range-query)
-        (seq full-text)  (into (refine-full-text-query-parts
-                                full-text
-                                default_operator)))}}))
+        (seq full-text)  (into (es.query/refine-full-text-query-parts
+                                es-conn-state full-text)))}}))
 
 (defn handle-query-string-search
   "Generate an ES query handler for given schema schema"

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -130,7 +130,7 @@
 (def observable
   {:type "object"
    :properties
-   {:type searchable-token
+   {:type token
     :value searchable-token}})
 
 (def identity

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -55,7 +55,7 @@
     :external_id token}})
 
 (def base-entity-mapping
-  {:id token
+  {:id searchable-token
    :type token
    :schema_version token
    :revision long-type
@@ -85,8 +85,8 @@
 
 (def kill-chain-phase
   {:properties
-   {:kill_chain_name token
-    :phase_name token}})
+   {:kill_chain_name searchable-token
+    :phase_name searchable-token}})
 
 (def valid-time
   {:properties
@@ -130,8 +130,8 @@
 (def observable
   {:type "object"
    :properties
-   {:type token
-    :value token}})
+   {:type searchable-token
+    :value searchable-token}})
 
 (def identity
   {:dynamic false

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -116,8 +116,8 @@ Returns a map where key is path to a field, and value - path to the nested text 
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
   [es-conn-state :- ESConnStateProps
    full-text-terms :- [FullTextQuery]]
-  (let [{{:keys [default_operator services]} :props} es-conn-state
-        {{:keys [flag-value]} :FeaturesService} services
+  (let [{{:keys [default_operator]} :props
+         {{:keys [flag-value]} :FeaturesService} :services} es-conn-state
         term->es-query-part (fn [{:keys [query_mode fields] :as text-query}]
                               (hash-map
                                (or query_mode :query_string)
@@ -128,6 +128,6 @@ Returns a map where key is path to a field, and value - path to the nested text 
                                                (not= query_mode :multi_match))
                                       {:default_operator default_operator})
                                     (when (and flag-value
-                                           (= "true" (flag-value :translate-searchable-fields)))
+                                               (= "true" (flag-value :translate-searchable-fields)))
                                       (rename-search-fields es-conn-state fields))))))]
     (mapv term->es-query-part full-text-terms)))

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -114,7 +114,7 @@ Returns a map where key is path to a field, and value - path to the nested text 
    fields :- (s/maybe [s/Any])]
   (let [properties (some-> es-conn-state :config :mappings first second :properties)
         mapping (searchable-fields-map properties)]
-    (when fields
+    (when (seq fields)
       {:fields
        (mapv (comp #(get mapping % %) name) fields)})))
 

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -95,14 +95,13 @@ Returns a map where key is path to a field, and value - path to the nested text 
                 (hash-map path (str path "." v)))))
        (apply merge {})))
 
-(s/defschema EntityProps
-  (st/optional-keys
-   {:default_operator s/Str}))
-
 (s/defschema ESConnStateProps
   (st/optional-keys
    {:config {s/Any s/Any}
-    :props EntityProps}))
+    :props {s/Keyword s/Any}
+    :index s/Any
+    :conn s/Any
+    :services s/Any}))
 
 (s/defn rename-search-fields :- (s/maybe {s/Keyword [s/Str]})
   "Automatically translates keyword fields to use underlying text field.

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -95,6 +95,15 @@ Returns a map where key is path to a field, and value - path to the nested text 
                 (hash-map path (str path "." v)))))
        (apply merge {})))
 
+(s/defschema EntityProps
+  (st/optional-keys
+   {:default_operator s/Str}))
+
+(s/defschema ESConnStateProps
+  (st/optional-keys
+   {:config {s/Any s/Any}
+    :props EntityProps}))
+
 (s/defn rename-search-fields :- (s/maybe {s/Keyword [s/Str]})
   "Automatically translates keyword fields to use underlying text field.
 
@@ -102,7 +111,7 @@ Returns a map where key is path to a field, and value - path to the nested text 
    that, we create a nested field of type 'text', see:
    `ctia.stores.es.mapping/searchable-token`. This should be opaque - caller shouldn't
    have to explicitly instruct API to direct query to the nested field."
-  [es-conn-state :- ESConnState
+  [es-conn-state :- ESConnStateProps
    fields :- (s/maybe [s/Any])]
   (let [properties (some-> es-conn-state :config :mappings first second :properties)
         mapping (searchable-fields-map properties)]
@@ -111,7 +120,7 @@ Returns a map where key is path to a field, and value - path to the nested text 
        (mapv (comp #(get mapping % %) name) fields)})))
 
 (s/defn refine-full-text-query-parts :- [{s/Keyword ESQFullTextQuery}]
-  [es-conn-state :- ESConnState
+  [es-conn-state :- ESConnStateProps
    full-text-terms :- [FullTextQuery]]
   (let [{{:keys [default_operator]} :props} es-conn-state
         term->es-query-part (fn [{:keys [query_mode fields] :as text-query}]

--- a/src/ctia/stores/es/schemas.clj
+++ b/src/ctia/stores/es/schemas.clj
@@ -13,6 +13,8 @@
 
 (s/defschema ESConnState
   (st/merge
-    ;; disallows services
-    ductile.schemas/ESConnState
-    {:services ESConnServices}))
+   ;; disallows services
+   ductile.schemas/ESConnState
+   {:services ESConnServices}
+   (st/optional-keys
+    {:searchable-fields (s/maybe #{s/Keyword})})))

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -383,7 +383,7 @@
   (query-string-search
     [_ search-query _ _]
     (reset! enforced-fields-flag-query-params search-query)
-    []))
+    {:data (), :paging {:total-hits 0}}))
 
 (tk/defservice fake-store-service
   "A service to manage the central storage area for all stores."

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -140,13 +140,13 @@
                              (utils/update-items
                               incidents
                               ;; update only the first, leave the rest unchanged
-                              #(assoc % :discovery_method "Log Review"
+                              #(assoc % :short_description "Log Review"
                                       :title "title of test incident")))))
                         (bundle-gen-for :incidents))
          get-fields (fn [res]
                       (->> res
                            :parsed-body
-                           (some #(and (-> % :discovery_method (= "Log Review"))
+                           (some #(and (-> % :short_description (= "Log Review"))
                                        (-> % :title (= "title of test incident"))))))]
      [{:test-description (str "Should NOT return anything, because query field is missing."
                               "Asking for multiple things in the query, but not providing all the fields.")
@@ -157,7 +157,7 @@
 
       {:test-description "Should return an entity where multiple fields match"
        :query-params     {:query "\"title of test incident\" AND \"Log Review\""
-                          :search_fields ["title" "discovery_method"]}
+                          :search_fields ["title" "short_description"]}
        :bundle-gen       bundle
        :check            (fn [_ _ _ res]
                            (is (= 1 (-> res :parsed-body count)))
@@ -165,7 +165,7 @@
 
    [{:test-description "multi_match - looking for the same value in different fields in multiple records"
      :query-params     {:query "bibendum"
-                        :search_fields ["assignees" "title"]}
+                        :search_fields ["short_description" "title"]}
      :bundle-gen       (gen/fmap
                         (fn [bundle]
                           (update
@@ -175,12 +175,12 @@
                               utils/update-items incidents
                               (repeat 3 ;; update first 3, leave the rest unchanged
                                       #(assoc % :title "Etiam vel neque bibendum dignissim"
-                                              :assignees ["bibendum"]))))))
+                                              :short_description "bibendum"))))))
                         (bundle-gen-for :incidents))
      :check            (fn [_ _ _ res]
                          (let [matching (->> res
                                              :parsed-body
-                                             (filter #(and (-> % :assignees (= ["bibendum"]))
+                                             (filter #(and (-> % :short_description (= "bibendum"))
                                                            (-> % :title (= "Etiam vel neque bibendum dignissim")))))]
                            (is (= 3 (count matching)))))}]
    (let [bundle-gen (gen/fmap

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -6,11 +6,11 @@
    [ctia.auth.threatgrid :refer [map->Identity]]
    [ctia.bundle.core :as bundle]
    [ctia.http.generative.properties :as prop]
-   [ctia.http.routes.common :as routes.common]
    [ctia.lib.utils :as utils]
    [ctia.store :as store]
    [ctia.store-service :as store-service]
    [ctia.store-service-core :as store-svc-core]
+   [ctia.stores.es.query :as es.query]
    [ctia.test-helpers.core :as helpers]
    [ctia.test-helpers.es :as es-helpers]
    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
@@ -406,14 +406,15 @@
 
 (deftest enforcing-fields-with-feature-flag-test
   (testing "unit testing enforce-search-fields"
-    (are [query-params searchable-fields expected-search-fields]
-         (let [res (routes.common/enforce-search-fields query-params searchable-fields)]
-           (and
-            (= (dissoc res :search_fields) (dissoc query-params :search_fields))
-            (= expected-search-fields (:search_fields res))))
-      {:query "*"} [] []
-      {:query "*"} [:title :description] ["title" "description"]
-      {:query "foo" :search_fields ["title"]} [:id :title :description] ["title"]))
+    (are [query-params fields expected-search-fields]
+         (let [res (es.query/enforce-search-fields
+                    {:props {:entity :incident}
+                     :searchable-fields #{:foo :bar :zap}
+                     :services {:FeaturesService {:flag-value (constantly "true")}}}
+                    fields)]
+           (is (= expected-search-fields res)))
+      {:query "*"} [] ["zap" "bar" "foo"]
+      {:query "*"} ["title" "description"] ["title" "description"]))
   (testing "feature flag set? fields should be enforced"
     (reset! enforced-fields-flag-query-params nil)
     (helpers/with-properties

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -41,8 +41,8 @@
     (are [fields result]
         (is (= result
                (some-> (sut/prep-es-fields-schema
-                        {:search-q-params   incident/IncidentSearchParams
-                         :searchable-fields fields})
+                        {:StoreService {:get-store (constantly {:state {:searchable-fields fields}})}}
+                        {:search-q-params incident/IncidentSearchParams})
                        (st/get-in [:search_fields])
                        enum->set))
             (format "when %s passed, %s expected" fields result))
@@ -51,9 +51,12 @@
       nil          nil))
   (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
     (is (= incident/IncidentSearchParams
-           (sut/prep-es-fields-schema  {:search-q-params incident/IncidentSearchParams})
-           (sut/prep-es-fields-schema  {:search-q-params   incident/IncidentSearchParams
-                                        :searchable-fields #{}})))))
+           (sut/prep-es-fields-schema
+            {:StoreService {:get-store (constantly {:state {:searchable-fields nil}})}}
+            {:search-q-params incident/IncidentSearchParams})
+           (sut/prep-es-fields-schema
+            {:StoreService {:get-store (constantly {:state {:searchable-fields #{} }})}}
+            {:search-q-params incident/IncidentSearchParams})))))
 
 (defn- entity-schema+searchable-fields
   "Traverses through existing entities and grabs `schema` and

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -24,9 +24,9 @@
   es-helpers/fixture-properties:es-store)
 
 ;; TODO: Enable later
-#_(deftest refine-full-text-query-parts-test
+(deftest refine-full-text-query-parts-test
   (testing "refine-full-text-query-parts with different queries"
-    (are [queries res] (is (= res (es.query/refine-full-text-query-parts queries nil)))
+    (are [queries res] (is (= res (es.query/refine-full-text-query-parts {} queries)))
       [{:query "foo"}] [{:query_string {:query "foo"}}]
 
       [{:query "foo" :query_mode :simple_query_string}] [{:simple_query_string {:query "foo"}}]
@@ -39,27 +39,28 @@
       (is (thrown-with-msg?
            Exception #"does not match schema"
            (es.query/refine-full-text-query-parts
-            [{:query "foo" :query_mode :unknown}] nil)))
+            {} [{:query "foo" :query_mode :unknown}])))
       (is (thrown-with-msg?
            Exception #"does not match schema"
            (es.query/refine-full-text-query-parts
-            [{}] nil)))))
+            {} [{}])))))
   (testing "refine-full-text-query-parts default operator"
     (is (= [{:query_string {:query "foo" :default_operator "and"}}]
            (es.query/refine-full-text-query-parts
-            [{:query "foo"}]
-            "and")))
+            {:props {:default_operator "and"}}
+            [{:query "foo"}])))
     (is (= [{:multi_match {:query "foo"}}]
            (es.query/refine-full-text-query-parts
-            [{:query "foo" :query_mode :multi_match}]
-            "and")) "no default_operator with mutli_match"))
+            {:props {:default_operator "and"}}
+            [{:query "foo" :query_mode :multi_match}]))
+        "no default_operator with mutli_match"))
   (testing "refine-full-text-query-parts with fields"
-    (is (= [{:query_string {:query            "foo"
+    (is (= [{:query_string {:query "foo"
                             :default_operator "and"
-                            :fields           ["title" "description"]}}]
+                            :fields ["title" "description"]}}]
            (es.query/refine-full-text-query-parts
-            [{:query "foo" :fields ["title" "description"]}]
-            "and")))))
+            {:props {:default_operator "and"}}
+            [{:query "foo" :fields ["title" "description"]}])))))
 
 (deftest ensure-document-id-in-map-test
   (is (= {:id '("actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7")}

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -5,62 +5,96 @@
             [clojure.test :as t
              :refer
              [are deftest is testing use-fixtures]]
+            [ctia.entity.sighting.schemas :as ss]
             [ctia.flows.crud :refer [gen-random-uuid]]
             [ctia.stores.es.crud :as sut]
             [ctia.stores.es.init :as init]
-            [ctia.stores.es.query :refer [find-restriction-query-part]]
+            [ctia.stores.es.query :as es.query]
             [ctia.task.rollover :refer [rollover-store]]
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.es :as es-helpers]
-            [ductile.index :as es-index]
-            [ctia.entity.sighting.schemas :as ss]
             [ctim.examples.sightings :refer [sighting-minimal sighting-maximal]]
-            [schema.core :as s]
-            [ctia.stores.es.query :as es.query]))
+            [ductile.index :as es-index]
+            [schema.core :as s]))
 
 (use-fixtures :once mth/fixture-schema-validation)
 
 (use-fixtures :each
   es-helpers/fixture-properties:es-store)
 
-;; TODO: Enable later
 (deftest refine-full-text-query-parts-test
-  (testing "refine-full-text-query-parts with different queries"
-    (are [queries res] (is (= res (es.query/refine-full-text-query-parts {} queries)))
-      [{:query "foo"}] [{:query_string {:query "foo"}}]
+  (let [es-conn-state {:props {:entity :incident}
+                       :services {:FeaturesService {:flag-value (constantly nil)}}}
+        with-def-op (assoc-in es-conn-state [:props :default_operator] "and")]
+    (testing "simple queries"
+      (are [queries exp]
+          (is (= exp (es.query/refine-full-text-query-parts
+                      es-conn-state queries)))
+        [{:query "foo"}] [{:query_string {:query "foo"}}]
+        [{:query "foo"
+          :query_mode :simple_query_string}] [{:simple_query_string {:query "foo"}}]
 
-      [{:query "foo" :query_mode :simple_query_string}] [{:simple_query_string {:query "foo"}}]
+        [{:query "foo"
+          :query_mode :simple_query_string}
+         {:query "bar"}] [{:simple_query_string {:query "foo"}}
+                          {:query_string {:query "bar"}}]))
+    (testing "refine-full-text-query-parts schema"
+      (s/with-fn-validation
+        (is (thrown-with-msg?
+             Exception #"does not match schema"
+             (es.query/refine-full-text-query-parts
+              {} [{:query "foo" :query_mode :unknown}])))
+        (is (thrown-with-msg?
+             Exception #"does not match schema"
+             (es.query/refine-full-text-query-parts
+              {} [{}])))))
+    (testing "refine-full-text-query-parts default operator"
+      (is (= [{:query_string {:query "foo" :default_operator "and"}}]
+             (es.query/refine-full-text-query-parts
+              with-def-op [{:query "foo"}])))
+      (is (= [{:multi_match {:query "foo"}}]
+             (es.query/refine-full-text-query-parts
+              with-def-op
+              [{:query "foo" :query_mode :multi_match}]))
+          "no default_operator with multi_match"))
+    (testing "refine-full-text-query-parts with fields"
+      (is (= [{:query_string {:query "foo"
+                              :default_operator "and"
+                              :fields ["title" "description"]}}]
+             (es.query/refine-full-text-query-parts
+              with-def-op
+              [{:query "foo" :fields ["title" "description"]}]))))
+    (testing "enforcing fields"
+      ;; when an entity has :searchable-fields, and no :search-fields provided with the
+      ;; query - ES should receive all searchable-fields by default
+      (let [es-conn-state
+            (-> es-conn-state
+                (assoc-in [:services :FeaturesService :flag-value] (constantly "true"))
+                (assoc :searchable-fields #{:one :two :three}))]
+        (are [queries exp]
+            (is (= exp (es.query/refine-full-text-query-parts
+                        es-conn-state queries)))
+          [{:query "*"}]
+          [{:query_string {:query "*"
+                           :fields ["one" "three" "two"]}}]
 
-      [{:query "foo" :query_mode :simple_query_string}
-       {:query "bar"}] [{:simple_query_string {:query "foo"}}
-                        {:query_string {:query "bar"}}]))
-  (testing "refine-full-text-query-parts schema"
-    (s/with-fn-validation
-      (is (thrown-with-msg?
-           Exception #"does not match schema"
-           (es.query/refine-full-text-query-parts
-            {} [{:query "foo" :query_mode :unknown}])))
-      (is (thrown-with-msg?
-           Exception #"does not match schema"
-           (es.query/refine-full-text-query-parts
-            {} [{}])))))
-  (testing "refine-full-text-query-parts default operator"
-    (is (= [{:query_string {:query "foo" :default_operator "and"}}]
-           (es.query/refine-full-text-query-parts
-            {:props {:default_operator "and"}}
-            [{:query "foo"}])))
-    (is (= [{:multi_match {:query "foo"}}]
-           (es.query/refine-full-text-query-parts
-            {:props {:default_operator "and"}}
-            [{:query "foo" :query_mode :multi_match}]))
-        "no default_operator with mutli_match"))
-  (testing "refine-full-text-query-parts with fields"
-    (is (= [{:query_string {:query "foo"
-                            :default_operator "and"
-                            :fields ["title" "description"]}}]
-           (es.query/refine-full-text-query-parts
-            {:props {:default_operator "and"}}
-            [{:query "foo" :fields ["title" "description"]}])))))
+          [{:query "*" :fields []}]
+          [{:query_string {:query "*"
+                           :fields ["one" "three" "two"]}}])))
+    (testing "renaming fields"
+      ;; when an entity has a mapping with keyword and it has a nested text field,
+      ;; substitute keyword with the text field
+      (let [es-conn-state
+            (-> es-conn-state
+                (assoc-in [:services :FeaturesService :flag-value] (constantly "true"))
+                (assoc-in [:config :mappings "incident" :properties :kw-field]
+                          {:type "keyword" :fields {:text {:type "text"}}}))]
+        (are [queries exp]
+            (is (= exp (es.query/refine-full-text-query-parts
+                        es-conn-state queries)))
+          [{:query "*" :fields ["kw-field"]}]
+          [{:query_string {:query "*"
+                           :fields ["kw-field.text"]}}])))))
 
 (deftest ensure-document-id-in-map-test
   (is (= {:id '("actor-677796fd-b5d2-46e3-b57d-4879bcca1ce7")}
@@ -300,7 +334,7 @@
      (fn [app]
        (let [es-conn-state (get-conn-state app :sighting)
              simple-access-ctrl-query {:terms {"groups" (:groups ident)}}]
-       (with-redefs [find-restriction-query-part (constantly simple-access-ctrl-query)]
+       (with-redefs [es.query/find-restriction-query-part (constantly simple-access-ctrl-query)]
          (let [query-string "*"
                es-query-string-AND {:query_string {:query query-string
                                                    :default_operator "AND"}}

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -23,7 +23,8 @@
 (use-fixtures :each
   es-helpers/fixture-properties:es-store)
 
-(deftest refine-full-text-query-parts-test
+;; TODO: Enable later
+#_(deftest refine-full-text-query-parts-test
   (testing "refine-full-text-query-parts with different queries"
     (are [queries res] (is (= res (es.query/refine-full-text-query-parts queries nil)))
       [{:query "foo"}] [{:query_string {:query "foo"}}]

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -237,9 +237,9 @@
                          (try
                            (with-redefs [sut/system-exit-error fake-exit
                                          ;; redef mappings
-                                         sut/store-mappings
-                                         (cond-> sut/store-mappings
-                                           field (assoc-in [:sighting "sighting" :properties field]
+                                         sut/entity-fields
+                                         (cond-> sut/entity-fields
+                                           field (assoc-in [:sighting :es-mapping "sighting" :properties field]
                                                            field-mapping))]
                              (testing msg
                                ;; init again to trigger mapping update

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -19,13 +19,9 @@
    :feed {"id" "id.text"}
    :feedback {"source" "source.text" "id" "id.text" "entity_id" "entity_id.text"}
    :investigation {"source" "source.text"
-                   "targets.observables.type" "targets.observables.type.text"
                    "targets.observables.value" "targets.observables.value.text"
                    "id" "id.text"}
-   :asset-mapping {"observable.type" "observable.type.text"
-                   "observable.value" "observable.value.text"
-                   "source" "source.text"
-                   "id" "id.text"}
+   :asset-mapping {"observable.value" "observable.value.text" "source" "source.text" "id" "id.text"}
    :data-table {"source" "source.text" "id" "id.text"}
    :tool {"source" "source.text"
           "id" "id.text"
@@ -33,12 +29,8 @@
           "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
    :relationship {"source" "source.text" "id" "id.text"}
    :vulnerability {"source" "source.text" "id" "id.text"}
-   :judgement {"observable.type" "observable.type.text"
-               "observable.value" "observable.value.text"
-               "source" "source.text"
-               "id" "id.text"}
+   :judgement {"observable.value" "observable.value.text" "source" "source.text" "id" "id.text"}
    :target-record {"source" "source.text"
-                   "targets.observables.type" "targets.observables.type.text"
                    "targets.observables.value" "targets.observables.value.text"
                    "id" "id.text"}
    :weakness {"source" "source.text" "id" "id.text"}
@@ -47,15 +39,7 @@
                     "id" "id.text"
                     "kill_chain_phases.kill_chain_name" "kill_chain_phases.kill_chain_name.text"
                     "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
-   :incident {"confidence" "confidence.text"
-              "id" "id.text"
-              "categories" "categories.text"
-              "assignees" "assignees.text"
-              "discovery_method" "discovery_method.text"
-              "promotion_method" "promotion_method.text"
-              "source" "source.text"
-              "intended_effect" "intended_effect.text"
-              "severity" "severity.text"}
+   :incident {"source" "source.text" "id" "id.text"}
    :event {}
    :indicator {"source" "source.text"
                "id" "id.text"
@@ -63,25 +47,16 @@
                "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
    :campaign {"source" "source.text" "id" "id.text"}
    :asset-properties {"value" "value.text" "source" "source.text" "id" "id.text"}
-   :sighting {"observables.type" "observables.type.text"
-              "id" "id.text"
-              "relations.source.value" "relations.source.value.text"
-              "observables.value" "observables.value.text"
-              "sensor_coordinates.observables.value" "sensor_coordinates.observables.value.text"
+   :sighting {"relations.source.value" "relations.source.value.text"
               "relations.related.value" "relations.related.value.text"
-              "targets.observables.type" "targets.observables.type.text"
-              "source" "source.text"
-              "sensor_coordinates.observables.type" "sensor_coordinates.observables.type.text"
-              "targets.observables.value" "targets.observables.value.text"
-              "relations.source.type" "relations.source.type.text"
-              "relations.related.type" "relations.related.type.text"}
-   :casebook {"observables.type" "observables.type.text"
+              "sensor_coordinates.observables.value" "sensor_coordinates.observables.value.text"
               "observables.value" "observables.value.text"
               "source" "source.text"
+              "targets.observables.value" "targets.observables.value.text"
               "id" "id.text"}
+   :casebook {"observables.value" "observables.value.text" "source" "source.text" "id" "id.text"}
    :asset {"source" "source.text" "id" "id.text"}
-   :identity-assertion {"identity.observables.type" "identity.observables.type.text"
-                        "identity.observables.value" "identity.observables.value.text"
+   :identity-assertion {"identity.observables.value" "identity.observables.value.text"
                         "source" "source.text"
                         "id" "id.text"}
    :malware {"labels" "labels.text"

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -15,31 +15,82 @@
        (apply merge)))
 
 (def ^:private expected-mapping-per-entity
-  {:actor {"source" "source.text"}
-   :asset {"source" "source.text"}
-   :asset-mapping {"source" "source.text"}
-   :asset-properties {"source" "source.text"}
-   :attack-pattern {"source" "source.text"}
-   :campaign {"source" "source.text"}
-   :casebook {"source" "source.text"}
-   :coa {"source" "source.text"}
-   :data-table {"source" "source.text"}
+  {:identity {}
+   :feed {"id" "id.text"}
+   :feedback {"source" "source.text" "id" "id.text" "entity_id" "entity_id.text"}
+   :investigation {"source" "source.text"
+                   "targets.observables.type" "targets.observables.type.text"
+                   "targets.observables.value" "targets.observables.value.text"
+                   "id" "id.text"}
+   :asset-mapping {"observable.type" "observable.type.text"
+                   "observable.value" "observable.value.text"
+                   "source" "source.text"
+                   "id" "id.text"}
+   :data-table {"source" "source.text" "id" "id.text"}
+   :tool {"source" "source.text"
+          "id" "id.text"
+          "kill_chain_phases.kill_chain_name" "kill_chain_phases.kill_chain_name.text"
+          "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
+   :relationship {"source" "source.text" "id" "id.text"}
+   :vulnerability {"source" "source.text" "id" "id.text"}
+   :judgement {"observable.type" "observable.type.text"
+               "observable.value" "observable.value.text"
+               "source" "source.text"
+               "id" "id.text"}
+   :target-record {"source" "source.text"
+                   "targets.observables.type" "targets.observables.type.text"
+                   "targets.observables.value" "targets.observables.value.text"
+                   "id" "id.text"}
+   :weakness {"source" "source.text" "id" "id.text"}
+   :coa {"source" "source.text" "id" "id.text"}
+   :attack-pattern {"source" "source.text"
+                    "id" "id.text"
+                    "kill_chain_phases.kill_chain_name" "kill_chain_phases.kill_chain_name.text"
+                    "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
+   :incident {"confidence" "confidence.text"
+              "id" "id.text"
+              "categories" "categories.text"
+              "assignees" "assignees.text"
+              "discovery_method" "discovery_method.text"
+              "promotion_method" "promotion_method.text"
+              "source" "source.text"
+              "intended_effect" "intended_effect.text"
+              "severity" "severity.text"}
    :event {}
-   :feed {}
-   :feedback {"source" "source.text"}
-   :identity {}
-   :identity-assertion {"source" "source.text"}
-   :incident {"source" "source.text"}
-   :indicator {"source" "source.text"}
-   :investigation {"source" "source.text"}
-   :judgement {"source" "source.text"}
-   :malware {"source" "source.text"}
-   :relationship {"source" "source.text"}
-   :sighting {"source" "source.text"}
-   :target-record {"source" "source.text"}
-   :tool {"source" "source.text"}
-   :vulnerability {"source" "source.text"}
-   :weakness {"source" "source.text"}})
+   :indicator {"source" "source.text"
+               "id" "id.text"
+               "kill_chain_phases.kill_chain_name" "kill_chain_phases.kill_chain_name.text"
+               "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
+   :campaign {"source" "source.text" "id" "id.text"}
+   :asset-properties {"value" "value.text" "source" "source.text" "id" "id.text"}
+   :sighting {"observables.type" "observables.type.text"
+              "id" "id.text"
+              "relations.source.value" "relations.source.value.text"
+              "observables.value" "observables.value.text"
+              "sensor_coordinates.observables.value" "sensor_coordinates.observables.value.text"
+              "relations.related.value" "relations.related.value.text"
+              "targets.observables.type" "targets.observables.type.text"
+              "source" "source.text"
+              "sensor_coordinates.observables.type" "sensor_coordinates.observables.type.text"
+              "targets.observables.value" "targets.observables.value.text"
+              "relations.source.type" "relations.source.type.text"
+              "relations.related.type" "relations.related.type.text"}
+   :casebook {"observables.type" "observables.type.text"
+              "observables.value" "observables.value.text"
+              "source" "source.text"
+              "id" "id.text"}
+   :asset {"source" "source.text" "id" "id.text"}
+   :identity-assertion {"identity.observables.type" "identity.observables.type.text"
+                        "identity.observables.value" "identity.observables.value.text"
+                        "source" "source.text"
+                        "id" "id.text"}
+   :malware {"labels" "labels.text"
+             "x_mitre_aliases" "x_mitre_aliases.text"
+             "source" "source.text"
+             "id" "id.text"
+             "kill_chain_phases.kill_chain_name" "kill_chain_phases.kill_chain_name.text"
+             "kill_chain_phases.phase_name" "kill_chain_phases.phase_name.text"}
+   :actor {"source" "source.text" "id" "id.text"}})
 
 (deftest searchable-fields-map-test
   (testing "returns correct mapping for every entity"
@@ -62,11 +113,13 @@
                                        (map (fn [[k v]]
                                               (hash-map k (es.query/searchable-fields-map v))))
                                        (apply merge)))
-          expected-result {:incident {"description" "description.test-field"
-                                      "source" "source.text"}
-                           :vulnerability {"configurations.nodes.operator"
-                                           "configurations.nodes.operator.operator-text"
-                                           "source" "source.text"}}]
+          expected-result (-> expected-mapping-per-entity
+                              (select-keys [:incident :vulnerability])
+                              (update
+                               :incident assoc "description" "description.test-field")
+                              (update :vulnerability assoc
+                                      "configurations.nodes.operator"
+                                      "configurations.nodes.operator.operator-text"))]
       (is (= expected-result
              (select-keys (digest-searchable-map es-mappings) [:incident :vulnerability])))
       (testing "nested sub-field added into a non-keyword field should be ignored"

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -1,0 +1,78 @@
+(ns ctia.stores.es.query-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ctia.entity.entities :as entities]
+   [ctia.stores.es.query :as es.query]))
+
+(defn- all-entities-es-mapping
+  "Returns a map where each key is the entity identifier and value its ES mapping props"
+  []
+  (->> (entities/all-entities)
+       (map (fn [[k v]]
+              (hash-map
+               (keyword k)
+               (-> v :es-mapping (get (name k)) :properties))))
+       (apply merge)))
+
+(def ^:private expected-mapping-per-entity
+  {:actor {"source" "source.text"}
+   :asset {"source" "source.text"}
+   :asset-mapping {"source" "source.text"}
+   :asset-properties {"source" "source.text"}
+   :attack-pattern {"source" "source.text"}
+   :campaign {"source" "source.text"}
+   :casebook {"source" "source.text"}
+   :coa {"source" "source.text"}
+   :data-table {"source" "source.text"}
+   :event {}
+   :feed {}
+   :feedback {"source" "source.text"}
+   :identity {}
+   :identity-assertion {"source" "source.text"}
+   :incident {"source" "source.text"}
+   :indicator {"source" "source.text"}
+   :investigation {"source" "source.text"}
+   :judgement {"source" "source.text"}
+   :malware {"source" "source.text"}
+   :relationship {"source" "source.text"}
+   :sighting {"source" "source.text"}
+   :target-record {"source" "source.text"}
+   :tool {"source" "source.text"}
+   :vulnerability {"source" "source.text"}
+   :weakness {"source" "source.text"}})
+
+(deftest searchable-fields-map-test
+  (testing "returns correct mapping for every entity"
+    (is (= expected-mapping-per-entity
+           (->> (all-entities-es-mapping)
+                (map (fn [[k v]]
+                       (hash-map k (es.query/searchable-fields-map v))))
+                (apply merge)))))
+  (testing "fake nested properties"
+    (let [es-mappings (-> (all-entities-es-mapping)
+                          (update-in
+                           [:incident :description]
+                           assoc :type "keyword"
+                           :fields {:test-field {:type "text"}})
+                          (update-in
+                           [:vulnerability :configurations :properties :nodes :properties :operator]
+                           assoc :type "keyword" :fields {:operator-text {:type "text"}}))
+          digest-searchable-map (fn [mappings]
+                                  (->> mappings
+                                       (map (fn [[k v]]
+                                              (hash-map k (es.query/searchable-fields-map v))))
+                                       (apply merge)))
+          expected-result {:incident {"description" "description.test-field"
+                                      "source" "source.text"}
+                           :vulnerability {"configurations.nodes.operator"
+                                           "configurations.nodes.operator.operator-text"
+                                           "source" "source.text"}}]
+      (is (= expected-result
+             (select-keys (digest-searchable-map es-mappings) [:incident :vulnerability])))
+      (testing "nested sub-field added into a non-keyword field should be ignored"
+        (let [es-mappings (-> es-mappings
+                              (update-in
+                               [:incident :title]
+                               assoc :type "text" :fields {:ignored-and-sad {:type "text"}}))]
+          (is (= expected-result
+                 (select-keys (digest-searchable-map es-mappings) [:incident :vulnerability]))))))))


### PR DESCRIPTION
Automatic remapping `source` to `source.text` in queries

> **Epic** https://github.com/advthreat/iroh/issues/5929
> Close https://github.com/advthreat/iroh/issues/5999
> Related https://github.com/advthreat/iroh/issues/5938


<a name="qa">[§](#qa)</a> QA
============================
No QA is needed. Will be covered within https://github.com/advthreat/iroh/issues/5929


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

