### PR TITLE
threatgrid/ctim/#381 Migrate actor 1.2.0

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.1.13:compile
++- threatgrid:ctim:jar:1.2.0:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.1.13</version>
+      <version>1.2.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -73,7 +73,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.1.13:compile
++- threatgrid:ctim:jar:1.2.0:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.1.13"]
+                 [threatgrid/ctim "1.2.0"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/src/ctia/entity/actor.clj
+++ b/src/ctia/entity/actor.clj
@@ -45,7 +45,7 @@
      em/sourcable-entity-mapping
      em/stored-entity-mapping
      {:valid_time                       em/valid-time
-      :actor_type                       em/token
+      :actor_types                      em/token
       :identity                         em/tg-identity
       :motivation                       em/token
       :sophistication                   em/token
@@ -60,7 +60,7 @@
   (concat sorting/default-entity-sort-fields
           [:valid_time.start_time
            :valid_time.end_time
-           :actor_type
+           :actor_types
            :motivation
            :sophistication
            :intended_effect]))
@@ -79,7 +79,7 @@
    routes.common/SearchableEntityParams
    ActorFieldsParam
    (st/optional-keys
-    {:actor_type      s/Str
+    {:actor_types     s/Str
      :motivation      s/Str
      :sophistication  s/Str
      :intended_effect s/Str
@@ -95,7 +95,7 @@
 
 (def actor-enumerable-fields
   [:source
-   :actor_type
+   :actor_types
    :motivation
    :sophistication
    :confidence
@@ -109,7 +109,7 @@
 (def searchable-fields
   #{:id
     :source
-    :actor_type
+    :actor_types
     :description
     :short_description
     :title})

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -175,7 +175,8 @@
    :1.0.0 (comp (append-version "1.0.0")
                 (rename-observable-type "pki-serial" "pki_serial")
                 simplify-incident)
-   :1.2.0 actor-type-array
+   :1.2.0 (comp (append-version "1.2.0")
+                actor-type-array)
    :investigation-actions (comp (append-version "1.1.0")
                                 migrate-action-data)
    :describe (comp (append-version "1.1.0")

--- a/src/ctia/task/migration/migrations.clj
+++ b/src/ctia/task/migration/migrations.clj
@@ -151,6 +151,15 @@
                (update :incident_time simplify-incident-time))
            doc))))
 
+(def actor-type-array
+  (map (fn [{type :type
+             actor-type :actor_type
+             :as doc}]
+         (if (and (= type "actor") actor-type)
+           (-> doc
+               (assoc :actor_types [actor-type])
+               (dissoc :actor_type))
+           doc))))
 
 (def available-migrations
   {:identity identity
@@ -166,6 +175,7 @@
    :1.0.0 (comp (append-version "1.0.0")
                 (rename-observable-type "pki-serial" "pki_serial")
                 simplify-incident)
+   :1.2.0 actor-type-array
    :investigation-actions (comp (append-version "1.1.0")
                                 migrate-action-data)
    :describe (comp (append-version "1.1.0")

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -36,7 +36,7 @@
    :title (str "actor-" n)
    :description (str "description: actor-" n)
    :short_description (str "short_description: actor-" n)
-   :actor_type "Hacker"
+   :actor_types ["Hacker"]
    :source "a source"
    :confidence "High"
    :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"

--- a/test/ctia/domain/entities_test.clj
+++ b/test/ctia/domain/entities_test.clj
@@ -25,7 +25,7 @@
     (testing "realized fn without previous object shall initiate all stored field"
       (is-submap? new-sighting-minimal realized-create)
       (is-submap? {:client_id "ireaux",
-                   :schema_version "1.1.3",
+                   :schema_version "1.2.0",
                    :type "sighting",
                    :id "sighting-id-1",
                    :tlp "green",
@@ -51,7 +51,7 @@
                                                   :services services})]
         (is-submap? new-sighting-maximal realized-update)
         (is-submap? {:client_id "ireaux",
-                     :schema_version "1.1.3",
+                     :schema_version "1.2.0",
                      :type "sighting",
                      :id "sighting-id-2",
                      :tlp "amber",

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -311,7 +311,7 @@
                       :source "ngfw_ips_event_service"}
             bundle   {:incidents
                       [{:description "desc",
-                        :schema_version "1.1.3",
+                        :schema_version "1.2.0",
                         :type "incident",
                         :source "ngfw_ips_event_service",
                         :tlp "green",
@@ -327,7 +327,7 @@
                         :status "New",
                         :confidence "High"}
                        {:description "desc",
-                        :schema_version "1.1.3",
+                        :schema_version "1.2.0",
                         :type "incident",
                         :tlp "green",
                         :source "ngfw_ips_event_service",

--- a/test/ctia/http/middleware/cache_control_test.clj
+++ b/test/ctia/http/middleware/cache_control_test.clj
@@ -36,7 +36,7 @@
                 :body {:title "actor"
                        :description "description"
                        :short_description "short description"
-                       :actor_type "Hacker"
+                       :actor_types ["Hacker"]
                        :source "a source"
                        :confidence "High"
                        :valid_time {:start_time "2016-02-11T00:40:48.212-00:00"

--- a/test/ctia/task/migration/migrations/describe_test.clj
+++ b/test/ctia/task/migration/migrations/describe_test.clj
@@ -11,7 +11,7 @@
     :title "title"
    :description "description"
    :short_description "short description"
-   :actor_type "Hacker",
+   :actor_types ["Hacker"],
    :confidence "High",
    :source "a source"
    :valid_time {}})

--- a/test/ctia/task/migration/migrations_test.clj
+++ b/test/ctia/task/migration/migrations_test.clj
@@ -310,11 +310,12 @@
                        casebook])))))
 
 (deftest actor-type-array-test
-  (let [entities [{:type "actor" :actor_type "Hacker"}
-                  {:type "actor"}
-                  {:type "foo" :other-stuff "blah"}]
-        expected [{:type "actor" :actor_types ["Hacker"]}
-                  {:type "actor"}
-                  {:type "foo" :other-stuff "blah"}]]
-    (is (= expected (into [] sut/actor-type-array entities)))))
+  (let [migration (:1.2.0 sut/available-migrations)
+        entities [{:type "actor" :schema_version "1.1.13" :actor_type "Hacker"}
+                  {:type "actor" :schema_version "1.1.13"}
+                  {:type "foo" :schema_version "1.1.13" :other-stuff "blah"}]
+        expected [{:type "actor" :schema_version "1.2.0" :actor_types ["Hacker"]}
+                  {:type "actor" :schema_version "1.2.0"}
+                  {:type "foo" :schema_version "1.2.0" :other-stuff "blah"}]]
+    (is (= expected (into [] migration entities)))))
 

--- a/test/ctia/task/migration/migrations_test.clj
+++ b/test/ctia/task/migration/migrations_test.clj
@@ -309,3 +309,12 @@
                        verdict
                        casebook])))))
 
