### PR TITLE
ctim 1.3.9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -87,7 +87,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.8"]
+                 [threatgrid/ctim "1.3.9"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]


### PR DESCRIPTION

> Related #threatgrid/ctim/issues/423

Release CTIM 1.3.9 for cortex agent id

<a name="qa">[§](#qa)</a> QA
============================

Check that you can use cortex_agent_id as an observable type
