### PR TITLE
Fix 2XX response swagger/coercion, ban `:return`

### DIFF
--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -50,7 +50,7 @@
                                            (common/wait_for->refresh wait_for)
                                            services)))
        (PUT "/" []
-         :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+         :responses {200 {:schema (s/maybe (bulk.schemas/BulkActionsRefs services))}}
          :summary "UPDATE many entities at once"
          :query-params [{wait_for :- (describe s/Bool "wait for updated entities to be available for search") nil}]
          :body [bulk (bulk.schemas/BulkUpdate services) {:description "a new Bulk Update object"}]
@@ -86,7 +86,7 @@
                         :read-vulnerability
                         :read-weakness}]
      (GET "/" []
-          :return (s/maybe (bulk.schemas/Bulk services))
+          :responses {200 {:schema (s/maybe (bulk.schemas/Bulk services))}}
           :summary "GET many entities at once"
           :query-params [{actors              :- [Reference] []}
                          {asset_mappings      :- [Reference] []}
@@ -141,7 +141,7 @@
             (ok (core/fetch-bulk bulk auth-identity services)))))
     (let [capabilities (bulk.schemas/bulk-patch-capabilities services)]
       (PATCH "/" []
-        :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+        :responses {200 {:schema (s/maybe (bulk.schemas/BulkActionsRefs services))}}
         :summary "PATCH many entities at once"
         :query-params [{wait_for :- (describe s/Bool "wait for patched entities to be available for search") nil}]
         :body [bulk (bulk.schemas/BulkPatch services) {:description "a new Bulk Patch object"}]
@@ -178,7 +178,7 @@
                          :delete-vulnerability
                          :delete-weakness}]
      (DELETE "/" []
-          :return (s/maybe (bulk.schemas/BulkActionsRefs services))
+          :responses {200 {:schema (s/maybe (bulk.schemas/BulkActionsRefs services))}}
           :summary "DELETE many entities at once"
           :query-params [{wait_for :- (describe s/Bool "wait for deleted entities to not be available anymore for search") nil}]
           :body [bulk (bulk.schemas/BulkRefs services) {:description "a new Bulk Delete object"}]

--- a/src/ctia/bundle/routes.clj
+++ b/src/ctia/bundle/routes.clj
@@ -77,7 +77,7 @@
            :tags ["Bundle"]
            (let [capabilities export-capabilities]
              (GET "/export" []
-                  :return NewBundleExport
+                  :responses {200 {:schema NewBundleExport}}
                   :query [query BundleExportQuery]
                   :summary "Export records with their local relationships. Ids are URIs (with port if specified)."
                   :description (common/capabilities->description capabilities)
@@ -87,7 +87,7 @@
 
            (let [capabilities export-capabilities]
              (POST "/export" []
-                  :return NewBundleExport
+                  :responses {200 {:schema NewBundleExport}}
                   :query [query BundleExportOptions]
                   :body [body BundleExportIds]
                   :summary "Export records with their local relationships. Ids are URIs (with port if specified)."
@@ -119,7 +119,7 @@
                                 :create-weakness
                                 :import-bundle}]
              (POST "/import" []
-                   :return BundleImportResult
+                   :responses {200 {:schema BundleImportResult}}
                    :body [bundle
                           (st/optional-keys-schema bundle-schema)
                           {:description "a Bundle to import, partial entities allowed for existing entities"}]

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -90,7 +90,7 @@
   (routes
    (let [capabilities :read-attack-pattern]
      (GET "/mitre/:mitre-id" []
-          :return (s/maybe PartialAttackPattern)
+          :responses {200 {:schema (s/maybe PartialAttackPattern)}}
           :path-params [mitre-id :- s/Str]
           :summary "AttackPattern corresponding to the MITRE external_references external_id"
           :description (routes.common/capabilities->description capabilities)

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -157,9 +157,9 @@
                             first
                             un-store)))]
       (context "/:id" []
-        :return Casebook
         :description (routes.common/capabilities->description capabilities)
         :capabilities capabilities
+        :responses {200 {:schema Casebook}}
         (PATCH "/" []
           :auth-identity identity
           :identity-map identity-map

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -125,7 +125,7 @@
   (routes
     (let [capabilities :search-event]
       (GET "/history/:entity_id" []
-           :return [EventBucket]
+           :responses {200 {:schema [EventBucket]}}
            :path-params [entity_id :- s/Str]
            :summary "Timeline history of an entity"
            :description (routes.common/capabilities->description capabilities)

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -387,7 +387,7 @@
        (DELETE "/search" []
                :capabilities capabilities
                :description (routes.common/capabilities->description capabilities)
-               :responses {200 nil}
+               :responses {200 {:schema s/Int}}
                :summary (format "Delete Feed entities matching given Lucene/ES query string or/and field filters")
                :auth-identity identity
                :identity-map identity-map
@@ -432,7 +432,7 @@
 
      (let [capabilities :delete-feed]
        (DELETE "/:id" []
-               :responses {204 {:schema s/Any}}
+               :responses {204 nil}
                :no-doc false
                :path-params [id :- s/Str]
                :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -387,7 +387,7 @@
        (DELETE "/search" []
                :capabilities capabilities
                :description (routes.common/capabilities->description capabilities)
-               :responses {200 {:schema s/Int}}
+               :responses {200 nil}
                :summary (format "Delete Feed entities matching given Lucene/ES query string or/and field filters")
                :auth-identity identity
                :identity-map identity-map

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -201,9 +201,9 @@
    (GET "/:id/view.txt" []
      :summary "Get a Feed View as newline separated entries"
      :path-params [id :- s/Str]
-     :return s/Str
      :produces #{"text/plain"}
-     :responses {404 {:schema s/Str}
+     :responses {200 {:schema s/Str}
+                 404 {:schema s/Str}
                  401 {:schema s/Str}}
      :query [params FeedViewQueryParams]
      (let [search_after (:search_after params)
@@ -233,7 +233,7 @@
    (GET "/:id/view" []
      :summary "Get a Feed View"
      :path-params [id :- s/Str]
-     :return FeedView
+     :responses {200 {:schema FeedView}}
      :query [params FeedViewQueryParams]
      (let [search_after (:search_after params)
            limit (:limit params)
@@ -273,7 +273,7 @@
     (routes
      (let [capabilities :create-feed]
        (POST "/" []
-             :return Feed
+             :responses {201 {:schema Feed}}
              :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
              :body [new-entity NewFeed {:description "a new Feed"}]
              :summary "Adds a new Feed"
@@ -302,7 +302,7 @@
 
      (let [capabilities :create-feed]
        (PUT "/:id" []
-            :return Feed
+            :responses {200 {:schema Feed}}
             :body [entity-update NewFeed {:description "an updated Feed"}]
             :summary "Updates a Feed"
             :query-params [{wait_for :- (describe s/Bool "wait for updated entity to be available for search") nil}]
@@ -330,7 +330,7 @@
 
      (let [capabilities :read-feed]
        (GET "/external_id/:external_id" []
-            :return PartialFeedList
+            :responses {200 {:schema PartialFeedList}}
             :query [q FeedByExternalIdQueryParams]
             :path-params [external_id :- s/Str]
             :summary "List Feeds by external_id"
@@ -350,7 +350,7 @@
 
      (let [capabilities :search-feed]
        (GET "/search" []
-            :return PartialFeedList
+            :responses {200 {:schema PartialFeedList}}
             :summary "Search for a Feed using a Lucene/ES query string"
             :query [params FeedSearchParams]
             :description (routes.common/capabilities->description capabilities)
@@ -370,7 +370,7 @@
 
      (let [capabilities :search-feed]
        (GET "/search/count" []
-            :return s/Int
+            :responses {200 {:schema s/Int}}
             :summary "Count Feed entities matching given search filters."
             :query [params FeedCountParams]
             :description (routes.common/capabilities->description capabilities)
@@ -387,7 +387,7 @@
        (DELETE "/search" []
                :capabilities capabilities
                :description (routes.common/capabilities->description capabilities)
-               :return s/Int
+               :responses {200 {:schema s/Int}}
                :summary (format "Delete Feed entities matching given Lucene/ES query string or/and field filters")
                :auth-identity identity
                :identity-map identity-map
@@ -410,7 +410,7 @@
 
      (let [capabilities :read-feed]
        (GET "/:id" []
-            :return (s/maybe PartialFeed)
+            :responses {200 {:schema (s/maybe PartialFeed)}}
             :summary "Gets a Feed by ID"
             :path-params [id :- s/Str]
             :query [params FeedGetParams]
@@ -432,6 +432,7 @@
 
      (let [capabilities :delete-feed]
        (DELETE "/:id" []
+               :responses {204 {:schema s/Any}}
                :no-doc false
                :path-params [id :- s/Str]
                :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -56,7 +56,7 @@
                                    :as services} :- APIHandlerServices]
   (let [capabilites :read-feedback]
     (GET "/" []
-         :return fs/PartialFeedbackList
+         :responses {200 {:schema fs/PartialFeedbackList}}
          :query [params FeedbackQueryParams]
          :summary "Search Feedback"
          :description (routes.common/capabilities->description capabilites)

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -184,7 +184,7 @@
   (routes
     (let [capabilities :create-incident]
       (POST "/:id/status" []
-            :return Incident
+            :responses {200 {:schema Incident}}
             :body [update IncidentStatusUpdate
                    {:description "an Incident Status Update"}]
             :summary "Update an Incident Status"

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -93,7 +93,7 @@
           :path-params [id :- s/Str]
           :query-params [reason :- (describe s/Str "Message to append to the Judgement's reason value")
                          {wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
-          :return entity-schema
+          :responses {200 {:schema entity-schema}}
           :description (routes.common/capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity identity

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -95,7 +95,7 @@
                        :read-relationship
                        :create-relationship}]
     (POST "/:id/link" []
-          :return rs/Relationship
+          :responses {201 {:schema rs/Relationship}}
           :body [link-req IncidentLinkRequest
                  {:description "an Incident Link request"}]
           :summary "Link an Incident to a Casebook or Investigation"

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -176,7 +176,7 @@
   (context "/cpe_match_strings" []
     (let [capabilities :search-vulnerability]
       (GET "/" []
-        :return PartialVulnerabilityList
+        :responses {200 {:schema PartialVulnerabilityList}}
         :query [{cpe23-match-strings :cpe23_match_strings
                  limit :limit
                  :as params}

--- a/src/ctia/graphql/routes.clj
+++ b/src/ctia/graphql/routes.clj
@@ -72,7 +72,7 @@
                          :read-vulnerability}]
       (POST "/graphql" []
             :tags ["GraphQL"]
-            :return gql/RelayGraphQLResponse
+            :responses {200 {:schema gql/RelayGraphQLResponse}}
             :body [body gql/RelayGraphQLQuery {:description "a Relay compatible GraphQL body"}]
             :summary "EXPERIMENTAL: Executes a Relay compatible GraphQL query"
             :description (common/capabilities->description capabilities)

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -85,21 +85,3 @@
   (update acc :lets into
           [bind-to `(auth/ident->map
                      (:identity ~'+compojure-api-request+))]))
-
-(defn wrap-capabilities [capabilities]
-  (let [check-capabilities! (fn [{:keys [identity]}]
-                              (require-capability!
-                                capabilities
-                                identity))]
-    (fn [handler]
-      (fn
-        ([request]
-         (check-capabilities! request)
-         (handler request))
-        ([request respond raise]
-         (when (try (check-capabilities! request)
-                    true
-                    (catch Throwable e
-                      (raise e)
-                      false))
-           (handler request respond raise)))))))

--- a/src/ctia/http/middleware/auth.clj
+++ b/src/ctia/http/middleware/auth.clj
@@ -85,3 +85,21 @@
   (update acc :lets into
           [bind-to `(auth/ident->map
                      (:identity ~'+compojure-api-request+))]))
+
+(defn wrap-capabilities [capabilities]
+  (let [check-capabilities! (fn [{:keys [identity]}]
+                              (require-capability!
+                                capabilities
+                                identity))]
+    (fn [handler]
+      (fn
+        ([request]
+         (check-capabilities! request)
+         (handler request))
+        ([request respond raise]
+         (when (try (check-capabilities! request)
+                    true
+                    (catch Throwable e
+                      (raise e)
+                      false))
+           (handler request respond raise)))))))

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -136,7 +136,7 @@
           :summary (format "Expires the supplied %s" (capitalize-entity entity))
           :path-params [id :- s/Str]
           :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
-          :return entity-schema
+          :responses {200 {:schema entity-schema}}
           :description (capabilities->description capabilities)
           :capabilities capabilities
           :auth-identity identity
@@ -265,7 +265,7 @@
      (when can-post?
        (let [capabilities post-capabilities]
          (POST "/" []
-               :return entity-schema
+               :responses {201 {:schema entity-schema}}
                :query-params [{wait_for :- (describe s/Bool "wait for entity to be available for search") nil}]
                :body [new-entity new-schema {:description (format "a new %s" capitalized)}]
                :summary (format "Adds a new %s" capitalized)
@@ -293,7 +293,7 @@
      (when can-update?
        (let [capabilities put-capabilities]
          (PUT "/:id" []
-              :return entity-schema
+              :responses {200 {:schema entity-schema}}
               :body [entity-update new-schema {:description (format "an updated %s" capitalized)}]
               :summary (format "Update an existing %s" capitalized)
               :query-params [{wait_for :- (describe s/Bool "wait for updated entity to be available for search") nil}]
@@ -320,7 +320,7 @@
      (when can-patch?
        (let [capabilities patch-capabilities]
          (PATCH "/:id" []
-                :return entity-schema
+                :responses {200 {:schema entity-schema}}
                 :body [partial-update patch-schema {:description (format "%s partial update" capitalized)}]
                 :summary (format "Partially update an existing %s" capitalized)
                 :query-params [{wait_for :- (describe s/Bool "wait for patched entity to be available for search") nil}]
@@ -350,7 +350,7 @@
              _ (assert capabilities
                        (str ":external-id-capabilities is missing for " entity))]
          (GET "/external_id/:external_id" []
-              :return list-schema
+              :responses {200 {:schema list-schema}}
               :query [q external-id-q-params]
               :path-params [external_id :- s/Str]
               :summary (format "List %s by external id" capitalized)
@@ -376,7 +376,7 @@
            (GET "/" []
              :auth-identity identity
              :identity-map identity-map
-             :return search-schema
+             :responses {200 {:schema search-schema}}
              :summary (format "Search for %s entities using a ES query syntax and field filters" capitalized)
              :description (capabilities->description search-capabilities)
              :capabilities search-capabilities
@@ -396,7 +396,7 @@
            (GET "/count" []
              :auth-identity identity
              :identity-map identity-map
-             :return s/Int
+             :responses {200 {:schema s/Int}}
              :summary (format "Count %s matching a Lucene/ES query string and field filters" capitalized)
              :description (capabilities->description search-capabilities)
              :capabilities search-capabilities
@@ -411,7 +411,7 @@
              :identity-map identity-map
              :capabilities delete-search-capabilities
              :description (capabilities->description delete-search-capabilities)
-             :return s/Int
+             :responses {200 {:schema s/Int}}
              :summary (format "Delete %s entities matching given Lucene/ES query string or/and field filters" capitalized)
              :query [params (add-flags-to-delete-search-query-params search-filters)]
              (let [query (search-query {:date-field date-field
@@ -439,7 +439,7 @@
                       (GET "/average" []
                            :auth-identity identity
                            :identity-map identity-map
-                           :return MetricResult
+                           :responses {200 {:schema MetricResult}}
                            :summary (format (str "Average for some %s field. Use X-Total-Hits header on response for count used for average."
                                                  " For aggregate-on field X.Y.Z, response body will be {:data {:X {:Y {:Z <average>}}}}."
                                                  " If X-Total-Hits is 0, then average will be nil.")
@@ -464,7 +464,7 @@
                     (GET "/histogram" []
                          :auth-identity identity
                          :identity-map identity-map
-                         :return MetricResult
+                         :responses {200 {:schema MetricResult}}
                          :summary (format "Histogram for some %s field" capitalized)
                          :query [params histogram-q-params]
                          (let [aggregate-on (keyword (:aggregate-on params))
@@ -483,7 +483,7 @@
                     (GET "/topn" []
                          :auth-identity identity
                          :identity-map identity-map
-                         :return MetricResult
+                         :responses {200 {:schema MetricResult}}
                          :summary (format "Topn for some %s field" capitalized)
                          :query [params topn-q-params]
                          (let [aggregate-on (:aggregate-on params)
@@ -502,7 +502,7 @@
                     (GET "/cardinality" []
                          :auth-identity identity
                          :identity-map identity-map
-                         :return MetricResult
+                         :responses {200 {:schema MetricResult}}
                          :summary (format "Cardinality for some %s field" capitalized)
                          :query [params cardinality-q-params]
                          (let [aggregate-on (:aggregate-on params)
@@ -520,7 +520,7 @@
                                routes.common/paginated-ok)))))))
      (let [capabilities get-capabilities]
        (GET "/:id" []
-            :return (s/maybe get-schema)
+            :responses {200 {:schema (s/maybe get-schema)}}
             :summary (format "Get one %s by ID" capitalized)
             :path-params [id :- s/Str]
             :query [params get-params]
@@ -541,6 +541,7 @@
 
      (let [capabilities delete-capabilities]
        (DELETE "/:id" []
+               :responses {204 {:schema s/Any}}
                :no-doc hide-delete?
                :path-params [id :- s/Str]
                :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -541,7 +541,7 @@
 
      (let [capabilities delete-capabilities]
        (DELETE "/:id" []
-               :responses {204 {:schema s/Any}}
+               :responses {204 nil}
                :no-doc hide-delete?
                :path-params [id :- s/Str]
                :query-params [{wait_for :- (describe s/Bool "wait for deleted entity to no more be available for search") nil}]

--- a/src/ctia/lib/compojure/api/core.clj
+++ b/src/ctia/lib/compojure/api/core.clj
@@ -60,7 +60,7 @@
     (throw (ex-info (format (str ":return is banned, please use :responses instead.\n"
                                  "In this case, :return %s is equivalent to :responses {200 {:schema %s}}.\n"
                                  "For 204, you can use :responses {204 nil}.\n"
-                                 "For catch-all, use :responses {:default SCHEMA}")
+                                 "For catch-all, use :responses {:default {:schema SCHEMA}}")
                             schema schema)
                     {}))))
 

--- a/src/ctia/lib/compojure/api/core.clj
+++ b/src/ctia/lib/compojure/api/core.clj
@@ -50,10 +50,18 @@
   [middleware & body]
   `(core/middleware ~middleware ~@body))
 
-(def ^:private allowed-context-options #{:tags :capabilities :description :return :summary})
+(def ^:private allowed-context-options #{:tags :capabilities :description :responses :summary})
 (def ^:private unevalated-options #{:tags})
 
 (def ^:private ^:dynamic *gensym* gensym)
+
+(defn check-return-banned! [options]
+  (when-some [[_ schema]] (find options :return)
+    (throw (ex-info (format (str ":return is banned, please use :responses instead.\n"
+                                 "In this case, :return %s is equivalent to :responses {200 {:schema %s}}.\n"
+                                 "For 204, you can use :responses {204 nil}.\n"
+                                 "For catch-all, use :responses {:default SCHEMA}"))
+                    {}))))
 
 (defmacro context
   "Like compojure.api.core/context, except the binding vector must be empty and
@@ -64,6 +72,7 @@
   (assert (vector? arg))
   (assert (= [] arg) (str "Not allowed to bind anything in context, push into HTTP verbs instead: " (pr-str arg)))
   (let [[options body] (common/extract-parameters args true)
+        _ (check-return-banned! options)
         _ (when-some [extra-keys (not-empty (set/difference (set (keys options))
                                                             allowed-context-options))]
             (throw (ex-info (str "Not allowed these options in `context`, push into HTTP verbs instead: "
@@ -84,11 +93,16 @@
                                options)
                      ~groutes))))
 
-(defmacro GET     {:style/indent 2} [& args] `(core/GET ~@args))
-(defmacro ANY     {:style/indent 2} [& args] `(core/ANY ~@args))
-(defmacro HEAD    {:style/indent 2} [& args] `(core/HEAD ~@args))
-(defmacro PATCH   {:style/indent 2} [& args] `(core/PATCH ~@args))
-(defmacro DELETE  {:style/indent 2} [& args] `(core/DELETE ~@args))
-(defmacro OPTIONS {:style/indent 2} [& args] `(core/OPTIONS ~@args))
-(defmacro POST    {:style/indent 2} [& args] `(core/POST ~@args))
-(defmacro PUT     {:style/indent 2} [& args] `(core/PUT ~@args))
+(defn restructure-endpoint [macro path arg & args]
+  (let [_ (let [[options _body] (common/extract-parameters args true)]
+            (check-return-banned! options))]
+    (list* macro path arg args)))
+
+(defmacro GET     {:style/indent 2} [& args] (apply restructure-endpoint `core/GET args))
+(defmacro ANY     {:style/indent 2} [& args] (apply restructure-endpoint `core/ANY args))
+(defmacro HEAD    {:style/indent 2} [& args] (apply restructure-endpoint `core/HEAD args))
+(defmacro PATCH   {:style/indent 2} [& args] (apply restructure-endpoint `core/PATCH args))
+(defmacro DELETE  {:style/indent 2} [& args] (apply restructure-endpoint `core/DELETE args))
+(defmacro OPTIONS {:style/indent 2} [& args] (apply restructure-endpoint `core/OPTIONS args))
+(defmacro POST    {:style/indent 2} [& args] (apply restructure-endpoint `core/POST args))
+(defmacro PUT     {:style/indent 2} [& args] (apply restructure-endpoint `core/PUT args))

--- a/src/ctia/lib/compojure/api/core.clj
+++ b/src/ctia/lib/compojure/api/core.clj
@@ -56,11 +56,12 @@
 (def ^:private ^:dynamic *gensym* gensym)
 
 (defn check-return-banned! [options]
-  (when-some [[_ schema]] (find options :return)
+  (when-some [[_ schema] (find options :return)]
     (throw (ex-info (format (str ":return is banned, please use :responses instead.\n"
                                  "In this case, :return %s is equivalent to :responses {200 {:schema %s}}.\n"
                                  "For 204, you can use :responses {204 nil}.\n"
-                                 "For catch-all, use :responses {:default SCHEMA}"))
+                                 "For catch-all, use :responses {:default SCHEMA}")
+                            schema schema)
                     {}))))
 
 (defmacro context

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -34,7 +34,7 @@
         :path-params [observable_type :- ObservableTypeIdentifier
                       observable_value :- s/Str]
         :query [params common/DateRangeParams]
-        :return (s/maybe Verdict)
+        :responses {200 {:schema (s/maybe Verdict)}}
         :summary (str "Returns the current Verdict associated with the specified "
                       "observable.")
         :description (common/capabilities->description capabilities)
@@ -57,7 +57,7 @@
         :query [params JudgementsByObservableQueryParams]
         :path-params [observable_type :- ObservableTypeIdentifier
                       observable_value :- s/Str]
-        :return PartialJudgementList
+        :responses {200 {:schema PartialJudgementList}}
         :summary "Returns the Judgements associated with the specified observable."
         :description (common/capabilities->description capabilities)
         :capabilities capabilities
@@ -78,7 +78,7 @@
         :query [params RefsByObservableQueryParams]
         :path-params [observable_type :- ObservableTypeIdentifier
                       observable_value :- s/Str]
-        :return [Reference]
+        :responses {200 {:schema [Reference]}}
         :summary (str "Returns the Indicator references associated with the "
                       "specified observable based on Judgement relationships.")
         :description (common/capabilities->description capabilities)
@@ -105,7 +105,7 @@
         :capabilities capabilities
         :auth-identity identity
         :identity-map identity-map
-        :return PartialSightingList
+        :responses {200 {:schema PartialSightingList}}
         :summary "Returns Sightings associated with the specified observable."
         (-> (core/observable->sightings
              {:type observable_type
@@ -123,7 +123,7 @@
         :query [params RefsByObservableQueryParams]
         :path-params [observable_type :- ObservableTypeIdentifier
                       observable_value :- s/Str]
-        :return [Reference]
+        :responses {200 {:schema [Reference]}}
         :summary (str "Returns Indicator references associated with the "
                       "specified observable based on Sighting relationships.")
         :description (common/capabilities->description capabilities)
@@ -145,7 +145,7 @@
         :query [params RefsByObservableQueryParams]
         :path-params [observable_type :- ObservableTypeIdentifier
                       observable_value :- s/Str]
-        :return [Reference]
+        :responses {200 {:schema [Reference]}}
         :summary (str "Returns Incident references associated with the "
                       "specified observable based on Sighting relationships")
         :description (common/capabilities->description capabilities)

--- a/src/ctia/status/routes.clj
+++ b/src/ctia/status/routes.clj
@@ -8,6 +8,6 @@
   (context "/status" []
            :tags ["Status"]
            (GET "/" []
-                :return StatusInfo
+                :responses {200 {:schema StatusInfo}}
                 :summary "Health Check"
                 (ok {:status :ok}))))

--- a/src/ctia/version/routes.clj
+++ b/src/ctia/version/routes.clj
@@ -12,6 +12,6 @@
   (context "/version" []
            :tags ["Version"]
            (GET "/" []
-                :return VersionInfo
+                :responses {200 {:schema VersionInfo}}
                 :summary "API version details"
                 (ok (version-data get-in-config))))))

--- a/test/ctia/lib/compojure/api/core_test.clj
+++ b/test/ctia/lib/compojure/api/core_test.clj
@@ -122,7 +122,7 @@
        ~'routes)
     (str ":return is banned, please use :responses instead.\n"
          "In this case, :return schema.core/Str is equivalent to :responses {200 {:schema schema.core/Str}}.\n"
-         "For 204, you can use :responses {204 nil}.\nFor catch-all, use :responses {:default SCHEMA}")))
+         "For 204, you can use :responses {204 nil}.\nFor catch-all, use :responses {:default {:schema SCHEMA}}")))
 
 (deftest endpoints-banned-test
   (doseq [macro [`sut/GET
@@ -140,4 +140,4 @@
          {:status 200})
       (str ":return is banned, please use :responses instead.\n"
            "In this case, :return schema.core/Str is equivalent to :responses {200 {:schema schema.core/Str}}.\n"
-           "For 204, you can use :responses {204 nil}.\nFor catch-all, use :responses {:default SCHEMA}"))))
+           "For 204, you can use :responses {204 nil}.\nFor catch-all, use :responses {:default {:schema SCHEMA}}"))))

--- a/test/ctia/lib/compojure/api/core_test.clj
+++ b/test/ctia/lib/compojure/api/core_test.clj
@@ -52,17 +52,17 @@
               "/my-route" []
               :description (str "Foo" "bar")
               ~'routes))))
-  ;; :return is evaluated
+  ;; :responses is evaluated
   (is (= '(clojure.core/let [routes__0 (compojure.api.core/routes routes)
-                             return__1 {:my-schema #{}}]
+                             responses__1 {200 {:schema {:my-schema #{}}}}]
             (compojure.api.core/context
               "/my-route" []
-              :return return__1
+              :responses responses__1
               routes__0))
          (dexpand-1
            `(sut/context
               "/my-route" []
-              :return {:my-schema #{}}
+              :responses {200 {:schema {:my-schema #{}}}}
               ~'routes))))
   ;; :summary is evaluated
   (is (= '(clojure.core/let [routes__0 (compojure.api.core/routes routes)


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

compojure-api's `:return` only covers 200 responses.

I've banned it with a helpful error message that teaches you how to use `:responses`.

<!--

Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

Please check the swagger page advertises these responses:
- these return 201
  - POST /ctia/feed
  - POST /ctia/relationship/:id/link
  - POST /ctia/<EVERY_ENTITY>
    - [list of all entities](https://github.com/threatgrid/ctia/blob/4a97edeaa8cced0dba8791f38ef78c43cba7ace7/src/ctia/entity/entities.clj#L37)
    - note that the enabled entities are slightly different on global and public intel, please check both
- these return 204
  - DELETE /ctia/feed
  - DELETE /ctia/<EVERY_ENTITY>
    - [list of all entities](https://github.com/threatgrid/ctia/blob/4a97edeaa8cced0dba8791f38ef78c43cba7ace7/src/ctia/entity/entities.clj#L37)
    - note that the enabled entities are slightly different on global and public intel, please check both


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Fix 2XX response swagger/coercion, ban :return
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

