### PR TITLE
fix wait_for for delete search

### DIFF
--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -416,7 +416,7 @@
                         (store/delete-search
                           query
                           identity-map
-                          (wait_for->refresh (:wait_for params))))
+                          {:wait_for_completion (boolean (:wait_for params))}))
                     (-> (get-store entity)
                         (store/query-string-count
                           query

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -653,13 +653,18 @@ It returns the documents with full hits meta data including the real index in wh
    ident
    es-params]
   (let [query (make-search-query es-conn-state search-query ident)
-        opts (select-keys es-params [:wait_for_completion])]
+        opts (select-keys es-params [:wait_for_completion])
+        nb-deleted (ductile.doc/count-docs conn index query)]
+    (log/info (format "deleting %s documents in %s (%s)"
+                      nb-deleted
+                      index
+                      (pr-str query)))
     (:deleted
      (ductile.doc/delete-by-query conn
                                   [index]
                                   query
                                   opts)
-     0)))
+     nb-deleted)))
 
 (s/defn handle-query-string-count :- (s/pred nat-int?)
   "ES count handler"

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -653,7 +653,7 @@ It returns the documents with full hits meta data including the real index in wh
    ident
    es-params]
   (let [query (make-search-query es-conn-state search-query ident)
-        opts (select-keys es-params [:wait_for_completion])
+        opts (select-keys es-params [:wait_for_completion :refresh])
         nb-deleted (ductile.doc/count-docs conn index query)]
     (log/info (format "deleting %s documents in %s (%s)"
                       nb-deleted

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -658,7 +658,8 @@ It returns the documents with full hits meta data including the real index in wh
      (ductile.doc/delete-by-query conn
                                   [index]
                                   query
-                                  opts))))
+                                  opts)
+     0)))
 
 (s/defn handle-query-string-count :- (s/pred nat-int?)
   "ES count handler"

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -652,12 +652,13 @@ It returns the documents with full hits meta data including the real index in wh
    search-query :- SearchQuery
    ident
    es-params]
-  (let [query (make-search-query es-conn-state search-query ident)]
+  (let [query (make-search-query es-conn-state search-query ident)
+        opts (select-keys es-params [:wait_for_completion])]
     (:deleted
      (ductile.doc/delete-by-query conn
                                   [index]
                                   query
-                                  (prepare-opts es-conn-state es-params)))))
+                                  opts))))
 
 (s/defn handle-query-string-count :- (s/pred nat-int?)
   "ES count handler"

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -114,6 +114,7 @@
                             {:app app
                              :patch-tests? true
                              :search-tests? true
+                             :delete-search-tests? true
                              :example (assoc new-incident-maximal
                                              :meta
                                              {:ai-generated-description true})

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -855,10 +855,18 @@
                                  "the number of deleted entities shall be equal to the number of matched")
                              (let [remaining (count-fn es-conn-state query ident)]
                                 (cond
-                                  (not deleted?) (is (= remaining (count matched))
-                                                     "only matched entities shall be deleted")
-                                  (true?  wait_for_completion) (is (= remaining 0))
-                                  (false?  wait_for_completion) (is (<= remaining (count matched)))))))]
+                                  (not deleted?)
+                                  (is (= remaining (count matched))
+                                      "only matched entities shall be deleted")
+
+                                  (true?  wait_for_completion)
+                                  (is (= remaining 0))
+
+                                  (false?  wait_for_completion)
+
+                                  (do (is (<= remaining (count matched)))
+                                      (Thread/sleep 1000)
+                                      (count-fn es-conn-state query ident))))))]
             (check-fn
              {:msg "queries that does not match anything shall not delete any data."
               :query {:filter-map {:title "DOES NOT MATCH ANYTHING"}}

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -93,7 +93,7 @@
                               :REALLY_DELETE_ALL_THESE_ENTITIES true
                               :wait_for true}
                :headers {"Authorization" "player-2-token"})
