### PR TITLE
Never match existing asset-* entities when patch-existing=false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ data/**/*.edn
 .clj-kondo/cache
 .clj-kondo/rewrite-clj/
 tmp
-response_*.json

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/**/*.edn
 .clj-kondo/cache
 .clj-kondo/rewrite-clj/
 tmp
+response_*.json

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -115,10 +115,8 @@
              (all-pages entity-type external-ids auth-identity get-store))
       [])))
 
-(s/defschema ExistingWithAssetRef {s/Str [(s/pred map?)]})
-
-(s/defn find-by-asset_refs :- ExistingWithAssetRef
-  "Returns a map from asset_ref to entities of entity-type that has
+(s/defn find-by-asset_refs :- {s/Str (s/pred map?)}
+  "Returns a map from asset_ref to entity of entity-type that has
   entry `:asset_ref asset_ref`."
   [asset_refs :- #{s/Str}
    entity-type :- (s/enum :asset-properties :asset-mapping)
@@ -141,9 +139,8 @@
                                                                query
                                                                (auth/ident->map auth-identity)
                                                                paging))
-                             entities (apply merge-with (fnil into [])
-                                             entities
-                                             (map (fn [e] {(:asset_ref e) [e]}) results))]
+                             entities (into entities (map (juxt :asset_ref identity))
+                                            results)]
                          (if next-page
                            (recur (apply disj asset_refs (map :asset_ref results))
                                   entities)
@@ -429,7 +426,7 @@
   [{:keys [id new-entity result] :as import-data} :- EntityImportData
    tempids :- TempIDs
    bulk-asset-kw :- (s/enum :asset_properties :asset_mappings)
-   asset_ref->old-entities :- ExistingWithAssetRef
+   asset_ref->old-entity :- {s/Str (s/pred map?)}
    merge-strategy :- AssetPropertiesMergeStrategy]
   (or (when (not= "error" result)
         (let [asset_ref (get tempids (:asset_ref new-entity) (:asset_ref new-entity))]
@@ -439,13 +436,12 @@
                 (assoc :error {:type :unresolvable-transient-id
                                :reason (str "Unresolvable asset_ref: " asset_ref)}
                        :result "error"))
-            (when-some [old-entity (or ;; already resolved by :external_ids or realized :id
-                                       (:old-entity import-data)
-                                       (some #(when (= id (:id %))
-                                                %)
-                                             (asset_ref->old-entities asset_ref)))]
+            (when-some [{:keys [id] :as old-entity} (or ;; already resolved by :external_ids or realized :id
+                                                        (:old-entity import-data)
+                                                        (asset_ref->old-entity asset_ref))]
               (-> import-data
                   (assoc :old-entity old-entity
+                         :id id
                          :result "exists"
                          :new-entity (-> new-entity
                                          (assoc :id id :asset_ref asset_ref)
@@ -473,15 +469,15 @@
                                                           (when-not (schemas/transient-id? asset_ref)
                                                             asset_ref)))))
                                           (bulk-asset-kw bundle-import-data))
-                         asset_ref->old-entities (find-by-asset_refs asset_refs
-                                                                     (bulk/entity-type-from-bulk-key bulk-asset-kw)
-                                                                     auth-identity
-                                                                     services)]
+                         asset_ref->old-entity (find-by-asset_refs asset_refs
+                                                                   (bulk/entity-type-from-bulk-key bulk-asset-kw)
+                                                                   auth-identity
+                                                                   services)]
                      (cond-> bundle-import-data
                        (seq (bulk-asset-kw bundle-import-data))
                        (update bulk-asset-kw
                                (fn [bulk-assets]
-                                 (mapv #(with-existing-asset-entity % tempids bulk-asset-kw asset_ref->old-entities merge-strategy)
+                                 (mapv #(with-existing-asset-entity % tempids bulk-asset-kw asset_ref->old-entity merge-strategy)
                                        bulk-assets))))))]
     (-> bundle-import-data
         (resolve* :asset_mappings)

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -543,8 +543,7 @@
                                  (let [bundle-import-data (prepare-import bundle-entities external-key-prefixes auth-identity services)
                                        tempids (bundle-import-data->tempids bundle-import-data tempids)
                                        bundle-import-data (-> bundle-import-data 
-                                                              (cond-> patch-existing
-                                                                (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services))
+                                                              (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services)
                                                               (cond-> (and patch-existing
                                                                            (= :merge-previous incident-tactics-techniques-merge-strategy))
                                                                 merge-existing-incident-tactics+techniques))

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -543,7 +543,8 @@
                                  (let [bundle-import-data (prepare-import bundle-entities external-key-prefixes auth-identity services)
                                        tempids (bundle-import-data->tempids bundle-import-data tempids)
                                        bundle-import-data (-> bundle-import-data 
-                                                              (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services)
+                                                              (cond-> patch-existing
+                                                                (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services))
                                                               (cond-> (and patch-existing
                                                                            (= :merge-previous incident-tactics-techniques-merge-strategy))
                                                                 merge-existing-incident-tactics+techniques))

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -547,7 +547,8 @@
                                  (let [bundle-import-data (prepare-import bundle-entities external-key-prefixes auth-identity services)
                                        tempids (bundle-import-data->tempids bundle-import-data tempids)
                                        bundle-import-data (-> bundle-import-data 
-                                                              (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services)
+                                                              (cond-> patch-existing
+                                                                (resolve-asset-properties+mappings tempids auth-identity asset_properties-merge-strategy services))
                                                               (cond-> (and patch-existing
                                                                            (= :merge-previous incident-tactics-techniques-merge-strategy))
                                                                 merge-existing-incident-tactics+techniques))

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1,10 +1,15 @@
 (ns ctia.bundle.routes-test
   (:require
+   [cheshire.core :refer [parse-string]]
    [clj-momo.test-helpers.http :refer [encode]]
+   [ctia.schemas.core :refer [NewBundle]]
+   [ring.swagger.coerce :as sc]
+   [ring.swagger.schema :refer [coerce!]]
    [clojure.edn :as edn]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :as t :refer [deftest is join-fixtures testing use-fixtures]]
+   [clojure.walk :as walk]
    [ctia.auth :as auth :refer [IIdentity]]
    [ctia.auth.capabilities :refer [all-capabilities]]
    [ctia.bulk.core :as bulk]
@@ -25,6 +30,7 @@
    [ductile.index :as es-index]
    [puppetlabs.trapperkeeper.app :as app]
    [schema.core :as s]
+   [schema.coerce :as c]
    [schema.test :refer [validate-schemas]]))
 
 (defn fixture-properties [t]
@@ -1304,6 +1310,75 @@
                       (mapcat (comp :results :parsed-body)))]
          (testing "there is a race condition for checking external ids"
            (is (< 1 (count (filter #(= "created" (:result %)) res))))))))))
+
+(defn make-relationships
+  [source-string incident-id entities]
+  (map (fn [entity] {:source_ref incident-id
+                     :target_ref (:id entity)
+                     :relationship_type "related-to"
+                     :source source-string})
+       entities))
+
+#_
+(deftest bundle-di-test
+  (test-for-each-store-with-app
+    (fn [app]
+      (helpers/set-capabilities! app "foouser" ["foogroup"] "user" (all-capabilities))
+      (whoami-helpers/set-whoami-response app
+                                          "45c1f5e3f05d0"
+                                          "foouser"
+                                          "foogroup"
+                                          "user")
+
+      (let [new-bundle (let [incident-id "https://private.intel.int.iroh.site:443/ctia/incident/incident-4fb91401-36a5-46d1-b0aa-01af02f00a7a"]
+                         (as-> (coerce! NewBundle
+                                        (-> bundle-minimal
+                                            (into (set/rename-keys (walk/keywordize-keys
+                                                                     (get-in (parse-string (slurp "response_asset_describe.json"))
+                                                                             ["data" 0 "data"]))
+                                                                   {:asset-mappings :asset_mappings
+                                                                    :asset-properties :asset_properties}))))
+                           new-bundle
+                           (assoc new-bundle :relationships (into #{} (mapcat (fn [bulk-kw]
+                                                                                (make-relationships
+                                                                                  "source"
+                                                                                  incident-id
+                                                                                  (bulk-kw new-bundle))))
+                                                                  [:asset_mappings :asset_properties]))))
+            create-response (POST app
+                                  "ctia/bundle/import"
+                                  :body new-bundle
+                                  :headers {"Authorization" "45c1f5e3f05d0"})
+            {create-results :results :as create-bundle-results} (:parsed-body create-response)]
+        (when (is (= 200 (:status create-response)))
+          #_
+          [{:id "http://localhost:63067/ctia/asset/asset-ce6e2277-2f93-41d8-8024-f429c9ffe553", :original_id "transient:63c8f5aa-2b02-4f03-bac3-c6735e2b24a8", :result "created", :type :asset}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-d5bc6080-724a-41f0-afd8-f3ed7e19205c", :original_id "transient:d0ca36fe-90f5-4cac-b343-c2df18b53a1a", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-6891b684-81ca-4e94-a499-fd33383b1a64", :original_id "transient:90f81959-5635-45da-bbef-4a03bafe74cd", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-a296c40c-f36f-4f6b-8fd0-d9fed1102f1c", :original_id "transient:82b5f9e3-3935-462d-b98d-0a5c05867a66", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-4c7641c0-a450-4d4c-8c51-ae420aba1d2c", :original_id "transient:9465e433-c063-4591-afce-0788218c1df6", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-3c12a5e8-a3a6-4a21-af93-f00abb4bf8c6", :original_id "transient:7f88e103-6a28-47bd-bb6c-e72de7559774", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-mapping/asset-mapping-65982946-980c-414f-8aa9-690b68a1bfe5", :original_id "transient:90c5ff9d-54f2-42eb-a0a6-53c15e06d136", :result "created", :type :asset-mapping}
+           {:id "http://localhost:63067/ctia/asset-properties/asset-properties-a52feb34-5d5a-4455-82d4-56bd08565251", :original_id "transient:4c52b95f-1217-48fe-bf07-739dd638df13", :result "created", :type :asset-properties}
+           {:id "http://localhost:63067/ctia/relationship/relationship-e2f47770-9e18-4695-ac89-9a05060b4c7e", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-d4778668-c8da-46a6-93ac-847c251fb588", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-d59563f8-3636-4aab-8e3d-b734d0af36c6", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-9335560c-6fcf-41de-9295-200aa4cd1c0d", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-1a43c118-f309-4b76-aed5-bb16d0b2d4fe", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-c58be038-c5bb-4c50-bafc-35e492097428", :result "created", :type :relationship}
+           {:id "http://localhost:63067/ctia/relationship/relationship-72c85e7e-e2d3-4102-93f0-0fc58a891632", :result "created", :type :relationship}]
+          (when (is (every? (comp #{"created"} :result) create-results))
+            (let [relationship-ids (keep #(when (= :relationship (:type %))
+                                            (:id %))
+                                         create-results)
+                  _ (is (= 7 (count relationship-ids)))
+                  {{:keys [relationships]} :parsed-body} (GET app
+                                                              "ctia/bundle/export"
+                                                              :query-params {:ids relationship-ids}
+                                                              :headers {"Authorization" "45c1f5e3f05d0"})
+                  actual-relationships (mapv (fn [e] (select-keys e [:source_ref :target_ref])) relationships)]
+              (is (apply distinct? (mapv :target_ref actual-relationships)))
+              )))))))
 
 (deftest bundle-asset-relationships-test
   (test-for-each-store-with-app

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1374,9 +1374,10 @@
             asset_property2 (assoc asset_property1 :id asset_property2-original-id)
             incident-id "https://private.intel.int.iroh.site:443/ctia/incident/incident-4fb91401-36a5-46d1-b0aa-01af02f00a7a"
             base-new-bundle (assoc bundle-minimal :assets #{asset1})
-            ;; try and induce a bug where asset_mappings / asset_properties erroneously "existing" then they should be "created".
+            ;; try and induce a bug where asset_mappings / asset_properties erroneously "exists" then they should be "created".
             ;; the conditions are if an asset_mappings / asset_properties already exists with the same asset_ref as the
-            ;; one we're about to import, then it the new entity will erroneously merge with the existing one.
+            ;; one we're about to import, then the new entity will erroneously merge with the existing one.
+            ;; we know the bug is fixed if we get the right number of result=created in the second bundle import result.
             new-bundle1 (-> base-new-bundle
                             (assoc :asset_mappings #{asset_mapping1}
                                    :asset_properties #{asset_property1}

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1,15 +1,10 @@
 (ns ctia.bundle.routes-test
   (:require
-   [cheshire.core :refer [parse-string]]
    [clj-momo.test-helpers.http :refer [encode]]
-   [ctia.schemas.core :refer [NewBundle]]
-   [ring.swagger.coerce :as sc]
-   [ring.swagger.schema :refer [coerce!]]
    [clojure.edn :as edn]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :as t :refer [deftest is join-fixtures testing use-fixtures]]
-   [clojure.walk :as walk]
    [ctia.auth :as auth :refer [IIdentity]]
    [ctia.auth.capabilities :refer [all-capabilities]]
    [ctia.bulk.core :as bulk]


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

This is the first of two fixes to this area of code.

There are two modes for `POST /bundle/import`: `patch-existing={true,false}`. If true, then existing entities are supposed to be detected and patched.

There is a bug where `asset_mappings` and `asset_properties` are erroneously mapped onto existing assets and essentially get merged when they should be created fresh.

This PR fixes this behavior for `patch-existing=false`, since no-one is using `patch-existing=true` yet and everyone is using `patch-existing=false`.

The merging code was made on the faulty assumption that there can only be one asset_mapping / asset_properties per asset.

There is a red test that is fixed by commit [Revert "Revert "green""](https://github.com/threatgrid/ctia/pull/1395/commits/79f4978455e8610795aaa675b2897f6b87b86872). The previous commit fails with the wrong number of results:

```
FAIL in ctia.bundle.routes-test/ (bundle-asset-relationships-test) (routes_test.clj:1504)
es-store relationships are created for asset mappings/properties
...
expected: (= 4 (count (filter (comp #{"created"} :result) create-results2)))
  actual: (not (= 4 2))

FAIL in ctia.bundle.routes-test/ (bundle-asset-relationships-test) (routes_test.clj:1506)
es-store relationships are created for asset mappings/properties
...
expected: (= 1 (count (filter (comp #{"exists"} :result) create-results2)))
  actual: (not (= 1 3))
```

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Never match existing asset-* entities when patch-existing=false
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