+(deftest actor-type-array-test
+  (let [entities [{:type "actor" :actor_type "Hacker"}
+                  {:type "actor"}
+                  {:type "foo" :other-stuff "blah"}]
+        expected [{:type "actor" :actor_types ["Hacker"]}
+                  {:type "actor"}
+                  {:type "foo" :other-stuff "blah"}]]
+    (is (= expected (into [] sut/actor-type-array entities)))))
+


### PR DESCRIPTION
Related threatgrid/ctim#381

Update actor to reflect new CTIM model, in which actor_types is modified to be both optional and an array. Add migration code.

I ran the migration locally following the directions in the migration.md doc and it worked fine. I also confirmed that I was able to search by actor_types afterward.

<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

**Not sure if something is needed here.**

<a name="qa">[§](#qa)</a> QA
============================

Describe the steps to test your PR.

1. Only testable in private CTIA because public CTIA doesn't have any loaded Actors.
2. Check that `actor_type` is gone and replaced with `actor_types`, containing a string array (with only a single element for now) for all Actors
3. Check that search by `actor_types` works correctly.

<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Migration and config change needed: https://github.com/advthreat/tenzin-config/pull/791

<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
**Not sure if anything is needed for public documentation**

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================
```
intern: changes to actor schema including `actor_type` -> `actor_types`
```

