### PR TITLE
Use `st/merge` to merge schemas instead of `into`

### DIFF
--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -73,20 +73,7 @@
    {(s/optional-key :sort_by) feed-sort-fields}))
 
 (s/defschema FeedDeleteSearchParams
-  (st/merge FeedCountParams
-            {(s/optional-key :wait_for)
-             (describe s/Bool "wait for matched entity to be deleted")
-             (s/optional-key :REALLY_DELETE_ALL_THESE_ENTITIES)
-             (describe s/Bool
-                       (str
-                        " If you do not set this value or set it to false"
-                        " this route will perform a dry run."
-                        " Set this value to true to perform the deletion."
-                        " You MUST confirm you will fix the mess after"
-                        " the inevitable disaster that will occur after"
-                        " you perform that operation."
-                        " DO NOT FORGET TO SET THAT TO FALSE AFTER EACH DELETION"
-                        " IF YOU INTEND TO USE THAT ROUTE MULTIPLE TIMES."))}))
+  (routes.crud/add-flags-to-delete-search-query-params FeedCountParams))
 
 (def FeedGetParams FeedFieldsParam)
 

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -392,20 +392,20 @@
              :description (capabilities->description delete-search-capabilities)
              :return s/Int
              :summary (format "Delete %s entities matching given Lucene/ES query string or/and field filters" capitalized)
-             :query [params (into search-filters
-                                  {(s/optional-key :wait_for)
-                                   (describe s/Bool "wait for matched entity to be deleted")
-                                   (s/optional-key :REALLY_DELETE_ALL_THESE_ENTITIES)
-                                   (describe s/Bool
-                                             (str
-                                              " If you do not set this value or set it to false"
-                                              " this route will perform a dry run."
-                                              " Set this value to true to perform the deletion."
-                                              " You MUST confirm you will fix the mess after"
-                                              " the inevitable disaster that will occur after"
-                                              " you perform that operation."
-                                              " DO NOT FORGET TO SET THAT TO FALSE AFTER EACH DELETION"
-                                              " IF YOU INTEND TO USE THAT ROUTE MULTIPLE TIMES."))})]
+             :query [params (st/merge search-filters
+                                      {(s/optional-key :wait_for)
+                                       (describe s/Bool "wait for matched entity to be deleted")
+                                       (s/optional-key :REALLY_DELETE_ALL_THESE_ENTITIES)
+                                       (describe s/Bool
+                                                 (str
+                                                   " If you do not set this value or set it to false"
+                                                   " this route will perform a dry run."
+                                                   " Set this value to true to perform the deletion."
+                                                   " You MUST confirm you will fix the mess after"
+                                                   " the inevitable disaster that will occur after"
+                                                   " you perform that operation."
+                                                   " DO NOT FORGET TO SET THAT TO FALSE AFTER EACH DELETION"
+                                                   " IF YOU INTEND TO USE THAT ROUTE MULTIPLE TIMES."))})]
              (let [query (search-query {:date-field date-field
                                         :params (dissoc params :wait_for :REALLY_DELETE_ALL_THESE_ENTITIES)})]
                (if (empty? query)

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -26,6 +26,23 @@
 (s/defn capitalize-entity [entity :- (s/pred simple-keyword?)]
   (-> entity name str/capitalize))
 
+(s/defn add-flags-to-delete-search-query-params :- (s/protocol s/Schema)
+  [search-filters :- (s/protocol s/Schema)]
+  (st/merge search-filters
+            {(s/optional-key :wait_for)
+             (describe s/Bool "wait for matched entity to be deleted")
+             (s/optional-key :REALLY_DELETE_ALL_THESE_ENTITIES)
+             (describe s/Bool
+                       (str
+                         " If you do not set this value or set it to false"
+                         " this route will perform a dry run."
+                         " Set this value to true to perform the deletion."
+                         " You MUST confirm you will fix the mess after"
+                         " the inevitable disaster that will occur after"
+                         " you perform that operation."
+                         " DO NOT FORGET TO SET THAT TO FALSE AFTER EACH DELETION"
+                         " IF YOU INTEND TO USE THAT ROUTE MULTIPLE TIMES."))}))
+
 (defn flow-get-by-ids-fn
   [{:keys [get-store entity identity-map]}]
   (let [s (get-store entity)]
@@ -392,20 +409,7 @@
              :description (capabilities->description delete-search-capabilities)
              :return s/Int
              :summary (format "Delete %s entities matching given Lucene/ES query string or/and field filters" capitalized)
-             :query [params (st/merge search-filters
-                                      {(s/optional-key :wait_for)
-                                       (describe s/Bool "wait for matched entity to be deleted")
-                                       (s/optional-key :REALLY_DELETE_ALL_THESE_ENTITIES)
-                                       (describe s/Bool
-                                                 (str
-                                                   " If you do not set this value or set it to false"
-                                                   " this route will perform a dry run."
-                                                   " Set this value to true to perform the deletion."
-                                                   " You MUST confirm you will fix the mess after"
-                                                   " the inevitable disaster that will occur after"
-                                                   " you perform that operation."
-                                                   " DO NOT FORGET TO SET THAT TO FALSE AFTER EACH DELETION"
-                                                   " IF YOU INTEND TO USE THAT ROUTE MULTIPLE TIMES."))})]
+             :query [params (add-flags-to-delete-search-query-params search-filters)]
              (let [query (search-query {:date-field date-field
                                         :params (dissoc params :wait_for :REALLY_DELETE_ALL_THESE_ENTITIES)})]
                (if (empty? query)


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

The crud routes namespace uses `into` to merge map schemas in the `DELETE /search` route.

Once fixed, the code becomes identical to the same logic in `ctia.entity.feed`, so an abstraction helps avoid code duplication.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Use st/merge to merge schemas instead of into
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

