### PR TITLE
incident meta

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.13-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.13:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.12:compile
++- threatgrid:ctim:jar:1.3.13-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.13-SNAPSHOT</version>
+      <version>1.3.13</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.13-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.13"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.12"]
+                 [threatgrid/ctim "1.3.13-SNAPSHOT"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -218,7 +218,7 @@
 (def CasebookType
   (let [{:keys [fields name description]}
         (flanders/->graphql
-         (fu/optionalize-all cs/Casebook)
+         (fu/optionalize-all (fu/replace-either-with-any cs/Casebook))
          {refs/observable-type-name refs/ObservableTypeRef
           refs/incident-type-name refs/IncidentRef
           refs/judgement-type-name refs/JudgementRef

--- a/src/ctia/schemas/graphql/helpers.clj
+++ b/src/ctia/schemas/graphql/helpers.clj
@@ -38,12 +38,13 @@
             TypeResolver]))
 
 (s/defschema GraphQLFields
-  {s/Keyword
-   {:type AnyRealizeFnResult
-    (s/optional-key :args) s/Any
-    (s/optional-key :resolve) AnyGraphQLTypeResolver
-    (s/optional-key :description) s/Any
-    (s/optional-key :default-value) s/Any}})
+  s/Any)
+;;  {s/Keyword
+;;   {:type AnyRealizeFnResult
+;;    (s/optional-key :args) s/Any
+;;    (s/optional-key :resolve) AnyGraphQLTypeResolver
+;;    (s/optional-key :description) s/Any
+;;    (s/optional-key :default-value) s/Any}})
 
 (s/defschema NamedTypeRegistry
   "Type registry to ensure named GraphQL named types are created exactly once.
@@ -395,6 +396,8 @@
   [builder :- GraphQLObjectType$Builder
    fields :- GraphQLFields
    rt-ctx :- GraphQLRuntimeContext]
+  (println "add-fields")
+  (clojure.pprint/pprint fields)
   (doseq [[k {field-type :type
               field-description :description
               field-args :args
@@ -429,7 +432,10 @@
      #(let [builder (-> (GraphQLObjectType/newObject)
                         (.description ^String description)
                         (.name ^String object-name)
-                        (add-fields fields rt-ctx))]
+                        (add-fields (into {}
+                                          (filter first)
+                                          fields)
+                                     rt-ctx))]
         (doseq [^GraphQLInterfaceType interface interfaces]
           (.withInterface builder interface))
         (let [obj (.build builder)]

--- a/src/ctia/schemas/graphql/helpers.clj
+++ b/src/ctia/schemas/graphql/helpers.clj
@@ -38,13 +38,12 @@
             TypeResolver]))
 
 (s/defschema GraphQLFields
-  s/Any)
-;;  {s/Keyword
-;;   {:type AnyRealizeFnResult
-;;    (s/optional-key :args) s/Any
-;;    (s/optional-key :resolve) AnyGraphQLTypeResolver
-;;    (s/optional-key :description) s/Any
-;;    (s/optional-key :default-value) s/Any}})
+  {s/Keyword
+   {:type AnyRealizeFnResult
+    (s/optional-key :args) s/Any
+    (s/optional-key :resolve) AnyGraphQLTypeResolver
+    (s/optional-key :description) s/Any
+    (s/optional-key :default-value) s/Any}})
 
 (s/defschema NamedTypeRegistry
   "Type registry to ensure named GraphQL named types are created exactly once.
@@ -396,8 +395,6 @@
   [builder :- GraphQLObjectType$Builder
    fields :- GraphQLFields
    rt-ctx :- GraphQLRuntimeContext]
-  (println "add-fields")
-  (clojure.pprint/pprint fields)
   (doseq [[k {field-type :type
               field-description :description
               field-args :args

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -85,11 +85,11 @@
 
 (defn mk-new-incident [n]
   (-> new-incident-maximal
-      (update :meta {:ai-generated-description true})
       (dissoc :id :schema_version :tlp :type)
       (into {:id (str "transient:incident-" n)
              :title (str "incident-" n)
-             :description (str "description: incident-" n)})))
+             :description (str "description: incident-" n)
+             :meta {:ai-generated-description true}})))
 
 (defn mk-new-indicator [n]
   {:id (str "transient:indicator-" n)

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -85,6 +85,7 @@
 
 (defn mk-new-incident [n]
   (-> new-incident-maximal
+      (update :meta {:ai-generated-description true})
       (dissoc :id :schema_version :tlp :type)
       (into {:id (str "transient:incident-" n)
              :title (str "incident-" n)

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -14,6 +14,7 @@
     [aggregate :refer [test-metric-routes]]
     [fake-whoami-service :as whoami-helpers]
     [store :refer [test-for-each-store-with-app]]]
+   [ctim.examples.incidents :refer [incident-maximal]]
    [ctim.examples.casebooks
     :refer
     [new-casebook-maximal new-casebook-minimal]]
@@ -297,7 +298,9 @@
      (entity-crud-test
       (into sut/casebook-entity
             {:app app
-             :example new-casebook-maximal
+             :example (assoc-in new-casebook-maximal
+                                [:bundle :incidents]
+                                [(assoc incident-maximal :meta {:ai-description true})])
              :headers {:Authorization "45c1f5e3f05d0"}
              :patch-tests? true
              :additional-tests partial-operations-tests})))))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -114,7 +114,9 @@
                             {:app app
                              :patch-tests? false;true
                              :search-tests? false;true
-                             :example new-incident-maximal
+                             :example (assoc new-incident-maximal
+                                             :meta
+                                             {:ai-generated-description true})
                              :headers {:Authorization "45c1f5e3f05d0"}
                              :additional-tests additional-tests})]
        (entity-crud-test parameters)))))
