### PR TITLE
Fix usage of search_after in scroll for results

### DIFF
--- a/test/ctia/bundle/scroll_with_limit_test.clj
+++ b/test/ctia/bundle/scroll_with_limit_test.clj
@@ -1,0 +1,49 @@
+(ns ctia.bundle.scroll-with-limit-test
+  (:require [clojure.test :refer [deftest is]]
+            [ctia.store :refer [IStore]]
+            [ctia.bundle.core :as sut]))
+
+(deftest scroll-with-limit-test
+  (let [fake-params-base {:limit 2
+                          :sort ["source_ref" "timestamp" "id"]}
+        fake-params->res { ;; 1. First request to ES returns limited amount of entities with the same source_ref
+                          ;;    this response should trigger another call to scroll-with-limit
+                          ;;    but with search_after parameter pointing to the entity with "next" source_ref
+                          fake-params-base
+                          {:data [{:source_ref "1"
+                                   :timestamp 0
+                                   :id "1"}
+                                  {:source_ref "1"
+                                   :timestamp 1
+                                   :id "2"}]
+                           :paging {:next {:offset 2
+                                           :search_after ["1" 1 "2"]}}}
+                          ;; 2. Second request to ES returns entities belongs to different source_refs
+                          ;;    such response used by scroll-with-limit function to identity
+                          (assoc fake-params-base
+                                 :search_after ["1" -1 ""])
+                          {:data [{:source_ref "2"
+                                   :timestamp 3
+                                   :id "3"}
+                                  {:source_ref "3"
+                                   :timestamp 4
+                                   :id "4"}]
+                           :paging {:next {:offset 4
+                                           :search_after ["3" 4 "4"]}}}
+                          ;; 3. The last request to ES should indicate that there are no more entities to fetch
+                          ;;    the loop must stop here
+                          (assoc fake-params-base
+                                 :search_after ["3" 4 "4"])
+                          {:data []}}
+        fake-query {:x 42}
+        fake-store (reify IStore
+                     (list-records [_this query _identity params]
+                       (is (= query fake-query) "Query must be the same!")
+                       (is (not (contains? params :offset)) "Offset must not be used!")
+                       (if-let [res (fake-params->res params)]
+                         res
+                         (throw (ex-info "Unexpected params" params)))))]
+    (#'sut/scroll-with-limit :source_ref
+                             fake-store fake-query
+                             nil
+                             fake-params-base)))


### PR DESCRIPTION
Fixes potential endless loop in the pagination process. There are two options to do pagination with ductile and ES queries: using offset returned by the previous result or using search_after. Those are entirely different ways to do pagination, and they should not be mixed into any pagination logic.

<a name="qa">[§](#qa)</a> QA
============================

[all_bundles.zip](https://github.com/threatgrid/ctia/files/9555933/all_bundles.zip)

1. Import bundle-0.json

```
curl 'https://visibility.test.iroh.site/iroh/private-intel/bundle/import' \
  -X POST \
  -H 'authorization: Bearer ...' \
  -H 'Content-Type: application/json' \
  --data @bundle-0.json \
  | jq '.results[].id'
```

Each id should look similar to this example: `"https://private.intel.test.iroh.site:443/ctia/sighting/sighting-b7213c75-a43e-4449-aa22-d1a9ea6f78bb"`. Take the last path segment and use it for the next step - `sighting-b7213c75-a43e-4449-aa22-d1a9ea6f78bb`.

2. Check if those sightings can be found in Elasticsearch:

Replace items for values with the list of ids from the previous step

```
curl 'https://es-private-storage.test.iroh.site/v1.1.0_private_ctia_sighting/_search' \
  -X GET \
  -H 'Content-Type: application/json; charset=UTF-8' \
  --data '{
    "sort": {"id": "desc"},
    "stored_fields": ["id"],
    "query": {
      "ids": {
        "values": [
          "sighting-4bdfabdd-0b81-4e9f-acac-446c176b4ba6",
          "sighting-36b3d721-b493-4678-969a-659e662b18fe",
          "sighting-bd451b1e-72e3-44cb-aa26-9fa58dc352ae"
        ]
      }
    }
  }' | jq '.hits.hits[]._id'
```

the result is the list of ids for the next step. The order is important.

3. Please replace all occurrences of a string `[[i]]` in every other bundle with an id from the previous step where `i` is an index in the array:

```
[
  "sighting-4bdfabdd-0b81-4e9f-acac-446c176b4ba6",
  "sighting-36b3d721-b493-4678-969a-659e662b18fe",
  "sighting-bd451b1e-72e3-44cb-aa26-9fa58dc352ae"
]

=>

[
  "https://private.intel.test.iroh.site:443/ctia/sighting/sighting-4bdfabdd-0b81-4e9f-acac-446c176b4ba6", 
  "https://private.intel.test.iroh.site:443/ctia/sighting/sighting-36b3d721-b493-4678-969a-659e662b18fe",
  "https://private.intel.test.iroh.site:443/ctia/sighting/sighting-bd451b1e-72e3-44cb-aa26-9fa58dc352ae"
]
```

4. Import all of them
5. Call bundle export endpoint using ids from step 1.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

