### PR TITLE
Sort on incident score

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.2.0:compile
++- threatgrid:ctim:jar:1.2.1:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -73,7 +73,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.2.0:compile
++- threatgrid:ctim:jar:1.2.1:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.2.0"]
+                 [threatgrid/ctim "1.2.1"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -57,6 +57,8 @@ ctia.http.swagger.oauth2.client-id=swagger
 ctia.http.swagger.oauth2.app-name=swagger
 ctia.http.swagger.oauth2.realm=blank
 
+ctia.http.incident.sortable-score-types=asset,ttp,probability,global
+
 ctia.events.enabled=true
 ctia.events.log=false
 

--- a/scripts/test5
+++ b/scripts/test5
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+set -e
 lein with-profile +es5 test "$@"
 lein with-profile +es5,+test-encoding "$@"

--- a/scripts/test5
+++ b/scripts/test5
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 lein with-profile +es5 test "$@"
-lein with-profile +es5,test-encoding "$@"
+lein with-profile +es5,+test-encoding "$@"

--- a/scripts/test7
+++ b/scripts/test7
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 lein with-profile +es7 test "$@"
-lein with-profile +es7,test-encoding test "$@"
+lein with-profile +es7,+test-encoding test "$@"

--- a/scripts/test7
+++ b/scripts/test7
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -e
+
 lein with-profile +es7 test "$@"
 lein with-profile +es7,+test-encoding test "$@"

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -1,5 +1,6 @@
 (ns ctia.entity.incident
   (:require
+   [clojure.string :as str]
    [clj-momo.lib.clj-time.core :as time]
    [ctia.domain.entities
     :refer [default-realize-fn un-store with-long-id]]
@@ -209,7 +210,7 @@
   )
 
 (s/defn sort-extension-templates :- SortExtensionTemplates
-  [services :- APIHandlerServices]
+  [{{:keys [get-in-config]} :ConfigService} :- APIHandlerServices]
   (-> {;; override :severity field to sort semantically
        :severity {:op :remap
                   :remappings {"Low" 1
@@ -248,8 +249,8 @@
                      :mode "max"
                      :field-name "scores.score"
                      :filter {"scores.type" score-type}}}))
-            ;; TODO get from config
-            ["asset" "ttp"])))
+            (some-> (get-in-config [:ctia :http :incident :sortable-score-types])
+                    (str/split #",")))))
 
 (s/defn incident-sort-fields
   [services :- APIHandlerServices]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -206,36 +206,43 @@
   )
 
 (s/def sort-extension-templates :- SortExtensionTemplates
-  {;; override :severity field to sort semantically
-   :severity {:op :remap
-              :remappings {"Low" 1
-                           "Medium" 2
-                           "High" 3
-                           "Critical" 4}
-              :remap-default 0}
-   ;; override :tactics field to sort by the highest risk score for
-   ;; any one tactic on an incident
-   ;; https://attack.mitre.org/versions/v11/tactics/enterprise/
-   :tactics {:op :remap-list-max
-             :remappings
-             ;; Note: don't use actual scores, they may be proprietary. instead,
-             ;; simulate the same ordering (not proprietary) with dummy scores.
-             ;; generate with `generate-mitre-tactic-scores`
-             {"TA0043" 2,
-              "TA0042" 1,
-              "TA0001" 3,
-              "TA0002" 11,
-              "TA0003" 9,
-              "TA0004" 7,
-              "TA0005" 11,
-              "TA0006" 10,
-              "TA0007" 9,
-              "TA0008" 5,
-              "TA0009" 8,
-              "TA0011" 8,
-              "TA0010" 6,
-              "TA0040" 4}
-             :remap-default 0}})
+  (-> {;; override :severity field to sort semantically
+       :severity {:op :remap
+                  :remappings {"Low" 1
+                               "Medium" 2
+                               "High" 3
+                               "Critical" 4}
+                  :remap-default 0}
+       ;; override :tactics field to sort by the highest risk score for
+       ;; any one tactic on an incident
+       ;; https://attack.mitre.org/versions/v11/tactics/enterprise/
+       :tactics {:op :remap-list-max
+                 :remappings
+                 ;; Note: don't use actual scores, they may be proprietary. instead,
+                 ;; simulate the same ordering (not proprietary) with dummy scores.
+                 ;; generate with `generate-mitre-tactic-scores`
+                 {"TA0043" 2,
+                  "TA0042" 1,
+                  "TA0001" 3,
+                  "TA0002" 11,
+                  "TA0003" 9,
+                  "TA0004" 7,
+                  "TA0005" 11,
+                  "TA0006" 10,
+                  "TA0007" 9,
+                  "TA0008" 5,
+                  "TA0009" 8,
+                  "TA0011" 8,
+                  "TA0010" 6,
+                  "TA0040" 4}
+                 :remap-default 0}}
+      (into (map (fn [score-type]
+                   {(keyword "scores." score-type)
+                    {:op :sort-by-list-max
+                     :field-name "scores"
+                     :max-entry "score"
+                     :filter-entry {"type" score-type}}}))
+            ["asset" "ttp"])))
 
 (def incident-sort-fields
   (apply s/enum

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -239,7 +239,7 @@
       ;; :scores.asset, :scores.ttp
       ;; Sort by maximum score of a particular type
       (into (map (fn [score-type]
-                   {(keyword "scores." score-type)
+                   {(keyword (str "scores." score-type))
                     {:op :sort-by-list-max
                      :field-name "scores"
                      :max-entry "score"

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -244,10 +244,11 @@
       ;; Sort by maximum score of a particular type
       (into (map (fn [score-type]
                    {(keyword (str "scores." score-type))
-                    {:op :sort-by-list-max
-                     :field-name "scores"
-                     :max-entry "score"
-                     :filter-entry {"type" score-type}}}))
+                    {:op :sort-by-list
+                     :mode "max"
+                     :field-name "scores.score"
+                     :filter {"scores.type" score-type}}}))
+            ;; TODO get from config
             ["asset" "ttp"])))
 
 (s/defn incident-sort-fields

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -140,7 +140,10 @@
       :assignees        em/token
       :promotion_method em/token
       :severity         em/token
-      :tactics          em/token})}})
+      :tactics          em/token
+      :scores           {:type "nested"
+                         :properties {:score em/float-type
+                                      :type em/token}}})}})
 
 (def-es-store IncidentStore :incident StoredIncident PartialStoredIncident)
 

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -241,7 +241,6 @@
                   "TA0010" 6,
                   "TA0040" 4}
                  :remap-default 0}}
