### PR TITLE
severity and created sorting

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -171,7 +171,12 @@
               :remap-default 0}})
 
 (def incident-sort-fields
-  (apply s/enum (distinct (concat (keys sort-extension-templates) incident-fields))))
+  (apply s/enum (distinct (concat (keys sort-extension-templates)
+                                  incident-fields
+                                  ["severity:asc,created:desc"
+                                   "severity:desc,created:desc"
+                                   "severity:asc,created:asc"
+                                   "severity:desc,created:asc"]))))
 
 (def incident-enumerable-fields
   [:assignees

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -171,12 +171,13 @@
               :remap-default 0}})
 
 (def incident-sort-fields
-  (apply s/enum (distinct (concat (keys sort-extension-templates)
-                                  incident-fields
-                                  ["severity:asc,timestamp:desc"
-                                   "severity:desc,timestamp:desc"
-                                   "severity:asc,timestamp:asc"
-                                   "severity:desc,timestamp:asc"]))))
+  (apply s/enum (map name
+                     (distinct (concat (keys sort-extension-templates)
+                                       incident-fields
+                                       ["severity:asc,timestamp:desc"
+                                        "severity:desc,timestamp:desc"
+                                        "severity:asc,timestamp:asc"
+                                        "severity:desc,timestamp:asc"])))))
 
 (def incident-enumerable-fields
   [:assignees

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -173,10 +173,10 @@
 (def incident-sort-fields
   (apply s/enum (distinct (concat (keys sort-extension-templates)
                                   incident-fields
-                                  ["severity:asc,created:desc"
-                                   "severity:desc,created:desc"
-                                   "severity:asc,created:asc"
-                                   "severity:desc,created:asc"]))))
+                                  ["severity:asc,timestamp:desc"
+                                   "severity:desc,timestamp:desc"
+                                   "severity:asc,timestamp:asc"
+                                   "severity:desc,timestamp:asc"]))))
 
 (def incident-enumerable-fields
   [:assignees

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -157,7 +157,7 @@
                              :let [test-id {:asc? asc?}]]
                        (testing (pr-str test-id)
                          (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:sort_by
-                                                                                                  (format "severity:%1$s,created:%1$s"
+                                                                                                  (format "severity:%1$s,timestamp:%1$s"
                                                                                                           (if asc? "asc" "desc"))})
                                expected-parsed-body (sort-by (fn [incident]
                                                                {:post [(number? %)]}


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/6679

sort by severity and date.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
 
Search incidents with new sort_by filter: `severity:desc,timestamp:desc`. Check that results are ordered by descending severity and for same severity values by descending created date.

