### PR TITLE
fix ES7 date coercion in mapping

### DIFF
--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -21,7 +21,8 @@
   {:type "integer"})
 
 (def ts
-  "A mapping for our timestamps, which should all be ISO8601 format"
+  "A mapping for our timestamps, which should all be ISO8601 format.
+   epoch_millis is enabled for search_after coercion."
   {:type "date"
    :format "date_time||epoch_millis"})
 

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -23,7 +23,7 @@
 (def ts
   "A mapping for our timestamps, which should all be ISO8601 format"
   {:type "date"
-   :format "date_time"})
+   :format "date_time||epoch_millis"})
 
 (def text
   "A mapping for free text, or markdown, fields.  They will be

--- a/test/ctia/stores/es/mapping_test.clj
+++ b/test/ctia/stores/es/mapping_test.clj
@@ -187,13 +187,11 @@
                  page-2 (search {}
                                 nil
                                 (into next-paging {:sort [:timestamp]}))]
-             (is (< (:timestamp page-1) (:timestemp page-2)))
+             (assert (seq page-2))
              (is (= page-2
                     (search {}
                             nil
-                            (into next-paging-str-epoch {:sort [:timestamp]}))))
-             ))
-         ))
+                            (into next-paging-str-epoch {:sort [:timestamp]}))))))))
      (testing "scalar type should be properly sorted"
        (doseq [[s r] (concat
                       (map vector

--- a/test/ctia/stores/es/mapping_test.clj
+++ b/test/ctia/stores/es/mapping_test.clj
@@ -176,7 +176,7 @@
                 (->> res-range
                      (map :id)
                      set)))
-         (testing "epoch date shall be properly coerced"
+         (testing "epoch date shall be properly coerced in search_after"
            (let [{page-1 :data
                   {next-paging :next} :paging}
                  (search-raw {}
@@ -187,7 +187,9 @@
                  page-2 (search {}
                                 nil
                                 (into next-paging {:sort [:timestamp]}))]
-             (assert (seq page-2))
+             (assert (seq page-2)
+                     "no data were matched to properly test search_after")
+             (is (not (= page-1 page-2)))
              (is (= page-2
                     (search {}
                             nil


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #https://github.com/advthreat/iroh/issues/3072
> Close #https://github.com/advthreat/iroh/issues/6543

This PR fixes `search_after` epoch-millis date coercion in ES7 when they provided as string from the API.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<a name="ops">[§](#ops)</a> Ops
===============================

We need to remigrate ES7 on INT.
