### PR TITLE
Incident status disposition

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.10:compile
++- threatgrid:ctim:jar:1.3.12:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.12</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.10"]
+                 [threatgrid/ctim "1.3.12"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -272,47 +272,6 @@
            :tactics
            :techniques]))
 
-(comment
-  (defn generate-mitre-tactic-scores
-    "script for stripping proprietary info from mitre tactic scores.
-    Use to generate new :remappings for :tactics sorting."
-    [csv-file]
-    (let [s (slurp csv-file)
-          ;; lifecycle order
-          relevant-tactics ["TA0043"
-                            "TA0042"
-                            "TA0001"
-                            "TA0002"
-                            "TA0003"
-                            "TA0004"
-                            "TA0005"
-                            "TA0006"
-                            "TA0007"
-                            "TA0008"
-                            "TA0009"
-                            "TA0011"
-                            "TA0010"
-                            "TA0040"]
-          tactic->pos (into {} (map-indexed (fn [i id] [id i]))
-                            relevant-tactics)
-          groups (-> s 
-                     ((requiring-resolve 'cheshire.core/parse-string))
-                     ((requiring-resolve 'clojure.walk/keywordize-keys))
-                     (->> (filter (comp (set relevant-tactics) :id))
-                          (group-by :risk_score)
-                          (sort-by key)
-                          (map second)))
-          out (into (sorted-map-by (fn [id1 id2]
-                                     (< (tactic->pos id1 0) (tactic->pos id2 0))))
-                    (map (fn [score group]
-                           (zipmap (map :id group) (repeat score)))
-                         (next (range)) groups))
-
-          _ (assert (= relevant-tactics (keys out))
-                    "missing score/s")]
-     ((requiring-resolve 'clojure.pprint/pprint) out)))
-  (generate-mitre-tactic-scores ""))
-
 (defn score-types
   [get-in-config]
   (some-> (get-in-config [:ctia :http :incident :score-types])

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -24,19 +24,19 @@
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 1")
-                 (dissoc :id :tactics :techniques :scores)))
+                 (dissoc :id :scores)))
         ap2 (gh/create-object
              app
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 2")
-                 (dissoc :id :tactics :techniques :scores)))
+                 (dissoc :id :scores)))
         ap3 (gh/create-object
              app
              "incident"
              (-> new-incident-maximal
                  (assoc :title "Incident 3")
-                 (dissoc :id :tactics :techniques :scores)))
+                 (dissoc :id :scores)))
         f1 (gh/create-object app "feedback" (gh/feedback-1 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))
         f2 (gh/create-object app "feedback" (gh/feedback-2 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))]
     (gh/create-object app

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -94,6 +94,7 @@ fragment incidentFields on Incident {
   short_description
   confidence
   status
+  status_disposition
   incident_time {
     ...incidentTimeFields
   }
@@ -105,4 +106,6 @@ fragment incidentFields on Incident {
   assignees
   promotion_method
   severity
+  tactics
+  techniques
 }


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Epic https://github.com/advthreat/iroh/issues/8181
> Close https://github.com/advthreat/iroh/issues/8581

This PR enables to set status_disposition for incidents.

<a name="qa">[§](#qa)</a> QA
============================

1) Check that you can create an incident with `status_disposition`. [Here](https://github.com/threatgrid/ctim/blob/e0e3cdcbcc8b94a6c3a53223ba4566fcb698f16f/src/ctim/schemas/vocabularies.cljc#L373) are allowed values.
2) Check that you can update this field using `/ctia/incident/:id/status`