### PR TITLE
New bundle/import option: merge previous incident tactics/techniques

### DIFF
--- a/resources/ctia/public/doc/bulk-bundle.org
+++ b/resources/ctia/public/doc/bulk-bundle.org
@@ -679,6 +679,13 @@ then sorting the list lexicographically by name before using this list to patch 
 
 If `asset_properties-merge-strategy=ignore-existing`, then asset properties will be patched to their new values as they appear in the request bundle.
 
+If provided query parameter `incident-tactics-techniques-merge-strategy=merge-previous`, then when patching incidents,
+existing tactics/techniques properties will be retrieved and combined with the new fields in the request bundle
+as if by concatenating existing and new fields together in a single list,
+removing duplicates, then sorting lexicographically.
+
+If `incident-tactics-techniques-merge-strategy=ignore-existing`, then incident fields tactics/techniques will be patched to their new values as they appear in the request bundle.
+
 Example for an incident along with its context, note the transient ids
 #+begin_src HTTP
 POST /ctia/bundle/import HTTP/1.1

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -513,7 +513,7 @@
 (s/defschema ImportBundleOptions
   {(s/optional-key :patch-existing) s/Bool
    (s/optional-key :asset_properties-merge-strategy) AssetPropertiesMergeStrategy
-   (s/optional-key :incident-tactics-techniques-merge-strategy IncidentTacticsTechniquesMergeStrategy)})
+   (s/optional-key :incident-tactics-techniques-merge-strategy) IncidentTacticsTechniquesMergeStrategy})
 
 (s/defn import-bundle :- BundleImportResult
   ([bundle :- (st/optional-keys-schema NewBundle)

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -542,7 +542,8 @@
                                        tempids (bundle-import-data->tempids bundle-import-data tempids)
                                        bundle-import-data (-> bundle-import-data 
                                                               (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services)
-                                                              (cond-> (= :merge-previous incident-tactics-techniques-merge-strategy)
+                                                              (cond-> (and patch-existing
+                                                                           (= :merge-previous incident-tactics-techniques-merge-strategy))
                                                                 merge-existing-incident-tactics+techniques))
                                        tempids (bundle-import-data->tempids bundle-import-data tempids)
                                        {:keys [creates-bulk create-bundle-import-data

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -526,7 +526,9 @@
     auth-identity :- auth/AuthIdentity
     {{:keys [get-in-config]} :ConfigService
      :as services} :- APIHandlerServices
-    {:keys [patch-existing asset_properties-merge-strategy]
+    {:keys [patch-existing
+            asset_properties-merge-strategy
+            incident-tactics-techniques-merge-strategy]
      :or {patch-existing false
           asset_properties-merge-strategy :ignore-existing
           incident-tactics-techniques-merge-strategy :ignore-existing}} :- ImportBundleOptions]

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -493,15 +493,14 @@
                                    entity-import-data
                                    (let [merge-existing (fn [entity-import-data field]
                                                           (let [old (get-in entity-import-data [:old-entity field])
-                                                                new (get-in entity-import-data [:new-entity field])
-                                                                merged (-> (sorted-set)
-                                                                           (into old)
-                                                                           (into new)
-                                                                           vec)]
-                                                            (prn "merge-existing" field old new merged)
+                                                                new (get-in entity-import-data [:new-entity field])]
                                                             (cond-> entity-import-data
                                                               (and old new)
-                                                              (assoc-in [:new-entity field] merged))))]
+                                                              (assoc-in [:new-entity field]
+                                                                        (-> (sorted-set)
+                                                                            (into old)
+                                                                            (into new)
+                                                                            vec)))))]
                                      (-> entity-import-data
                                          (merge-existing :tactics)
                                          (merge-existing :techniques)))))

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -12,7 +12,8 @@
                                 NewBundleExport
                                 BundleExportIds
                                 BundleExportOptions
-                                BundleExportQuery]]
+                                BundleExportQuery
+                                IncidentTacticsTechniquesMergeStrategy]]
    [ctia.http.routes.common :as common]
    [ctia.schemas.core :refer [APIHandlerServices NewBundle]]
    [ring.swagger.json-schema :refer [describe]]

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -142,6 +142,18 @@
                                     "then sorting the list lexicographically by name before using this list to patch the existing entity."
                                     "\n\n"
                                     " Defaults to ignore-existing"))
+                     :ignore-existing}
+                    {incident-tactics-techniques-merge-strategy :-
+                     (describe IncidentTacticsTechniquesMergeStrategy
+                               (str "Only relevant if patch-existing=true.\n\n" 
+                                    "If ignore-existing, then tactics and techniques on incidents will be patched to their new "
+                                    "values as they appear in the request bundle.\n\n"
+                                    "If merge-previous, then, for each incident, existing tactics and techniques "
+                                    "will each be retrieved and combined with those provided in the request bundle "
+                                    "as if by concatenating existing and new values together in a single list, "
+                                    "removing duplicates, then sorting lexicographically."
+                                    "\n\n"
+                                    " Defaults to ignore-existing"))
                      :ignore-existing}]
                    :summary "POST many new and partial entities using a single HTTP call"
                    :auth-identity auth-identity
