### PR TITLE
New RiemannService and metrics for export bundle function

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,11 @@
+((clojure-mode . ((eval . (progn
+                            ;; Define custom indentation for functions inside metabase.
+                            ;; This list isn't complete; add more forms as we come across them.
+                            ;; Described here:
+                            ;;   https://docs.cider.mx/cider/indent_spec.html#_examples
+                            (define-clojure-indent
+                              ;; defservice service-name [docstring] [protocol] [list-of-protocols] [list-of-methods]
+                              (puppetlabs.trapperkeeper.core/defservice '(:defn (:defn)))
+                              (trapperkeeper/defservice                 '(:defn (:defn)))
+                              (tk/defservice                            '(:defn (:defn)))
+                              (defservice                               '(:defn (:defn)))))))))

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -333,10 +333,16 @@
        (filter (comp seq second))
        (into {})))
 
+(def ^:dynamic correlation-id nil)
+
+(defn- get-epoch-second []
+  (.getEpochSecond (java.time.Instant/now)))
+
 (s/defn fetch-relationship-targets
   "given relationships, fetch all related objects"
   [relationships identity-map
-   services :- APIHandlerServices]
+   {{:keys [send-event]} :RiemannService
+    :as services} :- APIHandlerServices]
   (let [all-ids (->> relationships
                      (map (fn [{:keys [target_ref source_ref]}]
                             [target_ref source_ref]))
@@ -350,7 +356,13 @@
                           (map (fn [[k v]]
                                  {(bulk/bulk-key
                                    (keyword k)) v}) by-type))
+        start (System/currentTimeMillis)
         fetched (bulk/fetch-bulk by-bulk-key identity-map services)]
+    (send-event {:service "export-bundle"
+                 :correlation-id correlation-id
+                 :time (get-epoch-second)
+                 :event-type "fetch-relationships-targets"
+                 :metric (- (System/currentTimeMillis) start)})
     (clean-bundle fetched)))
 
 (defn relationships-filters
@@ -375,31 +387,47 @@
    identity-map
    filters
    {{:keys [get-in-config]} :ConfigService
-    {:keys [get-store]} :StoreService} :- APIHandlerServices]
+    {:keys [get-store]} :StoreService
+    {:keys [send-event]} :RiemannService} :- APIHandlerServices]
   (let [filter-map (relationships-filters id filters)
         max-relationships (get-in-config [:ctia :http :bundle :export :max-relationships]
-                                         1000)]
-    (some-> (get-store :relationship)
-            (list-fn
-              filter-map
-              identity-map
-              {:limit max-relationships
-               :sort_by "timestamp"
-               :sort_order "desc"})
-            :data
-            ent/un-store-all)))
+                                         1000)
+        start (System/currentTimeMillis)
+        res (some-> (get-store :relationship)
+                    (list-fn
+                     filter-map
+                     identity-map
+                     {:limit max-relationships
+                      :sort_by "timestamp"
+                      :sort_order "desc"})
+                    :data
+                    ent/un-store-all)]
+    (send-event {:service "export-bundle"
+                 :correlation-id correlation-id
+                 :time (get-epoch-second)
+                 :event-type "fetch-relationships"
+                 :metric (- (System/currentTimeMillis) start)})
+    res))
 
 (s/defn fetch-record
   "Fetch a record by ID guessing its type"
   [id identity-map
    {{:keys [get-store]} :StoreService
+    {:keys [send-event]} :RiemannService
     :as services} :- APIHandlerServices]
   (when-let [entity-type (ent/id->entity-type id services)]
-    (-> (get-store (keyword entity-type))
-        (read-fn
-          id
-          identity-map
-          {}))))
+    (let [start (System/currentTimeMillis)
+          res (-> (get-store (keyword entity-type))
+                  (read-fn
+                   id
+                   identity-map
+                   {}))]
+      (send-event {:service "export-bundle"
+                   :correlation-id correlation-id
+                   :time (get-epoch-second)
+                   :event-type "fetch-record"
+                   :metric (- (System/currentTimeMillis) start)})
+      res)))
 
 (s/defn export-entities
   "Given an entity id, export it along
@@ -442,9 +470,23 @@
    identity-map
    ident
    params
-   services :- APIHandlerServices]
+   {{:keys [send-event]} :RiemannService
+    :as services} :- APIHandlerServices]
   (if (seq ids)
-    (->> (map #(export-entities % identity-map ident params services) ids)
-         (reduce #(deep-merge-with coll/add-colls %1 %2))
-         (into empty-bundle))
+    (binding [correlation-id (str (java.util.UUID/randomUUID))]
+      (send-event {:service "export-bundle"
+                   :correlation-id correlation-id
+                   :time (get-epoch-second)
+                   :event-type "start"
+                   :metric (count ids)})
+      (let [start (System/currentTimeMillis)
+            res (->> (map #(export-entities % identity-map ident params services) ids)
+                     (reduce #(deep-merge-with coll/add-colls %1 %2))
+                     (into empty-bundle))]
+        (send-event {:service "export-bundle"
+                     :correlation-id correlation-id
+                     :time (get-epoch-second)
+                     :event-type "end"
+                     :metric (- (System/currentTimeMillis) start)})
+        res))
     empty-bundle))

--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -166,6 +166,7 @@
     :as http-config}
    {{:keys [identity-for-token]} :IAuth
     {:keys [get-in-config]} :ConfigService
+    {:keys [conn service-prefix]} :RiemannService
     :as services} :- APIHandlerServices]
   (doto
       (jetty/run-jetty
@@ -182,7 +183,7 @@
          ;; just after :jwt and :identity is attached to request
          ;; by rjwt/wrap-jwt-auth-fn below.
          (get-in-config [:ctia :log :riemann :enabled])
-         (rie/wrap-request-logs "API response time ms" get-in-config)
+         (rie/wrap-request-logs "API response time ms" conn service-prefix)
 
          (:enabled jwt)
          ((rjwt/wrap-jwt-auth-fn
@@ -190,7 +191,7 @@
             {:pubkey-fn ;; if :public-key-map is nil, will use just :public-key
              (when-let [pubkey-for-issuer-map
                         (auth-jwt/parse-jwt-pubkey-map (:public-key-map jwt))]
-               (fn [{:keys [iss] :as claims}]
+               (fn [{:keys [iss]}]
                  (get pubkey-for-issuer-map iss)))
              :pubkey-path (:public-key-path jwt)
              :no-jwt-handler rjwt/authorize-no-jwt-header-strategy}

--- a/src/ctia/http/server_service.clj
+++ b/src/ctia/http/server_service.clj
@@ -15,21 +15,24 @@
    GraphQLNamedTypeRegistryService
    IEncryption
    ConfigService
-   FeaturesService]
+   FeaturesService
+   EventsService]
   (start [this context] (core/start context
                                     ((:get-in-config ConfigService) [:ctia :http])
                                     {:ConfigService                   (-> ConfigService
-                                                        (select-keys #{:get-config
-                                                                       :get-in-config}))
+                                                                          (select-keys #{:get-config
+                                                                                         :get-in-config}))
                                      :HooksService                    (-> HooksService
-                                                       (select-keys #{:apply-event-hooks
-                                                                      :apply-hooks}))
+                                                                          (select-keys #{:apply-event-hooks
+                                                                                         :apply-hooks}))
                                      :StoreService                    (-> StoreService
-                                                       (select-keys #{:get-store}))
+                                                                          (select-keys #{:get-store}))
                                      :IAuth                           IAuth
                                      :GraphQLNamedTypeRegistryService GraphQLNamedTypeRegistryService
                                      :IEncryption                     IEncryption
-                                     :FeaturesService                 FeaturesService}))
+                                     :FeaturesService                 FeaturesService
+                                     :EventsService                   (-> EventsService
+                                                                          (select-keys #{:send-event}))}))
   (stop [this context] (core/stop context))
   (get-port [this]
             (core/get-port (service-context this)))

--- a/src/ctia/http/server_service.clj
+++ b/src/ctia/http/server_service.clj
@@ -16,7 +16,7 @@
    IEncryption
    ConfigService
    FeaturesService
-   EventsService]
+   RiemannService]
   (start [this context] (core/start context
                                     ((:get-in-config ConfigService) [:ctia :http])
                                     {:ConfigService                   (-> ConfigService
@@ -31,7 +31,7 @@
                                      :GraphQLNamedTypeRegistryService GraphQLNamedTypeRegistryService
                                      :IEncryption                     IEncryption
                                      :FeaturesService                 FeaturesService
-                                     :EventsService                   (-> EventsService
+                                     :RiemannService                  (-> RiemannService
                                                                           (select-keys #{:send-event}))}))
   (stop [this context] (core/stop context))
   (get-port [this]

--- a/src/ctia/init.clj
+++ b/src/ctia/init.clj
@@ -3,21 +3,19 @@
    [ctia.encryption.default :as encryption-default]
    [clj-momo.properties :as mp]
    [clojure.tools.logging :as log]
-   [ctia.lib.metrics
-    [riemann :as riemann]
-    [jmx :as jmx]
-    [console :as console]]
+   [ctia.lib.metrics.riemann :as riemann]
+   [ctia.lib.metrics.jmx :as jmx]
+   [ctia.lib.metrics.console :as console]
    [ctia.lib.utils :as utils]
-   [ctia
-    [events-service :as events-svc]
-    [features-service :as features-svc]
-    [logging :as event-logging]
-    [properties :as p]
-    [store-service :as store-svc]]
-   [ctia.auth
-    [allow-all :as allow-all]
-    [static :as static-auth]
-    [threatgrid :as threatgrid]]
+   [ctia.lib.riemann-service :as riemann-svc]
+   [ctia.events-service :as events-svc]
+   [ctia.features-service :as features-svc]
+   [ctia.logging :as event-logging]
+   [ctia.properties :as p]
+   [ctia.store-service :as store-svc]
+   [ctia.auth.allow-all :as allow-all]
+   [ctia.auth.static :as static-auth]
+   [ctia.auth.threatgrid :as threatgrid]
    [ctia.version :as version]
    [ctia.graphql-named-type-registry-service :as graphql-registry-svc]
    [ctia.flows.hooks-service :as hooks-svc]
@@ -58,7 +56,7 @@
                           {:message "Unknown service"
                            :requested-service auth-service-type})))
         encryption-svc
-        (let [{:keys [type] :as encryption-properties}
+        (let [{:keys [type]}
               (get-in config [:ctia :encryption])]
           (case type
             :default {:IEncryption encryption-default/default-encryption-service}
@@ -78,7 +76,8 @@
        :RiemannMetricsService riemann/riemann-metrics-service
        :JMXMetricsService jmx/jmx-metrics-service
        :ConsoleMetricsService console/console-metrics-service
-       :FeaturesService features-svc/features-service}
+       :FeaturesService features-svc/features-service
+       :RiemannService riemann-svc/riemann-service}
       ;; register event file logging only when enabled
       (when (get-in config [:ctia :events :log])
         {:EventLoggingService event-logging/event-logging-service}))))

--- a/src/ctia/lib/riemann.clj
+++ b/src/ctia/lib/riemann.clj
@@ -139,12 +139,12 @@
 ;; based on riemann-reporter.core/wrap-request-metrics
 (defn wrap-request-logs
   "Middleware to log all incoming connections to Riemann"
-  [handler metric-description get-in-config]
+  [handler metric-description conn service-prefix]
   (let [_ (assert (and (string? metric-description)
                        (seq metric-description))
                   (pr-str metric-description))
         _ (log/info "Riemann request logging initialization")
-        send-event-fn (client (get-in-config [:ctia :log :riemann]))]
+        send-event-fn (partial send-event conn service-prefix)]
     (fn [request]
       (let [start (System/nanoTime)]
         (try

--- a/src/ctia/lib/riemann.clj
+++ b/src/ctia/lib/riemann.clj
@@ -126,16 +126,6 @@
         (log/warnf "Riemann doesn't seem configured. Event: %s"
                    (utils/safe-pprint-str prepared-event))))))
 
-(defn client [config]
-  (let [conn (-> (select-keys config
-                              [:host :port :interval-in-ms])
-                 riemann/tcp-client
-                 (riemann/batch-client
-                  (or (:batch-size config) 10)))
-        service-prefix (or (:service-prefix config) "CTIA")]
-    (fn [event]
-      (send-event conn service-prefix event))))
-
 ;; based on riemann-reporter.core/wrap-request-metrics
 (defn wrap-request-logs
   "Middleware to log all incoming connections to Riemann"

--- a/src/ctia/lib/riemann.clj
+++ b/src/ctia/lib/riemann.clj
@@ -182,4 +182,4 @@
            :service-prefix service-prefix)))
 
 (defn stop [{:keys [^RiemannClient conn]}]
-  (.close conn))
+  (when conn (.close conn)))

--- a/src/ctia/lib/riemann_service.clj
+++ b/src/ctia/lib/riemann_service.clj
@@ -1,0 +1,17 @@
+(ns ctia.lib.riemann-service
+  (:require [ctia.lib.riemann :as core]
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.trapperkeeper.services :refer [service-context]]))
+
+(defprotocol RiemannService
+  (send-event [this event] [this service-prefix event]))
+
+(tk/defservice riemann-service
+  RiemannService
+  [[:ConfigService get-in-config]]
+  (start [this context] (core/start context (get-in-config [:ctia :log :riemann])))
+  (stop [this context] (core/stop context))
+  (send-event [this event] (let [{:keys [conn service-prefix]} (service-context this)]
+                             (core/send-event conn service-prefix event)))
+  (send-event [this service-prefix event] (let [{:keys [conn]} (service-context this)]
+                                            (core/send-event conn service-prefix event))))

--- a/src/ctia/lib/riemann_service.clj
+++ b/src/ctia/lib/riemann_service.clj
@@ -9,9 +9,13 @@
 (tk/defservice riemann-service
   RiemannService
   [[:ConfigService get-in-config]]
-  (start [this context] (core/start context (get-in-config [:ctia :log :riemann])))
-  (stop [this context] (core/stop context))
-  (send-event [this event] (let [{:keys [conn service-prefix]} (service-context this)]
-                             (core/send-event conn service-prefix event)))
-  (send-event [this service-prefix event] (let [{:keys [conn]} (service-context this)]
-                                            (core/send-event conn service-prefix event))))
+  (start [this context]
+    (core/start context (get-in-config [:ctia :log :riemann])))
+  (stop [this context]
+    (core/stop context))
+  (send-event [this event]
+    (let [{:keys [conn service-prefix]} (service-context this)]
+      (core/send-event conn service-prefix event)))
+  (send-event [this service-prefix event]
+    (let [{:keys [conn]} (service-context this)]
+      (core/send-event conn service-prefix event))))

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -5,6 +5,8 @@
    [ctia.schemas.services :as external-svc-fns]
    [ctia.schemas.utils :as csu]
    [ctia.store-service.schemas :refer [GetStoreFn]]