-      ;; :scores.asset, :scores.ttp
       ;; Sort by maximum score of a particular type
       (into (map (fn [score-type]
                    {(keyword (str "scores." score-type))

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -236,6 +236,8 @@
                   "TA0010" 6,
                   "TA0040" 4}
                  :remap-default 0}}
+      ;; :scores.asset, :scores.ttp
+      ;; Sort by maximum score of a particular type
       (into (map (fn [score-type]
                    {(keyword "scores." score-type)
                     {:op :sort-by-list-max

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -141,7 +141,8 @@
                       "ctia.http.show.path-prefix" s/Str
                       "ctia.http.show.port" s/Int
                       "ctia.http.bulk.max-size" s/Int
-                      "ctia.http.bundle.export.max-relationships" s/Int})
+                      "ctia.http.bundle.export.max-relationships" s/Int
+                      "ctia.http.incident.sortable-score-types" s/Str})
 
    (st/required-keys {"ctia.events.enabled" s/Bool
                       "ctia.hook.redis.enabled" s/Bool

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -346,7 +346,11 @@
     #(= :remap (:op %)) {:op (s/eq :remap)
                          (s/optional-key :field-name) (s/cond-pre s/Keyword s/Str)
                          :remappings {s/Str s/Num}
-                         :remap-default s/Num}))
+                         :remap-default s/Num}
+    #(= :sort-by-list-max (:op %)) {:op (s/eq :sort-by-list-max)
+                                    :field-name (s/cond-pre s/Keyword s/Str)
+                                    :max-entry s/Str
+                                    (s/optional-key :filter-entry) {s/Str s/Str}}))
 
 (s/defschema ConcreteSortExtension
   (s/conditional
@@ -362,7 +366,12 @@
                          :field-name (s/cond-pre s/Keyword s/Str)
                          (s/optional-key :sort_order) (s/cond-pre s/Keyword s/Str)
                          :remappings {s/Str s/Num}
-                         :remap-default s/Num}))
+                         :remap-default s/Num}
+    #(= :sort-by-list-max (:op %)) {:op (s/eq :sort-by-list-max)
+                                    :field-name (s/cond-pre s/Keyword s/Str)
+                                    :max-entry s/Str
+                                    (s/optional-key :filter-entry) {s/Str s/Str}
+                                    (s/optional-key :sort_order) (s/cond-pre s/Keyword s/Str)}))
 
 (s/defschema SortExtensionTemplates
   "A map to override the behavior of sorting by a field.

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -335,6 +335,8 @@
   [id]
   (and id (some? (re-matches id/transient-id-re id))))
 
