### PR TITLE
fix ES7 rename-search-field.

### DIFF
--- a/src/ctia/features_service.clj
+++ b/src/ctia/features_service.clj
@@ -24,6 +24,7 @@
 (tk/defservice features-service
   FeaturesService
   [[:ConfigService get-in-config]]
+  ;;TODO build a proper init to prepare fields only once
   (feature-flags
    [this]
    (when-let [fgs-str (some-> [:ctia :feature-flags]

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -408,15 +408,15 @@
 
 (deftest enforcing-fields-with-feature-flag-test
   (testing "unit testing enforce-search-fields"
-    (are [query-params fields expected-search-fields]
+    (are [fields expected-search-fields]
          (let [res (es.query/enforce-search-fields
                     {:props {:entity :incident}
                      :searchable-fields #{:foo :bar :zap}
                      :services {:FeaturesService {:flag-value (constantly "true")}}}
                     fields)]
            (is (= expected-search-fields res)))
-      {:query "*"} [] ["zap" "bar" "foo"]
-      {:query "*"} ["title" "description"] ["title" "description"]))
+      [] ["zap" "bar" "foo"]
+      ["title" "description"] ["title" "description"]))
   (testing "feature flag set? fields should be enforced"
     (reset! enforced-fields-flag-query-params nil)
     (helpers/with-properties

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -110,9 +110,10 @@
 (deftest rename-search-fields-map-test
   (doseq [es-version [5 7]]
     (helpers/with-properties
-      ["ctia.feature-flags" "translate-searchable-fields:true"
-       "ctia.store.es.default.port" (+ 9200 es-version)
-       "ctia.store.es.default.version" es-version]
+      (cond-> ["ctia.feature-flags" "translate-searchable-fields:true"
+               "ctia.store.es.default.port" (+ 9200 es-version)
+               "ctia.store.es.default.version" es-version]
+        (= es-version 7) (concat es-helpers/basic-auth-properties))
       (helpers/fixture-ctia-with-app
        (fn [app]
          (let [conn-state (:state (helpers/get-store app :sighting))]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/5953

The search on source as a text by default does not work on INT after ES7 migration.
After further investigation, the remapping of textual search for searchable token does not work on ES7 because the implementation did not consider the difference between ES5 and ES7 mappings.

<a name="qa">[§](#qa)</a> QA
============================

After ES7 migration on TEST, In the incident manager, search for `Endpoint`, all `Secure Endpoint` incidents should be returned.

