### PR TITLE
bulk update

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -285,7 +285,7 @@
 (defn validate-bulk-size!
   [bulk
    {{:keys [get-in-config]} :ConfigService}]
-  (when (> (bulk-size bulk) (get-bulk-max-size get-in-config))
+  (when (< (get-bulk-max-size get-in-config) (bulk-size bulk))
     (bad-request! (str "Bulk max number of entities: "
                        (get-bulk-max-size get-in-config)))))
 

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -299,7 +299,6 @@
   ([bulk login services :- APIHandlerServices] (create-bulk bulk {} login {} services))
   ([bulk tempids login params
     {{:keys [get-in-config]} :ConfigService :as services} :- APIHandlerServices]
-   (validate-bulk-size! bulk services)
    (let [{:keys [refresh]
           :or   {refresh (bulk-refresh? get-in-config)}} params
          new-entities (gen-bulk-from-fn
@@ -341,24 +340,20 @@
 (s/defn fetch-bulk
   [bulk auth-identity
    services :- APIHandlerServices]
-  (validate-bulk-size! bulk services)
   (ent/un-store-map
    (gen-bulk-from-fn read-entities bulk auth-identity services)))
 
 (s/defn delete-bulk
   [bulk auth-identity params
    services :- APIHandlerServices]
-  (validate-bulk-size! bulk services)
   (gen-bulk-from-fn delete-entities bulk auth-identity params services))
 
 (s/defn update-bulk
   [bulk auth-identity params
    services :- APIHandlerServices]
-  (validate-bulk-size! bulk services)
   (gen-bulk-from-fn update-entities bulk auth-identity params services))
 
 (s/defn patch-bulk
   [bulk auth-identity params
    services :- APIHandlerServices]
-  (validate-bulk-size! bulk services)
   (gen-bulk-from-fn patch-entities bulk auth-identity params services))

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -149,12 +149,11 @@
   "return the update function provided an entity type key"
   [k auth-identity params
    {{:keys [get-store]} :StoreService} :- APIHandlerServices]
-  (let [store (get-store k)]
-    (fn [docs]
-      (store/bulk-update store
-                         docs
-                         (auth/ident->map auth-identity)
-                         params))))
+  #(-> (get-store k)
+       (store/bulk-update
+        %
+        (auth/ident->map auth-identity)
+        params)))
 
 (defn get-success-entities-fn
   [action]
@@ -186,7 +185,7 @@
        :get-success-entities (get-success-entities-fn :deleted)))))
 
 (s/defn update-entities
-  "patch many entities provided their type and returns errored and successed entities' ids"
+  "update many entities provided their type and returns errored and successed entities' ids"
   [entities entity-type auth-identity params
    services :- APIHandlerServices]
   (when (seq entities)

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -267,9 +267,9 @@
   The create-entities set the enveloped-result? to True in the flow
   configuration to get :data and :tempids for each entity in the result."
   [entities-by-type]
-  (->> entities-by-type
-       (map (fn [[_ v]] (:tempids v)))
-       (reduce into {})))
+  (into {}
+        (map (fn [[_ v]] (:tempids v)))
+         entities-by-type))
 
 (defn bulk-refresh? [get-in-config]
   (get-in-config
@@ -330,10 +330,10 @@
          all-entities (merge new-entities new-linked-ents)
          ;; Extracting data from the enveloped flow result
          ;; {:entity-type {:data [] :tempids {}}
-         bulk-refs (->> all-entities
-                        (map (fn [[k {:keys [data]}]]
-                               {k data}))
-                        (into {}))]
+         bulk-refs (into {}
+                         (map (fn [[k {:keys [data]}]]
+                                {k data}))
+                         all-entities)]
      (cond-> bulk-refs
        (seq all-tempids) (assoc :tempids all-tempids)))))
 

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -6,10 +6,10 @@
    [ctia.lib.compojure.api.core :refer [GET POST DELETE PATCH PUT routes]]
    [ctia.schemas.core :refer [APIHandlerServices Reference]]
    [ring.swagger.json-schema :refer [describe]]
