### PR TITLE
generative.fulltext-search-test failures

### DIFF
--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -278,9 +278,14 @@
     (doseq [plural ent-keys]
       (let [entity (ffirst (helpers/plural-key->entity plural))
             search-res (th.search/search-raw app entity query-params)]
-        (is (= (-> bundle (get plural) count)
-               (get created entity))
-            "number of generated and imported entities should match")
+        (is (< 0 (get created entity))
+            (format "a bundle with at least one %s was imported" entity))
+        (let [numbers-match? (= (-> bundle (get plural) count)
+                                (get created entity))]
+          (is numbers-match? "number of generated and imported entities should match")
+          (when (not numbers-match?)
+            (println "generated bundle:")
+            (pp/pprint bundle)))
         (testing test-description (check test-case plural bundle search-res))
         (th.search/delete-search app entity {:query "*"
                                              :REALLY_DELETE_ALL_THESE_ENTITIES true})))))

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -1,5 +1,6 @@
 (ns ctia.http.generative.fulltext-search-test
   (:require
+   [clojure.pprint :as pp]
    [clojure.test :refer [deftest testing is are use-fixtures join-fixtures]]
    [clojure.test.check.generators :as gen]
    [ctia.auth.capabilities :as capabilities]
@@ -15,7 +16,6 @@
    [ctia.test-helpers.es :as es-helpers]
    [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
    [ctia.test-helpers.search :as th.search]
-   [clojure.pprint :as pp]
    [ctim.examples.bundles :refer [bundle-maximal]]
    [ctim.schemas.bundle :as bundle.schema]
    [ductile.index :as es-index]
@@ -75,10 +75,10 @@
                        (let [bundle-keys-to-remove (apply
                                                     disj bundle-entity-field-names
                                                     entity-keys)
-                             new-bundle            (apply
-                                                    dissoc
-                                                    bundle
-                                                    bundle-keys-to-remove)]
+                             new-bundle (apply
+                                         dissoc
+                                         bundle
+                                         bundle-keys-to-remove)]
                          (gen/return new-bundle)))))
             entities (apply entities-gen entity-keys)]
     (merge bundle entities)))