+(s/defschema ESSortMode (s/enum "max" "min" "sum" "avg" "median"))
+
 (s/defschema SortExtensionTemplate
   (s/conditional
     #(= :field (:op %)) {:op (s/eq :field)
@@ -347,10 +349,10 @@
                          (s/optional-key :field-name) (s/cond-pre s/Keyword s/Str)
                          :remappings {s/Str s/Num}
                          :remap-default s/Num}
-    #(= :sort-by-list-max (:op %)) {:op (s/eq :sort-by-list-max)
-                                    :field-name (s/cond-pre s/Keyword s/Str)
-                                    :max-entry s/Str
-                                    (s/optional-key :filter-entry) {s/Str s/Str}}))
+    #(= :sort-by-list (:op %)) {:op (s/eq :sort-by-list)
+                                :mode ESSortMode
+                                :field-name (s/cond-pre s/Keyword s/Str)
+                                (s/optional-key :filter) {s/Str s/Str}}))
 
 (s/defschema ConcreteSortExtension
   (s/conditional
@@ -367,11 +369,11 @@
                          (s/optional-key :sort_order) (s/cond-pre s/Keyword s/Str)
                          :remappings {s/Str s/Num}
                          :remap-default s/Num}
-    #(= :sort-by-list-max (:op %)) {:op (s/eq :sort-by-list-max)
-                                    :field-name (s/cond-pre s/Keyword s/Str)
-                                    :max-entry s/Str
-                                    (s/optional-key :filter-entry) {s/Str s/Str}
-                                    (s/optional-key :sort_order) (s/cond-pre s/Keyword s/Str)}))
+    #(= :sort-by-list (:op %)) {:op (s/eq :sort-by-list)
+                                :field-name (s/cond-pre s/Keyword s/Str)
+                                :mode ESSortMode
+                                (s/optional-key :filter) {s/Str s/Str}
+                                (s/optional-key :sort_order) (s/cond-pre s/Keyword s/Str)}))
 
 (s/defschema SortExtensionTemplates
   "A map to override the behavior of sorting by a field.

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -474,7 +474,6 @@ It returns the documents with full hits meta data including the real index in wh
                           query (update :filter conj query_string)
                           (seq date-range-query) (update :filter conj {:range date-range-query}))
             query-params (make-query-params es-params props)]
