### PR TITLE
Migration task: limit memory usage

### DIFF
--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -129,7 +129,7 @@
   [read-params :- (s/maybe BatchParams)]
   (lazy-seq
    (when-let [batch (read-source-batch read-params)]
-     (cons batch (read-source batch)))))
+     (cons batch (read-source (dissoc batch :documents))))))
 
 (s/defn write-target :- s/Int
   "This function writes a batch of documents which are (1) modified with `migrations` functions,

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -150,7 +150,7 @@
    services :- mst/MigrationStoreServices]
   (let [migrated (transduce migrations conj documents)
         {:keys [data errors]} (list-coerce migrated)
-        new-migrated-count (+ migrated-count (count data))]
+        new-migrated-count (+ (count data) migrated-count)]
     (doseq [entity errors]
       (let [message
             (format "%s - Cannot migrate entity: %s"

--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -185,13 +185,14 @@
              (pr-str query))
   (let [read-params (assoc migration-params :query query)
         data-queue (seque buffer-size
-                          (read-source read-params))
-        new-migrated-count (reduce #(write-target %1 %2 services)
-                                   migrated-count
-                                   data-queue)]
-    (assoc migration-params
-           :migrated-count
-           new-migrated-count)))
+                          (read-source read-params))]
+    (loop [total migrated-count
+           [batch & batches] data-queue]
+      (if batch
+        (recur (write-target total batch services) batches)
+        (assoc migration-params
+               :migrated-count
+               total)))))
 
 (s/defn migrate-store
   "migrate a single store"
@@ -233,9 +234,12 @@
                                   entity-type
                                   {:started (time/now)}
                                   services))
-    (->> (reduce #(migrate-query %1 %2 services)
-                 base-params
-                 queries)
+    (->> (loop [batch-params base-params
+                [query & next-queries] queries]
+           (if query
+             (recur (migrate-query batch-params query services)
+                    next-queries)
+             batch-params))
          :migrated-count
          (log/infof "%s - finished migrating %s documents"
                     (name entity-type)))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> related #https://github.com/advthreat/iroh/issues/7166

This PR is an attempt to fix a memory leak.
It seems that the `reduce` of the batches and slice queries do not release the head of the queue and causes an OOM.

