### PR TITLE
add tactics/techniques to incident search filters

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -306,7 +306,9 @@
      :sort_by          (incident-sort-fields services)
      :assignees        s/Str
      :promotion_method s/Str
-     :severity s/Str})))
+     :severity         s/Str
+     :tactics          s/Str
+     :techniques       s/Str})))
 
 (def IncidentGetParams IncidentFieldsParam)
 


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://github.com/advthreat/iroh/issues/7455

Simplifies tactics and techniques filtering in search and metrics for incidents.

<a name="qa">[§](#qa)</a> QA
============================

Check that you can filter incidents on `tactics`  and `techniques`