@@ -152,4 +164,5 @@
                        (bad-request (str "Bundle max nb of entities: " max-size))
                        (ok (import-bundle bundle external-key-prefixes auth-identity services
                                           {:patch-existing patch-existing
-                                           :asset_properties-merge-strategy asset_properties-merge-strategy})))))))))
+                                           :asset_properties-merge-strategy asset_properties-merge-strategy
+                                           :incident-tactics-techniques-merge-strategy incident-tactics-techniques-merge-strategy})))))))))

--- a/src/ctia/bundle/schemas.clj
+++ b/src/ctia/bundle/schemas.clj
@@ -61,3 +61,6 @@
 
 (s/defschema AssetPropertiesMergeStrategy
   (s/enum :ignore-existing :merge-overriding-previous))
+
+(s/defschema IncidentTacticsTechniquesMergeStrategy
+  (s/enum :ignore-existing :merge-previous))

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -113,7 +113,8 @@
                               :id->old-entity {id {:id id}}
                               :expected {:result "exists"
                                          :id id
-                                         :new-entity new-indicator}
+                                         :new-entity new-indicator
+                                         :old-entity {:id id}}
                               :existing-ids existing-ids})
                     (test-fn {:msg "non-existing long id"
                               :new-indicator {:new-entity new-indicator}
@@ -128,6 +129,8 @@
                         :expected (with-long-id {:result "exists"
                                                  :external_ids ["swe-alarm-indicator-1"]
                                                  :id indicator-id-1
+                                                 :old-entity (with-long-id {:id indicator-id-1}
+                                                               http-show-services)
                                                  :new-entity (with-long-id {:id indicator-id-1}
                                                                http-show-services)}
                                     http-show-services)
@@ -137,6 +140,8 @@
                         :expected (with-long-id {:result "exists"
                                                  :external_ids ["swe-alarm-indicator-1"]
                                                  :id indicator-id-2
+                                                 :old-entity (with-long-id {:id indicator-id-2}
+                                                               http-show-services)
                                                  :new-entity (with-long-id {:id indicator-id-2}
                                                                http-show-services)}
                                     http-show-services)

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1541,11 +1541,11 @@
                                                 (is (= expected-tactics (:tactics stored)))
                                                 (is (= expected-techniques (:techniques stored)))))))))]
             ;; the order in which we test these merge strategies is important since we're patching the same entities.
-            (test-merge-strategy "with asset_properties-merge-strategy=merge-overriding-previous"
+            (test-merge-strategy "with incident-tactics-techniques-merge-strategy=merge-previous"
                                  {"incident-tactics-techniques-merge-strategy" "merge-previous"}
                                  {:expected-tactics merged-tactics
                                   :expected-techniques merged-techniques})
-            (test-merge-strategy "no asset_properties merge strategy"
+            (test-merge-strategy "default incident-tactics-techniques-merge-strategy"
                                  {}
                                  {:expected-tactics new-tactics
                                   :expected-techniques new-techniques})))))))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1420,6 +1420,7 @@
                                                                                            (name (:type entity))
                                                                                            (encode realized-id))
                                                                                    :headers {"Authorization" "45c1f5e3f05d0"})]
+                                                                 (assert (= 200 (:status response)))
                                                                  (:parsed-body response)))]
                                               (testing ":asset_mappings"
                                                 (let [stored (get-stored updated-asset_mapping1)]
@@ -1485,3 +1486,66 @@
                           :result "updated"
                           :type :relationship}}
                        (set create+update-results)))))))))))
