### PR TITLE
Add wrap-request-logs to RiemannService

### DIFF
--- a/src/ctia/http/server.clj
+++ b/src/ctia/http/server.clj
@@ -6,7 +6,6 @@
             [ctia.auth.jwt :as auth-jwt]
             [ctia.http.handler :as handler]
             [ctia.http.middleware.auth :as auth]
-            [ctia.lib.riemann :as rie]
             [ctia.schemas.core :refer [APIHandlerServices]]
             [ring-jwt-middleware.core :as rjwt]
             [ring.adapter.jetty :as jetty]
@@ -166,7 +165,7 @@
     :as http-config}
    {{:keys [identity-for-token]} :IAuth
     {:keys [get-in-config]} :ConfigService
-    {:keys [conn service-prefix]} :RiemannService
+    {:keys [wrap-request-logs]} :RiemannService
     :as services} :- APIHandlerServices]
   (doto
       (jetty/run-jetty
@@ -183,7 +182,7 @@
          ;; just after :jwt and :identity is attached to request
          ;; by rjwt/wrap-jwt-auth-fn below.
          (get-in-config [:ctia :log :riemann :enabled])
-         (rie/wrap-request-logs "API response time ms" conn service-prefix)
+         (wrap-request-logs "API response time ms")
 
          (:enabled jwt)
          ((rjwt/wrap-jwt-auth-fn

--- a/src/ctia/http/server_service.clj
+++ b/src/ctia/http/server_service.clj
@@ -32,7 +32,8 @@
                                      :IEncryption                     IEncryption
                                      :FeaturesService                 FeaturesService
                                      :RiemannService                  (-> RiemannService
-                                                                          (select-keys #{:send-event}))}))
+                                                                          (select-keys #{:send-event
+                                                                                         :wrap-request-logs}))}))
   (stop [this context] (core/stop context))
   (get-port [this]
             (core/get-port (service-context this)))

--- a/src/ctia/lib/riemann_service.clj
+++ b/src/ctia/lib/riemann_service.clj
@@ -4,7 +4,8 @@
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defprotocol RiemannService
-  (send-event [this event] [this service-prefix event]))
+  (send-event [this event] [this service-prefix event])
+  (wrap-request-logs [this handler metric-description]))
 
 (tk/defservice riemann-service
   RiemannService
@@ -18,4 +19,7 @@
       (core/send-event conn service-prefix event)))
   (send-event [this service-prefix event]
     (let [{:keys [conn]} (service-context this)]
-      (core/send-event conn service-prefix event))))
+      (core/send-event conn service-prefix event)))
+  (wrap-request-logs [this handler metric-description]
+    (let [{:keys [conn service-prefix]} (service-context this)]
+      (core/wrap-request-logs handler metric-description conn service-prefix))))


### PR DESCRIPTION
Fix the way how wrap-request-logs middleware gets configuration parameters for riemann client.

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. API requests should not push a log entry saying that "Riemann Service is not configured"

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: wrap-request-logs moved to RiemannService
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

