### PR TITLE
ctim 1.1.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -81,7 +81,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.10"]
+                 [threatgrid/ctim "1.1.11"]
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.2"]
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close #https://github.com/advthreat/iroh/issues/6176

CTIM 1.1.11, fix indicator severity schema. 

<a name="qa">[§](#qa)</a> QA
============================

1. Impersonate the org id is `40e83802-1457-4af4-a179-f2d33a5f88d7`.
2. bundle import  [bundle](https://github.com/advthreat/iroh/files/7870446/ctia_input.1.json.zip)
3. check that the response status is 200

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: fix indicator severity schema.
```