### PR TITLE
Logging refinements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -151,7 +151,10 @@
                  ;; GraphQL
                  [base64-clj "0.1.1"]
                  [threatgrid/ring-graphql-ui "0.1.1"]
-                 [com.graphql-java/graphql-java "9.7"]]
+                 [com.graphql-java/graphql-java "9.7"]
+
+                 ;; Logging
+                 [org.slf4j/log4j-over-slf4j "1.7.20"]]
 
   :resource-paths ["resources" "doc"]
   :classpath ".:resources"

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration debug="false">
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %level \(%thread\) [%class{36}] - %msg%n</pattern>
+            <pattern>%d{"yyyy-MM-dd'T'HH:mm:ss.SSSXXX", UTC} %level \(%thread\) [%logger] - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
- Fixes a warning message by adding the dependency [`log4j-over-slf4j`](https://www.slf4j.org/legacy.html#log4j-over-slf4j). It contains replacement classes that redirect all work to their corresponding SLF4J classes.
- Changes the logback encoder pattern to replace the the class name by the logger name in the log message

`2022-01-28T15:14:12.057Z ERROR (qtp1714253032-39) [c.tools.logging$eval451$fn__456] - Request validation failed:`

->

`2022-01-28T15:14:12.057Z ERROR (qtp1714253032-39)  [ctia.http.exceptions] - Request validation failed:`

Usually the logger name matches the namespace from which the log fn is called. 

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Logging refinements
```