-   [ring.util.http-response :refer [bad-request ok]]
+   [ring.util.http-response :refer [ok]]
    [schema.core :as s]))
 
-(s/defn bulk-routes [{{:keys [get-in-config]} :ConfigService :as services} :- APIHandlerServices]
+(s/defn bulk-routes [services :- APIHandlerServices]
   (routes
     (let [capabilities #{:create-actor
                          :create-asset
@@ -42,12 +42,11 @@
          :auth-identity login
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
-         (or (core/bad-request? bulk services)
-             (common/created (core/create-bulk bulk
-                                               {}
-                                               login
-                                               (common/wait_for->refresh wait_for)
-                                               services))))
+         (common/created (core/create-bulk bulk
+                                           {}
+                                           login
+                                           (common/wait_for->refresh wait_for)
+                                           services)))
        (PUT "/" []
          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
          :summary "UPDATE many entities at once"
@@ -56,11 +55,10 @@
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
          :auth-identity auth-identity
-         (or (core/bad-request? bulk services)
-             (ok (core/update-bulk bulk
-                                   auth-identity
-                                   (common/wait_for->refresh wait_for)
-                                   services))))))
+         (ok (core/update-bulk bulk
+                               auth-identity
+                               (common/wait_for->refresh wait_for)
+                               services)))))
    (let [capabilities #{:read-actor
                         :read-asset
                         :read-asset-mapping
@@ -133,8 +131,7 @@
                       :tools               tools
                       :vulnerabilities     vulnerabilities
                       :weaknesses          weaknesses}]
