### PR TITLE
expose created and modified dates

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -5,7 +5,7 @@
    [clojure.tools.logging :as log]
    [ctia.auth :as auth]
    [ctia.bulk.schemas :refer [EntitiesResult]]
-   [ctia.domain.entities :as ent :refer [with-long-id short-id->long-id]]
+   [ctia.domain.entities :refer [with-long-id short-id->long-id]]
    [ctia.entity.entities :refer [all-entities]]
    [ctia.flows.crud :as flows]
    [ctia.schemas.core :as schemas :refer [APIHandlerServices TempIDs]]
@@ -381,8 +381,7 @@
   [bulk 
    auth-identity :- auth/AuthIdentity
    services :- APIHandlerServices]
-  (ent/un-store-map
-   (gen-bulk-from-fn read-entities bulk auth-identity services)))
+  (gen-bulk-from-fn read-entities bulk auth-identity services))
 
 (s/defn delete-bulk
   [bulk 

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -220,8 +220,7 @@
     (let [old-entities (mapcat find-by-external-id external_ids)
           old-entity (some-> (first old-entities)
                              :entity
-                             (with-long-id services)
-                             ent/un-store)]
+                             (with-long-id services))]
       (when (< 1 (count old-entities))
         (log/warn
          (format
@@ -600,8 +599,7 @@
                      {:limit max-relationships
                       :sort_by "timestamp"
                       :sort_order "desc"})
-                    :data
-                    ent/un-store-all)]
+                    :data)]
     (send-event {:service "Export bundle fetch relationships"
                  :correlation-id correlation-id
                  :time (get-epoch-second)
@@ -645,9 +643,7 @@
         (assoc (-> (:type record)
                    keyword
                    bulk/bulk-key)
-               #{(-> record
-                     ent/un-store
-                     (ent/with-long-id services))})
+               #{(ent/with-long-id record services)})
 
         (seq relationships)
         (assoc :relationships

--- a/src/ctia/domain/entities.clj
+++ b/src/ctia/domain/entities.clj
@@ -116,20 +116,3 @@
   (if (id/short-id? id-str)
     (short-id->entity-type id-str services)
     (long-id->entity-type id-str)))
-
-(defn un-store [record]
-  (dissoc record :created :modified))
-
-(defn un-store-all [x]
-  (if (sequential? x)
-    (map un-store x)
-    (un-store x)))
-
-(defn un-store-page [page]
-  (update page :data un-store-all))
-
-(defn un-store-map [m]
-  (into {}
-        (map (fn [[k v]]
-               [k (un-store-all v)])
-             m)))

--- a/src/ctia/entity/asset/graphql_schemas.clj
+++ b/src/ctia/entity/asset/graphql_schemas.clj
@@ -7,6 +7,7 @@
    [ctia.entity.relationship.graphql-schemas :as relationship]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.refs :as refs]
@@ -26,6 +27,7 @@
      name description []
      (merge
       fields
+      gc/time-metadata-fields
       go/graphql-ownership-fields))))
 
 (def AssetRefAssetMappingConnectionType
@@ -36,6 +38,7 @@
         (flanders/->graphql (fu/optionalize-all ctim-asset-properties/AssetProperties))]
     (g/new-object name description []
                   (merge fields
+                         gc/time-metadata-fields
                          go/graphql-ownership-fields))))
 
 (def AssetRefAssetPropertiesConnectionType
@@ -78,6 +81,7 @@
             feedback/feedback-connection-field
             asset-ref-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def asset-order-arg

--- a/src/ctia/entity/asset_mapping/graphql_schemas.clj
+++ b/src/ctia/entity/asset_mapping/graphql_schemas.clj
@@ -5,6 +5,7 @@
    [ctia.entity.relationship.graphql-schemas :as relationship]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as sorting]
@@ -23,6 +24,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def asset-mapping-order-arg

--- a/src/ctia/entity/asset_properties/graphql_schemas.clj
+++ b/src/ctia/entity/asset_properties/graphql_schemas.clj
@@ -5,6 +5,7 @@
    [ctia.entity.relationship.graphql-schemas :as relationship]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as sorting]
@@ -23,6 +24,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def asset-properties-order-arg

--- a/src/ctia/entity/attack_pattern.clj
+++ b/src/ctia/entity/attack_pattern.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.attack-pattern
   (:require
-   [ctia.domain.entities :refer [default-realize-fn un-store with-long-id]]
+   [ctia.domain.entities :refer [default-realize-fn with-long-id]]
    [ctia.entity.attack-pattern.core :as core]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
@@ -16,6 +16,7 @@
    [ctia.schemas.core :refer [APIHandlerServices]]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as graphql-sorting]
@@ -99,7 +100,6 @@
           :identity-map identity-map
           (or (some-> services
                       (core/mitre-attack-pattern identity-map mitre-id)
-                      un-store
                       (with-long-id services)
                       ok)
               (not-found {:error "attack-pattern not found"}))))))