@@ -89,61 +89,61 @@
 (defn test-cases []
   (concat
    [{:test-description "Returns all the records when the wildcard used"
-     :query-params     {:query "*"}
-     :bundle-gen       (bundle-gen-for :incidents :assets)
-     :check            (fn [_ entity bundle res]
-                         (is (= (-> res :parsed-body count)
-                                (-> bundle (get entity) count))))}]
-   (let [bundle   (gen/fmap
-                   (fn [bundle]
-                     (update
-                      bundle :incidents
-                      (fn [incidents]
-                        (apply
-                         utils/update-items incidents
-                         ;; update first 3 records, leave the rest unchanged
-                         (repeat 3 #(assoc % :title "nunc porta vulputate tellus"))))))
-                   (bundle-gen-for :incidents))
+     :query-params {:query "*"}
+     :bundle-gen (bundle-gen-for :incidents :assets)
+     :check (fn [_ entity bundle res]
+              (is (= (-> res :parsed-body count)
+                     (-> bundle (get entity) count))))}]
+   (let [bundle (gen/fmap
+                 (fn [bundle]
+                   (update
+                    bundle :incidents
+                    (fn [incidents]
+                      (apply
+                       utils/update-items incidents
+                       ;; update first 3 records, leave the rest unchanged
+                       (repeat 3 #(assoc % :title "nunc porta vulputate tellus"))))))
+                 (bundle-gen-for :incidents))
          check-fn (fn [{:keys [test-description]} _ _ res]
                     (let [matching (->> res
                                         :parsed-body
                                         (filter #(-> % :title (= "nunc porta vulputate tellus"))))]
                       (is (= 3 (count matching)) test-description)))]
      [{:test-description "Multiple records with the same value in a given field. Lucene syntax"
-       :query-params     {:query "title:nunc porta vulputate tellus"}
-       :bundle-gen       bundle
-       :check            check-fn}
+       :query-params {:query "title:nunc porta vulputate tellus"}
+       :bundle-gen bundle
+       :check check-fn}
       {:test-description "Multiple records with the same value in a given field set in search_fields"
-       :query-params     {:query "nunc porta vulputate tellus"
-                          :search_fields ["title"]}
-       :bundle-gen       bundle
-       :check            check-fn}
+       :query-params {:query "nunc porta vulputate tellus"
+                      :search_fields ["title"]}
+       :bundle-gen bundle
+       :check check-fn}
       {:test-description "Querying for non-existing value should yield no results. Lucene syntax."
-       :query-params     {:query "title:0e1c9f6a-c3ac-4fd5-982e-4981f86df07a"}
-       :bundle-gen       bundle
-       :check            (fn [_ _ _ res] (is (zero? (-> res :parsed-body count))))}
+       :query-params {:query "title:0e1c9f6a-c3ac-4fd5-982e-4981f86df07a"}
+       :bundle-gen bundle
+       :check (fn [_ _ _ res] (is (zero? (-> res :parsed-body count))))}
       {:test-description "Querying for non-existing field with wildcard should yield no results. Lucene syntax."
-       :query-params     {:query "74f93781-f370-46ea-bd53-3193db379e41:*"}
-       :bundle-gen       bundle
-       :check            (fn [_ _ _ res] (is (empty? (-> res :parsed-body))))}
+       :query-params {:query "74f93781-f370-46ea-bd53-3193db379e41:*"}
+       :bundle-gen bundle
+       :check (fn [_ _ _ res] (is (empty? (-> res :parsed-body))))}
       {:test-description "Querying for non-existing field with wildcard should fail the schema validation. search_fields"
-       :query-params     {:query "*"
-                          :search_fields ["512b8dce-0423-4e9a-aa63-d3c3b91eb8d8"]}
-       :bundle-gen       bundle
-       :check            (fn [_ _ _ res] (is (= 400 (-> res :status))))}])
+       :query-params {:query "*"
+                      :search_fields ["512b8dce-0423-4e9a-aa63-d3c3b91eb8d8"]}
+       :bundle-gen bundle
+       :check (fn [_ _ _ res] (is (= 400 (-> res :status))))}])
 
    ;; Test `AND` (set two different fields that contain the same word in the same entity)
-   (let [bundle        (gen/fmap
-                        (fn [bundle]
-                          (update
-                           bundle :incidents
-                           (fn [incidents]
-                             (utils/update-items
-                              incidents
-                              ;; update only the first, leave the rest unchanged
-                              #(assoc % :short_description "Log Review"
-                                      :title "title of test incident")))))
-                        (bundle-gen-for :incidents))
+   (let [bundle (gen/fmap
+                 (fn [bundle]
+                   (update
+                    bundle :incidents
+                    (fn [incidents]
+                      (utils/update-items
+                       incidents
+                       ;; update only the first, leave the rest unchanged
+                       #(assoc % :short_description "Log Review"
+                               :title "title of test incident")))))
+                 (bundle-gen-for :incidents))
          get-fields (fn [res]
                       (->> res
                            :parsed-body
@@ -151,39 +151,39 @@
                                        (-> % :title (= "title of test incident"))))))]
      [{:test-description (str "Should NOT return anything, because query field is missing."
                               "Asking for multiple things in the query, but not providing all the fields.")
-       :query-params     {:query "(title of test incident) AND (Log Review)"
-                          :search_fields ["title"]}
-       :bundle-gen       bundle
-       :check            (fn [_ _ _ res] (is (nil? (get-fields res))))}
+       :query-params {:query "(title of test incident) AND (Log Review)"
+                      :search_fields ["title"]}
+       :bundle-gen bundle
+       :check (fn [_ _ _ res] (is (nil? (get-fields res))))}
 
       {:test-description "Should return an entity where multiple fields match"
-       :query-params     {:query "\"title of test incident\" AND \"Log Review\""
-                          :search_fields ["title" "short_description"]}
-       :bundle-gen       bundle
-       :check            (fn [_ _ _ res]
-                           (is (= 1 (-> res :parsed-body count)))
-                           (is (get-fields res)))}])
+       :query-params {:query "\"title of test incident\" AND \"Log Review\""
+                      :search_fields ["title" "short_description"]}
+       :bundle-gen bundle
+       :check (fn [_ _ _ res]
+                (is (= 1 (-> res :parsed-body count)))
+                (is (get-fields res)))}])
 
    [{:test-description "multi_match - looking for the same value in different fields in multiple records"
-     :query-params     {:query "bibendum"
-                        :search_fields ["short_description" "title"]}
-     :bundle-gen       (gen/fmap
-                        (fn [bundle]
-                          (update
-                           bundle :incidents
-                           (fn [incidents]
-                             (apply
-                              utils/update-items incidents
-                              (repeat 3 ;; update first 3, leave the rest unchanged
-                                      #(assoc % :title "Etiam vel neque bibendum dignissim"
-                                              :short_description "bibendum"))))))
-                        (bundle-gen-for :incidents))
-     :check            (fn [_ _ _ res]
-                         (let [matching (->> res
-                                             :parsed-body
-                                             (filter #(and (-> % :short_description (= "bibendum"))
-                                                           (-> % :title (= "Etiam vel neque bibendum dignissim")))))]
-                           (is (= 3 (count matching)))))}]
+     :query-params {:query "bibendum"
+                    :search_fields ["short_description" "title"]}
+     :bundle-gen (gen/fmap
+                  (fn [bundle]
+                    (update
+                     bundle :incidents
+                     (fn [incidents]
+                       (apply
+                        utils/update-items incidents
+                        (repeat 3 ;; update first 3, leave the rest unchanged
+                                #(assoc % :title "Etiam vel neque bibendum dignissim"
+                                        :short_description "bibendum"))))))
+                  (bundle-gen-for :incidents))
+     :check (fn [_ _ _ res]
+              (let [matching (->> res
+                                  :parsed-body
+                                  (filter #(and (-> % :short_description (= "bibendum"))
+                                                (-> % :title (= "Etiam vel neque bibendum dignissim")))))]
+                (is (= 3 (count matching)))))}]
    (let [bundle-gen (gen/fmap
                      (fn [bundle]
                        (update
@@ -195,22 +195,22 @@
                            #(assoc % :title "fried eggs potato")
                            #(assoc % :title "fried eggs frittata")))))
                      (bundle-gen-for :incidents))
-         check-fn   (fn [_ _ _ res]
-                      (let [matching (->> res :parsed-body)]
-                        (is (= 2 (count matching)))
-                        (= #{"fried eggs eggplant" "fried eggs potato"}
-                           (->> matching (map :title) set))))]
+         check-fn (fn [_ _ _ res]
+                    (let [matching (->> res :parsed-body)]
+                      (is (= 2 (count matching)))
+                      (= #{"fried eggs eggplant" "fried eggs potato"}
+                         (->> matching (map :title) set))))]
      [{:test-description "simple_query_string"
-       :query-params     {:simple_query  "\"fried eggs\" +(eggplant | potato) -frittata"
-                          :search_fields ["title"]}
-       :bundle-gen       bundle-gen
-       :check            check-fn}
+       :query-params {:simple_query "\"fried eggs\" +(eggplant | potato) -frittata"
+                      :search_fields ["title"]}
+       :bundle-gen bundle-gen
+       :check check-fn}
       {:test-description "simple_query_string and query_string together"
-       :query-params     {:simple_query  "\"fried eggs\" +(eggplant | potato) -frittata"
-                          :query         "(fried eggs eggplant) OR (fried eggs potato)"
-                          :search_fields ["title"]}
-       :bundle-gen       bundle-gen
-       :check            check-fn}])
+       :query-params {:simple_query "\"fried eggs\" +(eggplant | potato) -frittata"
+                      :query "(fried eggs eggplant) OR (fried eggs potato)"
+                      :search_fields ["title"]}
+       :bundle-gen bundle-gen
+       :check check-fn}])
 
    (let [bundle-gen (->> :incidents
                          bundle-gen-for
@@ -222,19 +222,19 @@
                                (utils/update-items
                                 incidents
                                 #(assoc % :title "fried eggs")))))))
-         check-fn   (fn [_ _ _ res]
-                      (is (seq (get-in res [:parsed-body :errors :search_fields]))))]
+         check-fn (fn [_ _ _ res]
+                    (is (seq (get-in res [:parsed-body :errors :search_fields]))))]
      [{:test-description "passing non-existing fields shouldn't be allowed"
-       :query-params     {:query "*", :search_fields ["bad-field"]}
-       :bundle-gen       bundle-gen
-       :check            check-fn}
+       :query-params {:query "*", :search_fields ["bad-field"]}
+       :bundle-gen bundle-gen
+       :check check-fn}
       {:test-description "passing legit entity, albeit non-searchable fields still not allowed"
-       :query-params     {:query "*", :search_fields ["incident_time.discovered"]}
-       :bundle-gen       bundle-gen
-       :check            check-fn}])
+       :query-params {:query "*", :search_fields ["incident_time.discovered"]}
+       :bundle-gen bundle-gen
+       :check check-fn}])
 
    ;; TODO: Re-enable after solving https://github.com/threatgrid/ctia/pull/1152#pullrequestreview-780638906