+
+(deftest bundle-patch-merge-tactics+techniques-test
+  (test-for-each-store-with-app
+    (fn [app]
+      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+      (whoami-helpers/set-whoami-response app
+                                          "45c1f5e3f05d0"
+                                          "foouser"
+                                          "foogroup"
+                                          "user")
+
+      (let [[incident1-original-id] (map #(str "transient:" % "_" (random-uuid))
+                                         '[incident1-original-id])
+            old-tactics (shuffle ["TA0001" "TA0002"])
+            new-tactics (shuffle ["TA0003" "TA0004"])
+            merged-tactics ["TA0001" "TA0002" "TA0003" "TA0004"]
+            old-techniques (shuffle ["T0001" "T0002"])
+            new-techniques (shuffle ["T0003" "T0004"])
+            merged-techniques ["T0001" "T0002" "T0003" "T0004"]
+            new-bundle (-> bundle-minimal
+                           (assoc :incidents #{(assoc incident-maximal :d incident1-original-id)}))
+            create-response (POST app
+                                  "ctia/bundle/import"
+                                  :body new-bundle
+                                  :headers {"Authorization" "45c1f5e3f05d0"})
+            {create-results :results :as create-bundle-results} (:parsed-body create-response)
+            incident1-id (find-id-by-original-id :incident1-id create-bundle-results incident1-original-id)]
+        (testing "tactics and techniques respect merge strategy"
+          (let [update-bundle (-> bundle-minimal
+                                  (assoc :incidents #{{:id incident1-id
+                                                       :tactics new-tactics
+                                                       :techniques new-techniques}}))
+                test-merge-strategy (fn [msg query-params {:keys [expected-tactics
+                                                                  expected-techniques]}]
+                                      (testing msg
+                                        (let [update-response (POST app
+                                                                    "ctia/bundle/import"
+                                                                    :body update-bundle
+                                                                    :query-params (assoc query-params "patch-existing" true)
+                                                                    :headers {"Authorization" "45c1f5e3f05d0"})
+                                              {update-results :results :as update-bundle-result} (:parsed-body update-response)]
+                                          (when (is (= 200 (:status update-response)))
+                                            (is (= 1 (count update-results)) update-results)
+                                            (is (every? (comp #{"updated"} :result) update-results)
+                                                (pr-str (mapv :result update-results)))
+                                            (let [get-stored (fn [realized-id]
+                                                               (let [response (GET app
+                                                                                   (format "ctia/incident/%s" (encode realized-id))
+                                                                                   :headers {"Authorization" "45c1f5e3f05d0"})]
+                                                                 (assert (= 200 (:status response)))
+                                                                 (:parsed-body response)))]
+                                              (let [stored (get-stored incident1-id)]
+                                                (is (= expected-tactics (:tactics stored)))
+                                                (is (= expected-techniques (:techniques stored)))))))))]
+            ;; the order in which we test these merge strategies is important since we're patching the same entities.
+            (test-merge-strategy "with asset_properties-merge-strategy=merge-overriding-previous"
+                                 {"incident-tactics-techniques-merge-strategy" "merge-previous"}
+                                 {:expected-tactics merged-tactics
+                                  :expected-techniques merged-techniques})
+            (test-merge-strategy "no asset_properties merge strategy"
+                                 {}
+                                 {:expected-tactics new-tactics
+                                  :expected-techniques new-techniques})))))))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1506,7 +1506,7 @@
             new-techniques (shuffle ["T0003" "T0004"])
             merged-techniques ["T0001" "T0002" "T0003" "T0004"]
             new-bundle (-> bundle-minimal
-                           (assoc :incidents #{(assoc incident-maximal :d incident1-original-id)}))
+                           (assoc :incidents #{(assoc incident-maximal :id incident1-original-id)}))
             create-response (POST app
                                   "ctia/bundle/import"
                                   :body new-bundle


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

**Epic** https://github.com/advthreat/iroh/issues/7409
Related https://github.com/advthreat/iroh/issues/8504
Depends on this PR https://github.com/advthreat/iroh/pull/8492

Exposes a new query parameter for bundle imports that merges previous values of incident tactics/techniques when patching a bundle.


<a name="qa">[§](#qa)</a> QA
============================

1. Create an incident with populated `tactics` and `techniques` fields. Note the id of this incident.
e.g.,
```
POST /ctia/incident
{...
 :tactics ["TA0001"]
 :techniques ["T0001"]
 ...}
```
2. Call `POST /ctia/bundle/import?patch-existing=true&incident-tactics-techniques-merge-strategy=merge-previous` with a bundle that updates tactics/techniques to new values.
```
POST /ctia/bundle/import?patch-existing=true&incident-tactics-techniques-merge-strategy=merge-previous
{:type "bundle
 :incident #{{:id "incident-id-from-step1
              :tactics ["TA0002"]
              :techniques ["T0002"]
 ...}
```
3. Verify that BOTH previous (step 1) and new (step 2) values are now patched in the incident.
e.g.,
```
GET /ctia/incident/incident-id-from-step1
{...
 :tactics ["TA0001" "TA0002"]
 :techniques ["T0001" "T0002"]
 ...}
```
4. Repeat step 2, except remove the `incident-tactics-techniques-merge-strategy=merge-previous` query parameter (but keep the other one). Choose different tactics/techniques to patch this time.
```
POST /ctia/bundle/import?patch-existing=true
{:type "bundle
 :incident #{{:id "incident-id-from-step1
              :tactics ["TA0003"]
              :techniques ["T0003"]
 ...}
```
6. Verify that only the latest (step 4) tactics/techniques are stored on the incident.
e.g.,
```
GET /ctia/incident/incident-id-from-step1
{...
 :tactics ["TA0003"]
 :techniques ["T0003"]
 ...}
```
7. Repeat step 2, except remove ALL query parameters. Choose different tactics/techniques to patch this time.
e.g.,
```
POST /ctia/bundle/import?patch-existing=true
{:type "bundle
 :incident #{{:id "incident-id-from-step1
              :tactics ["TA0004"]
              :techniques ["T0004"]
 ...}
```
8. Verify that the tactics/techniques are the same as step 6 (i.e., step 7 had no effect).
e.g.,
```
GET /ctia/incident/incident-id-from-step1
{...
 :tactics ["TA0003"]
 :techniques ["T0003"]
 ...}
```
<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Exposes a new query parameter for bundle imports that merges previous values of incident tactics/techniques when patching a bundle.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

