### PR TITLE
Filter incidents on timestamp not created

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -1,7 +1,6 @@
 (ns ctia.entity.incident
   (:require
    [clj-momo.lib.clj-time.core :as time]
-   [clj-time.core :as clj-time]
    [clojure.string :as str]
    [ctia.domain.entities
     :refer [default-realize-fn un-store with-long-id]]
@@ -85,13 +84,12 @@
     [rt-ctx :- GraphQLRuntimeContext]
     (let [rfn (lift-realize-fn-with-context
                incident-default-realize rt-ctx)
-          e (-> (rfn new-obj id tempids ident-map prev-obj)
-                #_(assoc :timestamp
-                         (or (:timestamp new-obj)
-                             (:timestamp prev-obj)
-                             (clj-time/now))))]
-
-      e)))
+          now (time/internal-now)]
+      (-> (rfn new-obj id tempids ident-map prev-obj)
+          (assoc :timestamp
+                 (or (:timestamp new-obj)
+                     (:timestamp prev-obj)
+                     now))))))
 
 (s/defschema IncidentStatus
   (fs/->schema vocs/Status))

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -80,16 +80,16 @@
 
 (s/defn realize-incident
   :- (RealizeFnResult (with-error StoredIncident))
-  [{:keys [timestamp]
-    :as new-entity}
-   id tempids & rest-args]
+  [new-obj id tempids ident-map & [prev-obj]]
   (delayed/fn :- (with-error StoredIncident)
     [rt-ctx :- GraphQLRuntimeContext]
-    (let [e (-> incident-default-realize
-                (lift-realize-fn-with-context rt-ctx)
-                (apply new-entity id tempids rest-args)
-                (assoc :timestamp (or timestamp (clj-time/now))))]
-      (clojure.pprint/pprint e)
+    (let [rfn (lift-realize-fn-with-context
+               incident-default-realize rt-ctx)
+          e (-> (rfn new-obj id tempids ident-map prev-obj)
+                #_(assoc :timestamp
+                         (or (:timestamp new-obj)
+                             (:timestamp prev-obj)
+                             (clj-time/now))))]
 
       e)))
 


### PR DESCRIPTION
> Close [advthreat/iroh#7917 — CTIA: filter incidents on timestamp instead of created](https://github.com/advthreat/iroh/issues/7917)
> Close https://github.com/advthreat/iroh/issues/8519

<a name="qa">[§](#qa)</a> QA
============================

Testing this feature essentially entails creating an incident (or multiple) and ensuring that its timestamp remains unchanged after modifying it.

1. Create a minimal Incident

```
POST https://intel.test.iroh.site/ctia/incident
Accept: application/json
Content-Type: application/json
Authorization: Bearer TOKEN

    {
    "incident_time" : {
        "opened" : "2016-02-11T00:40:48Z"
    },
    "status" : "Open",
    "confidence" : "High",
    "severity" : "High",
    "title" : "Some incident For Testing",
    "revision" : 3
    }
```
    
 This request returns an entity with an Id field that would be something like: 
`https://intel.test.iroh.site/ctia/incident/ctia/incident/incident-66c2b363-42a4-4e76-9e0b-00317ba1a29e`. We call these "long-ids".

2. Grab `incident-66c2b363-42a4-4e76-9e0b-00317ba1a29e` part of it. We internally call them "short-ids"

If you're testing with curl in the command line, you can pipe it to `jq` and `sed` like so:

```
curl 'https://intel.test.iroh.site/ctia/incident' \
-H 'Accept: application/json' \
-H 'Content-Type: application/json' \
-H 'Authorization: Bearer TOKEN' \
-X POST \
--data-raw '{
"incident_time" : {
    "opened" : "2016-02-11T00:40:48Z"
},
"status" : "Open",
"confidence" : "High",
"severity" : "High",
"title" : "Some Incident For Testing",
"revision" : 3
}
' | jq .id | sed 's|.*/||' | sed 's/"$//'
```

*jq is a cmd-line JSON processor that basically tells it to retrieve `id:` field value from the query result. 
sed - stands for "stream editor" and here it says to remove everything but the last segment of the long id url, and remove the trailing double quote as well*

3. Note the timestamp of the Incident you created

```
curl 'https://intel.test.iroh.site/ctia/incident/search/incident-66c2b363-42a4-4e76-9e0b-00317ba1a29e' \
-H 'Accept: application/json' \
-H 'Authorization: Bearer TOKEN' \
-H 'Content-Type: application/json' | jq .timestamp
```

*Remember, the last segment in the request should be the short id of the incident created* 

4. Modify created Incident

Patch the incident you just created, adjusting one of the fields, e.g., `status`. It was an Incident with the status `Open`, now change it to `Incident Reported`. Different possible values for Incident Status are [listed in CTIM](https://github.com/threatgrid/ctim/blob/master/src/ctim/schemas/vocabularies.cljc#L346)

```
    curl 'https://intel.test.iroh.site/ctia/incident/incident-66c2b363-42a4-4e76-9e0b-00317ba1a29e' \
    -H 'Accept: application/json' \
    -H 'Content-Type: application/json' \
    -H 'Authorization: Bearer TOKEN' \
    -X PATCH \
    --data-raw '{
    "status" : "Incident Reported"
    }'
```

5. Finally, compare the timestamp of the modified Incident with the timestamp at the time of the initial creation.

**The timestamps should match**

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

