### PR TITLE
Issue 6978 - x-total-hits limited to 10,000

### DIFF
--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -417,6 +417,32 @@
                                ident
                                {}))))))))
 
+(deftest make-query-params-test
+  (are [es-params props expected] (= expected
+                                     (sut/make-query-params es-params props))
+
+    {}
+    {:default-sort "timestamp,id"
+     :version 5}
+    {:sort [{"timestamp" {:order :asc}}
+            {"id" {:order :asc}}]}
+
+    {}
+    {:default-sort "timestamp,id"
+     :version 7}
+    {:sort [{"timestamp" {:order :asc}}
+            {"id" {:order :asc}}]
+     :track_total_hits true}
+
+
+    {:fields [:id]}
+    {:default-sort "timestamp,id"
+     :version 7}
+    {:sort [{"timestamp" {:order :asc}}
+            {"id" {:order :asc}}]
+     :_source [:id :id :owner :groups :tlp :authorized_users :authorized_groups]
+     :track_total_hits true}))
+
 (deftest make-search-query-test
   (es-helpers/for-each-es-version
       "make-search-query shall build a proper query from given query string, filter map and date range"


### PR DESCRIPTION
> Close https://github.com/advthreat/iroh/issues/6978

ES 7 and higher provide a performance enhancement that results in :x-total-hits being set to 10,000 when there are 10,000 or greater hits. This PR will restore the behavior present in previous versions of ES where the exact number of hits found is computed even when greater than 10,000. This is implemented by setting :track_total_hits to true for CRUD `search` and `find` when querying ES versions 7 and higher.

<a name="qa">[§](#qa)</a> QA
============================
Use GET /ctia/event/search and ensure that if there are greater than 10,000 results that x-total-hits is greater than 10,000.