-        (prn "query-params" query-params)
         (cond-> (coerce! (ductile.doc/query conn
                                             index
                                             (q/bool bool-params)
@@ -519,7 +518,6 @@ It returns the documents with full hits meta data including the real index in wh
              :services}  es-conn-state
             query        (make-search-query es-conn-state search-query ident)
             query-params (make-query-params es-params props)]
-        (prn "query-params" query-params)
         (cond-> (coerce! (ductile.doc/query
                           conn
                           index

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -474,6 +474,7 @@ It returns the documents with full hits meta data including the real index in wh
                           query (update :filter conj query_string)
                           (seq date-range-query) (update :filter conj {:range date-range-query}))
             query-params (make-query-params es-params props)]
+        (prn "query-params" query-params)
         (cond-> (coerce! (ductile.doc/query conn
                                             index
                                             (q/bool bool-params)
@@ -518,6 +519,7 @@ It returns the documents with full hits meta data including the real index in wh
              :services}  es-conn-state
             query        (make-search-query es-conn-state search-query ident)
             query-params (make-query-params es-params props)]
+        (prn "query-params" query-params)
         (cond-> (coerce! (ductile.doc/query
                           conn
                           index

--- a/src/ctia/stores/es/sort.clj
+++ b/src/ctia/stores/es/sort.clj
@@ -59,7 +59,7 @@
 
       :sort-by-list-max
       ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#nested-sorting
-      (let [{:keys [max-entry filter-entry]}
+      (let [{:keys [max-entry filter-entry]} params
             list-field-name field-name
             field-name (str field-name "." max-entry)]
         {field-name {:order order
@@ -67,7 +67,6 @@
                      :mode "max"
                      :nested (cond-> {:path list-field-name}
                                filter-entry (assoc-in [:filter :term] filter-entry))}})
-
       (:remap :remap-list-max)
       (let [{:keys [remap-default remappings]} params
             remappings (normalize-remappings remappings)]

--- a/src/ctia/stores/es/sort.clj
+++ b/src/ctia/stores/es/sort.clj
@@ -41,7 +41,7 @@
   
   Sort by the maximum value in a filtered list.
 
-      e.g., sort by the maximum scores.score after filtering for scores.score == 'asset'.
+      e.g., sort by the maximum scores.score after filtering for scores.type == 'asset'.
       {:op :sort-by-list-max
        :field-name \"scores\"
        :max-entry \"score\"

--- a/src/ctia/stores/es/sort.clj
+++ b/src/ctia/stores/es/sort.clj
@@ -66,7 +66,7 @@
                      ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_sort_mode_option
                      :mode "max"
                      :nested (cond-> {:path list-field-name}
-                               filter-entry (assoc-in [:filter :term] filter-entry))}})
+                               filter-entry (assoc-in [:filter :term] (update-keys filter-entry #(str list-field-name "." %))))}})
       (:remap :remap-list-max)
       (let [{:keys [remap-default remappings]} params
             remappings (normalize-remappings remappings)]

--- a/src/ctia/stores/es/sort.clj
+++ b/src/ctia/stores/es/sort.clj
@@ -62,7 +62,7 @@
       (let [{filter-entry :filter :keys [mode max-entry]} params
             _ (assert mode "Mode required")
             [outer-field-name inner-field-name :as all-fields] (str/split field-name #"\.")
-            _ (assert (= 2 all-fields) (str "Exactly 1 level of nesting required: " field-name))]
+            _ (assert (= 2 (count all-fields)) (str "Exactly 1 level of nesting required: " field-name))]
         {field-name {:order order
                      ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_sort_mode_option
                      :mode mode

--- a/src/ctia/stores/es/sort.clj
+++ b/src/ctia/stores/es/sort.clj
@@ -44,8 +44,8 @@
       e.g., sort by the maximum scores.score after filtering for scores.score == 'asset'.
       {:op :sort-by-list-max
        :field-name \"scores\"
-       :sort-elements-field-name \"score\"
-       :filter-elements {\"type\" \"asset\"}
+       :max-entry \"score\"
+       :filter-entry {\"type\" \"asset\"}
        :sort_order :asc}"
   [{:keys [op field-name sort_order] :as params} :- ConcreteSortExtension
    default-sort_order :- (s/cond-pre s/Str s/Keyword)]
@@ -59,16 +59,14 @@
 
       :sort-by-list-max
       ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#nested-sorting
-      (let [{:keys [list-field-name
-                    sort-elements-field-name
-                    filter-elements]}
+      (let [{:keys [max-entry filter-entry]}
             list-field-name field-name
-            field-name (str field-name "." sort-elements-field-name)]
+            field-name (str field-name "." max-entry)]
         {field-name {:order order
                      ;; https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_sort_mode_option
                      :mode "max"
                      :nested (cond-> {:path list-field-name}
-                               filter-elements (assoc-in [:filter :term] filter-elements))}})
+                               filter-entry (assoc-in [:filter :term] filter-entry))}})
 
       (:remap :remap-list-max)
       (let [{:keys [remap-default remappings]} params

--- a/test/ctia/domain/entities_test.clj
+++ b/test/ctia/domain/entities_test.clj
@@ -1,5 +1,6 @@
 (ns ctia.domain.entities-test
   (:require [ctia.domain.entities :as sut]
+            [ctim.schemas.common :refer [ctim-schema-version]]
             [ctim.examples.sightings :refer [sighting-minimal sighting-maximal]]
             [ctia.entity.sighting.schemas :as ss]
             [ctia.test-helpers.collections :refer [is-submap?]]
@@ -25,7 +26,7 @@
     (testing "realized fn without previous object shall initiate all stored field"
       (is-submap? new-sighting-minimal realized-create)
       (is-submap? {:client_id "ireaux",
-                   :schema_version "1.2.0",
+                   :schema_version ctim-schema-version,
                    :type "sighting",
                    :id "sighting-id-1",
                    :tlp "green",
@@ -51,7 +52,7 @@
                                                   :services services})]
         (is-submap? new-sighting-maximal realized-update)
         (is-submap? {:client_id "ireaux",
-                     :schema_version "1.2.0",
+                     :schema_version ctim-schema-version,
                      :type "sighting",
                      :id "sighting-id-2",
                      :tlp "amber",

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -181,21 +181,21 @@
                                                  [true false])
                                            ;; multiple scores per incident
                                            (into (mapcat (fn [asc?]
-                                                           (let [asc (if asc? identity rseq)]
+                                                           (let [reorder (if asc? identity rseq)]
                                                              [;; simple asset sort
                                                               {:test-id (if asc? :asc-asset-multi :desc-asset-multi)
                                                                :sort_by (str "scores.asset:" (if asc? "asc" "desc"))
-                                                               :expected-score-order (asc [asset-000-ttp-000
-                                                                                           asset-002-ttp-004
-                                                                                           asset-004-ttp-002
-                                                                                           asset-100-ttp-100])}
+                                                               :expected-score-order (reorder [asset-000-ttp-000
+                                                                                               asset-002-ttp-004
+                                                                                               asset-004-ttp-002
+                                                                                               asset-100-ttp-100])}
                                                               ;; simple ttp sort
                                                               {:test-id (if asc? :asc-ttp-multi :desc-ttp-multi)
                                                                :sort_by (str "scores.ttp:" (if asc? "asc" "desc"))
-                                                               :expected-score-order (asc [asset-000-ttp-000
-                                                                                           asset-004-ttp-002
-                                                                                           asset-002-ttp-004
-                                                                                           asset-100-ttp-100])}])))
+                                                               :expected-score-order (reorder [asset-000-ttp-000
+                                                                                               asset-004-ttp-002
+                                                                                               asset-002-ttp-004
+                                                                                               asset-100-ttp-100])}])))
                                                  [true false])
                                            ;; composite sort_by param
                                            (into [{:test-id :asset-desc-then-ttp-asc

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -156,8 +156,9 @@
     "Can sort by multiple scores"
     [7]
     #(ductile.index/delete! % "ctia_*")
-    (helpers/with-properties (into ["ctia.auth.type" "allow-all"]
-                                   es-helpers/basic-auth-properties)
+    (helpers/with-properties (-> ["ctia.auth.type" "allow-all"]
+                                 (into es-helpers/basic-auth-properties)
+                                 (into ["ctia.http.incident.sortable-score-types" "asset,ttp"]))
       (helpers/fixture-ctia-with-app
         (fn [app]
           ;(helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -2,7 +2,6 @@
   (:require [clj-momo.lib.clj-time.coerce :as tc]
             [clj-momo.lib.clj-time.core :as t]
             [clj-momo.test-helpers.core :as mth]
-            [clojure.pprint :as pp]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
             [clojure.test.check.generators :as gen]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -51,8 +51,11 @@
                          name
                          (str "max-new-")
                          prop/spec-gen
-                         ;; remove IDs so it can be used it in Bundle import
-                         (gen/fmap #(dissoc % :id)))
+                         (gen/fmap #(-> %
+                                        ;; remove IDs so it can be used it in Bundle import
+                                        (dissoc :id)
+                                        ;; scores can generate NaN in CTIM 1.2.1
+                                        (cond-> (= :incidents e (dissoc :scores))))))
                     (gen/vector 5 11)))
               entity-keys)]
     (gen/bind

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -15,6 +15,7 @@
    [ctia.test-helpers.es :as es-helpers]
    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
    [ctia.test-helpers.search :as th.search]
+   [ctim.schemas.common :refer [ctim-schema-version]]
    [clojure.pprint :as pp]
    [ctim.examples.bundles :refer [bundle-maximal]]
    [ctim.schemas.bundle :as bundle.schema]
@@ -311,7 +312,7 @@
                       :source "ngfw_ips_event_service"}
             bundle   {:incidents
                       [{:description "desc",
-                        :schema_version "1.2.0",
+                        :schema_version ctim-schema-version,
                         :type "incident",
                         :source "ngfw_ips_event_service",
                         :tlp "green",
@@ -327,7 +328,7 @@
                         :status "New",
                         :confidence "High"}
                        {:description "desc",
-                        :schema_version "1.2.0",
+                        :schema_version ctim-schema-version,
                         :type "incident",
                         :tlp "green",
                         :source "ngfw_ips_event_service",

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -55,7 +55,7 @@
                                         ;; remove IDs so it can be used it in Bundle import
                                         (dissoc :id)
                                         ;; scores can generate NaN in CTIM 1.2.1
-                                        (cond-> (= :incidents e (dissoc :scores))))))
+                                        (cond-> (= :incidents e) (dissoc :scores)))))
                     (gen/vector 5 11)))
               entity-keys)]
     (gen/bind

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -10,6 +10,7 @@
             [ctia.test-helpers.crud :refer [crud-wait-for-test]]
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.store :refer [test-selected-stores-with-app]]
+            [ctia.test-helpers.http :refer [app->APIHandlerServices]]
             [ctim.examples.incidents :refer [new-incident-maximal]]
             [puppetlabs.trapperkeeper.app :as app]
             [schema-tools.core :as st]))
@@ -36,27 +37,30 @@
              (sut/coerce-date-range from to))))))
 
 (deftest prep-es-fields-schema-test
-  (let [enum->set (fn [enum-schema]
-                    (->> enum-schema ffirst (apply hash-map) :vs))]
-    (are [fields result]
-        (is (= result
-               (some-> (sut/prep-es-fields-schema
-                        {:StoreService {:get-store (constantly {:state {:searchable-fields fields}})}}
-                        {:search-q-params incident/IncidentSearchParams})
-                       (st/get-in [:search_fields])
-                       enum->set))
-            (format "when %s passed, %s expected" fields result))
-      #{:foo :bar} #{"foo" "bar"}
-      #{:foo}      #{"foo"}
-      nil          nil))
-  (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
-    (is (= incident/IncidentSearchParams
-           (sut/prep-es-fields-schema
-            {:StoreService {:get-store (constantly {:state {:searchable-fields nil}})}}
-            {:search-q-params incident/IncidentSearchParams})
-           (sut/prep-es-fields-schema
-            {:StoreService {:get-store (constantly {:state {:searchable-fields #{} }})}}
-            {:search-q-params incident/IncidentSearchParams})))))
+  (test-selected-stores-with-app
+    #{:es-store}
+    (fn [app]
+      (let [IncidentSearchParams (incident/IncidentSearchParams (app->APIHandlerServices app))
+            enum->set (fn [enum-schema]
+                        (->> enum-schema ffirst (apply hash-map) :vs))]
+        (are [fields result] (is (= result
+                                    (some-> (sut/prep-es-fields-schema
+                                              {:StoreService {:get-store (constantly {:state {:searchable-fields fields}})}}
+                                              {:search-q-params IncidentSearchParams})
+                                            (st/get-in [:search_fields])
+                                            enum->set))
+                                 (format "when %s passed, %s expected" fields result))
+          #{:foo :bar} #{"foo" "bar"}
+          #{:foo}      #{"foo"}
+          nil          nil))
+      (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
+        (is (= IncidentSearchParams
+               (sut/prep-es-fields-schema
+                {:StoreService {:get-store (constantly {:state {:searchable-fields nil}})}}
+                {:search-q-params IncidentSearchParams})
+               (sut/prep-es-fields-schema
+                {:StoreService {:get-store (constantly {:state {:searchable-fields #{} }})}}
+                {:search-q-params IncidentSearchParams})))))))
 
 (defn- entity-schema+searchable-fields
   "Traverses through existing entities and grabs `schema` and

--- a/test/ctia/http/routes/common_test.clj
+++ b/test/ctia/http/routes/common_test.clj
@@ -52,15 +52,15 @@
                                  (format "when %s passed, %s expected" fields result))
           #{:foo :bar} #{"foo" "bar"}
           #{:foo}      #{"foo"}
-          nil          nil))
-      (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
-        (is (= IncidentSearchParams
-               (sut/prep-es-fields-schema
-                {:StoreService {:get-store (constantly {:state {:searchable-fields nil}})}}
-                {:search-q-params IncidentSearchParams})
-               (sut/prep-es-fields-schema
-                {:StoreService {:get-store (constantly {:state {:searchable-fields #{} }})}}
-                {:search-q-params IncidentSearchParams})))))))
+          nil          nil)
+        (testing "search-q-params shall not be modified with searchable-fields of nil or empty"
+          (is (= IncidentSearchParams
+                 (sut/prep-es-fields-schema
+                  {:StoreService {:get-store (constantly {:state {:searchable-fields nil}})}}
+                  {:search-q-params IncidentSearchParams})
+                 (sut/prep-es-fields-schema
+                  {:StoreService {:get-store (constantly {:state {:searchable-fields #{} }})}}
+                  {:search-q-params IncidentSearchParams}))))))))
 
 (defn- entity-schema+searchable-fields
   "Traverses through existing entities and grabs `schema` and

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -24,19 +24,19 @@
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 1")
-                 (dissoc :id :tactics :techniques)))
+                 (dissoc :id :tactics :techniques :scores)))
         ap2 (gh/create-object
              app
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 2")
-                 (dissoc :id :tactics :techniques)))
+                 (dissoc :id :tactics :techniques :scores)))
         ap3 (gh/create-object
              app
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 3")
-                 (dissoc :id :tactics :techniques)))
+                 (dissoc :id :tactics :techniques :scores)))
         f1 (gh/create-object app "feedback" (gh/feedback-1 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))
         f2 (gh/create-object app "feedback" (gh/feedback-2 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))]
     (gh/create-object app

--- a/test/ctia/stores/es/sort_test.clj
+++ b/test/ctia/stores/es/sort_test.clj
@@ -1,6 +1,10 @@
 (ns ctia.stores.es.sort-test
-  (:require [clojure.test :refer [deftest is]]
-            [ctia.stores.es.sort :as sut]))
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [ctia.stores.es.sort :as sut]
+            [schema.test :refer [validate-schemas]]))
+
+(use-fixtures :once
+  validate-schemas)
 
 (deftest parse-sort-params-op-test
   (is (=
@@ -35,9 +39,9 @@
            :nested {:path "scores"
                     :filter {:term {"scores.type" "asset"}}}}}
          (sut/parse-sort-params-op
-           {:op :sort-by-list-max
-            :field-name "scores"
-            :max-entry "score"
-            :filter-entry {"type" "asset"}
+           {:op :sort-by-list
+            :mode "max"
+            :field-name "scores.score"
+            :filter {"scores.type" "asset"}
             :sort_order :asc}
            :asc))))