-   #_(let [expected {:title  "intrusion event 3:19187:7 incident"
+   #_(let [expected {:title "intrusion event 3:19187:7 incident"
                      :source "ngfw_ips_event_service"}
            bundle (gen/fmap
                    (fn [bndl]
@@ -246,10 +246,10 @@
                       (is (= expected
                              (-> res :parsed-body first (select-keys [:source :title])))))]
        [{:test-description "searching in mixed fields indexed as pure text and keyword"
-         :query-params     {:query "the intrusion event 3\\:19187\\:7 incident"
-                            :search_fields ["title" "source"]}
-         :bundle-gen       bundle
-         :check            check-fn}])))
+         :query-params {:query "the intrusion event 3\\:19187\\:7 incident"
+                        :search_fields ["title" "source"]}
+         :bundle-gen bundle
+         :check check-fn}])))
 
 (defn test-search-case
   [app
@@ -258,19 +258,29 @@
            check
            test-description] :as test-case}]
   (let [services (app/service-graph app)
-        bundle   (gen/generate bundle-gen)
+        bundle (gen/generate bundle-gen)
         ent-keys (->> bundle
                       keys
-                      (filter (partial contains? bundle-entity-field-names)))]
-    (bundle/import-bundle
-     bundle
-     nil    ;; external-key-prefixes
-     login
-     services)
-
+                      (filter (partial contains? bundle-entity-field-names)))
+        imported (bundle/import-bundle
+                  bundle
+                  nil ;; external-key-prefixes
+                  login
+                  services)
+        ;; a map where the key is entity type (singular name) and the value - number of
+        ;; entities created during the bundle import
+        created (->> imported
+                     :results
+                     (filter #(-> % :result (= "created")))
+                     (group-by :type)
+                     (map (fn [[k v]] {k (count v)}))
+                     (apply merge-with +))]
     (doseq [plural ent-keys]
       (let [entity (ffirst (helpers/plural-key->entity plural))
             search-res (th.search/search-raw app entity query-params)]
+        (is (= (-> bundle (get plural) count)
+               (get created entity))
+            "number of generated and imported entities should match")
         (testing test-description (check test-case plural bundle search-res))
         (th.search/delete-search app entity {:query "*"
                                              :REALLY_DELETE_ALL_THESE_ENTITIES true})))))
