### PR TITLE
bump snakeyaml to address CVE-2022-38751

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -27,8 +27,6 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- clj-commons:fs:jar:1.6.307:compile
 |  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
-|  +- clj-commons:clj-yaml:jar:0.7.2:compile
-|  |  \- org.flatland:ordered:jar:1.5.9:compile
 |  +- beckon:beckon:jar:0.1.1:compile
 |  +- puppetlabs:typesafe-config:jar:0.2.0:compile
 |  |  \- com.typesafe:config:jar:1.4.1:compile
@@ -44,6 +42,8 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- prismatic:plumbing:jar:0.5.5:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
 +- org.yaml:snakeyaml:jar:2.0:compile
++- clj-commons:clj-yaml:jar:1.0.26:compile
+|  \- org.flatland:ordered:jar:1.5.9:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -41,8 +41,8 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- digest:digest:jar:1.4.3:compile
 +- prismatic:plumbing:jar:0.5.5:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
-+- org.yaml:snakeyaml:jar:2.0:compile
 +- clj-commons:clj-yaml:jar:1.0.26:compile
+|  +- org.yaml:snakeyaml:jar:1.33:compile
 |  \- org.flatland:ordered:jar:1.5.9:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -43,7 +43,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- digest:digest:jar:1.4.3:compile
 +- prismatic:plumbing:jar:0.5.5:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
-+- org.yaml:snakeyaml:jar:1.33:compile
++- org.yaml:snakeyaml:jar:2.0:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -28,7 +28,6 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
 |  +- clj-commons:clj-yaml:jar:0.7.2:compile
-|  |  +- org.yaml:snakeyaml:jar:1.26:compile
 |  |  \- org.flatland:ordered:jar:1.5.9:compile
 |  +- beckon:beckon:jar:0.1.1:compile
 |  +- puppetlabs:typesafe-config:jar:0.2.0:compile
@@ -44,6 +43,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- digest:digest:jar:1.4.3:compile
 +- prismatic:plumbing:jar:0.5.5:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
++- org.yaml:snakeyaml:jar:1.33:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -348,6 +348,25 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>prismatic</groupId>
       <artifactId>schema</artifactId>
       <version>1.2.0</version>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -348,25 +348,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-      <version>2.0</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-nop</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>slf4j-log4j12</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>clj-yaml</artifactId>
       <version>1.0.26</version>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -367,6 +367,25 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>clj-commons</groupId>
+      <artifactId>clj-yaml</artifactId>
+      <version>1.0.26</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>prismatic</groupId>
       <artifactId>schema</artifactId>
       <version>1.2.0</version>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -350,7 +350,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.33</version>
+      <version>2.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -55,26 +55,6 @@
         <enabled>true</enabled>
       </releases>
     </repository>
-    <repository>
-      <id>public-github</id>
-      <url>git://github.com</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-    <repository>
-      <id>private-github</id>
-      <url>git://github.com</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
   </repositories>
   <dependencyManagement>
     <dependencies/>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -62,9 +62,8 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- prismatic:plumbing:jar:0.5.5:compile
 |  +- (prismatic:schema:jar:1.1.7:compile - omitted for conflict with 1.1.12)
 |  \- de.kotka:lazymap:jar:3.1.0:compile
-+- org.yaml:snakeyaml:jar:2.0:compile
 +- clj-commons:clj-yaml:jar:1.0.26:compile
-|  +- (org.yaml:snakeyaml:jar:1.33:compile - omitted for conflict with 2.0)
+|  +- org.yaml:snakeyaml:jar:1.33:compile
 |  \- org.flatland:ordered:jar:1.5.9:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -38,7 +38,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
 |  +- clj-commons:clj-yaml:jar:0.7.2:compile
-|  |  +- (org.yaml:snakeyaml:jar:1.26:compile - omitted for conflict with 1.33)
+|  |  +- (org.yaml:snakeyaml:jar:1.26:compile - omitted for conflict with 2.0)
 |  |  \- org.flatland:ordered:jar:1.5.9:compile
 |  +- (prismatic:plumbing:jar:0.4.2:compile - omitted for conflict with 0.5.5)
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
@@ -64,7 +64,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- prismatic:plumbing:jar:0.5.5:compile
 |  +- (prismatic:schema:jar:1.1.7:compile - omitted for conflict with 1.1.12)
 |  \- de.kotka:lazymap:jar:3.1.0:compile
-+- org.yaml:snakeyaml:jar:1.33:compile
++- org.yaml:snakeyaml:jar:2.0:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 |  \- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -37,9 +37,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- clj-commons:fs:jar:1.6.307:compile
 |  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
