### PR TITLE
Delegate handling of 404 response to outer router

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 A Pragmatic, Operationalized Threat Intel Service and Data Model
 
-For full documentation see [doc](resources/public/doc/)
+For full documentation see [doc](resources/ctia/public/doc/)
 
-We also think the [Use Cases](resources/public/doc/use_cases.md) document is a good
+We also think the [Use Cases](resources/ctia/public/doc/use_cases.md) document is a good
 starting point.
 
 Interactive, Swagger docs for the API are available once
@@ -289,7 +289,7 @@ since "foogroup" and "bargroup" are marked as `authorized_groups` identities in 
 ## Bulk and Bundle
 
 CTIA provides Bulk and Bundle routes to help processing multiple entities.
-see [Bulk and Bundle documentation](resources/public/doc/bulk-bundle.org)
+see [Bulk and Bundle documentation](resources/ctia/public/doc/bulk-bundle.org)
 
 ### Bundle import
 
@@ -342,11 +342,11 @@ CTIA will then return the realized `Feed` document including two new fields: `fe
 
 ### Elasticsearch Store management
 
-see [CTIA Elasticsearch Stores: managing big Indices](resources/public/doc/es_stores.md)
+see [CTIA Elasticsearch Stores: managing big Indices](resources/ctia/public/doc/es_stores.md)
 
-see [Migration procedure](resources/public/doc/migration.md)
+see [Migration procedure](resources/ctia/public/doc/migration.md)
 
-see [CTIA Elasticsearch CRUD details](resources/public/doc/es_stores.pdf)
+see [CTIA Elasticsearch CRUD details](resources/ctia/public/doc/es_stores.pdf)
 
 
 ### Store Checks

--- a/src/ctia/documentation/routes.clj
+++ b/src/ctia/documentation/routes.clj
@@ -48,10 +48,8 @@
 (defn render-request
   "read the requested file from resources, render it if needed"
   [path-info]
-  (or (resource-response (str doc-resource-prefix path-info)
-                         {:allow-symlinks? false})
-      {:status 404
-       :body "The requested page couldn't be found."}))
+  (resource-response (str doc-resource-prefix path-info)
+                     {:allow-symlinks? false}))
 
 (def render-request-with-cache
   "request cache wrapper"
@@ -78,16 +76,16 @@
               resp))]
     (fn
       ([req]
-       (-> req (handler) (render)))
+       (some-> req (handler) (render)))
       ([req respond raise]
        (handler req
                 (fn [resp]
-                  (-> resp (render) (respond)))
+                  (some-> resp (render) (respond)))
                 raise)))))
 
 (defn documentation-routes []
   (context "/doc" []
-    (GET "/*.*" req
+    (GET "/*" req
       :no-doc true
       :middleware [[render-resource-file]
                    [content-type/wrap-content-type

--- a/test/ctia/http/handler_test.clj
+++ b/test/ctia/http/handler_test.clj
@@ -33,7 +33,7 @@
    (fn [app]
      (let [;; these routes don't have descriptions (yet)
            expected-no-doc #{"/swagger.json"
-                             "/doc/*.*"
+                             "/doc/*"
                              "/ctia/feed/:id/view.txt"
                              "/ctia/feed/:id/view"
                              "/ctia/version"


### PR DESCRIPTION
1. /doc/ routes now catch all paths instead of only those with extension
2. if a requested file can not be found in /resources/ctia/public/, return nil to indicate that the handler should return a 404 response to the client.
3. 404 responses for URLs like /doc/foo and /doc/foo.md now identical

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