@@ -142,6 +142,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship-graphql/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def attack-pattern-order-arg

--- a/src/ctia/entity/casebook.clj
+++ b/src/ctia/entity/casebook.clj
@@ -1,6 +1,6 @@
 (ns ctia.entity.casebook
   (:require
-   [ctia.domain.entities :refer [default-realize-fn un-store with-long-id]]
+   [ctia.domain.entities :refer [default-realize-fn with-long-id]]
    [ctia.flows.crud :as flows]
    [ctia.http.routes.common :as routes.common]
    [ctia.http.routes.crud :as routes.crud]
@@ -8,6 +8,7 @@
    [ctia.schemas.core :refer [APIHandlerServices Bundle def-acl-schema def-stored-schema]]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.refs :as refs]
@@ -153,9 +154,7 @@
                              :patch-operation patch-operation
                              :partial-entities  [(assoc partial-entity :id id)]
                              :spec :new-casebook/map)]
-                        (-> patch-res
-                            first
-                            un-store)))]
+                        (first patch-res)))]
       (context "/:id" []
         :description (routes.common/capabilities->description capabilities)
         :capabilities capabilities
@@ -245,6 +244,7 @@
      []
      (merge
       fields
+      gc/time-metadata-fields
       go/graphql-ownership-fields))))
 
 (def casebook-order-arg

--- a/src/ctia/entity/event.clj
+++ b/src/ctia/entity/event.clj
@@ -114,8 +114,7 @@
                  :entity.target_ref _id}
         event-store (get-store :event)]
     (sequence
-     (comp (mapcat :data)
-           (map ent/un-store))
+     (mapcat :data)
      (store/paginate event-store
                      #(store/list-records %1 {:one-of filters} identity-map %2)
                      q))))

--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as string]
    [ctia.domain.entities
-    :refer [page-with-long-id un-store un-store-page with-long-id]]
+    :refer [page-with-long-id with-long-id]]
    [ctia.entity.feed.schemas
     :refer [Feed FeedViewQueryParams NewFeed PartialFeed PartialFeedList
             PartialStoredFeed realize-feed StoredFeed]]
@@ -181,8 +181,7 @@
                                  (mapcat read-judgements)
                                  (remove nil?)
                                  (remove #(not (cdv/valid-now? now %)))
-                                 (map #(with-long-id % services))
-                                 (map un-store))
+                                 (map #(with-long-id % services)))
                            relationships)]
          (cond-> {}
            (= :observables output)
@@ -296,7 +295,6 @@
                   :entities [new-entity]
                   :spec :new-feed/map)
                  first
-                 un-store
                  (decrypt-feed services)
                  routes.common/created)))
 
@@ -323,7 +321,6 @@
                           :entities [(assoc entity-update :id id)]
                           :spec :new-feed/map)
                          first
-                         un-store
                          (decrypt-feed services))]
               (ok updated-rec)
               (not-found))))
@@ -344,7 +341,6 @@
                  identity-map
                  q)
                 (page-with-long-id services)
-                un-store-page
                 (decrypt-feed-page services)
                 routes.common/paginated-ok)))
 
@@ -364,7 +360,6 @@
                    :ident identity-map
                    :params (select-keys params routes.common/search-options)})
                 (page-with-long-id services)
-                un-store-page
                 (decrypt-feed-page services)
                 routes.common/paginated-ok)))
 
@@ -425,7 +420,6 @@
                               params))]
               (-> rec
                   (with-long-id services)
-                  un-store
                   (decrypt-feed services)
                   ok)
               (not-found))))

--- a/src/ctia/entity/feedback.clj
+++ b/src/ctia/entity/feedback.clj
@@ -1,5 +1,5 @@
 (ns ctia.entity.feedback
-  (:require [ctia.domain.entities :refer [page-with-long-id un-store-page]]
+  (:require [ctia.domain.entities :refer [page-with-long-id]]
             [ctia.entity.feedback.schemas :as fs]
             [ctia.http.routes.common :as routes.common]
             [ctia.http.routes.crud :refer [services->entity-crud-routes]]
@@ -69,7 +69,6 @@
                identity-map
                (dissoc params :entity_id))
              (page-with-long-id services)
-             un-store-page
              routes.common/paginated-ok))))
 
 (def capabilities

--- a/src/ctia/entity/feedback/graphql_schemas.clj
+++ b/src/ctia/entity/feedback/graphql_schemas.clj
@@ -2,6 +2,7 @@
   (:require
    [ctim.schemas.feedback :as ctim-feedback]
    [ctia.entity.feedback.schemas :as feedbacks]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql
     [flanders :as f]
     [helpers :as g]
@@ -16,6 +17,7 @@
         (f/->graphql (fu/optionalize-all ctim-feedback/Feedback))]
     (g/new-object name description []
                   (merge fields
+                         gc/time-metadata-fields
                          go/graphql-ownership-fields))))
 
 (def feedback-order-arg

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -3,7 +3,7 @@
    [clj-momo.lib.clj-time.core :as time]
    [clojure.string :as str]
    [ctia.domain.entities
-    :refer [default-realize-fn un-store with-long-id]]
+    :refer [default-realize-fn with-long-id]]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.relationship.graphql-schemas :as relationship-graphql]
    [ctia.flows.crud :as flows]
