### PR TITLE
Remove redundant doall

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -88,17 +88,17 @@
    {{:keys [get-store]} :StoreService
     :as services} :- ReadEntitiesServices]
   (let [store (get-store entity-type)]
-    (doall (map #(when %
-                   (try
-                     (with-long-id % services)
-                     (catch Exception e
-                       (log/error e))))
-                (try
-                  (store/read-records store ids
-                                      (auth/ident->map auth-identity)
-                                      {:suppress-access-control-error? true})
-                  (catch Exception e
-                    (log/error e)))))))
+    (map #(when %
+            (try
+              (with-long-id % services)
+              (catch Exception e
+                (log/error e))))
+         (try
+           (store/read-records store ids
+                               (auth/ident->map auth-identity)
+                               {:suppress-access-control-error? true})
+           (catch Exception e
+             (log/error e))))))
 
 (defn to-long-id
   [id services]

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -220,19 +220,18 @@ It returns the documents with full hits meta data including the real index in wh
        {:keys [suppress-access-control-error?]
         :or {suppress-access-control-error? false}
         :as es-params}]
-      (doall
-       (sequence
-        (comp (map :_source)
-              (map coerce!)
-              (map (fn [record]
-                     (if (allow-read? record ident get-in-config)
-                       record
-                       (let [ex (ex-info "You are not allowed to read this document"
-                                         {:type :access-control-error})]
-                         (if suppress-access-control-error?
-                           (log/error ex)
-                           (throw ex)))))))
-        (get-docs-with-indices conn-state ids (make-es-read-params es-params)))))))
+      (sequence
+       (comp (map :_source)
+             (map coerce!)
+             (map (fn [record]
+                    (if (allow-read? record ident get-in-config)
+                      record
+                      (let [ex (ex-info "You are not allowed to read this document"
+                                        {:type :access-control-error})]
+                        (if suppress-access-control-error?
+                          (log/error ex)
+                          (throw ex)))))))
+       (get-docs-with-indices conn-state ids (make-es-read-params es-params))))))
 
 (defn access-control-filter-list
   "Given an ident, keep only documents it is allowed to read"


### PR DESCRIPTION
PR with a fix for bundle export function introduces unnecessary doall expressions. This one just to cleanup those leftovers.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

