### PR TITLE
Update README to account for updated memory requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ On Mac OS X, you should use
 includes all the dependencies you need to run Docker containers.
 
 **With Kafka and Zookeeper now part of the dev cluster, you will need
-  to increase the memory you allocate to Docker.  You can do this thru
-  your Docker preferences.  This has been tested with a 4GB
+  to increase the memory you allocate to Docker.  You can do this through
+  your Docker preferences.  This has been tested with a 6GB
   allocation.**
 
 We provide a default `containers/dev/docker-compose.yml`  which will


### PR DESCRIPTION
Starting CTIA and its docker setup locally I noticed that the ES5 container would segfault some time after startup.
I remembered the memory allocation requirements but even set to 4GB I still see the segfault, this might be due to the double ES setup (ES5 and ES7), in the meantime I think it's safer to update the README to reflect this requirement.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```

```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