@@ -21,6 +21,7 @@
                               lift-realize-fn-with-context]]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as graphql-sorting]
@@ -217,8 +218,7 @@
                          :patch-operation :replace
                          :partial-entities [status-update]
                          :spec :new-incident/map)
-                        first
-                        un-store)]
+                        first)]
                 (ok updated)
                 (not-found)))))))
 
@@ -461,6 +461,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship-graphql/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def incident-order-arg

--- a/src/ctia/entity/indicator.clj
+++ b/src/ctia/entity/indicator.clj
@@ -10,6 +10,7 @@
                               CTIAEntity]]
    [ctia.schemas.graphql.flanders :as f]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.refs :as refs]
@@ -190,6 +191,7 @@
                   (merge fields
                          feedback/feedback-connection-field
                          relationship/relatable-entity-fields
+                         gc/time-metadata-fields
                          go/graphql-ownership-fields))))
 
 (def indicator-order-arg

--- a/src/ctia/entity/investigation/graphql_schemas.clj
+++ b/src/ctia/entity/investigation/graphql_schemas.clj
@@ -4,6 +4,7 @@
              [sorting :as graphql-sorting]
              [flanders :as flanders]
              [helpers :as g]
+             [common :as gc]
              [pagination :as pagination]]
             [ctia.schemas.graphql.refs :as refs]
             [ctia.entity.investigation.flanders-schemas :as f-inv]
