### PR TITLE
signature change of fixture-ctia-with-app

### DIFF
--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -401,19 +401,18 @@
       {:query "*"} [:title :description] ["title" "description"]
       {:query "foo" :search_fields ["title"]} [:id :title :description] ["title"]))
   (testing "feature flag set? fields should be enforced"
-    (let [http-server? true]
-      (reset! enforced-fields-flag-query-params nil)
-      (helpers/with-properties
-        ["ctia.feature-flags" "enforce-search-fields:false"]
-        (helpers/fixture-ctia-with-app
-         (fn [app]
-           (helpers/set-capabilities!
-            app "foouser" ["foogroup"] "user" (capabilities/all-capabilities))
-           (whoami-helpers/set-whoami-response
-            app "45c1f5e3f05d0" "foouser" "foogroup" "user")
-           (th.search/search-raw app :incident {:query "*"})
-           (is (->> @enforced-fields-flag-query-params
-                    :full-text
-                    (every? #(not (contains? % :fields))))))
-         http-server?
-         {:StoreService fake-store-service})))))
+    (reset! enforced-fields-flag-query-params nil)
+    (helpers/with-properties
+      ["ctia.feature-flags" "enforce-search-fields:false"]
+      (helpers/fixture-ctia-with-app
+       {:enable-http? true
+        :services {:StoreService fake-store-service}}
+       (fn [app]
+         (helpers/set-capabilities!
+          app "foouser" ["foogroup"] "user" (capabilities/all-capabilities))
+         (whoami-helpers/set-whoami-response
+          app "45c1f5e3f05d0" "foouser" "foogroup" "user")
+         (th.search/search-raw app :incident {:query "*"})
+         (is (->> @enforced-fields-flag-query-params
+                  :full-text
+                  (every? #(not (contains? % :fields))))))))))

--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -29,33 +29,32 @@
 
 (deftest api-handler-swagger-test
   (helpers/fixture-ctia-with-app
-    (fn [app]
-      (let [;; these routes don't have descriptions (yet)
-            expected-no-doc #{"/swagger.json"
-                              "/doc/*.*"
-                              "/ctia/feed/:id/view.txt"
-                              "/ctia/feed/:id/view"
-                              "/ctia/version"
-                              "/ctia/status"}
-            actual-no-doc (->> 
-                            (sut/api-handler (app->APIHandlerServices app))
-                            routes/get-routes
-                            routes/ring-swagger-paths
-                            :paths
-                            (remove (fn [[_ m]]
-                                      (every? (comp seq :description) (vals m))))
-                            (map first)
-                            set)]
-        (is (= expected-no-doc actual-no-doc)
-            (let [missing-docs (sort (set/difference actual-no-doc expected-no-doc))
-                  extra-docs (sort (set/difference expected-no-doc actual-no-doc))]
-              (str
-                (when (seq missing-docs)
-                  (str "Consider adding a :description with capabilities to these routes: "
-                       (str/join ", " missing-docs)
-                       "\n\n"))
-                (when (seq extra-docs)
-                  (str "Expected no :description on these routes, but found some: "
-                       (str/join ", " extra-docs))))))))
-    ;; disable http
-    false nil))
+   {:enable-http? false}
+   (fn [app]
+     (let [;; these routes don't have descriptions (yet)
+           expected-no-doc #{"/swagger.json"
+                             "/doc/*.*"
+                             "/ctia/feed/:id/view.txt"
+                             "/ctia/feed/:id/view"
+                             "/ctia/version"
+                             "/ctia/status"}
+           actual-no-doc (->>
+                          (sut/api-handler (app->APIHandlerServices app))
+                          routes/get-routes
+                          routes/ring-swagger-paths
+                          :paths
+                          (remove (fn [[_ m]]
+                                    (every? (comp seq :description) (vals m))))
+                          (map first)
+                          set)]
+       (is (= expected-no-doc actual-no-doc)
+           (let [missing-docs (sort (set/difference actual-no-doc expected-no-doc))
+                 extra-docs (sort (set/difference expected-no-doc actual-no-doc))]
+             (str
+              (when (seq missing-docs)
+                (str "Consider adding a :description with capabilities to these routes: "
+                     (str/join ", " missing-docs)
+                     "\n\n"))
+              (when (seq extra-docs)
+                (str "Expected no :description on these routes, but found some: "
+                     (str/join ", " extra-docs))))))))))

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -1,18 +1,17 @@
 (ns ctia.test-helpers.aggregate
-  (:require [java-time :as jt]
-            [clj-momo.lib.map :refer [deep-merge-with]]
-            [ctia.test-helpers
-             [auth :refer [all-capabilities]]
-             [fake-whoami-service :as helpers.whoami]
-             [core :as helpers.core :refer [GET POST-bulk fixture-ctia-with-app]]
-             [store :refer [test-selected-stores-with-app]]]
-            [clojure.string :as string]
+  (:require [clj-momo.lib.map :refer [deep-merge-with]]
             [clojure.pprint :refer [pprint]]
-            [schema-generators.generators :as g]
-            [schema-tools.core :as st]
-            [clojure.walk :refer [keywordize-keys]]
+            [clojure.string :as string]
             [clojure.test :refer [is testing]]
             [clojure.test.check.generators :as gen]
+            [clojure.walk :refer [keywordize-keys]]
+            [ctia.test-helpers.auth :refer [all-capabilities]]
+            [ctia.test-helpers.core :as helpers.core :refer [GET POST-bulk]]
+            [ctia.test-helpers.fake-whoami-service :as helpers.whoami]
+            [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
+            [java-time :as jt]
+            [schema-generators.generators :as g]
+            [schema-tools.core :as st]
             [schema.core :as s]))
 
 (defn metric-raw


### PR DESCRIPTION
`ctia.test-helpers.core/fixture-ctia-with-app` feels like a weird macro where the body is not in the tail
position. Let's change that.

Per discussion [in this PR](https://github.com/threatgrid/ctia/pull/1171#discussion_r755405226)

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

