### PR TITLE
bump ctim / remove status disposition

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.15:compile
++- threatgrid:ctim:jar:1.3.17-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -48,7 +48,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.12.2:compile
 +- threatgrid:flanders:jar:0.1.23:compile
 |  \- org.clojure:core.match:jar:0.3.0:compile
-+- threatgrid:ctim:jar:1.3.17-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.16:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.17-SNAPSHOT</version>
+      <version>1.3.16</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -550,7 +550,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.15</version>
+      <version>1.3.17-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.17-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.16"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.2.0"]
                  [metosin/schema-tools "0.12.2"]
                  [threatgrid/flanders "0.1.23"]
-                 [threatgrid/ctim "1.3.15"]
+                 [threatgrid/ctim "1.3.17-SNAPSHOT"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.4.5"]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -110,15 +110,11 @@
 (s/defschema IncidentStatus
   (f-schema/->schema vocs/Status))
 
-(s/defschema IncidentStatusDisposition
-  (f-schema/->schema vocs/StatusDisposition))
-
 (s/defschema IncidentStatusUpdate
-  {:status IncidentStatus
-   (s/optional-key :status_disposition) IncidentStatusDisposition})
+  {:status IncidentStatus})
 
 (defn make-status-update
-  [{:keys [status status_disposition]}]
+  [{:keys [status]}]
   (let [t (time/internal-now)
         verb (case status
                "New" nil
@@ -133,7 +129,6 @@
                "Incident Reported" :reported
                nil)]
     (cond-> {:status status}
-      status_disposition (assoc :status_disposition status_disposition)
       verb (assoc :incident_time {verb t}))))
 
 (s/defn ^:private update-interval :- ESStoredIncident
@@ -240,7 +235,6 @@
      em/stored-entity-mapping
      {:confidence         em/token
       :status             em/token
-      :status_disposition em/token
       :incident_time      em/incident-time
       :categories         em/token
       :discovery_method   em/token
@@ -272,7 +266,6 @@
           sourcable-entity-sort-fields
           [:confidence
            :status
-           :status_disposition
            :incident_time.opened
            :incident_time.discovered
            :incident_time.reported
@@ -353,7 +346,6 @@
    :promotion_method
    :source
    :status
-   :status_disposition
    :title
    :severity
    :tactics
@@ -387,7 +379,6 @@
    (st/optional-keys
     {:confidence         s/Str
      :status             s/Str
-     :status_disposition s/Str
      :discovery_method   s/Str
      :intended_effect    s/Str
      :categories         s/Str

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -43,15 +43,12 @@
     (is (= {} (sut/mk-scores-schema {:ConfigService {:get-in-config (constantly nil)}})))))
 
 (defn post-status
-  ([app uri-encoded-id new-status]
-   (post-status app uri-encoded-id new-status nil))
-  ([app uri-encoded-id new-status status-disposition]
-   (POST app
-       (str "ctia/incident/" uri-encoded-id "/status")
-     :body (cond-> {:status new-status}
-             status-disposition (assoc :status_disposition status-disposition))
-     :headers {"Authorization" "45c1f5e3f05d0"
-               "wait_for" true})))
+  [app uri-encoded-id new-status]
+  (POST app
+        (str "ctia/incident/" uri-encoded-id "/status")
+        :body {:status new-status}
+        :headers {"Authorization" "45c1f5e3f05d0"
+                  "wait_for" true}))
 
 (defn get-incident [app id]
   (GET app (str "ctia/incident/" (uri/uri-encode id))
@@ -81,13 +78,11 @@
            (is (= (get-in updated-incident [:incident_time :opened])
                   (tc/to-date fixed-now)))))
 
-       (testing "POST /ctia/incident/:id/status Closed / False Positive"
+       (testing "POST /ctia/incident/:id/status Closed"
          (let [new-status "Closed"
-               status-disposition "False Positive"
-               response (post-status app (:short-id incident-id) new-status status-disposition)
+               response (post-status app (:short-id incident-id) new-status)
                updated-incident (:parsed-body response)]
            (is (= 200 (:status response)))
-           (is (= status-disposition (:status_disposition updated-incident)))
            (is (= "Closed" (:status updated-incident)))
            (is (get-in updated-incident [:incident_time :closed]))
 

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -96,7 +96,6 @@ fragment incidentFields on Incident {
   short_description
   confidence
   status
-  status_disposition
   incident_time {
     ...incidentTimeFields
   }


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #advthreat/iroh/issues/8181

It requires an ES surgery. The field was not indexed yet since everything was on hold
I will handle it myself.


<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->

- check that you can use new statuses in `POST /ctia/incident/{incident-id}/status`:
New: Processing
New: Presented
Open: Investigating
Open: Reported
Open: Contained
Open: Recovered
Hold: Internal
Hold: External
Hold: Legal
Closed: Under Review
Closed: Confirmed Threat
Closed: Suspected
Closed: False Positive
Closed: Near-Miss
Closed: Other

- check that you cannot use the field "status_disposition" for incidents.



