### PR TITLE
Add techniques to enumerable fields

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -142,6 +142,7 @@
       :promotion_method em/token
       :severity         em/token
       :tactics          em/token
+      :techniques          em/token
       :scores           {:type "nested"
                          :properties {:score em/float-type
                                       :type em/token}}})}})
@@ -165,7 +166,8 @@
            :assignees
            :promotion_method
            :severity
-           :tactics]))
+           :tactics
+           :techniques]))
 
 (comment
   (defn generate-mitre-tactic-scores
@@ -270,7 +272,8 @@
    :status
    :title
    :severity
-   :tactics])
+   :tactics
+   :techniques])
 
 (def incident-histogram-fields
   [:timestamp


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/7455

This PR adds `techniques` mapping and adds this field as enumerable fields for topn metric.

<a name="qa">[§](#qa)</a> QA
============================

1) request topn techniques for incidents `GET /ctia/incident/metric/topn?from=2022-06-01T00.00.00.000Z&aggregate-on=techniques`
2) validate that the response do have MITRE techniques ordered by their frequency in incidents.