@@ -20,7 +21,7 @@
      description
      []
      (merge
-      fields go/graphql-ownership-fields))))
+      fields gc/time-metadata-fields go/graphql-ownership-fields))))
 
 (def investigation-order-arg
   (graphql-sorting/order-by-arg

--- a/src/ctia/entity/judgement.clj
+++ b/src/ctia/entity/judgement.clj
@@ -2,7 +2,6 @@
   (:require
    [clj-momo.lib.clj-time.core :as time]
    [compojure.api.resource :refer [resource]]
-   [ctia.domain.entities :refer [un-store with-long-id]]
    [ctia.entity.feedback.graphql-schemas :as feedback]
    [ctia.entity.judgement.es-store :as j-store]
    [ctia.entity.judgement.schemas :as js]
@@ -14,6 +13,7 @@
    [ctia.schemas.core :refer [APIHandlerServices Entity]]
    [ctia.schemas.graphql.flanders :as f]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.refs :as refs]
@@ -165,6 +165,7 @@
       fields
       feedback/feedback-connection-field
       relationship/relatable-entity-fields
+      gc/time-metadata-fields
       go/graphql-ownership-fields))))
 
 (def judgement-order-arg

--- a/src/ctia/entity/malware.clj
+++ b/src/ctia/entity/malware.clj
@@ -8,6 +8,7 @@
    [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as graphql-sorting]
@@ -111,6 +112,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def malware-order-arg

--- a/src/ctia/entity/note.clj
+++ b/src/ctia/entity/note.clj
@@ -1,5 +1,5 @@
 (ns ctia.entity.note
-  (:require [ctia.domain.entities :refer [page-with-long-id un-store-page]]
+  (:require [ctia.domain.entities :refer [page-with-long-id]]
             [ctia.entity.note.schemas :as note-schemas]
             [ctia.http.routes.common :as routes.common]
             [ctia.http.routes.crud :refer [services->entity-crud-routes]]

--- a/src/ctia/entity/relationship.clj
+++ b/src/ctia/entity/relationship.clj
@@ -1,7 +1,7 @@
 (ns ctia.entity.relationship
   (:require
    [clojure.string :as str]
-   [ctia.domain.entities :refer [long-id->id short-id->long-id un-store with-long-id]]
+   [ctia.domain.entities :refer [long-id->id short-id->long-id with-long-id]]
    [ctia.entity.relationship.schemas :as rs]
    [ctia.flows.crud :as flows]
    [ctia.http.middleware.auth :refer [require-capability!]]
@@ -191,8 +191,7 @@
                          :identity identity
                          :entities [new-relationship]
                          :spec :new-relationship/map)
-                        first
-                        un-store)]
+                        first)]
                 (routes.common/created stored-relationship)))))))
 
 (def relationship-histogram-fields

--- a/src/ctia/entity/sighting/graphql_schemas.clj
+++ b/src/ctia/entity/sighting/graphql_schemas.clj
@@ -2,6 +2,7 @@
   (:require [ctia.entity.feedback.graphql-schemas :as feedback]
             [ctia.entity.relationship.graphql-schemas :as relationship]
             [ctia.entity.sighting.schemas :as ss]
+            [ctia.schemas.graphql.common :as gc]
             [ctia.schemas.graphql
              [flanders :as flanders]
              [helpers :as g]
@@ -24,6 +25,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def sighting-order-arg

--- a/src/ctia/entity/target_record/graphql_schemas.clj
+++ b/src/ctia/entity/target_record/graphql_schemas.clj
@@ -5,6 +5,7 @@
    [ctia.entity.target-record :as target-record]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.refs :as refs]
@@ -24,6 +25,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def target-record-order-arg

--- a/src/ctia/entity/tool/graphql_schemas.clj
+++ b/src/ctia/entity/tool/graphql_schemas.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.tool.graphql-schemas
   (:require [ctia.entity.feedback.graphql-schemas :as feedback]
             [ctia.entity.relationship.graphql-schemas :as relationship]
+            [ctia.schemas.graphql.common :as gc]
             [ctia.schemas.graphql
              [flanders :as flanders]
              [helpers :as g]
@@ -23,6 +24,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def tool-order-arg

--- a/src/ctia/entity/vulnerability.clj
+++ b/src/ctia/entity/vulnerability.clj
@@ -10,6 +10,7 @@
    [ctia.http.routes.crud :refer [services->entity-crud-routes]]
    [ctia.lib.compojure.api.core :refer [context GET routes]]
    [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
    [ctia.schemas.graphql.ownership :as go]
@@ -90,6 +91,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def vulnerability-order-arg
@@ -201,7 +203,6 @@
                               :params params
                               :store store})
               (ent/page-with-long-id services)
-              ent/un-store-page
               routes.common/paginated-ok))))))
 
 (def searchable-fields

--- a/src/ctia/entity/weakness.clj
+++ b/src/ctia/entity/weakness.clj
@@ -9,6 +9,7 @@
    [ctia.schemas.core :refer [APIHandlerServices def-acl-schema def-stored-schema]]
    [ctia.schemas.graphql.flanders :as flanders]
    [ctia.schemas.graphql.helpers :as g]
+   [ctia.schemas.graphql.common :as gc]
    [ctia.schemas.graphql.ownership :as go]
    [ctia.schemas.graphql.pagination :as pagination]
    [ctia.schemas.graphql.sorting :as graphql-sorting]
@@ -99,6 +100,7 @@
      (merge fields
             feedback/feedback-connection-field
             relationship/relatable-entity-fields
+            gc/time-metadata-fields
             go/graphql-ownership-fields))))
 
 (def weakness-order-arg

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -9,7 +9,6 @@
    [clojure.tools.logging :as log]
    [ctia.auth :as auth]
    [ctia.domain.access-control :refer [allowed-tlp? allowed-tlps]]
-   [ctia.domain.entities :refer [un-store]]
    [ctia.entity.event.obj-to-event :refer
     [to-create-event to-delete-event to-update-event]]
    [ctia.lib.collection :as coll]
@@ -384,7 +383,6 @@
     (-> (deep-merge-with patch-fn
                          prev-entity
                          (dissoc partial-entity :id))
-        un-store
         (dissoc :schema_version))))
 
 (s/defn patch-entities :- FlowMap

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -121,7 +121,6 @@
            :partial-entities [patch]
            :spec new-spec)
           first
-          ent/un-store
           ok)
       (not-found (str (capitalize-entity entity) " not found")))))
 
@@ -288,7 +287,6 @@
                     :entities [new-entity]
                     :spec new-spec)
                    first
-                   ent/un-store
                    routes.common/created))))
      (when can-update?
        (let [capabilities put-capabilities]
@@ -313,8 +311,7 @@
                             :identity identity
                             :entities [(assoc entity-update :id id)]
                             :spec new-spec)
-                           first
-                           ent/un-store)]
+                           first)]
                 (ok updated-rec)
                 (not-found)))))
      (when can-patch?
@@ -341,8 +338,7 @@
                               :patch-operation :replace
                               :partial-entities [(assoc partial-update :id id)]
                               :spec new-spec)
-                             first
-                             ent/un-store)]
+                             first)]
                   (ok updated-rec)
                   (not-found)))))
      (when can-get-by-external-id?
@@ -365,7 +361,6 @@
                     identity-map
                     q)
                   (ent/page-with-long-id services)
-                  ent/un-store-page
                   routes.common/paginated-ok))))
 
      (when can-search?
@@ -391,7 +386,6 @@
                         :params (select-keys params routes.common/search-options)}
                        add-search-extensions))
                  (ent/page-with-long-id services)
-                 ent/un-store-page
                  routes.common/paginated-ok))
            (GET "/count" []
              :auth-identity identity
@@ -535,7 +529,6 @@
                                params))]
               (-> rec
                   (with-long-id services)
-                  ent/un-store
                   ok)
               (not-found))))
 