-            (or (core/bad-request? bulk services)
-                (ok (core/fetch-bulk bulk auth-identity services))))))
+            (ok (core/fetch-bulk bulk auth-identity services)))))
     (let [capabilities (bulk.schemas/bulk-patch-capabilities services)]
       (PATCH "/" []
         :return (s/maybe (bulk.schemas/BulkActionsRefs services))
@@ -144,11 +141,10 @@
         :description (common/capabilities->description capabilities)
         :capabilities capabilities
         :auth-identity auth-identity
-        (or (core/bad-request? bulk services)
-            (ok (core/patch-bulk bulk
-                                 auth-identity
-                                 (common/wait_for->refresh wait_for)
-                                 services)))))
+        (ok (core/patch-bulk bulk
+                             auth-identity
+                             (common/wait_for->refresh wait_for)
+                             services))))
     (let [capabilities #{:delete-actor
                          :delete-asset
                          :delete-asset-mapping
@@ -179,8 +175,7 @@
           :description (common/capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity auth-identity
-          (or (core/bad-request? bulk services)
-              (ok (core/delete-bulk bulk
-                                    auth-identity
-                                    (common/wait_for->refresh wait_for)
-                                    services)))))))
+          (ok (core/delete-bulk bulk
+                                auth-identity
+                                (common/wait_for->refresh wait_for)
+                                services))))))

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -42,6 +42,7 @@
          :auth-identity login
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
+         (core/validate-bulk-size! bulk services)
          (common/created (core/create-bulk bulk
                                            {}
                                            login
@@ -55,6 +56,7 @@
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
          :auth-identity auth-identity
+         (core/validate-bulk-size! bulk services)
          (ok (core/update-bulk bulk
                                auth-identity
                                (common/wait_for->refresh wait_for)
@@ -131,6 +133,7 @@
                       :tools               tools
                       :vulnerabilities     vulnerabilities
                       :weaknesses          weaknesses}]
+            (core/validate-bulk-size! bulk services)
             (ok (core/fetch-bulk bulk auth-identity services)))))
     (let [capabilities (bulk.schemas/bulk-patch-capabilities services)]
       (PATCH "/" []
@@ -141,6 +144,7 @@
         :description (common/capabilities->description capabilities)
         :capabilities capabilities
         :auth-identity auth-identity
+        (core/validate-bulk-size! bulk services)
         (ok (core/patch-bulk bulk
                              auth-identity
                              (common/wait_for->refresh wait_for)
@@ -175,6 +179,7 @@
           :description (common/capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity auth-identity
+          (core/validate-bulk-size! bulk services)
           (ok (core/delete-bulk bulk
                                 auth-identity
                                 (common/wait_for->refresh wait_for)

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -52,7 +52,7 @@
          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
          :summary "UPDATE many entities at once"
          :query-params [{wait_for :- (describe s/Bool "wait for updated entities to be available for search") nil}]
-         :body [bulk (bulk.schemas/BulkUpdate services) {:description "a new Bulk Patch object"}]
+         :body [bulk (bulk.schemas/BulkUpdate services) {:description "a new Bulk Update object"}]
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
          :auth-identity auth-identity

--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -1,9 +1,9 @@
 (ns ctia.bulk.routes
   (:require
-   [ctia.bulk.core :refer [bulk-size create-bulk fetch-bulk delete-bulk get-bulk-max-size patch-bulk]]
+   [ctia.bulk.core :as core]
    [ctia.bulk.schemas :as bulk.schemas]
    [ctia.http.routes.common :as common]
-   [ctia.lib.compojure.api.core :refer [GET POST DELETE PATCH routes]]
+   [ctia.lib.compojure.api.core :refer [GET POST DELETE PATCH PUT routes]]
    [ctia.schemas.core :refer [APIHandlerServices Reference]]
    [ring.swagger.json-schema :refer [describe]]
    [ring.util.http-response :refer [bad-request ok]]
@@ -33,23 +33,35 @@
                          :create-tool
                          :create-vulnerability
                          :create-weakness}]
-      (POST "/" []
-            :return (bulk.schemas/BulkCreateRes services)
-            :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
-            :body [bulk (bulk.schemas/NewBulk services) {:description "a new Bulk object"}]
-            :summary "POST many new entities using a single HTTP call"
-            :auth-identity login
-            :description (common/capabilities->description capabilities)
-            :capabilities capabilities
-            (if (> (bulk-size bulk)
-                   (get-bulk-max-size get-in-config))
-              (bad-request (str "Bulk max nb of entities: " (get-bulk-max-size get-in-config)))
-              (common/created (create-bulk bulk
-                                           {}
-                                           login
-                                           (common/wait_for->refresh wait_for)
-                                           services)))))
-
+      (routes
+       (POST "/" []
+         :return (bulk.schemas/BulkCreateRes services)
+         :query-params [{wait_for :- (describe s/Bool "wait for created entities to be available for search") nil}]
+         :body [bulk (bulk.schemas/NewBulk services) {:description "a new Bulk object"}]
+         :summary "POST many new entities using a single HTTP call"
+         :auth-identity login
+         :description (common/capabilities->description capabilities)
+         :capabilities capabilities
+         (if (> (core/bulk-size bulk) ;; TODO move this check in core
+                (core/get-bulk-max-size get-in-config))
+           (bad-request (str "Bulk max nb of entities: " (core/get-bulk-max-size get-in-config)))
+           (common/created (core/create-bulk bulk
+                                             {}
+                                             login
+                                             (common/wait_for->refresh wait_for)
+                                             services))))
+       (PUT "/" []
+         :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+         :summary "UPDATE many entities at once"
+         :query-params [{wait_for :- (describe s/Bool "wait for updated entities to be available for search") nil}]
+         :body [bulk (bulk.schemas/BulkUpdate services) {:description "a new Bulk Patch object"}]
+         :description (common/capabilities->description capabilities)
+         :capabilities capabilities
+         :auth-identity auth-identity
+         (ok (core/update-bulk bulk
+                               auth-identity
+                               (common/wait_for->refresh wait_for)
+                               services)))))
    (let [capabilities #{:read-actor
                         :read-asset
                         :read-asset-mapping
@@ -122,20 +134,20 @@
                               :tools               tools
                               :vulnerabilities     vulnerabilities
                               :weaknesses          weaknesses}]
-            (ok (fetch-bulk entities-map auth-identity services)))))
+            (ok (core/fetch-bulk entities-map auth-identity services)))))
     (let [capabilities (bulk.schemas/bulk-patch-capabilities services)]
-     (PATCH "/" []
-          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
-          :summary "PATCH many entities at once"
-          :query-params [{wait_for :- (describe s/Bool "wait for patched entities to be available for search") nil}]
-          :body [bulk (bulk.schemas/BulkPatch services) {:description "a new Bulk Patch object"}]
-          :description (common/capabilities->description capabilities)
-          :capabilities capabilities
-          :auth-identity auth-identity
-          (ok (patch-bulk bulk
-                          auth-identity
-                          (common/wait_for->refresh wait_for)
-                          services))))
+      (PATCH "/" []
+        :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+        :summary "PATCH many entities at once"
+        :query-params [{wait_for :- (describe s/Bool "wait for patched entities to be available for search") nil}]
+        :body [bulk (bulk.schemas/BulkPatch services) {:description "a new Bulk Patch object"}]
+        :description (common/capabilities->description capabilities)
+        :capabilities capabilities
+        :auth-identity auth-identity
+        (ok (core/patch-bulk bulk
+                             auth-identity
+                             (common/wait_for->refresh wait_for)
+                             services))))
     (let [capabilities #{:delete-actor
                          :delete-asset
                          :delete-asset-mapping
@@ -166,7 +178,7 @@
           :description (common/capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity auth-identity
-          (ok (delete-bulk bulk
-                           auth-identity
-                           (common/wait_for->refresh wait_for)
-                           services))))))
+          (ok (core/delete-bulk bulk
+                                auth-identity
+                                (common/wait_for->refresh wait_for)
+                                services))))))

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -48,12 +48,17 @@
        set))
 
 (s/defn BulkPatch :- (s/protocol s/Schema)
-  "Returns BulkUpdate schema without disabled entities and only entities that can be patched"
+  "Returns BulkPatch schema without disabled entities and only entities that can be patched"
   [services :- GetEntitiesServices]
   (let [patchable-entities (into {}
                                  (filter #(:can-patch? (second %)))
                                  (get-entities services))]
     (entities-bulk-schema patchable-entities :partial-schema)))
+
+(s/defn BulkUpdate :- (s/protocol s/Schema)
+  "Returns BulkUpdate schema without disabled entities"
+  [services :- GetEntitiesServices]
+  (entities-bulk-schema (get-entities services) :new-schema))
 
 (s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- GetEntitiesServices]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -166,7 +166,7 @@
                                   services)})]
     (assoc fm
            :entities
-           (doall
+           (remove nil?
             (for [entity entities
                   :let [entity-id (find-entity-id fm entity)]]
               (cond
@@ -178,16 +178,12 @@
                                             tempids
                                             identity-map)
                         :update
-                        (if-let [prev-entity (get-prev-entity entity-id)]
+                        (when-let [prev-entity (get-prev-entity entity-id)]
                           (realize-fn entity
                                       entity-id
                                       tempids
                                       identity-map
-                                      prev-entity)
-                          (realize-fn entity
-                                      entity-id
-                                      tempids
-                                      identity-map))
+                                      prev-entity))
                         :delete entity)))))))
 
 (s/defn ^:private throw-validation-error
@@ -486,13 +482,13 @@
     - `:before-update` hooks can modify the entity stored.
     - `:after-update` hooks are read only"
   [& {:keys [entity-type
+             services
              get-fn
              realize-fn
              update-fn
              identity
              entities
              long-id-fn
-             services
              spec
              get-success-entities
              make-result]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -39,7 +39,6 @@
    (s/optional-key :events)               [{s/Keyword s/Any}]
    (s/optional-key :long-id-fn)           (s/maybe (s/=> s/Any s/Any))
    (s/optional-key :get-prev-entity)      (s/pred fn?)
-   (s/optional-key :partial-entities)     [(s/maybe {s/Keyword s/Any})]
    (s/optional-key :patch-operation)      (s/enum :add :remove :replace)
    (s/optional-key :realize-fn)           RealizeFn
    (s/optional-key :find-entity-id)       (s/pred fn?)
@@ -553,7 +552,6 @@
          :entities partial-entities
          :services services
          :get-prev-entity prev-entity-fn
-         :partial-entities partial-entities
          :patch-operation patch-operation
          :identity identity
          :long-id-fn long-id-fn
@@ -564,8 +562,8 @@
          :create-event-fn to-update-event
          :get-success-entities get-success-entities
          :make-result make-result}
-        not-found
         patch-entities
+        not-found
         validate-entities
         realize-entities
         throw-validation-error

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -386,7 +386,7 @@
 
 (s/defn patch-entities :- FlowMap
   [{:keys [get-prev-entity
-           partial-entities
+           entities
            patch-operation]
     :as fm} :- FlowMap]
   (let [patch-fn (case patch-operation
@@ -394,14 +394,14 @@
                    :remove coll/remove-colls
                    :replace coll/replace-colls
                    coll/replace-colls)
-        entities (for [partial-entity partial-entities
+        patched (for [partial-entity entities
                        :let [prev-entity (some->> partial-entity
                                                   :id
-                                                  get-prev-entity)]
-
-                       :when (some? prev-entity)]
-                   (patch-entity patch-fn prev-entity partial-entity))]
-    (assoc fm :entities entities)))
+                                                  get-prev-entity)]]
+                      (cond->> partial-entity
+                       (some? prev-entity)
+                       (patch-entity patch-fn prev-entity)))]
+    (assoc fm :entities patched)))
 
 (defn create-flow
   "This function centralizes the create workflow.

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -319,7 +319,6 @@ It returns the documents with full hits meta data including the real index in wh
           {:keys [prepared errors]} (check-and-prepare-bulk conn-state
                                                             ids
                                                             ident)
-
           prepared-docs (map (fn [meta]
                                (-> (:_id meta)
                                    by-id

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -275,10 +275,10 @@
                (is (= (set sighting-ids) (set (:updated sightings))))
                (is (= (set indicator-ids) (set (:updated indicators))))
                (doseq [sighting-id (:updated sightings)]
-                 (is (= "updateed sighting"
+                 (is (= "updated sighting"
                         (:source (read-record sighting-store sighting-id ident-map {})))))
                (doseq [indicator-id (:updated indicators)]
-                 (is (= "updateed indicator"
+                 (is (= "updated indicator"
                         (:source (read-record indicator-store indicator-id ident-map {})))))))
 
            (testing "bulk-delete shall properly delete entities with allowed entities and manage visibilities"

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -75,6 +75,22 @@
                      :forbidden [(to-long-ids "tool-82240bee-3915-44dd-af7d-d4b650d71724")]}}]
        (is (= expected (sut/format-bulk-flow-res bulk-flow-res services)))))))
 
