### PR TITLE
Note Entity API changes

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.1:compile
++- threatgrid:ctim:jar:1.3.2-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.2-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.2:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.1</version>
+      <version>1.3.2-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -407,7 +407,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.2-SNAPSHOT</version>
+      <version>1.3.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -73,7 +73,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.3.1:compile
++- threatgrid:ctim:jar:1.3.2-SNAPSHOT:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -73,7 +73,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.3.2-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.2:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.1"]
+                 [threatgrid/ctim "1.3.2-SNAPSHOT"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.2-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.2"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/src/ctia/entity/note.clj
+++ b/src/ctia/entity/note.clj
@@ -15,13 +15,13 @@
   {"note"
    {:dynamic false
     :properties
-    (merge
-     em/base-entity-mapping
-     em/sourcable-entity-mapping
-     em/stored-entity-mapping
-     {:entity_id em/token
-      :content em/text
-      :author em/token})}})
+    (merge em/base-entity-mapping
+           em/sourcable-entity-mapping
+           em/stored-entity-mapping
+           {:related_entities em/note-related-entity
+            :content em/text
+            :note_class em/token
+            :author em/token})}})
 
 (def-es-store NoteStore
   :note

--- a/src/ctia/entity/note.clj
+++ b/src/ctia/entity/note.clj
@@ -11,6 +11,12 @@
             [schema-tools.core :as st]
             [schema.core :as s]))
 
+(def note-related-entity
+  {:type "object"
+   :properties
+   {:entity_type em/token
+    :entity_id em/token}})
+
 (def note-mapping
   {"note"
    {:dynamic false
@@ -18,7 +24,7 @@
     (merge em/base-entity-mapping
            em/sourcable-entity-mapping
            em/stored-entity-mapping
-           {:related_entities em/note-related-entity
+           {:related_entities note-related-entity
             :content em/text
             :note_class em/token
             :author em/token})}})

--- a/src/ctia/entity/note/schemas.clj
+++ b/src/ctia/entity/note/schemas.clj
@@ -37,8 +37,8 @@
 (def note-fields
   (concat sorting/base-entity-sort-fields
           sorting/sourcable-entity-sort-fields
-          [:related_entities.id
-           :related_entities.type
+          [:related_entities.entity_id
+           :related_entities.entity_type
            :note_class
            :author
            :content]))
@@ -49,8 +49,8 @@
 (def searchable-fields
   #{:id
     :source
-    :related_entities.id
-    :related_entities.type
+    :related_entities.entity_id
+    :related_entities.entity_type
     :note_class
     :content})
 
@@ -70,8 +70,8 @@
    routes.common/SourcableEntityFilterParams
    routes.common/SearchableEntityParams
    (st/optional-keys
-    {:related_entities.id s/Str
-     :related_entities.type s/Str
+    {:related_entities.entity_id s/Str
+     :related_entities.entity_type s/Str
      :note_class s/Str
      :content s/Str})))
 
@@ -79,8 +79,8 @@
   (st/merge
    NoteFieldsParam
    routes.common/PagingParams
-   {:related_entities.id s/Str
-    :related_entities.type s/Str
+   {:related_entities.entity_id s/Str
+    :related_entities.entity_type s/Str
     :note_class s/Str
     (s/optional-key :sort_by) note-sort-fields}))
 
@@ -88,6 +88,6 @@
 
 (s/defschema NoteByExternalIdQueryParams
   (st/dissoc NoteQueryParams
-             :related_entities.id
-             :related_entities.type
+             :related_entities.entity_id
+             :related_entities.entity_type
              :note_class))

--- a/src/ctia/entity/note/schemas.clj
+++ b/src/ctia/entity/note/schemas.clj
@@ -37,7 +37,9 @@
 (def note-fields
   (concat sorting/base-entity-sort-fields
           sorting/sourcable-entity-sort-fields
-          [:entity_id
+          [:related_entities.id
+           :related_entities.type
+           :note_class
            :author
            :content]))
 
@@ -47,11 +49,13 @@
 (def searchable-fields
   #{:id
     :source
-    :entity_id
+    :related_entities.id
+    :related_entities.type
+    :note_class
     :content})
 
 (def note-histogram-fields [:timestamp])
