### PR TITLE
Upgrade ductile version 0.4.4 -> 0.4.5

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -158,6 +158,58 @@ jobs:
         # poor man's travis_retry
         run: for i in {1..${ACTIONS_RETRY_TIMES}}; do lein warm-ci-deps && break; done
       - run: ./scripts/check-dependabot
+
+  test-encoding:
+    runs-on: ubuntu-20.04
+    needs: [setup]
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Start Docker environment
+        run: docker compose -f containers/dev/docker-compose.yml up --no-color --quiet-pull -d
+
+      - name: Maven Cache
+        id: maven-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ctia-m2-cache-${{ env.ACTIONS_CACHE_VERSION }}-${{ hashFiles('project.clj') }}-${{ env.LEIN_VERSION }}
+          restore-keys: |
+            ctia-m2-cache-${{ env.ACTIONS_CACHE_VERSION }}-${{ hashFiles('project.clj') }}-
+            ctia-m2-cache-${{ env.ACTIONS_CACHE_VERSION }}-
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.DEFAULT_JAVA_VERSION }}
+
+      # install lein using cache to avoid extra download and startup time
+      - name: Install Leiningen from Cache
+        uses: actions/cache@v3
+        id: lein-cache
+        with:
+          path: ${{env.LEIN_HOME}}
+          key: ctia-lein-cache-${{ env.ACTIONS_CACHE_VERSION }}-${{ env.LEIN_VERSION }}
+
+      - name: Install Leiningen
+        if: steps.lein-cache.outputs.cache-hit != 'true'
+        run: ./scripts/actions/install-lein.sh
+
+      # we should get a cache hit from maven here, since the `setup` job only succeeds if it exists.
+      # in the unlikely event we don't, download deps for this specific job only.
+      - name: Warm dependency cache
+        if: steps.maven-cache.outputs.cache-hit != 'true'
+        # poor man's travis_retry
+        run: for i in {1..${ACTIONS_RETRY_TIMES}}; do lein warm-ci-deps && break; done
+
+      - name: Run encoding tests
+        run: lein with-profile +test-encoding test
+
   test-matrix:
     runs-on: ubuntu-20.04
     needs: [setup]

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -62,7 +62,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- com.andrewmcveigh:cljs-time:jar:0.5.2:compile
 |  \- threatgrid:metrics-clojure-riemann:jar:2.10.1:compile
 |     \- io.riemann:metrics3-riemann-reporter:jar:0.4.6:compile
-+- threatgrid:ductile:jar:0.4.4:compile
++- threatgrid:ductile:jar:0.4.5:compile
 +- com.arohner:uri:jar:0.1.2:compile
 |  \- pathetic:pathetic:jar:0.5.0:compile
 |     \- com.cemerick:clojurescript.test:jar:0.0.4:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -470,7 +470,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ductile</artifactId>
-      <version>0.4.4</version>
+      <version>0.4.5</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -118,7 +118,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  |     +- (io.dropwizard.metrics:metrics-core:jar:3.1.5:compile - omitted for conflict with 3.2.2)
 |  |     \- (io.riemann:riemann-java-client:jar:0.4.6:compile - omitted for conflict with 0.5.1)
 |  \- (clout:clout:jar:2.2.1:compile - omitted for duplicate)
-+- threatgrid:ductile:jar:0.4.4:compile
++- threatgrid:ductile:jar:0.4.5:compile
 |  +- (org.clojure:tools.logging:jar:0.5.0:compile - omitted for conflict with 1.1.0)
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [threatgrid/ctim "1.1.12"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
-                 [threatgrid/ductile "0.4.4"]
+                 [threatgrid/ductile "0.4.5"]
 
                  [com.arohner/uri "0.1.2"]
 

--- a/project.clj
+++ b/project.clj
@@ -246,6 +246,9 @@
                                    [prismatic/schema-generators ~schema-generators-version]]
                     :resource-paths ["test-resources"]}
 
