### PR TITLE
Stop using single-segment ns `java-time`, migrate to `java-time.api`

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -5,8 +5,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- clj-time:clj-time:jar:0.15.2:compile
 |  \- joda-time:joda-time:jar:2.10:compile
 +- org.threeten:threeten-extra:jar:1.2:compile
-+- clojure.java-time:clojure.java-time:jar:0.3.3:compile
-|  \- clj-tuple:clj-tuple:jar:0.2.2:compile
++- clojure.java-time:clojure.java-time:jar:1.1.0:compile
 +- org.clojure:core.async:jar:1.5.648:compile
 |  \- org.clojure:tools.analyzer.jvm:jar:1.2.2:compile
 |     +- org.clojure:tools.analyzer:jar:1.1.0:compile
@@ -69,6 +68,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |     \- com.cemerick:clojurescript.test:jar:0.0.4:compile
 +- metosin:compojure-api:jar:1.1.13:compile
 |  +- potemkin:potemkin:jar:0.4.5:compile
+|  |  +- clj-tuple:clj-tuple:jar:0.2.2:compile
 |  |  \- riddley:riddley:jar:0.1.12:compile
 |  +- compojure:compojure:jar:1.6.1:compile
 |  |  \- medley:medley:jar:1.0.0:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>clojure.java-time</groupId>
       <artifactId>clojure.java-time</artifactId>
-      <version>0.3.3</version>
+      <version>1.1.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -5,8 +5,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- clj-time:clj-time:jar:0.15.2:compile
 |  \- joda-time:joda-time:jar:2.10:compile
 +- org.threeten:threeten-extra:jar:1.2:compile
-+- clojure.java-time:clojure.java-time:jar:0.3.3:compile
-|  \- clj-tuple:clj-tuple:jar:0.2.2:compile
++- clojure.java-time:clojure.java-time:jar:1.1.0:compile
 +- org.clojure:core.async:jar:1.5.648:compile
 |  \- org.clojure:tools.analyzer.jvm:jar:1.2.2:compile
 |     +- org.clojure:tools.analyzer:jar:1.1.0:compile
@@ -134,7 +133,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:compojure-api:jar:1.1.13:compile
 |  +- (prismatic:plumbing:jar:0.5.5:compile - omitted for duplicate)
 |  +- potemkin:potemkin:jar:0.4.5:compile
-|  |  +- (clj-tuple:clj-tuple:jar:0.2.2:compile - omitted for duplicate)
+|  |  +- clj-tuple:clj-tuple:jar:0.2.2:compile
 |  |  \- riddley:riddley:jar:0.1.12:compile
 |  +- (cheshire:cheshire:jar:5.9.0:compile - omitted for conflict with 5.8.0)
 |  +- compojure:compojure:jar:1.6.1:compile

--- a/project.clj
+++ b/project.clj
@@ -67,7 +67,7 @@
   :dependencies [[org.clojure/clojure ~clj-version]
                  [clj-time "0.15.2"]
                  [org.threeten/threeten-extra "1.2"]
-                 [clojure.java-time "0.3.3"]
+                 [clojure.java-time "1.1.0"]
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/core.memoize "1.0.257"]
                  [org.clojure/tools.logging "1.1.0"]

--- a/test/ctia/entity/attack_pattern/core_test.clj
+++ b/test/ctia/entity/attack_pattern/core_test.clj
@@ -5,7 +5,7 @@
             [ctia.test-helpers.core :as helpers]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.fixtures :as fixtures]
-            [java-time :as jt]
+            [java-time.api :as jt]
             [puppetlabs.trapperkeeper.app :as app]
             [schema.test :refer [validate-schemas]]))
 

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -22,7 +22,7 @@
             ductile.index
             [puppetlabs.trapperkeeper.app :as app]
             [schema.core :as s]
-            [java-time :as jt]))
+            [java-time.api :as jt]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -9,7 +9,7 @@
             [ctia.test-helpers.core :as helpers]
             [ctim.examples.sightings :refer [sighting-minimal]]
             [ctia.domain.entities :refer [short-id->long-id]]
-            [java-time :as jt]
+            [java-time.api :as jt]
             [puppetlabs.trapperkeeper.app :as app]))
 
 (deftest deep-merge-with-add-colls-test

--- a/test/ctia/test_helpers/aggregate.clj
+++ b/test/ctia/test_helpers/aggregate.clj
@@ -9,7 +9,7 @@
             [ctia.test-helpers.core :as helpers.core :refer [GET POST-bulk]]
             [ctia.test-helpers.fake-whoami-service :as helpers.whoami]
             [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
-            [java-time :as jt]
+            [java-time.api :as jt]
             [schema-generators.generators :as g]
             [schema-tools.core :as st]
             [schema.core :as s]))


### PR DESCRIPTION
There is a new namespace java-time.api which is exactly the same as java-time and coexists peacefully. Both are automatically generated and will stay in sync in the future. It was created because of this issue: https://github.com/dm3/clojure.java-time/issues/91

I like java-time.api better because it's not a single-segment name. What do we think?

```
intern: Stop using single-segment ns `java-time`, migrate to `java-time.api`
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

