### PR TITLE
Fix some ES related tests

### DIFF
--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -277,6 +277,9 @@
    :aliased true
    :rollover {:max_docs 3}
    :refresh "true"
+   :auth {:type :basic-auth
+          :params {:user "elastic"
+                   :pwd "ductile"}}
    :version 5})
 
 (defn props-not-aliased [app]
@@ -285,6 +288,9 @@
    :host "localhost"
    :port 9205
    :refresh "true"
+   :auth {:type :basic-auth
+          :params {:user "elastic"
+                   :pwd "ductile"}}
    :version 5})
 
 (defn get-conn-state

--- a/test/ctia/task/migration/store_test.clj
+++ b/test/ctia/task/migration/store_test.clj
@@ -288,25 +288,24 @@
                               :as state}
                              nb]
                           (let [rollover? (<= max-docs (+ current-index-size nb))
-                                cat-before (es-helpers/get-cat-indices conn)
+                                cat-before (es-helpers/get-cat-indices-clean conn)
                                 indices-before (set (keys cat-before))
-                                _ (es-helpers/load-bulk conn
-                                                        (take nb source-docs)
-                                                        "false")
+                                bulk-res (es-helpers/load-bulk conn
+                                                               (take nb source-docs)
+                                                               "false")
                                 res (when rollover?
                                       (sut/rollover storemap
                                                     max-batch-size
                                                     (+ nb migrated-count)
                                                     services))
-                                cat-after (es-helpers/get-cat-indices conn)
+                                cat-after (es-helpers/get-cat-indices-clean conn)
                                 indices-after (set (keys cat-after))
                                 total-after (reduce + (vals cat-after))]
                             (when rollover?
                               (is (true? (:rolled_over res)))
                               (is (< (count indices-before)
                                      (count indices-after)))
-                              (is (= (+ nb migrated-count)
-                                     total-after)))
+                              (is (= (+ nb migrated-count) total-after)))
                             (when-not rollover?
                               (is (= indices-before indices-after)))
 

--- a/test/ctia/task/update_mapping_test.clj
+++ b/test/ctia/task/update_mapping_test.clj
@@ -57,7 +57,10 @@
                                        :host "localhost"
                                        :port es-port
                                        :aliased aliased?
-                                       :version version}
+                                       :version version
+                                       :auth {:type :basic-auth
+                                              :params {:user "elastic"
+                                                      :pwd "ductile"}}}
                                 ;; cheap trick to rollover store without adding docs
                                 aliased? (assoc :rollover {:max_docs 0}))
 

--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -2,6 +2,7 @@
   "ES test helpers"
   (:require [cheshire.core :as json]
             [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :refer [testing]]
             [ctia.stores.es.init :as es-init]
             [ctia.stores.es.schemas :refer [ESConnServices]]
@@ -245,6 +246,13 @@
        (map (fn [{:keys [index] docs_count :docs.count}]
               {(keyword index) docs_count}))
        (into {})))
+
+(defn get-cat-indices-clean
+  "GET /_cat/indices removing system indices"
+  [conn]
+  (->> (get-cat-indices conn)
+       (remove (fn [[k _]]
+                 (string/starts-with? (name k) ".")))))
 
 (defn -filter-activated-es-versions [versions]
   (filter (h/set-of-es-versions-to-test) versions))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #
Related #6999

Since the tests are now running again locally, I spotted some failing items:

1. ES Authentication
some issues related to the default ES configuration change as we are now recommending to use authenticated connections by default for the local setup.

2. System indexes

new ES versions seem to be storing more items in some system indices, this fails tests relying on `/_cat/indices`

This PR fixes both classes of issues and should allow you to get a successful local test suite.