+   ;; [ctia.entity.event.schemas :as es]
+   ;; [ctia.lib.async :as la]
    [ctim.domain.id :as id]
    [ctim.schemas.bundle :as bundle]
    [ctim.schemas.common :as cos]
@@ -41,7 +43,10 @@
     :IEncryption                     {:encrypt (s/=> s/Any s/Any)
                                       :decrypt (s/=> s/Any s/Any)}
     :FeaturesService                 {:entity-enabled? (s/=> s/Bool s/Keyword)
-                                      :feature-flags (s/=> [s/Str])}}))
+                                      :feature-flags (s/=> [s/Str])}
+    :EventsService                   {:send-event (s/=>* s/Any
+                                                         [s/Any]
+                                                         [s/Any s/Any])}}))
 
 (s/defschema HTTPShowServices
   (-> APIHandlerServices

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -5,8 +5,6 @@
    [ctia.schemas.services :as external-svc-fns]
    [ctia.schemas.utils :as csu]
    [ctia.store-service.schemas :refer [GetStoreFn]]
-   ;; [ctia.entity.event.schemas :as es]
-   ;; [ctia.lib.async :as la]
    [ctim.domain.id :as id]
    [ctim.schemas.bundle :as bundle]
    [ctim.schemas.common :as cos]
@@ -44,7 +42,7 @@
                                       :decrypt (s/=> s/Any s/Any)}
     :FeaturesService                 {:entity-enabled? (s/=> s/Bool s/Keyword)
                                       :feature-flags (s/=> [s/Str])}
-    :EventsService                   {:send-event (s/=>* s/Any
+    :RiemannService                  {:send-event (s/=>* s/Any
                                                          [s/Any]
                                                          [s/Any s/Any])}}))
 


### PR DESCRIPTION
> Related advthreat/iroh#4958

Introduce RiemannService tk service. Then riemann events can be used to collect information about some important metrics related to bundle export functionality. Those events are grouped together via a correlation id set for each bundle export call. There are three main interesting events:

* Number of ids to export
* Overall timing
* Timings for ES requests to fetch entity, relationships and relationships targets

Those metrics are needed as a temporary extension and should be removed after proper performance improvements for export-bundle function.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: calls to send-event in ctia.bundle.core namespace should be removed after advthreat/iroh#4958 is fixed
public: new RiemanService with single method send-event
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

