### PR TITLE
Default "no-pagination" for feed

### DIFF
--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -172,9 +172,9 @@
         (let [feed-update (assoc feed :output :judgements)
               updated-feed-response
               (helpers/PUT app
-                           (str "ctia/feed/" (:short-id feed-id))
-                           :body feed-update
-                           :headers {"Authorization" "45c1f5e3f05d0"})
+                  (str "ctia/feed/" (:short-id feed-id))
+                  :body feed-update
+                  :headers {"Authorization" "45c1f5e3f05d0"})
               updated-feed (:parsed-body updated-feed-response)]
           (is (= 200 (:status updated-feed-response)))
           (is (= (dissoc feed-update :feed_view_url)
@@ -197,9 +197,9 @@
             ;;teardown
             (is (= 200 (:status
                         (helpers/PUT app
-                                     (str "ctia/feed/" (:short-id feed-id))
-                                     :body feed
-                                     :headers {"Authorization" "45c1f5e3f05d0"})))))))))
+                            (str "ctia/feed/" (:short-id feed-id))
+                            :body feed
+                            :headers {"Authorization" "45c1f5e3f05d0"})))))))))
 
   (testing "pagination"
     (let [feed-view-url (:feed_view_url feed)
@@ -216,7 +216,15 @@
                                 (edn/read-string (get headers "X-Search_after")))
                          acc)))]
       (is (= response expected-response))
-      (is (= (inc (/ (count expected-response) 20)) @counter)))))
+      (is (= (inc (/ (count expected-response) 20)) @counter))))
+
+  (testing "when no pagination params - return entire collection"
+    (let [feed-view-url (:feed_view_url feed)
+          expected-response (into #{} (map #(-> % :observable :value)) judgements)
+          response (let [{:keys [body]} (client/get feed-view-url)]
+                     (into #{} (string/split-lines body)))]
+      (is (= 100 (count response)))
+      (is (= response expected-response)))))
 
 (deftest test-feed-routes
   (test-for-each-store-with-app
@@ -232,9 +240,9 @@
                                          "foogroup"
                                          "user")
      (let [response (helpers/POST app
-                                  "ctia/bundle/import"
-                                  :body blocklist-bundle
-                                  :headers {"Authorization" "45c1f5e3f05d0"})
+                        "ctia/bundle/import"
+                        :body blocklist-bundle
+                        :headers {"Authorization" "45c1f5e3f05d0"})
            bundle-import-result (:parsed-body response)
            indicator-id (some->> (:results bundle-import-result)
                                  (filter #(= (:type %) :indicator))


### PR DESCRIPTION
> **Epic** #
> Close #
> Related #

Return all related entities in case of no explicit pagination params.

<a name="qa">[§](#qa)</a> QA
============================

1. Import a single indicator and a lot of judgements (more than 10000) related to that indicator via related relationships with `"source_ref": "%indicator-id%"`
2. Create a feed using indicator id from the result of the first step
3. Get a view of the feed `GET /ctia/feed/:feed-id/view?s=:secret`. The response should contain all related judgements without pagination headers.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

