### PR TITLE
Properly filter Relationships to assemble a Feed View

### DIFF
--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -169,7 +169,8 @@
              (get-paginated-response
               (store/paginate
                relationship-store
-               #(store/list-records %1 {:all-of {:target_ref indicator_id}} feed-identity %2)
+               #(store/list-records %1 {:all-of {:relationship_type "element-of"
+                                                 :target_ref indicator_id}} feed-identity %2)
                (merge {:fields [:source_ref]
                        :limit relationship-max-result-window
                        :sort_by "timestamp:desc,id"}


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #
> Related https://github.com/advthreat/iroh/issues/9111

Here are the steps to render a Feed in CTIA:

1. Fetch the feed document
2. Fetch the referenced indicator
3. Fetch all the relationships of the indicator
4. Fetch all the objects referenced by the `source_ref` field of the relationships
5. extract the observables from the Judgements and render the response  

The query on step 3 is too naive as it attempts to list any kind of relationship even though we're looking only for indicators with an "element-of" relationship_type, some indicators are linked to a very large number of Sightings, retrieving them consumes a huge amount of resources and ultimately leads to a failure.

This PR updates the filter so we only fetch the proper indicators relevant for a Feed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================


Describe the steps to test your PR.

1. Create and Query a Feed
2. The functionality should still work as expected and there should be no regression


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
public: Feed performance improvements
```