+             :test-encoding {:jvm-opts ["-Dfile.encoding=ANSI_X3.4-1968"]
+                             :test-selectors ^:replace {:default :encoding}}
+
              :prepush {:plugins [[yogsototh/lein-kibit "0.1.6-SNAPSHOT"]
                                  [lein-bikeshed "0.3.0"]]}
              :es5 {:jvm-opts ["-Dctia.store.es.default.port=9205"

--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 lein test "$@"
+lein with-profile +test-encoding test "$@"

--- a/scripts/test5
+++ b/scripts/test5
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 lein with-profile +es5 test "$@"
+lein with-profile +es5,test-encoding "$@"

--- a/scripts/test7
+++ b/scripts/test7
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 lein with-profile +es7 test "$@"
+lein with-profile +es7,test-encoding test "$@"

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -24,8 +24,7 @@
    [ductile.index :as es-index]
    [puppetlabs.trapperkeeper.app :as app]
    [schema.core :as s]
-   [schema.test :refer [validate-schemas]])
-  (:import java.io.ByteArrayInputStream))
+   [schema.test :refer [validate-schemas]]))
 
 (defn fixture-properties [t]
   (helpers/with-properties ["ctia.http.bulk.max-size" 1000
@@ -423,6 +422,35 @@
            ;; reopen index to enable cleaning
            (es-index/open! (:conn indicator-store-state) indexname)))))))
 
+(deftest ^:encoding bundle-import-non-utf-8-encoding
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+     (whoami-helpers/set-whoami-response app
+                                         "45c1f5e3f05d0"
+                                         "foouser"
+                                         "foogroup"
+                                         "user")
+     (let [indicator (-> (mk-indicator 0)
+                         (assoc :description "qй"))]
+       (testing "Non-ASCII symbols imported with UTF-8 encoding"
+         (let [bundle (assoc ctia.bundle.core/empty-bundle
+                             :indicators #{indicator})
+               import-response (POST app
+                                     "ctia/bundle/import"
+                                     :body bundle
+                                     :headers {"Authorization" "45c1f5e3f05d0"})
+               indicator-id (get-in import-response [:parsed-body :results 0 :id])
+               export-response (GET app
+                                    "ctia/bundle/export"
+                                    :query-params {:ids [indicator-id]}
+                                    :headers {"Authorization" "45c1f5e3f05d0"})]
+           (is (= 200 (:status import-response)))
+           (is (= "qй" (-> export-response
+                           (get-in [:parsed-body :indicators])
+                           (first)
+                           (get :description))))))))))
+
 (deftest bundle-import-should-not-allow-disabled-entities
   (testing "disabled entities should be removed from Bundle schema"
     (let [selected-keys    #{:asset :target-record :asset-properties}
@@ -629,12 +657,6 @@
      :indicators (set indicators)
      :sightings (set sightings)
      :relationships (set relationships)}))
-
-(defn string->input-stream
-  [^String s]
-  (-> s
-      (.getBytes)
-      (ByteArrayInputStream.)))
 
 (deftest bundle-export-test
   (test-for-each-store-with-app

--- a/test/ctia/test_helpers/http.clj
+++ b/test/ctia/test_helpers/http.clj
@@ -8,19 +8,12 @@
    [ctia.schemas.utils :as csu]
    [clj-http.client :as http]
    [puppetlabs.trapperkeeper.app :as app]
-   [schema.core :as s])
-  (:import java.io.ByteArrayInputStream))
+   [schema.core :as s]))
 
 (def api-key "45c1f5e3f05d0")
 
 (defn local-url [path port]
   (format "http://localhost:%d/%s" port path))
-
-(defn string->input-stream
-  [^String s]
-  (-> s
-      (.getBytes)
-      (ByteArrayInputStream.)))
 
 (defn content-type? [expected-str]
   (fn [test-str]
@@ -40,11 +33,10 @@
 
 (defn encode-body
   [body content-type]
-  (string->input-stream
-   (cond
-     (edn? content-type) (pr-str body)
-     (json? content-type) (json/generate-string body)
-     :else body)))
+  (cond
+    (edn? content-type) (pr-str body)
+    (json? content-type) (json/generate-string body)
+    :else body))
 
 (def base-opts
   {:accept :edn


### PR DESCRIPTION
> Related https://github.com/advthreat/iroh/issues/7056

Version 0.4.5 fixes encoding for the bulk insert operation. Those changes should fix bundle-import related issues when non-ASCII symbols got replaced with `?`.

<a name="qa">[§](#qa)</a> QA
============================

1. Import bundle with entities containing non-ASCII characters somewhere in the description.
2. Fetch that entity
3. Non-ASCII symbols should not be replaced with `?` or altered in any other way.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
public: entities fields can have non-ASCII symbols
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

