### PR TITLE
Performance improvements for bundle-export function

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -97,9 +97,15 @@
     :as services} :- ReadEntitiesServices]
   (let [store (get-store entity-type)]
     (map #(when %
-            (with-long-id % services))
+            (try
+              (with-long-id % services)
+              (catch Exception e
+                (log/error (pr-str e)))))
          (binding [es-crud/*throw-access-control-error?* false]
-           (store/read-records store ids auth-identity {})))))
+           (try
+             (store/read-records store ids auth-identity {})
+             (catch Exception e
+               (log/error (pr-str e))))))))
 
 (defn to-long-id
   [id services]

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -10,7 +10,6 @@
    [ctia.schemas.core :as schemas :refer [APIHandlerServices]]
    [ctia.schemas.utils :as csu]
    [ctia.store :as store]
-   [ctia.stores.es.crud :as es-crud]
    [ring.util.http-response :refer [bad-request!]]
    [schema-tools.core :as st]
    [schema.core :as s]
@@ -100,12 +99,11 @@
             (try
               (with-long-id % services)
               (catch Exception e
-                (log/error (pr-str e)))))
-         (binding [es-crud/*throw-access-control-error?* false]
-           (try
-             (store/read-records store ids auth-identity {})
-             (catch Exception e
-               (log/error (pr-str e))))))))
+                (log/error e))))
+         (try
+           (store/read-records store ids auth-identity {:suppress-access-control-error? true})
+           (catch Exception e
+             (log/error e))))))
 
 (defn to-long-id
   [id services]

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -95,7 +95,7 @@
   [ids entity-type auth-identity
    {{:keys [get-store]} :StoreService
     :as services} :- ReadEntitiesServices]
-  (when-let [store (get-store entity-type)]
+  (let [store (get-store entity-type)]
     (map #(when %
             (with-long-id % services))
          (binding [es-crud/*throw-access-control-error?* false]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -425,8 +425,7 @@
                                                 identity-map
                                                 {:limit limit
                                                  :sort [{"timestamp" "desc"}
-                                                        {(name %) "desc"}
-                                                        {"id" "desc"}]}))
+                                                        {(name %) "desc"}]}))
                     (set related_to))]
       (send-event {:service "Export bundle fetch relationships"
                    :correlation-id correlation-id

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -318,12 +318,13 @@
   "Returns true if this entity'ID is hosted by this CTIA instance,
    false otherwise"
   [id services :- HTTPShowServices]
-  (when id
+  (if (seq id)
     (if (id/long-id? id)
       (let [id-rec (id/long-id->id id)
             this-host (:hostname (p/get-http-show services))]
         (= (:hostname id-rec) this-host))
-      true)))
+      true)
+    false))
 
 (defn clean-bundle
   [bundle]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -337,7 +337,7 @@
 (defn- get-epoch-second []
   (.getEpochSecond (Instant/now)))
 
-(s/defn fetch-targets
+(s/defn fetch-nodes
   "given relationships, fetch all related objects"
   [relationships identity-map
    {{:keys [send-event]} :RiemannService
@@ -491,7 +491,7 @@
           relationships (when (:include_related_entities params true)
                           (map #(ent/with-long-id % services)
                                (fetch-relationships records identity-map params services)))
-          targets (fetch-targets relationships ident services)
+          targets (fetch-nodes relationships ident services)
           res (combine-bundle records relationships targets)]
       (send-event {:service "Export bundle end"
                    :correlation-id correlation-id

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -318,13 +318,12 @@
   "Returns true if this entity'ID is hosted by this CTIA instance,
    false otherwise"
   [id services :- HTTPShowServices]
-  (if (seq id)
+  (when id
     (if (id/long-id? id)
       (let [id-rec (id/long-id->id id)
             this-host (:hostname (p/get-http-show services))]
         (= (:hostname id-rec) this-host))
-      true)
-    false))
+      true)))
 
 (defn clean-bundle
   [bundle]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -402,6 +402,8 @@
   {:query (cond->> [(format "%s:(%s)" (name related-to) (string/join " OR " (map #(format "\"%s\"" %) (map :id records))))]
             source-type (cons (format "source_ref:*%s*" (name source-type)))
             target-type (cons (format "target_ref:*%s*" (name target-type)))
+            ;; NOTE reverse is important to ensure more strict filter `source_ref:("id1" OR "id2")`
+            ;;      takes precedence over wildcard filter
             :always (reverse)
             :always (string/join " AND "))})
 
@@ -423,7 +425,8 @@
                                                 identity-map
                                                 {:limit limit
                                                  :sort [{"timestamp" "desc"}
-                                                        {(name %) "desc"}]}))
+                                                        {(name %) "desc"}
+                                                        {"id" "desc"}]}))
                     (set related_to))]
       (send-event {:service "Export bundle fetch relationships"
                    :correlation-id correlation-id

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -474,8 +474,7 @@
     (let [start (System/currentTimeMillis)
           res (->> (distinct ids)
                    (map #(export-entities % identity-map ident params services))
-                   (reduce #(deep-merge-with coll/add-colls %1 %2))
-                   (into empty-bundle))]
+                   (reduce #(deep-merge-with coll/add-colls %1 %2) empty-bundle))]
       (send-event {:service "Export bundle end"
                    :correlation-id correlation-id
                    :time (get-epoch-second)

--- a/src/ctia/entity/event/store.clj
+++ b/src/ctia/entity/event/store.clj
@@ -9,9 +9,9 @@
   (read-record [_ id ident params]
     (crud/handle-read state id ident params))
   IEventStore
-  (create-events [this new-events]
+  (create-events [_ new-events]
     (crud/handle-create state new-events))
-  (list-events [this filter-map ident params]
+  (list-events [_ filter-map ident params]
     (crud/handle-list state filter-map ident params))
   (close [_] (close-connections! state))
   IQueryStringSearchableStore

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -44,6 +44,7 @@
 (def handle-create (crud/handle-create :judgement StoredJudgement))
 (def handle-update (crud/handle-update :judgement StoredJudgement))
 (def handle-read (crud/handle-read PartialStoredJudgement))
+(def handle-read-many (crud/handle-read-many PartialStoredJudgement))
 (def handle-delete (crud/handle-delete :judgement))
 (def handle-list (crud/handle-find PartialStoredJudgement))
 (def handle-bulk-delete crud/bulk-delete)
@@ -109,6 +110,8 @@
     (handle-create state new-judgements ident params))
   (read-record [_ id ident params]
     (handle-read state id ident params))
+  (read-records [_ ids ident params]
+    (handle-read-many state ids ident params))
   (delete-record [_ id ident params]
     (handle-delete state id ident params))
   (update-record [_ id judgement ident params]

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -118,7 +118,7 @@
   (es-partial-stored-sighting->partial-stored-sighting
    (read-fn state id ident params)))
 
-(s/defn handle-read-many :- [PartialStoredSighting]
+(s/defn handle-read-many :- [(s/maybe PartialStoredSighting)]
   [state ids ident params]
   (map es-partial-stored-sighting->partial-stored-sighting
        (read-many-fn state ids ident params)))

--- a/src/ctia/entity/sighting/es_store.clj
+++ b/src/ctia/entity/sighting/es_store.clj
@@ -53,6 +53,7 @@
 
 (def create-fn (crud/handle-create :sighting ESStoredSighting))
 (def read-fn (crud/handle-read ESPartialStoredSighting))
+(def read-many-fn (crud/handle-read-many ESPartialStoredSighting))
 (def update-fn (crud/handle-update :sighting ESStoredSighting))
 (def list-fn (crud/handle-find ESPartialStoredSighting))
 (def handle-query-string-search (crud/handle-query-string-search ESPartialStoredSighting))
@@ -117,6 +118,11 @@
   (es-partial-stored-sighting->partial-stored-sighting
    (read-fn state id ident params)))
 
+(s/defn handle-read-many :- [PartialStoredSighting]
+  [state ids ident params]
+  (map es-partial-stored-sighting->partial-stored-sighting
+       (read-many-fn state ids ident params)))
+
 (s/defn handle-update :- StoredSighting
   [state id realized ident params]
   (as-> (stored-sighting->es-stored-sighting realized) $
@@ -163,6 +169,8 @@
   IStore
   (read-record [_ id ident params]
     (handle-read state id ident params))
+  (read-records [_ ids ident params]
+    (handle-read-many state ids ident params))
   (create-record [_ new-sightings ident params]
     (handle-create state new-sightings ident params))
   (update-record [_ id sighting ident params]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -26,13 +26,9 @@
 
 (defn flow-get-by-ids-fn
   [{:keys [get-store entity identity-map]}]
-  (let [get-by-id #(-> (get-store entity)
-                       (store/read-record
-                        %
-                        identity-map
-                        {}))]
+  (let [s (get-store entity)]
     (fn [ids]
-      (keep get-by-id ids))))
+      (store/read-records s ids identity-map {}))))
 
 (defn flow-update-fn
   [{:keys [identity-map wait_for get-store entity]}]

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -10,11 +10,7 @@
                      AnyGraphQLTypeResolver
                      RealizeFnResult]]
             [ctia.schemas.graphql.pagination :as pagination]
-            [ctia.store :refer [list-judgements-by-observable
-                                list-records
-                                list-sightings-by-observables
-                                query-string-search
-                                read-fn]]
+            [ctia.store :as store]
             [schema.core :as s]))
 
 ;; Default fields that must always be retrieved
@@ -42,7 +38,7 @@
     (log/debugf "Search entity %s graphql args %s" entity-type args)
 
     (some-> (get-store entity-type)
-            (query-string-search
+            (store/query-string-search
              {:full-text  [{:query query}]
               :filter-map (remove-map-empty-values filtermap)}
               ident
@@ -54,7 +50,7 @@
 (s/defn search-entity-resolver :- AnyGraphQLTypeResolver
   [entity-type-kw]
   (s/fn :- (RealizeFnResult s/Any)
-    [context args field-selection src]
+    [context args field-selection _src]
     (delayed/fn [{:keys [services]
                   :as rt-ctx} :- GraphQLRuntimeContext]
       (search-entity entity-type-kw
@@ -80,10 +76,7 @@
                 id
                 field-selection)
     (some-> (get-store entity-type-kw)
-            (read-fn
-              id
-              ident
-              {:fields (concat default-fields field-selection)})
+            (store/read-record id ident {:fields (concat default-fields field-selection)})
             (with-long-id services)
             un-store)))
 
@@ -110,10 +103,7 @@
                                         (concat default-fields field-selection)))]
     (log/debug "Search feedback for entity id: " entity-id)
     (some-> (get-store :feedback)
-            (list-records
-              {:all-of {:entity_id entity-id}}
-              (:ident context)
-              params)
+            (store/list-records {:all-of {:entity_id entity-id}} (:ident context) params)
             un-store-page
             (pagination/result->connection-response paging-params)))))
 
@@ -133,10 +123,7 @@
                  field-selection (assoc :fields
                                         (concat default-fields field-selection)))]
     (some-> (get-store :judgement)
-            (list-judgements-by-observable
-              observable
-              (:ident context)
-              params)
+            (store/list-judgements-by-observable observable (:ident context) params)
             (page-with-long-id services)
             un-store
             (pagination/result->connection-response paging-params)))))
@@ -157,10 +144,7 @@
                  field-selection (assoc :fields
                                         (concat default-fields field-selection)))]
     (some-> (get-store :sighting)
-            (list-sightings-by-observables
-              [observable]
-              (:ident context)
-              params)
+            (store/list-sightings-by-observables [observable] (:ident context) params)
             (page-with-long-id services)
             un-store
             (pagination/result->connection-response paging-params)))))
@@ -201,10 +185,7 @@
                                                  (concat default-fields field-selection)))]
       (log/debug "Search for AssetMappings for asset-ref: " entity-id)
       (some-> (get-store :asset-mapping)
-              (list-records
-               {:all-of {:asset_ref entity-id}}
-               (:ident context)
-               params)
+              (store/list-records {:all-of {:asset_ref entity-id}} (:ident context) params)
               un-store-page
               (pagination/result->connection-response paging-params)))))
 
@@ -224,9 +205,6 @@
                                                  (concat default-fields field-selection)))]
       (log/debug "Search for AssetProperties for asset-ref: " entity-id)
       (some-> (get-store :asset-properties)
-              (list-records
-               {:all-of {:asset_ref entity-id}}
-               (:ident context)
-               params)
+              (store/list-records {:all-of {:asset_ref entity-id}} (:ident context) params)
               un-store-page
               (pagination/result->connection-response paging-params)))))

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -62,10 +62,6 @@
    :vulnerability []
    :weakness []})
 
-(def read-fn read-record)
-(def create-fn create-record)
-(def list-fn list-records)
-
 (s/defn list-all-pages
   [entity
    list-fn

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -5,6 +5,7 @@
 (defprotocol IStore
   (create-record [this new-records ident params])
   (read-record [this id ident params])
+  (read-records [this ids ident params])
   (update-record [this id record ident params])
   (delete-record [this id ident params])
   (bulk-delete [this ids ident params])

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -230,9 +230,11 @@ It returns the documents with full hits meta data including the real index in wh
              (map (fn [record]
                     (if (allow-read? record ident get-in-config)
                       record
-                      (when *throw-access-control-error?*
-                        (throw (ex-info "You are not allowed to read this document"
-                                        {:type :access-control-error})))))))
+                      (let [ex (ex-info "You are not allowed to read this document"
+                                        {:type :access-control-error})]
+                        (if *throw-access-control-error?*
+                          (throw ex)
+                          (log/error (pr-str ex))))))))
        (get-docs-with-indices conn-state ids (make-es-read-params es-params))))))
 
 (defn access-control-filter-list

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -206,6 +206,28 @@ It returns the documents with full hits meta data including the real index in wh
           (throw (ex-info "You are not allowed to read this document"
                           {:type :access-control-error})))))))
 
+(defn handle-read-many
+  "Generate an ES read-many handler using some mapping and schema"
+  [Model]
+  (let [coerce! (coerce-to-fn Model)]
+    (s/fn :- [Model]
+      [{{{:keys [get-in-config]} :ConfigService}
+        :services
+        :as conn-state}
+       :- ESConnState
+       ids :- [s/Str]
+       ident
+       es-params]
+      (sequence
+       (comp (map :_source)
+             (map coerce!)
+             (map (fn [record]
+                    (if (allow-read? record ident get-in-config)
+                      record
+                      (throw (ex-info "You are not allowed to read this document"
+                                      {:type :access-control-error}))))))
+       (get-docs-with-indices conn-state ids (make-es-read-params es-params))))))
+
 (defn access-control-filter-list
   "Given an ident, keep only documents it is allowed to read"
   [docs ident get-in-config]
@@ -431,12 +453,12 @@ It returns the documents with full hits meta data including the real index in wh
                          (restricted-read? ident)
                          (conj (es.query/find-restriction-query-part ident get-in-config)))
 
-            query_string  {:query_string {:query query}}
+            query-string  {:query_string {:query query}}
             bool-params (cond-> {:filter filter-val}
                           (seq one-of) (into
                                         {:should (q/prepare-terms one-of)
                                          :minimum_should_match 1})
-                          query (update :filter conj query_string))]
+                          query (update :filter conj query-string))]
         (cond-> (coerce! (ductile.doc/query conn
                                             index
                                             (q/bool bool-params)

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -1,9 +1,8 @@
 (ns ctia.stores.es.store
   (:require [schema.core :as s]
-            [ductile
-             [conn :as es-conn]
-             [index :as es-index]
-             [schemas :refer [ESConn]]]
+            [ductile.conn :as es-conn]
+            [ductile.index :as es-index]
+            [ductile.schemas :refer [ESConn]]
             [ctia.store :refer [IStore IQueryStringSearchableStore]]
             [ctia.stores.es.crud :as crud]))
 

--- a/src/ctia/stores/es/store.clj
+++ b/src/ctia/stores/es/store.clj
@@ -7,7 +7,7 @@
             [ctia.store :refer [IStore IQueryStringSearchableStore]]
             [ctia.stores.es.crud :as crud]))
 
-(defn delete-state-indexes [{:keys [conn index config] :as state}]
+(defn delete-state-indexes [{:keys [conn index]}]
   (when conn
     (es-index/delete-template! conn (str index "*"))
     (es-index/delete! conn (str index "*"))))
@@ -30,7 +30,10 @@
      IStore
      (~(symbol "read-record") [_# id# ident# params#]
       ((crud/handle-read ~partial-stored-schema)
-       ~(symbol "state")  id# ident# params#))
+       ~(symbol "state") id# ident# params#))
+     (~(symbol "read-records") [_# ids# ident# params#]
+      ((crud/handle-read-many ~partial-stored-schema)
+       ~(symbol "state") ids# ident# params#))
      (~(symbol "create-record") [_# new-actors# ident# params#]
       ((crud/handle-create ~entity ~stored-schema)
        ~(symbol "state") new-actors# ident# params#))

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -30,8 +30,9 @@
                                  :judgement
                                  identity-singleton
                                  {:ConfigService {:get-in-config get-in-config}
+                                  ;; NOTE "unreachable" entity === unknown store
                                   :StoreService {:get-store (constantly nil)}})]
-      (is (= [nil] res)))))
+      (is (= nil res)))))
 
 (defn schema->keys
   "Extracts both: required and optional keys of schema as set of keywords"
@@ -277,14 +278,14 @@
 
            (testing "bulk-update shall properly update submitties entitites"
              (let [other-group-res (sut/update-bulk bulk-update
-                                                   other-group-ident
-                                                   {:refresh "true"}
-                                                   services)
+                                                    other-group-ident
+                                                    {:refresh "true"}
+                                                    services)
                    {:keys [sightings indicators]}
                    (sut/update-bulk bulk-update
-                                   ident
-                                   {:refresh "true"}
-                                   services)]
+                                    ident
+                                    {:refresh "true"}
+                                    services)]
                (check-tlp other-group-res)
                (is (= #{missing-id-1 missing-id-2} (set (get-in indicators [:errors :not-found]))))
                (is (nil? (:not-found sightings)))

--- a/test/ctia/bulk/core_test.clj
+++ b/test/ctia/bulk/core_test.clj
@@ -30,9 +30,10 @@
                                  :judgement
                                  identity-singleton
                                  {:ConfigService {:get-in-config get-in-config}
-                                  ;; NOTE "unreachable" entity === unknown store
-                                  :StoreService {:get-store (constantly nil)}})]
-      (is (= nil res)))))
+                                  :StoreService {:get-store (constantly (reify ctia.store/IStore
+                                                                          (read-records [_ _ _ _]
+                                                                            [nil])))}})]
+      (is (= [nil] res)))))
 
 (defn schema->keys
   "Extracts both: required and optional keys of schema as set of keywords"

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -433,8 +433,8 @@
              (doseq [[k res] delete-res-2]
                (is (= (set (get-in expected-not-found [k :errors :not-found]))
                       (set (get-in res [:errors :not-found])))))
-             (doseq [[_k entity-res] (dissoc get-res :tempids)]
-               (is (= #{} (set/intersection (set (get delete-bulk-query _k))
+             (doseq [[k entity-res] (dissoc get-res :tempids)]
+               (is (= #{} (set/intersection (set (get delete-bulk-query k))
                                             (set (map :id entity-res))))
                    "the deleted entities must not be found"))
              (let [expected-deleted-ids (mapcat val delete-bulk-query)]

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -17,10 +17,10 @@
              :refer
              [test-for-each-store-with-app test-selected-stores-with-app]]
             [ctim.domain.id :as id]
-            [ctim.examples.incidents :refer [new-incident-maximal new-incident-minimal]]
-            [ctim.examples.sightings :refer [new-sighting-minimal]]
+            [ctim.examples.incidents :refer [new-incident-maximal]]
             [ductile.index :as es-index]
-            [schema.core :as s]))
+            [schema.core :as s]
+            [clojure.set :as set]))
 
 (defn fixture-properties:small-max-bulk-size [t]
   ;; Note: These properties may be overwritten by ENV variables
@@ -315,12 +315,14 @@
            (testing (str "number of created " (name type))
              (is (= (count (get new-bulk type))
                     (count (get bulk-ids type))))))
+
          (testing "created events are generated"
            (let [expected-created-ids (mapcat val (dissoc bulk-ids :tempids))]
-               (check-events event-store
-                             ident
-                             expected-created-ids
-                             :record-created)))
+             (check-events event-store
+                           ident
+                           expected-created-ids
+                           :record-created)))
+
          (testing "GET /ctia/bulk"
            (let [{status :status
                   response :parsed-body}
@@ -332,10 +334,12 @@
 
              (doseq [k (keys new-bulk)]
                (testing (str "retrieved " (name k))
-                 (is (= (map #(dissoc % :id :timestamp :source_ref :target_ref)
-                             (get new-bulk k))
-                        (map #(dissoc % :id :timestamp :type :tlp :schema_version :disposition_name :source_ref :target_ref :owner :groups)
-                             (get response k))))
+                 (is (= (into #{}
+                              (map #(dissoc % :id :timestamp :source_ref :target_ref))
+                              (get new-bulk k))
+                        (into #{}
+                              (map #(dissoc % :id :timestamp :type :tlp :schema_version :disposition_name :source_ref :target_ref :owner :groups))
+                              (get response k))))
 
                  (let [id (id/long-id->id (:id (first (get response k))))]
                    (is (= (:hostname id)         (:hostname show-props)))
@@ -373,9 +377,9 @@
                                            (map #(array-map :id % :source "patched") sighting-ids))
                  expected-patch {:incidents {:updated (set incident-ids)}}
                  {:keys [status parsed-body]} (PATCH app
-                                                      bulk-url
-                                                      :form-params patch-bulk
-                                                      :headers {"Authorization" "45c1f5e3f05d0"})]
+                                                     bulk-url
+                                                     :form-params patch-bulk
+                                                     :headers {"Authorization" "45c1f5e3f05d0"})]
              (is (= 200 status))
              (is (= expected-patch
                     (update-in parsed-body [:incidents :updated] set)))
@@ -398,13 +402,13 @@
                                                 {k (take 2 ids)}))
                                          (dissoc bulk-ids :tempids))
                  expected-deleted (into {}
-                                       (map (fn [[k ids]]
-                                              {k {:deleted ids}}))
-                                       delete-bulk-query)
+                                        (map (fn [[k ids]]
+                                               {k {:deleted ids}}))
+                                        delete-bulk-query)
                  expected-not-found (into {}
-                                       (map (fn [[k ids]]
-                                              {k {:errors {:not-found ids}}}))
-                                       delete-bulk-query)
+                                          (map (fn [[k ids]]
+                                                 {k {:errors {:not-found ids}}}))
+                                          delete-bulk-query)
                  delete-bulk-url "ctia/bulk?wait_for=true"
                  {delete-status-1 :status delete-res-1 :parsed-body}
                  (DELETE app
@@ -430,7 +434,8 @@
                (is (= (set (get-in expected-not-found [k :errors :not-found]))
                       (set (get-in res [:errors :not-found])))))
              (doseq [[_k entity-res] (dissoc get-res :tempids)]
-               (is (= [nil nil] (take 2 entity-res))
+               (is (= #{} (set/intersection (set (get delete-bulk-query _k))
+                                            (set (map :id entity-res))))
                    "the deleted entities must not be found"))
              (let [expected-deleted-ids (mapcat val delete-bulk-query)]
                (check-events event-store
@@ -650,8 +655,7 @@
            ;; Retrieve all entities that have been created
            query-string (make-get-query-str-from-bulkrefs
                          (dissoc bulk-ids :tempids :tools :vulnerabilities))
-           {status-get :status
-            {:keys [sightings] :as body} :parsed-body}
+           {status-get :status {:keys [sightings]} :parsed-body}
            (GET app
                 (str "ctia/bulk?"
                      query-string)

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -23,35 +23,6 @@
   (is (= {:b '(1 2 3) :d '(1 3)}
          (sut/clean-bundle {:a '(nil) :b '(1 2 3) :c '() :d '(1 nil 3)}))))
 
-(deftest relationships-filters
-  (testing "relationships-filters should properly add related_to filters to handle edge direction"
-    (is (= {:source_ref "id"
-            :target_ref "id"}
-           (:one-of (sut/relationships-filters "id" {})))
-        "default related-_to param is #{:source_ref :target_ref}")
-    (is (= {:source_ref "id"}
-           (:one-of (sut/relationships-filters "id" {:related_to [:source_ref]}))))
-    (is (= {:target_ref "id"}
-           (:one-of (sut/relationships-filters "id" {:related_to [:target_ref]}))))
-    (is (= {:source_ref "id"
-            :target_ref "id"}
-           (:one-of (sut/relationships-filters "id" {:related_to [:source_ref :target_ref]})))))
-
-  (testing "relationships-filters should properly add query filters"
-    (is (= "source_ref:*malware*"
-           (:query (sut/relationships-filters "id" {:source_type :malware}))))
-    (is (= "target_ref:*sighting*"
-           (:query (sut/relationships-filters "id" {:target_type :sighting}))))
-    (is (= "target_ref:*sighting* AND source_ref:*malware*"
-           (:query (sut/relationships-filters "id" {:source_type :malware
-                                                    :target_type :sighting})))))
-
-  (testing "relationships-filters should return proper fields and combine filters"
-    (is (= {:one-of {:source_ref "id"}
-            :query "source_ref:*malware*"}
-           (sut/relationships-filters "id" {:source_type :malware
-                                            :related_to [:source_ref]})))))
-
 (deftest with-existing-entity-test
   (testing "with-existing-entity"
     (let [app (h/get-current-app)

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -14,7 +14,7 @@
 
 (deftest local-entity?-test
   (are [x y] (= x (sut/local-entity? y (app->HTTPShowServices (h/get-current-app))))
-    false nil
+    nil   nil
     false "http://unknown.site/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"
     true "indicator-56067199-47c0-4294-8957-13d6b265bdc4"
     true "http://localhost:57254/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"))

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -14,10 +14,11 @@
 
 (deftest local-entity?-test
   (are [x y] (= x (sut/local-entity? y (app->HTTPShowServices (h/get-current-app))))
-    nil   nil
+    false nil
+    false ""
     false "http://unknown.site/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"
-    true "indicator-56067199-47c0-4294-8957-13d6b265bdc4"
-    true "http://localhost:57254/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"))
+    true  "indicator-56067199-47c0-4294-8957-13d6b265bdc4"
+    true  "http://localhost:57254/ctia/indicator/indicator-56067199-47c0-4294-8957-13d6b265bdc4"))
 
 (deftest clean-bundle-test
   (is (= {:b '(1 2 3) :d '(1 3)}

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1024,6 +1024,179 @@
            (is (nil?  (:indicators bundle-incident-target-get)))
            (is (= bundle-incident-target-get bundle-incident-target-post))))))))
 
+(deftest bundle-export-scroll-search-result-test
+  (testing "respect max relationships config when relationships related to one id"
+    (testing "more than set as a limit"
+      (let [indicators (map mk-indicator (range 200))
+            sightings (map mk-sighting (range 10))
+            relationships (map
+                           (fn [idx indicator sighting]
+                             (mk-relationship idx indicator sighting "indicates"))
+                           (range)
+                           indicators
+                           (cycle sightings))
+            bundle {:type "bundle"
+                    :source "source"
+                    :indicators (set indicators)
+                    :sightings (set sightings)
+                    :relationships (set relationships)}
+            max-relationships 2]
+        (helpers/with-properties ["ctia.http.bundle.export.max-relationships" max-relationships]
+          (test-for-each-store-with-app
+           (fn [app]
+             (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+             (whoami-helpers/set-whoami-response app
+                                                 "45c1f5e3f05d0"
+                                                 "foouser"
+                                                 "foogroup"
+                                                 "user")
+             (let [imported-bundle (POST app
+                                         "ctia/bundle/import"
+                                         :body bundle
+                                         :headers {"Authorization" "45c1f5e3f05d0"})
+                   sighting-ids (->> (-> imported-bundle :parsed-body :results)
+                                     (filter #(= (:type %) :sighting))
+                                     (map :id))
+                   exported-bundle
+                   (:parsed-body
+                    (GET app
+                         "ctia/bundle/export"
+                         :query-params {:ids sighting-ids}
+                         :headers {"Authorization" "45c1f5e3f05d0"}))]
+               (is (= (* max-relationships (count sighting-ids))
+                      (count (:relationships exported-bundle))))))))))
+
+    (testing "less than set as a limit"
+      (let [indicators (map mk-indicator (range 200))
+            sightings (map mk-sighting (range 10))
+            relationships (map
+                           (fn [idx indicator sighting]
+                             (mk-relationship idx indicator sighting "indicates"))
+                           (range)
+                           indicators
+                           (cycle sightings))
+            bundle {:type "bundle"
+                    :source "source"
+                    :indicators (set indicators)
+                    :sightings (set sightings)
+                    :relationships (set relationships)}
+            max-relationships 90]
+        (helpers/with-properties ["ctia.http.bundle.export.max-relationships" max-relationships]
+          (test-for-each-store-with-app
+           (fn [app]
+             (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+             (whoami-helpers/set-whoami-response app
+                                                 "45c1f5e3f05d0"
+                                                 "foouser"
+                                                 "foogroup"
+                                                 "user")
+             (let [imported-bundle (POST app
+                                         "ctia/bundle/import"
+                                         :body bundle
+                                         :headers {"Authorization" "45c1f5e3f05d0"})
+                   sighting-ids (->> (-> imported-bundle :parsed-body :results)
+                                     (filter #(= (:type %) :sighting))
+                                     (map :id))
+                   exported-bundle
+                   (:parsed-body
+                    (GET app
+                         "ctia/bundle/export"
+                         :query-params {:ids sighting-ids}
+                         :headers {"Authorization" "45c1f5e3f05d0"}))]
+               (is (= (count relationships)
+                      (count (:relationships exported-bundle)))))))))))
+
+  (testing "different timestamps"
+    (let [indicators (map mk-indicator (range 200))
+          sightings (map mk-sighting (range 10))
+          bundles (map (fn [sightings indicators ids]
+                         (let [relationships (map
+                                              (fn [idx indicator sighting]
+                                                (mk-relationship idx indicator sighting "indicates"))
+                                              ids
+                                              indicators
+                                              (cycle sightings))]
+                           {:type "bundle"
+                            :source "source"
+                            :indicators (set indicators)
+                            :sightings (set sightings)
+                            :relationships (set relationships)}))
+                       (partition 2 sightings)
+                       (partition 40 indicators)
+                       (partition 40 (range)))
+          max-relationships 2]
+      (helpers/with-properties ["ctia.http.bundle.export.max-relationships" max-relationships]
+        (test-for-each-store-with-app
+         (fn [app]
+           (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+           (whoami-helpers/set-whoami-response app
+                                               "45c1f5e3f05d0"
+                                               "foouser"
+                                               "foogroup"
+                                               "user")
+           (let [sighting-ids (doall (mapcat (fn [bundle]
+                                               (let [imported-bundle (POST app
+                                                                           "ctia/bundle/import"
+                                                                           :body bundle
+                                                                           :headers {"Authorization" "45c1f5e3f05d0"})]
+                                                 (->> (-> imported-bundle :parsed-body :results)
+                                                      (filter #(= (:type %) :sighting))
+                                                      (map :id))))
+                                             bundles))
+                 exported-bundle
+                 (:parsed-body
+                  (GET app
+                       "ctia/bundle/export"
+                       :query-params {:ids sighting-ids}
+                       :headers {"Authorization" "45c1f5e3f05d0"}))]
+             (is (= (* max-relationships (count sighting-ids))
+                    (count (:relationships exported-bundle)))))))))
+
+    (let [indicators (map mk-indicator (range 200))
+          sightings (map mk-sighting (range 10))
+          bundles (map (fn [sightings indicators ids]
+                         (let [relationships (map
+                                              (fn [idx indicator sighting]
+                                                (mk-relationship idx indicator sighting "indicates"))
+                                              ids
+                                              indicators
+                                              (cycle sightings))]
+                           {:type "bundle"
+                            :source "source"
+                            :indicators (set indicators)
+                            :sightings (set sightings)
+                            :relationships (set relationships)}))
+                       (partition 2 sightings)
+                       (partition 40 indicators)
+                       (partition 40 (range)))
+          max-relationships 90]
+      (helpers/with-properties ["ctia.http.bundle.export.max-relationships" max-relationships]
+        (test-for-each-store-with-app
+         (fn [app]
+           (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+           (whoami-helpers/set-whoami-response app
+                                               "45c1f5e3f05d0"
+                                               "foouser"
+                                               "foogroup"
+                                               "user")
+           (let [sighting-ids (doall (mapcat (fn [bundle]
+                                               (let [imported-bundle (POST app
+                                                                           "ctia/bundle/import"
+                                                                           :body bundle
+                                                                           :headers {"Authorization" "45c1f5e3f05d0"})]
+                                                 (->> (-> imported-bundle :parsed-body :results)
+                                                      (filter #(= (:type %) :sighting))
+                                                      (map :id))))
+                                             bundles))
+                 exported-bundle
+                 (:parsed-body
+                  (GET app
+                       "ctia/bundle/export"
+                       :query-params {:ids sighting-ids}
+                       :headers {"Authorization" "45c1f5e3f05d0"}))]
+             (is (= 200
+                    (count (:relationships exported-bundle)))))))))))
+
 (defn with-tlp-property-setting [tlp f]
   (helpers/with-config-transformer*
     #(-> %

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -738,6 +738,7 @@
          (is (= {:type "bundle"
                  :source "ctia"} bundle-post-res-empty-ids)
              "POST bundle/export with an empty ids list should return an empty bundle"))))))
+
 (deftest bundle-export-with-unreachable-entities
   (testing "external and deleted entities in fetched relationships should be ignored"
     (test-for-each-store-with-app

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -890,23 +890,23 @@
 
              [indicator-id-1
               indicator-id-2
-              indicator-id-3] (->> (:indicator by-type)
-                                   (sort-by :external_ids)
-                                   (map :id))
+              _indicator-id-3] (->> (:indicator by-type)
+                                    (sort-by :external_ids)
+                                    (map :id))
              [incident-id-1
               incident-id-2] (->> (:incident by-type)
-                                   (sort-by :external_ids)
-                                   (map :id))
+                                  (sort-by :external_ids)
+                                  (map :id))
              [relationship-id-1
               relationship-id-2
               relationship-id-3
-              relationship-id-4
+              _relationship-id-4
               relationship-id-5
               relationship-id-6
               relationship-id-7
-              relationship-id-8] (->> (:relationship by-type)
-                                      (sort-by :external_ids)
-                                      (map :id))
+              _relationship-id-8] (->> (:relationship by-type)
+                                       (sort-by :external_ids)
+                                       (map :id))
              ;; related to queries
              bundle-from-source
              (:parsed-body
@@ -1018,9 +1018,9 @@
                                         set)))
            (is (= #{relationship-id-5
                     relationship-id-7} (->> bundle-incident-target-get
-                                        :relationships
-                                        (map :id)
-                                        set)))
+                                            :relationships
+                                            (map :id)
+                                            set)))
            (is (nil?  (:indicators bundle-incident-target-get)))
            (is (= bundle-incident-target-get bundle-incident-target-post))))))))
 

--- a/test/ctia/store_test.clj
+++ b/test/ctia/store_test.clj
@@ -23,19 +23,19 @@
          (is
           (= (count incidents)
              (count (sut/list-all-pages :incident
-                                        sut/list-fn
+                                        sut/list-records
                                         {:query "*"}
                                         admin-ident
                                         {}
                                         services))
              (count (sut/list-all-pages :incident
-                                        sut/list-fn
+                                        sut/list-records
                                         {:query "*"}
                                         admin-ident
                                         {:limit 2}
                                         services))
              (count (sut/list-all-pages :incident
-                                        sut/list-fn
+                                        sut/list-records
                                         {:query "*"}
                                         admin-ident
                                         {:limit 3}
@@ -44,7 +44,7 @@
          (is
           (= (count incidents)
              (count (sut/list-all-pages :incident
-                                        sut/list-fn
+                                        sut/list-records
                                         {:query "*"}
                                         admin-ident
                                         {}
@@ -58,7 +58,7 @@
           "all store shall be properly listed.")
          (is (= (count incidents-2)
                 (count (sut/list-all-pages :incident
-                                           sut/list-fn
+                                           sut/list-records
                                            {:one-of {:source "incident-2-source"}}
                                            admin-ident
                                            {}


### PR DESCRIPTION
> Related https://github.com/advthreat/iroh/issues/4958

Optimizations for bundle-export functionality:

- [x] Extend `IStore` protocol with `read-records` method to fetch multiple records using a single ES search request.
- [x] Add the ability to fetch relationships related to the bunch of records using two ES requests instead of doing an ES request per id.
- [x] Replace iteration over provided ids with bulk operations in `bundle-export` logic.

## `scroll-with-limit` implementation details

The result of each invocation of `list-records` can have two main possible cases:

1. all results belong to the same record. The next call to `list-records` must use `search_after` to 'fast forward' the cursor to the next record id.
2. results list begins with records belonging to the same id, but then the tail might have 1-N partitions. That means the last partition in the result list is incomplete, and we must use `offset` to fetch the next page.

### `search_after` optimization

The second element must contain a numeric value guaranteed not to be contained in any document. For the timestamp, the value is -1. Only in this case, using "search_after" will ensure that the cursor moves to the next identifier.


<a name="qa">[§](#qa)</a> QA
============================

1. Import that bundle [bundle-0.json.zip](https://github.com/threatgrid/ctia/files/8463390/bundle-0.json.zip). It contains two sightings. Note their ids after a successful import.
2. Replace in every file from that archive [bundles.zip](https://github.com/threatgrid/ctia/files/8463400/bundles.zip) all occurrences of substrings `[[0]]` and `[[1]]` with sighting's ids from the result of step 1.
3. Import all 5 bundles.
4. Call bundle export with ids from the result of step 1. It should retrieve corresponding sightings together with related indicators. The result should not contain more than 1000 indicators per sighting.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: preffer using `ctia.store/read-records` method instead of `ctia.store/read-record` in the loop to fetch multiple records by its ids.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

