### PR TITLE
Fix X-Total-Hits in incident average metric

### DIFF
--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -742,7 +742,11 @@
                                                 :opened_to_closed third-opened_to_closed}]])
                  +sec #(jt/plus epoch (jt/seconds %))
                  incident-ids (mapv (fn [[incident {:keys [created]}]]
-                                     (create-incident-at-time app (jt/java-date (+sec created)) incident))
+                                      ;; create extra incidents whose statuses are never changed to simulate a real environment
+                                      (second
+                                        (repeatedly
+                                          2
+                                          #(create-incident-at-time app (jt/java-date (+sec created)) incident))))
                                     incident->intervals)
                  incident-id->incident+intervals (map vector incident-ids incident->intervals)
                  _ (assert (= (count incident-id->incident+intervals) (count incident->intervals))

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -617,6 +617,36 @@
          (sut/make-aggregation {:agg-type     :avg
                                 :aggregate-on "intervals.something"}))))
 
+(deftest aggregation-filters-test
+  (is (= []
+         (sut/aggregation-filters
+           {:agg-type     :topn
+            :aggregate-on "title"
+            :limit        20
+            :sort_order   :desc})))
+  (is (= [{:bool {:must {:exists {:field "intervals.something"}}}}]
+         (sut/aggregation-filters
+           {:agg-type     :avg
+            :aggregate-on "intervals.something"})))
+  (is (= [{:bool {:must {:exists {:field "intervals.something1"}}}}
+          {:bool {:must {:exists {:field "intervals.something2"}}}}]
+         (sut/aggregation-filters
+           {:agg-type     :avg
+            :aggregate-on "intervals.something1"
+            :aggs {:agg-type     :avg
+                   :aggregate-on "intervals.something22"}})))
+  (is (= [{:bool {:must {:exists {:field "intervals.something1"}}}}
+          {:bool {:must {:exists {:field "intervals.something2"}}}}]
+         (sut/aggregation-filters
+           {:agg-type     :avg
+            :aggregate-on "intervals.something1"
+            :aggs {:agg-type     :topn
+                   :aggregate-on "title"
+                   :limit        20
+                   :sort_order   :desc
+                   :aggs {:agg-type     :avg
+                          :aggregate-on "intervals.something22"}}}))))
+
 (defn generate-sightings
   [nb confidence title timestamp]
   (repeatedly nb

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -628,15 +628,15 @@
          (sut/aggregation-filters
            {:agg-type     :avg
             :aggregate-on "intervals.something"})))
-  (is (= [{:bool {:must {:exists {:field "intervals.something1"}}}}
-          {:bool {:must {:exists {:field "intervals.something2"}}}}]
+  (is (= [{:bool {:must {:exists {:field "intervals.something2"}}}}
+          {:bool {:must {:exists {:field "intervals.something1"}}}}]
          (sut/aggregation-filters
            {:agg-type     :avg
             :aggregate-on "intervals.something1"
             :aggs {:agg-type     :avg
-                   :aggregate-on "intervals.something22"}})))
-  (is (= [{:bool {:must {:exists {:field "intervals.something1"}}}}
-          {:bool {:must {:exists {:field "intervals.something2"}}}}]
+                   :aggregate-on "intervals.something2"}})))
+  (is (= [{:bool {:must {:exists {:field "intervals.something2"}}}}
+          {:bool {:must {:exists {:field "intervals.something1"}}}}]
          (sut/aggregation-filters
            {:agg-type     :avg
             :aggregate-on "intervals.something1"
@@ -645,7 +645,7 @@
                    :limit        20
                    :sort_order   :desc
                    :aggs {:agg-type     :avg
-                          :aggregate-on "intervals.something22"}}}))))
+                          :aggregate-on "intervals.something2"}}}))))
 
 (defn generate-sightings
   [nb confidence title timestamp]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

**Epic** https://github.com/advthreat/iroh/issues/7380

X-Total-Hits should be the divisor in the incident average metric. Instead, it's all the incidents created in the from/to range of the query. This fixes the problem by adding extra filters to restrict such queries to only incidents that have the relevant field in the aggregation.

For example, if getting the average of the intervals.new_to_opened field, we add a filter to the aggregation query that filters incidents that only have the intervals.new_to_opened field.

To test this, I create extra garbage incidents within the from/to range of the existing unit test. This fails the existing test and makes the count higher than it should. Then, by adding extra filters, the test passes again.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Fix X-Total-Hits in incident average metric
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