--- a/test/ctia/stores/es/sort_test.clj
+++ b/test/ctia/stores/es/sort_test.clj
@@ -28,4 +28,16 @@
                        "High" 1}
           :sort_order :asc
           :remap-default 0}
-         :asc))))
+         :asc)))
+  (is (= '{"scores.score"
+           {:order :asc
+            :mode "max"
+            :nested {:path "scores"
+                     :filter {:term {"type" "asset"}}}}}
+         (sut/parse-sort-params-op
+           {:op :sort-by-list-max
+            :field-name "scores"
+            :max-entry "score"
+            :filter-entry {"type" "asset"}
+            :sort_order :asc}
+           :asc))))

--- a/test/ctia/stores/es/sort_test.clj
+++ b/test/ctia/stores/es/sort_test.clj
@@ -29,11 +29,11 @@
           :sort_order :asc
           :remap-default 0}
          :asc)))
-  (is (= '{"scores.score"
-           {:order :asc
-            :mode "max"
-            :nested {:path "scores"
-                     :filter {:term {"type" "asset"}}}}}
+  (is (= {"scores.score"
+          {:order :asc
+           :mode "max"
+           :nested {:path "scores"
+                    :filter {:term {"type" "asset"}}}}}
          (sut/parse-sort-params-op
            {:op :sort-by-list-max
             :field-name "scores"

--- a/test/ctia/stores/es/sort_test.clj
+++ b/test/ctia/stores/es/sort_test.clj
@@ -33,7 +33,7 @@
           {:order :asc
            :mode "max"
            :nested {:path "scores"
-                    :filter {:term {"type" "asset"}}}}}
+                    :filter {:term {"scores.type" "asset"}}}}}
          (sut/parse-sort-params-op
            {:op :sort-by-list-max
             :field-name "scores"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

**Epic** https://github.com/advthreat/iroh/issues/7341
Close https://github.com/advthreat/iroh/issues/7347
Related https://github.com/advthreat/iroh/issues/7344

Adds the ability to sort on incident score. New sorting fields are allowed of the form `scores.X`, `scores.Y` on incidents, when a configuration `ctia.http.incident.sortable-score-types=X,Y` is provided.

These fields can be combined as usual for more complex (nested) sorts.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Sort on incident score
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