@@ -368,42 +378,42 @@
                                                       (with-out-str (pp/pprint bundle)))
                                        (check-fn res desc)
                                        true))
-            "base query matches expected data"
-            {:full-text [{:query "intrusion event 3\\:19187\\:7 incident"}]}
-            (fn [res desc]
-              (is (= 1 (count res)) desc)
-              (is (= expected
-                     (-> res first
-                         (select-keys (keys expected))))
-                  desc))
+          "base query matches expected data"
+          {:full-text [{:query "intrusion event 3\\:19187\\:7 incident"}]}
+          (fn [res desc]
+            (is (= 1 (count res)) desc)
+            (is (= expected
+                   (-> res first
+                       (select-keys (keys expected))))
+                desc))
 
-            "querying all, matches generated incidents, minus selected fields in each entity"
-            {:full-text [{:query "*"}]}
-            (fn [res desc]
-              (let [norm (fn [data] (->> data (map #(apply dissoc % ignore-ks)) set))]
-                (is (= (-> bundle :incidents norm)
-                       (-> res norm))
-                    desc)))
+          "querying all, matches generated incidents, minus selected fields in each entity"
+          {:full-text [{:query "*"}]}
+          (fn [res desc]
+            (let [norm (fn [data] (->> data (map #(apply dissoc % ignore-ks)) set))]
+              (is (= (-> bundle :incidents norm)
+                     (-> res norm))
+                  desc)))
 
-            "using 'title' and 'source' fields + a stop word"
-            {:full-text [{:query "that intrusion event 3\\:19187\\:7 incident"}]
-             :fields ["title" "source"]}
-            (fn [res desc]
-              (is (= 1 (count res)) desc)
-              (is (= expected
-                     (-> res first
-                         (select-keys (keys expected))))
-                  desc))
+          "using 'title' and 'source' fields + a stop word"
+          {:full-text [{:query "that intrusion event 3\\:19187\\:7 incident"}]
+           :fields ["title" "source"]}
+          (fn [res desc]
+            (is (= 1 (count res)) desc)
+            (is (= expected
+                   (-> res first
+                       (select-keys (keys expected))))
+                desc))
 
-            "using double-quotes at the end of the query"
-            {:full-text [{:query "intrusion event 3\\:19187\\:7 incident \\\"\\\""}]
-             :fields ["title" "source"]}
-            (fn [res desc]
-              (is (= 1 (count res)) desc)
-              (is (= expected
-                     (-> res first
-                         (select-keys (keys expected))))
-                  desc))))))))
+          "using double-quotes at the end of the query"
+          {:full-text [{:query "intrusion event 3\\:19187\\:7 incident \\\"\\\""}]
+           :fields ["title" "source"]}
+          (fn [res desc]
+            (is (= 1 (count res)) desc)
+            (is (= expected
+                   (-> res first
+                       (select-keys (keys expected))))
+                desc))))))))
 
 (def enforced-fields-flag-query-params (atom nil))
 


### PR DESCRIPTION
The test is failing randomly in CI, and I'm trying to figure out what's causing it.

This PR doesn't fix the test, but I have a clue now about what's causing it. It's possible that the number of generated and imported entities doesn't match. Perhaps it generates some values that it cannot import. 

I have placed an additional check that would fail the test when that happens. Hopefully that would give me more clues of what to change in the generator.

_As always, please ignore whitespace changes._

update: found the culprit. https://github.com/threatgrid/ctim/pull/392

<a name="qa">[§](#qa)</a> QA
============================
No QA is needed.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

