### PR TITLE
Fix bundle export

### DIFF
--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -93,35 +93,23 @@
            (let [capabilities export-capabilities]
              (GET "/export" []
                   :return NewBundleExport
-                  :query [q BundleExportQuery]
+                  :query [query BundleExportQuery]
                   :summary "Export records with their local relationships. Ids are URIs (with port if specified)."
                   :description (common/capabilities->description capabilities)
                   :capabilities capabilities
                   :auth-identity identity
-                  :identity-map identity-map
-                  (ok (export-bundle
-                       (:ids q)
-                       identity-map
-                       identity
-                       q
-                       services))))
+                  (ok (export-bundle (:ids query) identity query services))))
 
            (let [capabilities export-capabilities]
              (POST "/export" []
                   :return NewBundleExport
-                  :query [q BundleExportOptions]
-                  :body [b BundleExportIds]
+                  :query [query BundleExportOptions]
+                  :body [body BundleExportIds]
                   :summary "Export records with their local relationships. Ids are URIs (with port if specified)."
                   :description (common/capabilities->description capabilities)
                   :capabilities capabilities
                   :auth-identity identity
-                  :identity-map identity-map
-                  (ok (export-bundle
-                       (:ids b)
-                       identity-map
-                       identity
-                       q
-                       services))))
+                  (ok (export-bundle (:ids body) identity query services))))
 
            (let [capabilities #{:create-actor
                                 :create-asset

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -118,7 +118,7 @@
     (long-id->entity-type id-str)))
 
 (defn un-store [record]
-  (apply dissoc record [:created :modified]))
+  (dissoc record :created :modified))
 
 (defn un-store-all [x]
   (if (sequential? x)

--- a/src/ctia/lib/collection.clj
+++ b/src/ctia/lib/collection.clj
@@ -37,7 +37,40 @@
   (let [new-coll (last args)]
     (recast (first args) new-coll)))
 
-(defn fmap [f m]
+(defn fmap
+  "TODO deprecate in favor of update-vals after migrating to clojure 1.11.x"
+  [f m]
   (into {}
         (for [[k v] m]
           [k (f v)])))
+
+;; Backport from clojure 1.11
+(defn update-vals
+  "m f => {k (f v) ...}
+  Given a map m and a function f of 1-argument, returns a new map where the keys of m
+  are mapped to result of applying f to the corresponding values of m."
+  {:added "1.11"}
+  [m f]
+  (with-meta
+    (persistent!
+     (reduce-kv (fn [acc k v] (assoc! acc k (f v)))
+                (if (instance? clojure.lang.IEditableCollection m)
+                  (transient m)
+                  (transient {}))
+                m))
+    (meta m)))
+
+;; Backport from clojure 1.11
+(defn update-keys
+  "m f => {(f k) v ...}
+  Given a map m and a function f of 1-argument, returns a new map whose
+  keys are the result of applying f to the keys of m, mapped to the
+  corresponding values of m.
+  f must return a unique key for each key of m, else the behavior is undefined."
+  {:added "1.11"}
+  [m f]
+  (let [ret (persistent!
+             (reduce-kv (fn [acc k v] (assoc! acc (f k) v))
+                        (transient {})
+                        m))]
+    (with-meta ret (meta m))))

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -220,18 +220,19 @@ It returns the documents with full hits meta data including the real index in wh
        {:keys [suppress-access-control-error?]
         :or {suppress-access-control-error? false}
         :as es-params}]
-      (sequence
-       (comp (map :_source)
-             (map coerce!)
-             (map (fn [record]
-                    (if (allow-read? record ident get-in-config)
-                      record
-                      (let [ex (ex-info "You are not allowed to read this document"
-                                        {:type :access-control-error})]
-                        (if suppress-access-control-error?
-                          (log/error ex)
-                          (throw ex)))))))
-       (get-docs-with-indices conn-state ids (make-es-read-params es-params))))))
+      (doall
+       (sequence
+        (comp (map :_source)
+              (map coerce!)
+              (map (fn [record]
+                     (if (allow-read? record ident get-in-config)
+                       record
+                       (let [ex (ex-info "You are not allowed to read this document"
+                                         {:type :access-control-error})]
+                         (if suppress-access-control-error?
+                           (log/error ex)
+                           (throw ex)))))))
+        (get-docs-with-indices conn-state ids (make-es-read-params es-params)))))))
 
 (defn access-control-filter-list
   "Given an ident, keep only documents it is allowed to read"


### PR DESCRIPTION
> Related advthreat/iroh#4958 #1285 

Performance improvements PR contains a bug where identity is passed as a record instead of a map into a function to fetch related nodes. Unfortunatelly, implementation silently delists records as inaccessible, making response almost empty. This PR fixes that by normalising arglist for bundle-export function.

<a name="qa">[§](#qa)</a> QA
============================

QA instructions are in #1285

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