+(deftest merge-tempids-test
+  (let [bundle-res {:entity-type1 {:data []
+                                   :tempids {"transientid1" "id1"
+                                             "transientid2" "id2"}}
+                    :entity-type2 {:data []
+                                   :tempids {"transientid3" "id3"
+                                             "transientid4" "id4"
+                                             "transientid5" "id4"}}
+                    :entity-type3 {:data []}}]
+    (is (= {"transientid1" "id1"
+            "transientid2" "id2"
+            "transientid3" "id3"
+            "transientid4" "id4"
+            "transientid5" "id4"}
+           (sut/merge-tempids bundle-res)))))
+
 
 (defn with-tlp
   [fixtures tlp]

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -10,14 +10,15 @@
             [ctia.properties :refer [get-http-show]]
             [ctia.store :refer [query-string-search]]
             [ctia.test-helpers.auth :refer [all-capabilities]]
-            [ctia.test-helpers.core :as helpers :refer [DELETE GET POST PATCH]]
+            [ctia.test-helpers.core :as helpers :refer [DELETE GET POST PATCH PUT]]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.http :refer [app->HTTPShowServices]]
             [ctia.test-helpers.store
              :refer
              [test-for-each-store-with-app test-selected-stores-with-app]]
             [ctim.domain.id :as id]
