### PR TITLE
Bad route returns 404

### DIFF
--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -40,6 +40,13 @@
                                :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 200 (:status response)))))
 
+       (testing "Bad route returns 400"
+         (let [response (PATCH app
+                               (str "ctia/incident/" (:short-id incident-id) "/tactics")
+                               :body {:incident_time {}}
+                               :headers {"Authorization" "45c1f5e3f05d0"})]
+           (is (= 400 (:status response)))))
+
        (testing "POST /ctia/incident/:id/status Open"
          (let [new-status {:status "Open"}
                response (POST app

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -9,7 +9,7 @@
             [ctia.test-helpers.access-control :refer [access-control-test]]
             [ctia.test-helpers.aggregate :refer [test-metric-routes]]
             [ctia.test-helpers.auth :refer [all-capabilities]]
-            [ctia.test-helpers.core :as helpers :refer [PATCH POST]]
+            [ctia.test-helpers.core :as helpers :refer [GET PATCH POST]]
             [ctia.test-helpers.crud :refer [entity-crud-test]]
             [ctia.test-helpers.es :as es-helpers]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
@@ -41,10 +41,9 @@
            (is (= 200 (:status response)))))
 
        (testing "Bad route returns 400"
-         (let [response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id) "/tactics")
-                               :body {:incident_time {}}
-                               :headers {"Authorization" "45c1f5e3f05d0"})]
+         (let [response (GET app
+                             (str "ctia/incident/" (:short-id incident-id) "/tactics")
+                             :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 400 (:status response)))))
 
        (testing "POST /ctia/incident/:id/status Open"

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -40,11 +40,11 @@
                                :headers {"Authorization" "45c1f5e3f05d0"})]
            (is (= 200 (:status response)))))
 
-       (testing "Bad route returns 400"
+       (testing "Bad route returns 404"
          (let [response (GET app
                              (str "ctia/incident/" (:short-id incident-id) "/tactics")
                              :headers {"Authorization" "45c1f5e3f05d0"})]
-           (is (= 400 (:status response)))))
+           (is (= 404 (:status response)))))
 
        (testing "POST /ctia/incident/:id/status Open"
          (let [new-status {:status "Open"}


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close https://github.com/advthreat/iroh/issues/7183


Unsuccessfully attempting to reproduce https://github.com/advthreat/iroh/issues/7183

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

