### PR TITLE
Bump CTIM to 1.3.7

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.7-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.7:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.6:compile
++- threatgrid:ctim:jar:1.3.7-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.7-SNAPSHOT</version>
+      <version>1.3.7</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.6</version>
+      <version>1.3.7-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -74,7 +74,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.3.7-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.7:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/dependabot/verbose-dependency-tree.txt
+++ b/dependabot/verbose-dependency-tree.txt
@@ -74,7 +74,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (metosin:ring-swagger:jar:0.26.2:compile - omitted for duplicate)
 |  \- (metosin:schema-tools:jar:0.12.2:compile - omitted for duplicate)
-+- threatgrid:ctim:jar:1.3.6:compile
++- threatgrid:ctim:jar:1.3.7-SNAPSHOT:compile
 |  +- (prismatic:schema:jar:1.1.12:compile - omitted for conflict with 1.2.0)
 |  +- (com.google.protobuf:protobuf-java:jar:3.7.1:compile - omitted for conflict with 3.19.6)
 |  +- (threatgrid:clj-momo:jar:0.3.5:compile - omitted for duplicate)

--- a/project.clj
+++ b/project.clj
@@ -87,7 +87,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.7-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.7"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -87,7 +87,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.6"]
+                 [threatgrid/ctim "1.3.7-SNAPSHOT"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]


### PR DESCRIPTION
Bump the CTIM dependency to 1.3.7 in order to get the latest changes for the Sighting contextual events

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.