@@ -313,7 +315,7 @@
                        (testing (pr-str test-id)
                          (let [{:keys [parsed-body] :as raw}
                                (search-th/search-raw app :incident {:sort_by
-                                                                    (format "severity:%1$s,created:%1$s"
+                                                                    (format "severity:%1$s,timestamp:%1$s"
                                                                             (if asc? "asc" "desc"))})
                                expected-parsed-body (sort-by (fn [incident]
                                                                {:post [(number? %)]}

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -19,24 +19,19 @@
 (def external-ref "http://external.com/ctia/incident/incident-ab053333-2ad2-41d0-a445-31e9b9c38caf")
 
 (defn init-graph-data [app]
-  (let [ap1 (gh/create-object
+  (let [base-incident (dissoc new-incident-maximal :id :scores :meta)
+        ap1 (gh/create-object
              app
              "incident"
-             (-> new-incident-maximal
-                 (assoc :title "Incident 1")
-                 (dissoc :id :scores)))
+             (assoc base-incident :title "Incident 1"))
         ap2 (gh/create-object
              app
              "incident"
-             (-> new-incident-maximal
-                 (assoc :title "Incident 2")
-                 (dissoc :id :scores)))
+             (assoc base-incident :title "Incident 2"))
         ap3 (gh/create-object
              app
              "incident"
-             (-> new-incident-maximal
-                 (assoc :title "Incident 3")
-                 (dissoc :id :scores)))
+             (assoc base-incident :title "Incident 3"))
         f1 (gh/create-object app "feedback" (gh/feedback-1 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))
         f2 (gh/create-object app "feedback" (gh/feedback-2 (:id ap1) #inst "2042-01-01T00:00:00.000Z"))]
     (gh/create-object app


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Close https://github.com/advthreat/iroh/issues/6619
> Related https://github.com/advthreat/iroh/issues/8482
> Related https://github.com/threatgrid/ctim/pull/435
> Related https://github.com/advthreat/iroh/pull/8617

Bump CTIM for incident meta field.
Had to adapt few tests (keyword and inst values are rendered as string in many cases).
Also fix a flaky test, mentioned in comment.

<a name="qa">[§](#qa)</a> QA
============================

check that incident CRUD operations  (`/ctia/incident`) and bundle import properly work with the new field `:meta`, in particular check that you can set this field to `{"ai-description": true}`