### PR TITLE
Revert "Bump icu4j from 65.1 to 71.1 in /dependabot"

### DIFF
--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -546,7 +546,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>71.1</version>
+      <version>65.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -97,7 +97,7 @@
                  [ring-middleware-format "0.7.4"]
                  ;; optional ring-middleware-format dep (Note: ring-middleware-format is also a transitive dep for compojure-api)
                  ;; see: https://github.com/ngrunwald/ring-middleware-format/issues/74
-                 [com.ibm.icu/icu4j "71.1"]
+                 [com.ibm.icu/icu4j "65.1"]
                  [metosin/ring-swagger "0.26.2"]
                  [metosin/ring-swagger-ui "3.24.3"]
                  [ring/ring-core ~ring-version] ;ring/ring-jetty-adapter > metosin/ring-swagger


### PR DESCRIPTION
Reverts threatgrid/ctia#1248

Trips trojan scanner, revert for now. https://github.com/threatgrid/ctia/runs/6040985095?check_suite_focus=true#step:16:49