-|  +- clj-commons:clj-yaml:jar:0.7.2:compile
-|  |  +- (org.yaml:snakeyaml:jar:1.26:compile - omitted for conflict with 2.0)
-|  |  \- org.flatland:ordered:jar:1.5.9:compile
+|  +- (clj-commons:clj-yaml:jar:0.7.2:compile - omitted for conflict with 1.0.26)
 |  +- (prismatic:plumbing:jar:0.4.2:compile - omitted for conflict with 0.5.5)
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- beckon:beckon:jar:0.1.1:compile
@@ -65,6 +63,9 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.7:compile - omitted for conflict with 1.1.12)
 |  \- de.kotka:lazymap:jar:3.1.0:compile
 +- org.yaml:snakeyaml:jar:2.0:compile
++- clj-commons:clj-yaml:jar:1.0.26:compile
+|  +- (org.yaml:snakeyaml:jar:1.33:compile - omitted for conflict with 2.0)
+|  \- org.flatland:ordered:jar:1.5.9:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 |  \- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
@@ -157,7 +158,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (ring:ring-core:jar:1.7.1:compile - omitted for conflict with 1.9.5)
 |  +- (cheshire:cheshire:jar:5.8.1:compile - omitted for conflict with 5.8.0)
 |  +- (org.clojure:tools.reader:jar:1.3.2:compile - omitted for conflict with 1.3.6)
-|  +- (clj-commons:clj-yaml:jar:0.6.0:compile - omitted for conflict with 0.7.2)
+|  +- (clj-commons:clj-yaml:jar:0.6.0:compile - omitted for conflict with 1.0.26)
 |  +- clojure-msgpack:clojure-msgpack:jar:1.2.1:compile
 |  \- com.cognitect:transit-clj:jar:0.8.313:compile
 |     \- com.cognitect:transit-java:jar:0.8.337:compile
@@ -404,7 +405,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:compile
 |  \- jakarta.activation:jakarta.activation-api:jar:1.2.1:compile
 +- markdown-clj:markdown-clj:jar:1.10.1:compile
-|  \- (clj-commons:clj-yaml:jar:0.7.0:compile - omitted for conflict with 0.7.2)
+|  \- (clj-commons:clj-yaml:jar:0.7.0:compile - omitted for conflict with 1.0.26)
 +- hiccup:hiccup:jar:2.0.0-alpha2:compile
 +- lock-key:lock-key:jar:1.5.0:compile
 |  +- charset:charset:jar:1.2.1:compile
@@ -617,7 +618,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (org.codehaus.janino:janino:jar:3.0.8:test - omitted for duplicate)
 |  +- (clj-time:clj-time:jar:0.11.0:test - omitted for conflict with 0.15.2)
 |  +- (clj-commons:fs:jar:1.6.307:test - omitted for duplicate)
-|  +- (clj-commons:clj-yaml:jar:0.7.2:test - omitted for duplicate)
+|  +- (clj-commons:clj-yaml:jar:0.7.2:test - omitted for conflict with 1.0.26)
 |  +- (prismatic:plumbing:jar:0.4.2:test - omitted for conflict with 0.5.5)
 |  +- (prismatic:schema:jar:1.1.12:test - omitted for conflict with 1.2.0)
 |  +- (beckon:beckon:jar:0.1.1:test - omitted for duplicate)

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -38,7 +38,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
 |  +- clj-commons:clj-yaml:jar:0.7.2:compile
-|  |  +- org.yaml:snakeyaml:jar:1.26:compile
+|  |  +- (org.yaml:snakeyaml:jar:1.26:compile - omitted for conflict with 1.33)
 |  |  \- org.flatland:ordered:jar:1.5.9:compile
 |  +- (prismatic:plumbing:jar:0.4.2:compile - omitted for conflict with 0.5.5)
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
@@ -64,6 +64,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- prismatic:plumbing:jar:0.5.5:compile
 |  +- (prismatic:schema:jar:1.1.7:compile - omitted for conflict with 1.1.12)
 |  \- de.kotka:lazymap:jar:3.1.0:compile
++- org.yaml:snakeyaml:jar:1.33:compile
 +- prismatic:schema:jar:1.2.0:compile
 +- metosin:schema-tools:jar:0.12.2:compile
 |  \- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)

--- a/project.clj
+++ b/project.clj
@@ -81,6 +81,7 @@
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
                  [org.yaml/snakeyaml "2.0"] ;; security fix
