### PR TITLE
Fix ES7 migration rollover and strengthen migration parameter checks

### DIFF
--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -282,10 +282,13 @@
 (s/defn ^:always-validate check-migration-params
   [{:keys [prefix
            restart?
-           store-keys]} :- mst/MigrationParams
+           store-keys
+           migrations]} :- mst/MigrationParams
    get-in-config]
   (when-not restart?
-    (assert prefix "Please provide an indexname prefix for target store creation"))
+    (assert prefix "Please provide an indexname prefix for target store creation")
+    (assert (seq store-keys) "Please provide the store-keys for source store to migrate")
+    (assert (seq migrations) "Please provide the migrations' ids to apply"))
   (doseq [store-key store-keys]
     (let [index (get-in-config [:ctia :store :es store-key :indexname])]
       (when (= (mst/prefixed-index index prefix)
@@ -298,7 +301,7 @@
 (s/defn prepare-params :- mst/MigrationParams
   [migration-properties]
   (let [string-to-coll #(map (comp keyword string/trim)
-                             (string/split % #","))]
+                             (string/split (or % "") #","))]
     (-> migration-properties
         (update :migrations string-to-coll)
         (update :store-keys string-to-coll))))

--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -495,16 +495,15 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
              {:refresh "true"
               :wait_for_completion true}))))
 
-(defn target-index-config
+(defn target-template-config
   "Generates the configuration of an index while migrating"
-  [indexname config props]
+  [indexname config]
   (-> (update config
               :settings
               assoc
               :number_of_replicas 0
               :refresh_interval -1)
-      (assoc :aliases {(:write-index props) {}
-                       indexname {}})))
+      (assoc :aliases {indexname {}})))
 
 (defn revert-optimizations-settings
   "Revert configuration settings used for speeding up migration"
@@ -528,12 +527,13 @@ Rollover requires refresh so we cannot just call ES with condition since refresh
   [{:keys [conn indexname config props] entity-type :type}]
   (when (retry es-max-retry ductile.index/index-exists? conn indexname)
     (log/warnf "tried to create target store %s, but it already exists. Recreating it." indexname))
-  (let [index-config (target-index-config indexname config props)]
+  (let [template-config (target-template-config indexname config)
+        first-index-config (assoc template-config :aliases {(:write-index props) {}})]
     (log/infof "%s - creating index template: %s" entity-type indexname)
     (purge-store entity-type conn indexname)
     (log/infof "%s - creating store: %s" entity-type indexname)
-    (retry es-max-retry ductile.index/create-template! conn indexname index-config)
-    (retry es-max-retry ductile.index/create! conn (format "<%s-{now/d}-000001>" indexname) index-config)))
+    (retry es-max-retry ductile.index/create-template! conn indexname template-config)
+    (retry es-max-retry ductile.index/create! conn (format "<%s-{now/d}-000001>" indexname) first-index-config)))
 
 (s/defn init-storemap :- StoreMap
   [props :- es.init/StoreProperties

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -24,25 +24,21 @@
   (is (= "v0.4.2_ctia_actor"
          (sut/prefixed-index "v0.4.1_ctia_actor" "0.4.2"))))
 
-(deftest target-index-config-test
+(deftest target-template-config-test
   (is (= {:settings {:number_of_replicas 0
                      :refresh_interval -1}
-          :aliases {"test_index" {}
-                    "test_index-write" {}}}
-         (sut/target-index-config "test_index"
-                                  {}
-                                  {:write-index "test_index-write"})))
+          :aliases {"test_index" {}}}
+         (sut/target-template-config "test_index"
+                                  {})))
   (is (= {:settings {:number_of_replicas 0
                      :refresh_interval -1
                      :number_of_shards 3}
           :mappings {:a :b}
-          :aliases {"test_index" {}
-                    "test_index-write" {}}}
-         (sut/target-index-config "test_index"
+          :aliases {"test_index" {}}}
+         (sut/target-template-config "test_index"
                                   {:settings {:refresh_interval 2
                                               :number_of_shards 3}
-                                   :mappings {:a :b}}
-                                  {:write-index "test_index-write"}))))
+                                   :mappings {:a :b}}))))
 
 (deftest missing-query-test
   (is (= {:bool


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

The templates of the target indices contain the "rolled over" alias, which should only be set on the index. ES5 has some tolerance over it but ES7 does not.
I also strenghten the parameter check to improve error messages on misconfiguration.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
