### PR TITLE
Attempt to speedup bundle export

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -491,9 +491,9 @@
                    :metric (count ids)})
       (let [start (System/currentTimeMillis)
             identity-map (auth/ident->map identity)
-            res (->> (map #(export-entities % identity-map identity params services) ids)
-                       (reduce #(deep-merge-with coll/add-colls %1 %2))
-                       (into empty-bundle))]
+            res (->> (pmap #(export-entities % identity-map identity params services) ids)
+                     (reduce #(deep-merge-with coll/add-colls %1 %2))
+                     (into empty-bundle))]
         (send-event {:service "Export bundle end"
                      :correlation-id correlation-id
                      :time (get-epoch-second)


### PR DESCRIPTION
`map` -> `pmap` should be enough to boost performance of `export-bundle` function.

> **Epic** https://github.com/advthreat/iroh/issues/7107
> Related https://github.com/advthreat/iroh/issues/4958

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