-
+        _ (Thread/sleep 1000)
         ;; re-count
         player-1-entity-count-2 (search-count "player-1-token")
         player-2-entity-count-2 (search-count "player-2-token")

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -36,7 +36,8 @@
     (DELETE app
             delete-search-uri
             :headers {"Authorization" "45c1f5e3f05d0"}
-            :query-params query-params)))
+            :query-params query-params)
+    (Thread/sleep 1000)))
 
 (defn search-raw
   [app entity query-params]

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -349,9 +349,9 @@
         count-fn #(:parsed-body (count-raw app entity %))
         delete-search-fn (fn [q confirm?]
                            (let [query (if (boolean? confirm?)
-                                         (assoc q
-                                                :REALLY_DELETE_ALL_THESE_ENTITIES confirm?
-                                                :wait_for true)
+                                         (into {:REALLY_DELETE_ALL_THESE_ENTITIES confirm?
+                                                :wait_for true}
+                                               q)
                                          q)]
                              (-> (delete-search app entity query)
                                  :body
@@ -384,7 +384,8 @@
              (count-fn filter-red))))
     (testing "delete with :REALLY_DELETE_ALL_THESE_ENTITIES set to true must really delete entities"
       (is (= (count green-docs)
-             (delete-search-fn filter-green true)))
+             (delete-search-fn (assoc filter-green :wait_for false)
+                               true)))
       (is (= (count amber-docs)
              (delete-search-fn filter-amber true)))
       (is (= (count red-docs)

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -341,7 +341,7 @@
 (defn test-delete-search
   [{:keys [app entity bundle-key example]}]
   (let [docs (->> (dissoc example :id)
-                  (repeat 100)
+                  (repeat 10)
                   (map #(assoc % :tlp (rand-nth ["green" "amber" "red"]))))
         {green-docs "green"
          amber-docs "amber"
@@ -349,7 +349,9 @@
         count-fn #(:parsed-body (count-raw app entity %))
         delete-search-fn (fn [q confirm?]
                            (let [query (if (boolean? confirm?)
-                                         (assoc q :REALLY_DELETE_ALL_THESE_ENTITIES confirm?)
+                                         (assoc q
+                                                :REALLY_DELETE_ALL_THESE_ENTITIES confirm?
+                                                :wait_for true)
                                          q)]
                              (-> (delete-search app entity query)
                                  :body

--- a/test/ctia/test_helpers/search.clj
+++ b/test/ctia/test_helpers/search.clj
@@ -32,12 +32,13 @@
 
 (defn delete-search
   [app entity query-params]
-  (let [delete-search-uri (format "ctia/%s/search" (name entity))]
-    (DELETE app
-            delete-search-uri
-            :headers {"Authorization" "45c1f5e3f05d0"}
-            :query-params query-params)
-    (Thread/sleep 1000)))
+  (let [delete-search-uri (format "ctia/%s/search" (name entity))
+        res (DELETE app
+                delete-search-uri
+              :headers {"Authorization" "45c1f5e3f05d0"}
+              :query-params query-params)]
+    (Thread/sleep 1000)
+    res))
 
 (defn search-raw
   [app entity query-params]


### PR DESCRIPTION
I found in ES doc that the [refresh parameters behaves otherwise](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html#_refreshing_shards) with `_delete_by_query` and that "Unlike the delete API, it does not support wait_for".
This PR modifies current behaviour to use `wait_for_completion` instead of refresh to wait for the completion of the task. If it's set to `true` it returns the count of documents that match the request.

<a name="qa">[§](#qa)</a> QA
============================

Check that when `wait_for` is set to true for `DELETE /ctia/incident/search` the http response wait for the completion of the task.
This can be more easily verified on queries that match a large number of documents in which case it should take more time to complete.
One option is to insert 10000 incidents with a unique word in the description (like a uuid) and check that with `wait_for` set to true the query takes few seconds to complete, but once finished all the documents are actually deleted while with `wait_for` set to false, the response will be faster but the documents will be deleted in the background.
In both cases the number of deleted documents is returned.