-(def note-enumerable-fields [:entity_id])
+(def note-enumerable-fields [])
 
 (s/defschema NoteFieldsParam
   {(s/optional-key :fields) [(apply s/enum note-fields)]})
@@ -66,17 +70,24 @@
    routes.common/SourcableEntityFilterParams
    routes.common/SearchableEntityParams
    (st/optional-keys
-    {:entity_id s/Str
+    {:related_entities.id s/Str
+     :related_entities.type s/Str
+     :note_class s/Str
      :content s/Str})))
 
 (s/defschema NoteQueryParams
   (st/merge
    NoteFieldsParam
    routes.common/PagingParams
-   {:entity_id s/Str
+   {:related_entities.id s/Str
+    :related_entities.type s/Str
+    :note_class s/Str
     (s/optional-key :sort_by) note-sort-fields}))
 
 (def NoteGetParams NoteFieldsParam)
 
 (s/defschema NoteByExternalIdQueryParams
-  (st/dissoc NoteQueryParams :entity_id))
+  (st/dissoc NoteQueryParams
+             :related_entities.id
+             :related_entities.type
+             :note_class))

--- a/src/ctia/entity/note/schemas.clj
+++ b/src/ctia/entity/note/schemas.clj
@@ -49,9 +49,6 @@
 (def searchable-fields
   #{:id
     :source
-    :related_entities.entity_id
-    :related_entities.entity_type
-    :note_class
     :content})
 
 (def note-histogram-fields [:timestamp])

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -259,8 +259,8 @@
 (def note-related-entity
   {:type "object"
    :properties
-   {:type token
-    :id token}})
+   {:entity_type token
+    :entity_id token}})
 
 (def texts
   {:properties {:type token

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -256,6 +256,12 @@
     :columns {:enabled false}
     :rows {:enabled false}}})
 
+(def note-related-entity
+  {:type "object"
+   :properties
+   {:type token
+    :id token}})
+
 (def texts
   {:properties {:type token
                 :text text}})

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -256,12 +256,6 @@
     :columns {:enabled false}
     :rows {:enabled false}}})
 
-(def note-related-entity
-  {:type "object"
-   :properties
-   {:entity_type token
-    :entity_id token}})
-
 (def texts
   {:properties {:type token
                 :text text}})

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -155,8 +155,8 @@
   {:id (str "transient:note-" n)
    :content (str "content: note-" n)
    :note_class :default
-   :related_entities [{:type "incident"
-                       :id "https://ex.tld/ctia/incident/incident-0ecb71f3-6b04-4bbe-ba81-a0acf6f78394"}]
+   :related_entities [{:entity_type "incident"
+                       :entity_id "https://ex.tld/ctia/incident/incident-0ecb71f3-6b04-4bbe-ba81-a0acf6f78394"}]
    :source "Cisco Threat Response"})
 
 (defn mk-new-tool [n]

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -151,11 +151,12 @@
    :assertions [{:name "cisco:ctr:device:owner" :value "Bob"}]
    :source "source"})
 
-
 (defn mk-new-note [n]
   {:id (str "transient:note-" n)
    :content (str "content: note-" n)
-   :entity_id "https://ex.tld/ctia/note/note-0ecb71f3-6b04-4bbe-ba81-a0acf6f78394"
+   :note_class :default
+   :related_entities [{:type "incident"
+                       :id "https://ex.tld/ctia/incident/incident-0ecb71f3-6b04-4bbe-ba81-a0acf6f78394"}]
    :source "Cisco Threat Response"})
 
 (defn mk-new-tool [n]


### PR DESCRIPTION
This PR accommodates for the changes in the CTIM Note entity, namely:

- remove `entity_id` and introduce `related_entities` in the schema
- introduce `note_class` in the schema
- updated the entity search query parameters

<a name="qa">[§](#qa)</a> QA
============================

You can test the API following all the sample calls in the design documentation

  
<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
public: updated Note Entity API
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