-            [ctim.examples.incidents :refer [new-incident-maximal]]
+            [ctim.examples.incidents :refer [new-incident-maximal new-incident-minimal]]
+            [ctim.examples.sightings :refer [new-sighting-minimal]]
             [ductile.index :as es-index]
             [schema.core :as s]))
 
@@ -341,6 +342,27 @@
                    (is (= (:protocol id)         (:protocol show-props)))
                    (is (= (:port id)             (:port show-props)))
                    (is (= (:path-prefix id) (seq (:path-prefix show-props)))))))))
+
+         (testing "PUT /ctia/bulk"
+           (let [incident-ids (:incidents bulk-ids)
+                 sighting-ids (:sightings bulk-ids)
+                 update-bulk {:incidents (map #(assoc new-incident-maximal :id % :source "updated") incident-ids)
+                              :sightings (map #(assoc new-sighting-minimal :id % :source "updated") sighting-ids)}
+                 expected-update {:incidents {:updated (set incident-ids)}
+                                  :sightings {:updated (set sighting-ids)}}
+                 {:keys [status parsed-body]} (PUT app
+                                                   bulk-url
+                                                   :form-params update-bulk
+                                                   :headers {"Authorization" "45c1f5e3f05d0"})]
+             (is (= 200 status))
+             (is (= expected-update
+                    (-> parsed-body
+                        (update-in [:incidents :updated] set)
+                        (update-in [:sightings :updated] set))))
+             (check-events event-store
+                           ident
+                           (concat incident-ids sighting-ids)
+                           :record-updated)))
 
          (testing "PATCH /ctia/bulk"
            (let [incident-ids (:incidents bulk-ids)

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -344,11 +344,11 @@
                    (is (= (:path-prefix id) (seq (:path-prefix show-props)))))))))
 
          (testing "PUT /ctia/bulk"
-           (let [incident-ids (:incidents bulk-ids)
+           (let [indicator-ids (:indicators bulk-ids)
                  sighting-ids (:sightings bulk-ids)
-                 update-bulk {:incidents (map #(assoc new-incident-maximal :id % :source "updated") incident-ids)
-                              :sightings (map #(assoc new-sighting-minimal :id % :source "updated") sighting-ids)}
-                 expected-update {:incidents {:updated (set incident-ids)}
+                 update-bulk {:indicators (map #(assoc (mk-new-indicator 0) :id % :source "updated") indicator-ids)
+                              :sightings (map #(assoc (mk-new-sighting 0) :id % :source "updated") sighting-ids)}
+                 expected-update {:indicators {:updated (set indicator-ids)}
                                   :sightings {:updated (set sighting-ids)}}
                  {:keys [status parsed-body]} (PUT app
                                                    bulk-url
@@ -357,11 +357,11 @@
              (is (= 200 status))
              (is (= expected-update
                     (-> parsed-body
-                        (update-in [:incidents :updated] set)
+                        (update-in [:indicators :updated] set)
                         (update-in [:sightings :updated] set))))
              (check-events event-store
                            ident
-                           (concat incident-ids sighting-ids)
+                           (concat indicator-ids sighting-ids)
                            :record-updated)))
 
          (testing "PATCH /ctia/bulk"

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -186,7 +186,7 @@
              check-update (fn [now source-value expected]
                             (doseq [[id updated?] expected]
                               (is (= updated?
-                                     (= source-value"updated"
+                                     (= source-value
                                         (:source (get @store id))))
                                   (format "the expected update result for %s is %s (%s)" id updated? (pr-str (get @store id))))
                               (is (= updated?

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -348,7 +348,6 @@
                            :identity (map->Identity {:login "user1" :groups ["g1"]})
                            :store-fn identity
                            :get-prev-entity store
-                           :partial-entities partial-entities
                            :patch-operation :replace}
            expected-entities (conj (map #(-> (store %)
                                              (assoc :source "patched")

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -353,7 +353,6 @@
                                                (dissoc :schema_version))
                                           patched-sighting-ids)
            expected (assoc patch-flow-map
-                           :entities expected-patched-entities
-                           :not-found ["not-found"])]
+                           :entities expected-patched-entities)]
        (is (= expected
               (flows.crud/patch-entities patch-flow-map)))))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/2249
This PR implements bulk update and fixes 404 on update.

- bulk update implements the documentation [already submitted](https://github.com/threatgrid/ctia/blob/master/doc/bulk-bundle.org#delete--patch--update).
- Update was implemented as an upsert in the flow, while the update events expected only update with a [precondition of non nil previous document](https://github.com/threatgrid/ctia/blob/5be5876f63780612ea0e24a41efbf0485b9fc640/src/ctia/entity/event/obj_to_event.clj#L22).
Then trying to create a document with PUT triggers a 500, at least since the introduction of the mentionned `pre`, 2 years ago.
I chose the behavior of IROH with PUT that only update.


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================
## test bulk update
1) bulk create few entities `POST /ctia/bulk`
``` javascript
{
  "incidents": [
    {
      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
      "assignees": [
        "saintx"
      ],
      "type": "incident",
      "source": "Modeling Incidents in CTIM Tutorial",
      "external_ids": [
        "pr1187-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f"
      ],
      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
      "title": "2020-06-15-0334-emotet-botnet-report",
      "incident_time": {
        "opened": "2020-06-15T03:43:27.368Z",
        "reported": "2020-06-15T03:34:36.298Z"
      },
      "discovery_method": "NIDS",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "categories": [
        "Malicious Code"
      ],
      "status": "Containment Achieved",
      "id": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
      "confidence": "High"
    }
  ],
  "sightings": [
    {
      "observables": [
        {
          "type": "ip",
          "value": "98.15.140.226"
        }
      ],
      "type": "sighting",
      "source": "Modeling Incidents in CTIM Tutorial",
      "external_ids": [
        "pr1187-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
      ],
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "id": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
      "count": 1,
      "severity": "High",
      "tlp": "green",
      "timestamp": "2020-06-15T03:34:36.298Z",
      "confidence": "High",
      "observed_time": {
        "start_time": "2020-06-15T03:34:36.298Z"
      }
    }
  ],
  "relationships": [
    {
      "type": "relationship",
      "source": "Modeling Incidents in CTIM Tutorial",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
      "target_ref": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
      "relationship_type": "member-of",
      "external_ids": [
        "pr1187-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"
      ]
    },
    {
      "type": "relationship",
      "source": "Modeling Incidents in CTIM Tutorial",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
      "target_ref": "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
      "description": "Sighting of host communication with known Emotet Epoch 2 C&C server",
      "relationship_type": "sighting-of",
      "external_ids": [
        "pr1187-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"
      ]
    }
  ]
}
```

2) Note all the ids and bulk update `POST /ctia/bulk` by changing the source
``` javascript
{
  "incidents": [
    {
      "id": "${incident-id}",
      "description": "bulk updated",
      "source": "bulk update test",
      "short_description": "bulk updated",
      "title": "2020-06-15-0334-emotet-botnet-report",
      "incident_time": {
        "opened": "2020-06-15T03:43:27.368Z",
        "reported": "2020-06-15T03:34:36.298Z"
      },
      "discovery_method": "NIDS",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "external_ids": [
        "pr1187-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
      ],
      "categories": [
        "Malicious Code"
      ],
      "status": "Containment Achieved",
      "confidence": "High"
    }
  ],
  "sightings": [
    {
      "id": "${sighting-id}",
      "observables": [
        {
          "type": "ip",
          "value": "98.15.140.226"
        }
      ],
      "type": "sighting",
      "source": "bulk update test,
      "external_ids": [
        "pr1187-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d"
      ],
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "count": 1,
      "severity": "High",
      "tlp": "green",
      "timestamp": "2020-06-15T03:34:36.298Z",
      "confidence": "High",
      "observed_time": {
        "start_time": "2020-06-15T03:34:36.298Z"
      }
    }
  ],
  "relationships": [
    {
     "id": "${relationship-id-1}",
      "type": "relationship",
      "source": "bulk update test",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
      "target_ref": "transient:ctim-tutorial-incident-c56de1c94c1ce862c4e6d9883393aacc58275c0c4dc4d8b48cc4db692bf11e4f",
      "relationship_type": "member-of",
      "external_ids": [
        "pr1187p-2c1f3fcaf89d294bf7d038f470f6cb4a81dc1fad6ff5deeed18a41bf6fe14f00"
      ]
    },
    {
      "id": "${relationship-id-2}",
      "type": "relationship",
      "source": "bulk update test",
      "source_uri": "https://github.com/threatgrid/ctim/blob/master/src/doc/tutorials/modeling-incidents-in-ctim.md",
      "source_ref": "transient:ctim-tutorial-sighting-7b36e0fa2169a3ca330c7790f63c97fd3c9f482f88ee1b350511d8a51fcecc8d",
      "target_ref": "https://ex.tld/ctia/indicator/indicator-b790ade3-e45e-48d4-7d06-f0079e6453a0",
      "description": "Sighting of host communication with known Emotet Epoch 2 C&C server",
      "relationship_type": "sighting-of",
      "external_ids": [
        "pr1187-f879541251b139dfbfbed0f5c66a7c6d20246074241fa2f814f0f3eb2250def8"
      ]
    }
  ]
}
```
3) bulk export the incident `GET /ctia/bulk?incidents=${incident-id}`and check that all entities were fully updated with `"source": "bulk update test"` for all entities and `"description": "bulk updated"` for the incident.

## test the fix of 404 on update
 
1. Try to create an incident with PUT with a non existing id, it should return a 404.
``` javascript
PUT /ctia/incident/missing-0e14cef7-fbd9-4c06-a6d6-332ad82d5b32
{
      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
      "source": "Modeling Incidents in CTIM Tutorial",
      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
      "title": "2020-06-15-0334-emotet-botnet-report",
      "incident_time": {
        "opened": "2020-06-15T03:43:27.368Z",
        "reported": "2020-06-15T03:34:36.298Z"
      },
      "discovery_method": "NIDS",
      "status": "Containment Achieved",
      "confidence": "High"
    }
```
2. Create this entity, with the POST route and note the returned entity id 
``` javascript
POST /ctia/incident
{
      "description": "## Summary:\n\nOn Monday, June 15th at 3:34am GMT, a host (UUID #dc0415fe-af42-11ea-b3de-0242ac130004) on VLAN 414 established contact with a known Emotet Epoch 2 Command and Control server, triggering an event alarm..",
      "source": "Modeling Incidents in CTIM Tutorial",
      "short_description": "Incident Report: 2020-06-15 3:34am (Emotet Botnet Attack)",
      "title": "2020-06-15-0334-emotet-botnet-report",
      "incident_time": {
        "opened": "2020-06-15T03:43:27.368Z",
        "reported": "2020-06-15T03:34:36.298Z"
      },
      "discovery_method": "NIDS",
      "status": "Containment Achieved",
      "confidence": "High"
    }
```
3. update this entity (using the created id), it should return a 200.
``` javascript
PUT /ctia/incident/{incident-id}
{
      "description": "updated",
      "source": "Modeling Incidents in CTIM Tutorial",
      "short_description": "updated",
      "title": "updated",
      "status": "Open",
      "confidence": "High"
    }
```
4. Retrieve this entity and check that it was properly updated 
``` javascript
GET /ctia/incident/{incident-id}
```



<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

