### PR TITLE
silent this too noisy log

### DIFF
--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -178,7 +178,7 @@
                              :entity
                              (with-long-id services))]
       (when (< 1 (count old-entities))
-        (log/warn
+        (log/debug
          (format
           (str "More than one entity is "
                "linked to the external ids %s (examples: %s)")

--- a/test/ctia/bundle/core_test.clj
+++ b/test/ctia/bundle/core_test.clj
@@ -83,7 +83,7 @@
                                  http-show-services)))
                         (is (= log?
                                (logged? 'ctia.bundle.core
-                                        :warn
+                                        :debug
                                         #"More than one entity is linked to the external ids"))))))]
       (test-fn {:msg "no existing external id"
                 :expected {:id indicator-id-3


### PR DESCRIPTION
Set the log level to debug when multiple entities are matched for a given external id are matched during a bundle import.
This situation can simply happens with a race conditions with 2 bundles pointing at the same indicator for a given org, in particular when we receive too many incidents from misconfigured sources.
We have millions of these logs per month:
<img width="1944" alt="Screenshot 2024-02-28 at 11 15 16" src="https://github.com/threatgrid/ctia/assets/3592199/5f02a9b1-84f7-4d34-9dcf-b0d95a353485">


<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.