--- a/src/ctia/observable/routes.clj
+++ b/src/ctia/observable/routes.clj
@@ -1,7 +1,7 @@
 (ns ctia.observable.routes
   (:require [ctia.domain.entities
              :refer
-             [page-with-long-id short-id->long-id un-store-page]]
+             [page-with-long-id short-id->long-id]]
             [ctia.entity.judgement :refer [JudgementsByObservableQueryParams]]
             [ctia.entity.judgement.schemas :refer [PartialJudgementList]]
             [ctia.entity.sighting :refer [SightingsByObservableQueryParams]]
@@ -69,7 +69,6 @@
                                          params
                                          services)
             (page-with-long-id services)
-            un-store-page
             paginated-ok)))
 
     (let [capabilities #{:list-judgements :list-relationships}]
@@ -114,7 +113,6 @@
              params
              services)
             (page-with-long-id services)
-            un-store-page
             paginated-ok)))
 
     (let [capabilities #{:list-sightings :list-relationships}]

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -221,7 +221,9 @@
      :authorized_groups [Str]
      :client_id s/Str
      :owner s/Str
-     :groups [s/Str]})))
+     :groups [s/Str]
+     :created java.util.Date
+     :modified java.util.Date})))
 
 (s/defschema CTIAStoredEntity
   (st/merge CTIAEntity

--- a/src/ctia/schemas/graphql/common.clj
+++ b/src/ctia/schemas/graphql/common.clj
@@ -1,4 +1,5 @@
 (ns ctia.schemas.graphql.common
+  (:require [ctia.schemas.graphql.scalars :refer [GraphQLDate]])
   (:import graphql.Scalars))
 
 (def lucene-query-arguments
@@ -6,3 +7,10 @@
            :description (str "A Lucene query string, will only "
                              "return nodes matching it.")
            :default "*"}})
+
+(def time-metadata-fields
+  "default internal time metadata fields"
+  {:created  {:type GraphQLDate
+              :description "CTIA Record creation date"}
+   :modified  {:type GraphQLDate
+               :description "CTIA Record last modification date"}})

--- a/src/ctia/schemas/graphql/resolvers.clj
+++ b/src/ctia/schemas/graphql/resolvers.clj
@@ -2,7 +2,7 @@
   (:require [clojure.tools.logging :as log]
             [ctia.domain.entities
              :refer
-             [page-with-long-id un-store un-store-page with-long-id]]
+             [page-with-long-id with-long-id]]
             [ctia.graphql.delayed :as delayed]
             [ctia.schemas.core :as ctia-schemas
              :refer [GraphQLRuntimeContext
@@ -44,7 +44,6 @@
                :ident ident
                :params params})
             with-long-id-fn
-            un-store-page
             (pagination/result->connection-response paging-params))))
 
 (s/defn search-entity-resolver :- AnyGraphQLTypeResolver
@@ -77,8 +76,7 @@
                 field-selection)
     (some-> (get-store entity-type-kw)
             (store/read-record id ident {:fields (concat default-fields field-selection)})
-            (with-long-id services)
-            un-store)))
+            (with-long-id services))))
 
 (s/defn entity-by-id-resolver :- AnyGraphQLTypeResolver
   [entity-type-kw]
@@ -107,7 +105,6 @@
               {:all-of {:entity_id entity-id}}
               (:ident context)
               params)
-            un-store-page
             (pagination/result->connection-response paging-params)))))
 
 ;;---- Judgement
@@ -131,7 +128,6 @@
               (:ident context)
               params)
             (page-with-long-id services)
-            un-store
             (pagination/result->connection-response paging-params)))))
 
 ;;---- Sighting
@@ -155,7 +151,6 @@
               (:ident context)
               params)
             (page-with-long-id services)
-            un-store
             (pagination/result->connection-response paging-params)))))
 
 ;;---- Relationship
@@ -198,7 +193,6 @@
                {:all-of {:asset_ref entity-id}}
                (:ident context)
                params)
-              un-store-page
               (pagination/result->connection-response paging-params)))))
 
 ;;--- AssetProperties
@@ -221,5 +215,4 @@
                {:all-of {:asset_ref entity-id}}
                (:ident context)
                params)
