### PR TITLE
Injects FeaturesService in StoreService

### DIFF
--- a/src/ctia/schemas/services.clj
+++ b/src/ctia/schemas/services.clj
@@ -11,3 +11,6 @@
    :get-in-config (s/=>* s/Any
                          [[s/Any]]
                          [[s/Any] s/Any])})
+
+(s/defschema FeaturesServiceFns
+  {:flag-value (s/=> s/Any)})

--- a/src/ctia/store_service.clj
+++ b/src/ctia/store_service.clj
@@ -4,28 +4,30 @@
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defprotocol StoreService
-  (all-stores [this] "Returns a map of current stores.
-
-                     See also: ctia.store-service.schemas/AllStoresFn")
+  (all-stores [this]
+    "Returns a map of current stores.
+     See also: ctia.store-service.schemas/AllStoresFn")
   (get-store [this store-id]
-              "Returns the identified store.
-
-              See also: ctia.store-service.schemas/GetStoreFn"))
+    "Returns the identified store.
+     See also: ctia.store-service.schemas/GetStoreFn"))
 
 (tk/defservice store-service
   "A service to manage the central storage area for all stores."
   StoreService
-  [[:ConfigService get-in-config]]
+  [[:ConfigService get-in-config]
+   [:FeaturesService flag-value]]
   (init [this context]
         (core/init context))
   (start [this context]
-         (core/start context
-                     get-in-config))
+         (core/start
+          {:ConfigService {:get-in-config get-in-config}
+           :FeaturesService {:flag-value flag-value}}
+          context))
   (stop [this context]
         (core/stop context))
 
   (all-stores [this]
               (core/all-stores (service-context this)))
   (get-store [this store-id]
-              (core/get-store (service-context this)
-                               store-id)))
+             (core/get-store (service-context this)
+                             store-id)))

--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -205,6 +205,7 @@
                 {entity (make-factory es-store services)})
               (entities/all-entities))))
 
-(s/defn init-store! [store-kw services :- ESConnServices]
+(s/defn init-store! [services :- ESConnServices
+                     store-kw]
   (when-let [factory (get (factories services) store-kw)]
     (factory store-kw)))

--- a/src/ctia/stores/es/schemas.clj
+++ b/src/ctia/stores/es/schemas.clj
@@ -7,7 +7,9 @@
 
 (s/defschema ESConnServices
   {:ConfigService (-> external-svc-fns/ConfigServiceFns
-                      (csu/select-all-keys #{:get-in-config}))})
+                      (csu/select-all-keys #{:get-in-config}))
+   :FeaturesService (-> external-svc-fns/FeaturesServiceFns
+                      (csu/select-all-keys #{:flag-value}))})
 
 (s/defschema ESConnState
   (st/merge

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -63,7 +63,8 @@
 (s/defschema MigrationStoreServices
   {:ConfigService (-> external-svc-fns/ConfigServiceFns
                       (csu/select-all-keys #{:get-config
-                                             :get-in-config}))})
+                                             :get-in-config}))
+   :FeaturesService  external-svc-fns/FeaturesServiceFns})
 
 (s/defn MigrationStoreServices->ESConnServices
   :- ESConnServices

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -388,9 +388,13 @@
 (tk/defservice fake-store-service
   "A service to manage the central storage area for all stores."
   store-service/StoreService
-  [[:ConfigService get-in-config]]
+  [[:ConfigService get-in-config]
+   [:FeaturesService flag-value]]
   (init [this context] (store-svc-core/init context))
-  (start [this context] (store-svc-core/start context get-in-config))
+  (start [this context] (store-svc-core/start
+                         {:ConfigService {:get-in-config get-in-config}
+                          :FeaturesService {:flag-value flag-value}}
+                         context))
   (stop [this context] (store-svc-core/stop context))
   (all-stores [this]
               (store-svc-core/all-stores (tk-svcs/service-context this)))

--- a/test/ctia/test_helpers/core.clj
+++ b/test/ctia/test_helpers/core.clj
@@ -265,15 +265,17 @@
   "Stop and garbage collect a running app."
   [app]
   (let [{{:keys [get-config]} :ConfigService
-         {:keys [all-stores]} :StoreService} (app/service-graph app)
+         {:keys [all-stores]} :StoreService
+         {:keys [flag-value]} :FeaturesService} (app/service-graph app)
         ;; simulate the current output of these functions before we stop or restart
         ;; the app
         get-in-config (partial get-in (get-config))
         all-stores (constantly (all-stores))]
     (app/stop app)
     (@purge-indices-and-templates
-      all-stores
-      get-in-config)))
+     all-stores
+     {:ConfigService {:get-in-config get-in-config}
+      :FeaturesService {:flag-value flag-value}})))
 
 (s/defschema WithAppOptions
   (st/optional-keys

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -18,7 +18,9 @@
   "Create a ESConnServices map with an app"
   [app]
   (let [get-in-config (h/current-get-in-config-fn app)]
-    {:ConfigService {:get-in-config get-in-config}}))
+    {:ConfigService {:get-in-config get-in-config}
+     :FeaturesService (-> (h/get-service-map app :FeaturesService)
+                          (select-keys [:flag-value]))}))
 
 (s/defn ->ESConnServices
   :- ESConnServices
@@ -44,7 +46,7 @@
        (es-init/init-es-conn!
          (es-init/get-store-properties (get-in state [:props :entity])
                                        get-in-config)
-         {:ConfigService {:get-in-config get-in-config}})))))
+         (app->ESConnServices (h/get-current-app)))))))
 
 (defn ^{:deprecated "1.1"
         :superseded-by "ctia.test-helpers.core/stop-and-cleanup"}
@@ -82,9 +84,9 @@
       (finally
         (purge-index-and-template :event services)))))
 
-(defn purge-indices-and-templates [all-stores get-in-config]
+(defn purge-indices-and-templates [all-stores services]
   (doseq [entity (keys (all-stores))]
-    (purge-index-and-template entity {:ConfigService {:get-in-config get-in-config}})))
+    (purge-index-and-template entity services)))
 
 (defn fixture-properties:es-store [t]
   ;; Note: These properties may be overwritten by ENV variables

--- a/test/ctia/test_helpers/migration.clj
+++ b/test/ctia/test_helpers/migration.clj
@@ -8,4 +8,6 @@
   [app]
   {:ConfigService (-> (helpers/get-service-map app :ConfigService)
                       (select-keys [:get-config
-                                    :get-in-config]))})
+                                    :get-in-config]))
+   :FeaturesService (-> (helpers/get-service-map app :FeaturesService)
+                        (select-keys [:flag-value]))})


### PR DESCRIPTION
This refactoring is related to:
[threatgrid/ctia#1167 adds rename-search-fields fn](https://github.com/threatgrid/ctia/pull/1167)

I need access to `FeaturesService` down at the level of `IQueryStringSearchableStore` implementation.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed since it's going to be handled upstream in the [epic](https://github.com/advthreat/iroh/issues/5929)


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

8c6f30a1 adds FeaturesService to StoreService
842038db adjust test helpers
6a0a42e3 injects__features-svc__in__store-svc adjust breaking test