### PR TITLE
Bumps CTIM version to 1.3.10

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.9:compile
++- threatgrid:ctim:jar:1.3.10:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.9</version>
+      <version>1.3.10</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.9"]
+                 [threatgrid/ctim "1.3.10"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]
@@ -290,7 +290,7 @@
                  ;; 10m
                  :repl-timeout 600000}
   ;; lein-git-down config
-  ;; 
+  ;;
   ;; to simultaneously work on an upstream dependency and have
   ;; Travis pick up on it:
   ;; 1. add an entry mapping the upstream's maven coordinate to its dev GitHub repository


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Close #1384 

Bumps CTIM version to 1.3.10 to bring in the `darktrace_id` observable type.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

1. verify observable type `darktrace_id` is accepted.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: bumps CTIM version to allow `darktrace_id` observable type
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

