### PR TITLE
Save few polar bears

### DIFF
--- a/test/ctia/entity/asset_mapping_test.clj
+++ b/test/ctia/entity/asset_mapping_test.clj
@@ -15,7 +15,7 @@
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
 
-(defn additional-tests [app {:keys [short-id]} asset-mapping-sample]
+(defn additional-tests [app _id asset-mapping-sample]
   (testing "GET /ctia/asset-mapping/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
@@ -53,7 +53,6 @@
              :invalid-tests?     true
              :invalid-test-field :asset_ref
              :update-tests?      true
-             :search-tests?      true
              :search-field       :confidence
              :search-value       "High"
              :update-field       :source

--- a/test/ctia/entity/asset_properties_test.clj
+++ b/test/ctia/entity/asset_properties_test.clj
@@ -15,7 +15,7 @@
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
 
-(defn additional-tests [app {:keys [short-id]} asset-properties-sample]
+(defn additional-tests [app _id asset-properties-sample]
   (testing "GET /ctia/asset-properties/search"
    (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
     ;; only when ES store
@@ -59,7 +59,6 @@
              :invalid-test-field :asset_ref
              :update-tests?      true
              :update-field       :source
-             :search-tests?      true
              :search-field       :source
              :search-value       "cisco:unified_connect"
              :additional-tests   additional-tests

--- a/test/ctia/entity/asset_test.clj
+++ b/test/ctia/entity/asset_test.clj
@@ -41,7 +41,7 @@
               {"http://non-transient-asset-id" "http://different-asset-id"}))
           "it shouldn't try to renew non-transient asset_ref, even when tempids has it"))))
 
-(defn additional-tests [app asset-id asset-sample]
+(defn additional-tests [app _asset-id asset-sample]
   (testing "GET /ctia/asset/search"
     (do
       (are [term check-fn expected desc] (let [response (helpers/GET app
@@ -67,7 +67,6 @@
              :example          new-asset-maximal
              :invalid-tests?   true
              :update-tests?    true
-             :search-tests?    true
              :update-field     :source
              :additional-tests additional-tests
              :headers          {:Authorization "45c1f5e3f05d0"}})))))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -83,6 +83,7 @@
      (let [parameters (into sut/incident-entity
                             {:app app
                              :patch-tests? true
+                             :search-tests? true
                              :example new-incident-maximal
                              :headers {:Authorization "45c1f5e3f05d0"}
                              :additional-tests partial-operations-tests})]

--- a/test/ctia/entity/indicator_test.clj
+++ b/test/ctia/entity/indicator_test.clj
@@ -63,6 +63,8 @@
       (into sut/indicator-entity
             {:app app
              :example new-indicator-maximal
+             ;; set search-tests? to false to quickly test crud
+             :search-tests? true
              :additional-tests search-tests
              :headers {:Authorization "45c1f5e3f05d0"}})))))
 

--- a/test/ctia/entity/sighting_test.clj
+++ b/test/ctia/entity/sighting_test.clj
@@ -45,6 +45,8 @@
       (into sut/sighting-entity
             {:app app
              :example new-sighting-maximal
+             ;; set search-tests? to false to quickly test crud
+             :search-tests? true
              :headers {:Authorization "45c1f5e3f05d0"}})))))
 
 (deftest test-sighting-metric-routes

--- a/test/ctia/entity/target_record_test.clj
+++ b/test/ctia/entity/target_record_test.clj
@@ -60,7 +60,6 @@
              :invalid-tests?   true
              :update-tests?    true
              :update-field     :source
-             :search-tests?    true
              :additional-tests additional-tests
              :headers          {:Authorization "45c1f5e3f05d0"}})))))
 

--- a/test/ctia/test_helpers/crud.clj
+++ b/test/ctia/test_helpers/crud.clj
@@ -221,8 +221,8 @@
          optional-field :external_ids
          update-tests? true
          patch-tests? false
-         search-tests? true}
-    :as params}]
+         search-tests? false}
+    :as _params}]
  (assert app "Must pass :app to entity-crud-test")
   (let [get-in-config (helpers/current-get-in-config-fn app)
         entity-str (name entity)]


### PR DESCRIPTION
Limit the search test to few entities. 
For more context, I made few tests locally, and crud test takes 2 more minutes with search tests which are very repetitive across entities.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
