### PR TITLE
Allow setting `allow_partial_search_results` in ES search queries

### DIFF
--- a/resources/ctia-default.properties
+++ b/resources/ctia-default.properties
@@ -79,6 +79,7 @@ ctia.store.es.default.shards=5
 ctia.store.es.default.refresh=false
 ctia.store.es.default.rollover.max_docs=10000000
 ctia.store.es.default.aliased=true
+ctia.store.es.default.allow_partial_search_results=false
 ctia.store.es.default.version=5
 ctia.store.es.default.update-mappings=false
 ctia.store.es.default.update-settings=false

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -40,6 +40,7 @@
    (str prefix store ".default_operator") (s/enum "OR" "AND")
    (str prefix store ".timeout") s/Num
    (str prefix store ".version") s/Num
+   (str prefix store ".allow_partial_search_results") s/Bool
    (str prefix store ".update-mappings")  s/Bool
    (str prefix store ".update-settings")  s/Bool
    (str prefix store ".refresh-mappings") s/Bool

--- a/test/ctia/properties_test.clj
+++ b/test/ctia/properties_test.clj
@@ -19,6 +19,7 @@
             "ctia.store.es.malware.rollover.max_age" s/Str
             "ctia.store.es.malware.aliased"  s/Bool
             "ctia.store.es.malware.default_operator" (s/enum "OR" "AND")
+            "ctia.store.es.malware.allow_partial_search_results" s/Bool
             "ctia.store.es.malware.version" s/Num
             "ctia.store.es.malware.update-mappings" s/Bool
             "ctia.store.es.malware.update-settings" s/Bool
@@ -46,6 +47,7 @@
             "prefix.sighting.rollover.max_age" s/Str
             "prefix.sighting.aliased"  s/Bool
             "prefix.sighting.default_operator" (s/enum "OR" "AND")
+            "prefix.sighting.allow_partial_search_results" s/Bool
             "prefix.sighting.version" s/Num
             "prefix.sighting.update-mappings" s/Bool
             "prefix.sighting.update-settings" s/Bool

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -443,7 +443,17 @@
     {:sort [{"timestamp" {:order :asc}}
             {"id" {:order :asc}}]
      :_source [:id :id :owner :groups :tlp :authorized_users :authorized_groups]
-     :track_total_hits true}))
+     :track_total_hits true}
+
+    {:fields [:id]}
+    {:default-sort "timestamp,id"
+     :version 7
+     :allow_partial_search_results false}
+    {:sort [{"timestamp" {:order :asc}}
+            {"id" {:order :asc}}]
+     :_source [:id :id :owner :groups :tlp :authorized_users :authorized_groups]
+     :track_total_hits true
+     :allow_partial_search_results false}))
 
 (deftest make-search-query-test
   (es-helpers/for-each-es-version


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close https://github.com/advthreat/iroh/issues/3057
> Related #

- Expose a new configuration property at the ES Store level `allow_partial_search_results`
- This boolean is transmitted in the ES query params if specified

This ES option is documented here: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-search.html

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
public: allow setting the `allow_partial_search_results` as an ES Store option
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