+                 [clj-commons/clj-yaml "1.0.26"] ;; compatible with snakeyaml 2.0
 
                  ;; Schemas
                  [prismatic/schema "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,7 @@
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
-                 [clj-commons/clj-yaml "1.0.26"] ;; for transitive dep snakeyaml's CVE-2022-38751 security fix
+                 [clj-commons/clj-yaml "1.0.26"] ;; upgrade snakeyaml dep
 
                  ;; Schemas
                  [prismatic/schema "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -80,6 +80,7 @@
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
+                 [org.yaml/snakeyaml "1.33"] ;; security fix
 
                  ;; Schemas
                  [prismatic/schema "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -80,8 +80,7 @@
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
-                 [org.yaml/snakeyaml "2.0"] ;; security fix
-                 [clj-commons/clj-yaml "1.0.26"] ;; compatible with snakeyaml 2.0
+                 [clj-commons/clj-yaml "1.0.26"] ;; for transitive dep snakeyaml's CVE-2022-38751 security fix
 
                  ;; Schemas
                  [prismatic/schema "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -225,7 +225,7 @@
                   :jvm-opts [ ;; actually print stack traces instead of useless
                              ;; "Full report at: /tmp/clojure-8187773283812483853.edn"
                              "-Dclojure.main.report=stderr"]}
-             :next-clojure {:dependencies [[org.clojure/clojure "1.11.0-rc1"]]}
+             :next-clojure {:dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]]}
              :jmx {:jvm-opts ["-Dcom.sun.management.jmxremote"
                               "-Dcom.sun.management.jmxremote.port=9010"
                               "-Dcom.sun.management.jmxremote.local.only=false"
@@ -271,7 +271,7 @@
   :plugins [[lein-shell "0.5.0"]
             [org.clojure/clojure ~clj-version] ;override perforate
             [perforate ~perforate-version]
-            [reifyhealth/lein-git-down "0.3.5"]]
+            #_[reifyhealth/lein-git-down "0.3.5"]]
   :repl-options {:welcome (println
                            (clojure.string/join
                             "\n"
@@ -284,10 +284,8 @@
                              " (current-app)      => get current app, or nil"]))
                  ;; 10m
                  :repl-timeout 600000}
-  :middleware [lein-git-down.plugin/inject-properties]
   ;; lein-git-down config
-  :repositories [["public-github" {:url "git://github.com"}]
-                 ["private-github" {:url "git://github.com" :protocol :ssh}]]
+  ;; 
   ;; to simultaneously work on an upstream dependency and have
   ;; Travis pick up on it:
   ;; 1. add an entry mapping the upstream's maven coordinate to its dev GitHub repository
@@ -296,6 +294,10 @@
   ;;         :git-down {threatgrid/ctim {:coordinates frenchy64/ctim}}
   ;; 2. change the upstream dependency's version to the relevant sha
   ;;    eg., [threatgrid/ctim "9acbc93333d630d9b9a0a9fc19981b0ba0ddec1c"]
+  ;; 3. uncomment the following :middleware and :repositories forms and the dependency in the :plugins entry.
+  #_#_:middleware [lein-git-down.plugin/inject-properties]
+  #_#_:repositories [["public-github" {:url "git://github.com"}]
+                     ["private-github" {:url "git://github.com" :protocol :ssh}]]
   ;;
   ;; To work on the library locally without restarting the REPL, you can use lein checkouts.
   ;; 1. $ mkdir checkouts

--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,7 @@
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
-                 [org.yaml/snakeyaml "1.33"] ;; security fix
+                 [org.yaml/snakeyaml "2.0"] ;; security fix
 
                  ;; Schemas
                  [prismatic/schema "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -225,7 +225,8 @@
                   :jvm-opts [ ;; actually print stack traces instead of useless
                              ;; "Full report at: /tmp/clojure-8187773283812483853.edn"
                              "-Dclojure.main.report=stderr"]}
-             :next-clojure {:dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]]}
+             :next-clojure {:dependencies [[org.clojure/clojure "1.12.0-master-SNAPSHOT"]]
+                            :repositories [["snapshots" "https://oss.sonatype.org/content/repositories/snapshots/"]]}
              :jmx {:jvm-opts ["-Dcom.sun.management.jmxremote"
                               "-Dcom.sun.management.jmxremote.port=9010"
                               "-Dcom.sun.management.jmxremote.local.only=false"


### PR DESCRIPTION
Bump snakeyaml version to fix a security issue.

See [this conversation](url) to confirm we are not vulnerable to CVE-2022-1471.

The only place that CTIA might parse yaml is during trapperkeeper's [bootstrap](https://github.com/puppetlabs/trapperkeeper/blob/5ac89448d149838f19649856b17178c7d943d1da/src/puppetlabs/trapperkeeper/config.clj#L61). But we don't use yaml configs and we'd always trust our own configuration anyway.

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