-              un-store-page
               (pagination/result->connection-response paging-params)))))

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -350,10 +350,10 @@
                          :id :timestamp :source_ref :target_ref)
 
                  (is (= (into #{}
-                              (map #(dissoc % :id :timestamp :source_ref :target_ref)
+                              (map #(dissoc % :id :timestamp :created :modified :source_ref :target_ref)
                                    (get new-bulk k)))
                         (into #{}
-                              (map #(dissoc % :id :timestamp :type :tlp :schema_version :disposition_name :source_ref :target_ref :owner :groups)
+                              (map #(dissoc % :id :timestamp :created :modified :type :tlp :schema_version :disposition_name :source_ref :target_ref :owner :groups)
                                    (get response k)))))
 
                  (let [id (id/long-id->id (:id (first (get response k))))]

--- a/test/ctia/bundle/routes_test.clj
+++ b/test/ctia/bundle/routes_test.clj
@@ -1492,9 +1492,9 @@
                                               (testing ":asset_mappings"
                                                 (let [stored (get-stored updated-asset_mapping1)]
                                                   ;; no interesting merging logic on asset mappings
-                                                  (is (= (dissoc stored :id :schema_version :asset_ref :owner :groups :timestamp)
+                                                  (is (= (dissoc stored :id :schema_version :asset_ref :owner :groups :timestamp :created :modified)
                                                          (-> updated-asset_mapping1
-                                                             (dissoc :id :schema_version :asset_ref :timestamp)
+                                                             (dissoc :id :schema_version :asset_ref :timestamp :created :modified)
                                                              (assoc :tlp "green")
                                                              (assoc-in [:valid_time :end_time] #inst "2525-01-01T00:00:00.000-00:00"))))))
                                               (testing ":asset_properties"

--- a/test/ctia/entity/casebook_test.clj
+++ b/test/ctia/entity/casebook_test.clj
@@ -36,7 +36,8 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (= expected-entity updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/observables :add on non existing casebook"
     (let [new-observables [{:type "ip" :value "42.42.42.42"}]
@@ -58,8 +59,8 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (= expected-entity
-                 updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/observables :remove on non existing casebook"
     (let [deleted-observables [{:value "85:28:cb:6a:21:41" :type "mac_address"}
@@ -81,8 +82,8 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (= expected-entity
-                 updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/observables :replace"
     (let [observables (:observables new-casebook-maximal)
@@ -94,8 +95,8 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (= expected-entity
-                 updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/observables :replace on non existing casebook"
     (let [observables (:observables new-casebook-maximal)
@@ -118,7 +119,8 @@
 
 
       (is (= 200 (:status response)))
-      (is (= expected-entity updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/texts :add on non existing casebook"
     (let [new-texts [{:type "some" :text "text"}]
@@ -139,7 +141,8 @@
                          :headers {"Authorization" "45c1f5e3f05d0"})
           updated-casebook (:parsed-body response)]
       (is (= 200 (:status response)))
-      (is (= expected-entity updated-casebook))))
+      (is (= (dissoc expected-entity :modified)
+             (dissoc updated-casebook :modified)))))
 
   (testing "POST /ctia/casebook/:id/texts :remove on non existing casebook"
     (let [deleted-texts [{:type "some" :text "text"}]
@@ -219,8 +222,10 @@
                            :headers {"Authorization" "45c1f5e3f05d0"})
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (= (update casebook :bundle dissoc :malwares)
-                   (update updated-casebook :bundle dissoc :malwares)))
+        (is (= (-> (update casebook :bundle dissoc :malwares)
+                   (dissoc :modified))
+               (-> (update updated-casebook :bundle dissoc :malwares)
+                   (dissoc :modified))))
         (is (not (subset? (set (:malwares bundle-entities))
                           (set (-> updated-casebook :bundle :malwares)))))))
 
@@ -240,8 +245,10 @@
                            :headers {"Authorization" "45c1f5e3f05d0"})
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (= (update casebook :bundle dissoc :malwares)
-                   (update updated-casebook :bundle dissoc :malwares)))
+        (is (= (-> (update casebook :bundle dissoc :malwares)
+                   (dissoc :modified))
+               (-> (update updated-casebook :bundle dissoc :malwares)
+                   (dissoc :modified))))
         (is (= (:malwares bundle-entities)
                (-> updated-casebook :bundle :malwares set)))))
 
@@ -264,7 +271,8 @@
                             :headers {"Authorization" "45c1f5e3f05d0"}))
             updated-casebook (:parsed-body response)]
         (is (= 200 (:status response)))
-        (is (= expected-entity updated-casebook))
+        (is (= (dissoc expected-entity :modified)
+               (dissoc updated-casebook :modified)))
 
         (testing "Adding an observable should work and update the schema_version"
           (testing "POST /ctia/casebook/:id/observables :add"
@@ -279,7 +287,9 @@
                                  :headers {"Authorization" "45c1f5e3f05d0"})
                   final-casebook (:parsed-body response)]
               (is (= 200 (:status response)))
-              (is (= expected-entity final-casebook)))))))))
+
+              (is (= (dissoc expected-entity :modified)
+                     (dissoc final-casebook :modified))))))))))
 
 (deftest test-casebook-routes
   (test-for-each-store-with-app

--- a/test/ctia/entity/feed_test.clj
+++ b/test/ctia/entity/feed_test.clj
@@ -177,9 +177,8 @@
                   :headers {"Authorization" "45c1f5e3f05d0"})
               updated-feed (:parsed-body updated-feed-response)]
           (is (= 200 (:status updated-feed-response)))
-          (is (= (dissoc feed-update :feed_view_url)
-                 (dissoc updated-feed
-                         :feed_view_url)))
+          (is (= (dissoc feed-update :feed_view_url :created :modified)
+                 (dissoc updated-feed :feed_view_url :created :modified)))
 
           (let [feed-view-url (:feed_view_url updated-feed)
                 valid-response  (client/get feed-view-url

--- a/test/ctia/entity/feedback_test.clj
+++ b/test/ctia/entity/feedback_test.clj
@@ -32,7 +32,7 @@
           feedbacks (:parsed-body response)]
       (is (= 200 (:status response)))
       (is (= [(assoc new-feedback :id (id/long-id feedback-id))]
-             (map #(dissoc % :owner :groups) feedbacks))))))
+             (map #(dissoc % :owner :groups :created :modified) feedbacks))))))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))

--- a/test/ctia/entity/judgement_test.clj
+++ b/test/ctia/entity/judgement_test.clj
@@ -248,10 +248,7 @@
                :schema_version schema-version
                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                             :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-              (dissoc judgement
-                      :id
-                      :groups ["foogroup"]
-                      :owner "foouser")))))
+              (dissoc judgement :id :groups :owner :created :modified)))))
 
      (testing "POST a judgement with disposition_name"
        (let [{status :status
@@ -285,8 +282,7 @@
                  :groups ["foogroup"]
                  :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                               :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                (dissoc judgement
-                        :id)))))
+                (dissoc judgement :id :created :modified)))))
 
      (testing "POST a judgement without disposition"
        (let [{status :status
@@ -320,8 +316,7 @@
                :schema_version schema-version
                :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                             :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-              (dissoc judgement
-                      :id)))))
+              (dissoc judgement :id :created :modified)))))
 
      (testing "POST a judgement with mismatched disposition/disposition_name"
        (let [{status :status

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -145,7 +145,7 @@
                           :reason "This is a bad IP address that talked to some evil servers"
                           :valid_time {:start_time #inst "2016-02-11T00:40:48.212-00:00"
                                        :end_time #inst "2525-01-01T00:00:00.000-00:00"}}
-                         (dissoc judgement :owner :groups)))
+                         (dissoc judgement :owner :groups :created :modified)))
                   (is (= expected-headers
                          (select-keys (:headers response)
                                       ["Access-Control-Expose-Headers"
@@ -196,7 +196,7 @@
                       (str "ctia/judgement/" (:short-id judgement-id))
                       :headers {"Authorization" bearer})]
              (is (= 200 status))
-             (is (= expected-get-res parsed-body)))
+             (is (= (dissoc expected-get-res :created :modified) (dissoc parsed-body :created :modified))))
 
            (testing "Search must properly filter on client-id."
              (let [search-by-client #(GET app
@@ -205,7 +205,7 @@
                    matched (search-by-client jwt-client-id)
                    not-matched (search-by-client "does not exist")]
                (is (= 200 (:status matched) (:status not-matched)))
-               (is (= [expected-get-res] (:parsed-body matched)))
+               (is (= [expected-get-res] (map #(dissoc % :created :modified) (:parsed-body matched))))
                (is (= [] (:parsed-body not-matched)))))
 
            (testing "Normal users are not allowed to set the ids during creation."

--- a/test/ctia/flows/hooks/firehose_event_hook_test.clj
+++ b/test/ctia/flows/hooks/firehose_event_hook_test.clj
@@ -64,10 +64,11 @@
 (defn clean-entity
   [entity]
   (-> entity
-      (dissoc :created :modified)
       (update-instant [:valid_time :start_time])
       (update-instant [:valid_time :end_time])
-      (update-instant [:timestamp])))
+      (update-instant [:timestamp])
+      (update-instant [:created])
+      (update-instant [:modified])))
 
 (defn make-entry
   [event]

--- a/test/ctia/http/handler/allow_all_test.clj
+++ b/test/ctia/http/handler/allow_all_test.clj
@@ -51,7 +51,7 @@
             :owner "Unknown"
             :valid_time {:start_time #inst "2016-02-11T00:00:00.000-00:00"
                          :end_time #inst "2016-03-11T00:00:00.000-00:00"}}
-           (dissoc judgement :id)))
+           (dissoc judgement :id :created :modified)))
 
       (testing "GET /ctia/judgement"
         (let [{status :status
@@ -61,6 +61,8 @@
           (is (= 200 status))
           (is (=
                {:id (:id judgement)
+                :created (:created judgement)
+                :modified (:modified judgement)
                 :type "judgement"
                 :observable {:value "1.2.3.4"
                              :type "ip"}

--- a/test/ctia/http/handler/static_auth_test.clj
+++ b/test/ctia/http/handler/static_auth_test.clj
@@ -74,6 +74,8 @@
           (is (= 200 status))
           (is (=
                {:id (:id judgement)
+                :created (:created judgement)
+                :modified (:modified judgement)
                 :type "judgement"
                 :observable {:value "1.2.3.4"
                              :type "ip"}

--- a/test/data/asset.graphql
+++ b/test/data/asset.graphql
@@ -31,6 +31,8 @@ fragment assetFields on Asset {
   source
   source_uri
   timestamp
+  created
+  modified
   title
   tlp
   type
@@ -85,6 +87,8 @@ fragment assetMappingFields on AssetMapping {
   specificity
   stability
   timestamp
+  created
+  modified
   tlp
   type
   valid_time { ...validTimeFields}
@@ -130,6 +134,8 @@ fragment assetPropertiesFields on AssetProperties {
   source
   source_uri
   timestamp
+  created
+  modified
   tlp
   type
   valid_time { ...validTimeFields}

--- a/test/data/attack-pattern.graphql
+++ b/test/data/attack-pattern.graphql
@@ -81,6 +81,8 @@ fragment attackPatternFields on AttackPattern {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/fragments.graphql
+++ b/test/data/fragments.graphql
@@ -26,6 +26,8 @@ fragment feedbackFields on Feedback {
   feedback
   entity_id
   timestamp
+  created
+  modified
   reason
   owner
   groups

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -85,6 +85,8 @@ fragment incidentFields on Incident {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/investigation.graphql
+++ b/test/data/investigation.graphql
@@ -44,6 +44,8 @@ fragment investigationFields on Investigation {
   short_description
   title
   timestamp
+  created
+  modified
   tlp
   source
   source_uri

--- a/test/data/malware.graphql
+++ b/test/data/malware.graphql
@@ -81,6 +81,8 @@ fragment malwareFields on Malware {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/queries.graphql
+++ b/test/data/queries.graphql
@@ -234,6 +234,8 @@ fragment indicatorFields on Indicator {
   producer
   description
   timestamp
+  created
+  modified
   indicator_type
   valid_time {
     ...validTimeFields
@@ -275,6 +277,8 @@ fragment casebookFields on Casebook {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   title
   description
@@ -335,6 +339,8 @@ fragment judgementFields on Judgement {
   tlp
   priority
   timestamp
+  created
+  modified
   owner
   groups
 }
@@ -355,6 +361,8 @@ fragment sightingFields on Sighting {
   sensor
   source
   timestamp
+  created
+  modified
   tlp
   owner
   groups

--- a/test/data/target_record.graphql
+++ b/test/data/target_record.graphql
@@ -46,6 +46,8 @@ fragment targetRecordFields on TargetRecord {
   source_uri
   targets { ...targetsFields}
   timestamp
+  created
+  modified
   title
   tlp
   type

--- a/test/data/tool.graphql
+++ b/test/data/tool.graphql
@@ -81,6 +81,8 @@ fragment toolFields on Tool {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/vulnerability.graphql
+++ b/test/data/vulnerability.graphql
@@ -77,6 +77,8 @@ fragment vulnerabilityFields on Vulnerability {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/vulnerability_fragments.graphql
+++ b/test/data/vulnerability_fragments.graphql
@@ -26,6 +26,8 @@ fragment feedbackFields on Feedback {
   feedback
   entity_id
   timestamp
+  created
+  modified
   reason
   owner
   groups

--- a/test/data/weakness.graphql
+++ b/test/data/weakness.graphql
@@ -77,6 +77,8 @@ fragment weaknessFields on Weakness {
     ...externalReferenceFields
   }
   timestamp
+  created
+  modified
   language
   tlp
   source

--- a/test/data/weakness_fragments.graphql
+++ b/test/data/weakness_fragments.graphql
@@ -25,6 +25,8 @@ fragment externalReferenceFields on ExternalReference {
 fragment feedbackFields on Feedback {
   feedback
   timestamp
+  created
+  modified
   entity_id
   reason
   owner


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #advthreat/iroh/issues/8788

DO NOT MERGE, need to update ctia investigate module accordingly.

This PR expose created and modified date to (try to) stop the confusion on date filtering and date presentations in incidents.

The main change is to remove `un-store` fns from `src/ctia/domain/entities.clj` and references in routes that removed `created` and `modified` fields before returning documents. Then there is a test in the crud store helper to check that `modified` is properly updated on changes.
The other changes are fixing tests accordingly.

<a name="qa">[§](#qa)</a> QA
============================

1. Create an incident, check that the returned entity has `created` and `modified` fields set to the creation time. These dates should be different than the provided `timestamp` if any.
2. Retrieve this entity, check that the value of `created` and `modified` are available.
3. update the incident (patch the status for instance), and check that `created` did not change and `modified` was updated with the time of the change.
4. perform a search query that matches this incident and check that `created` and `modified` are returned in the result.
5. bundle export this incident and check that `created` and `modified` are returned

