### PR TITLE
Change type hint to prevent exception during shutdown phase

### DIFF
--- a/src/ctia/lib/riemann.clj
+++ b/src/ctia/lib/riemann.clj
@@ -4,7 +4,7 @@
             [riemann.client :as riemann]
             [ctia.lib.utils :as utils])
   (:import [clojure.lang ExceptionInfo]
-           [io.riemann.riemann.client RiemannClient]))
+           [io.riemann.riemann.client RiemannBatchClient]))
 
 ;; based on riemann-reporter.core/request-to-event
 (defn request->event
@@ -181,5 +181,5 @@
            :conn conn
            :service-prefix service-prefix)))
 
-(defn stop [{:keys [^RiemannClient conn]}]
+(defn stop [{:keys [^RiemannBatchClient conn]}]
   (when conn (.close conn)))


### PR DESCRIPTION
> **Epic** #
> Close #
> Related #

<details>
  <summary>Example of the error</summary>
  
```
2022-04-05T09:38:22.373Z ERROR (async-dispatch-7) [puppetlabs.trapperkeeper.internal] - Encountered error during shutdown sequence
java.lang.ClassCastException: class io.riemann.riemann.client.RiemannBatchClient cannot be cast to class io.riemann.riemann.client.RiemannClient (io.riemann.riemann.client.RiemannBatchClient and io.riemann.riemann.client.RiemannClient are in unnamed module of loader 'app')
	at ctia.lib.riemann$stop.invokeStatic(riemann.clj:185)
	at ctia.lib.riemann$stop.invoke(riemann.clj:184)
	at ctia.lib.riemann_service$reify__25040$service_fnk__12025__auto___positional$reify__25047.stop(riemann_service.clj:15)
	at puppetlabs.trapperkeeper.services$eval11823$fn__11850$G__11815__11853.invoke(services.clj:9)
	at puppetlabs.trapperkeeper.services$eval11823$fn__11850$G__11814__11857.invoke(services.clj:9)
	at puppetlabs.trapperkeeper.internal$eval22075$run_lifecycle_fn_BANG___22082$fn__22083.invoke(internal.clj:196)
	at puppetlabs.trapperkeeper.internal$eval22075$run_lifecycle_fn_BANG___22082.invoke(internal.clj:179)
	at puppetlabs.trapperkeeper.internal$eval22645$shutdown_BANG___22650$fn__22651$shutdown_fn__22653$fn__22668.invoke(internal.clj:459)
	at puppetlabs.trapperkeeper.internal$eval22645$shutdown_BANG___22650$fn__22651$shutdown_fn__22653.invoke(internal.clj:458)
	at puppetlabs.trapperkeeper.internal$eval22149$initialize_lifecycle_worker__22160$fn__22161$fn__22312$state_machine__19342__auto____22337$fn__22340$fn__22354.invoke(internal.clj:274)
	at puppetlabs.trapperkeeper.internal$eval22149$initialize_lifecycle_worker__22160$fn__22161$fn__22312$state_machine__19342__auto____22337$fn__22340.invoke(internal.clj:258)
	at puppetlabs.trapperkeeper.internal$eval22149$initialize_lifecycle_worker__22160$fn__22161$fn__22312$state_machine__19342__auto____22337.invoke(internal.clj:249)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invokeStatic(ioc_macros.clj:978)
	at clojure.core.async.impl.ioc_macros$run_state_machine.invoke(ioc_macros.clj:977)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invokeStatic(ioc_macros.clj:982)
	at clojure.core.async.impl.ioc_macros$run_state_machine_wrapped.invoke(ioc_macros.clj:980)
	at clojure.core.async$ioc_alts_BANG_$fn__19589.invoke(async.clj:421)
	at clojure.core.async$do_alts$fn__19520$fn__19523.invoke(async.clj:288)
	at clojure.core.async.impl.channels.ManyToManyChannel$fn__14093.invoke(channels.clj:135)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at clojure.core.async.impl.concurrent$counted_thread_factory$reify__13946$fn__13947.invoke(concurrent.clj:29)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
  
</details>

During the shutdown, RiemannService is throwing exception because of the wrong type hint for the stop method. TK will still continue shutdown sequence but because of the exception riemann client will not close properly. In this PR instead of RiemannClient the type hint pointing to the right RiemannBatchClient.

<a name="qa">[§](#qa)</a> QA
============================


1. Start CTIA
2. Shutdown CTIA
3. Check that there are no errors like the one above in the logs


<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

