### PR TITLE
ctim 1.1.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.10-SNAPSHOT"]
+                 [threatgrid/ctim "1.1.10"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.2"]
 

--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.8"]
+                 [threatgrid/ctim "1.1.10-SNAPSHOT"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.2"]
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Bump CTIM version to remove `Critical`in HighMedLow vocabularity, with a dedicated vocabulary for `severity`.

<a name="qa">[§](#qa)</a> QA
============================

check that it's impossible to set the `confidence` field of an incident to `Critical`.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->
