### PR TITLE
Indicator severity mapping

### DIFF
--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -81,6 +81,7 @@
                                         :indicator_ids em/token}}
       :likely_impact em/token
       :confidence em/token
+      :severity em/token
       :kill_chain_phases em/kill-chain-phase
       :test_mechanisms em/token
       :specification {:enabled false}})}})

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -102,6 +102,7 @@
    :indicator_type
    :likely_impact
    :confidence
+   :severity
    :producer
    :tags])
 
@@ -127,6 +128,7 @@
      :producer          s/Str
      :specification     s/Str
      :confidence        s/Str
+     :severity          s/Str
      :sort_by           indicator-sort-fields})))
 
 (def IndicatorGetParams IndicatorFieldsParam)


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/6176

While investigating errors on bundle import I discovered that the `severity` field of indicator was never indexed.
This PR add `severity` to indicator and expose it for searching and aggregating.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
