### PR TITLE
dependencies: add logstash-logback-encoder and upgrade slf4j and Jackson

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -19,8 +19,6 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- version-clj:version-clj:jar:2.0.1:compile
 +- puppetlabs:trapperkeeper:jar:3.2.0:compile
 |  +- org.clojure:tools.macro:jar:0.1.5:compile
-|  +- ch.qos.logback:logback-classic:jar:1.2.3:compile
-|  +- ch.qos.logback:logback-core:jar:1.2.3:compile
 |  +- ch.qos.logback:logback-access:jar:1.2.3:compile
 |  +- org.codehaus.janino:janino:jar:3.0.8:compile
 |  |  \- org.codehaus.janino:commons-compiler:jar:3.0.8:compile
@@ -206,8 +204,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- org.apache.zookeeper:zookeeper:jar:3.5.6:compile
 |  +- org.apache.zookeeper:zookeeper-jute:jar:3.5.6:compile
 |  +- org.apache.yetus:audience-annotations:jar:0.5.0:compile
-|  +- io.netty:netty-transport-native-epoll:jar:4.1.42.Final:compile
-|  \- org.slf4j:slf4j-api:jar:1.7.25:compile
+|  \- io.netty:netty-transport-native-epoll:jar:4.1.42.Final:compile
 +- args4j:args4j:jar:2.33:compile
 +- com.stuartsierra:component:jar:1.1.0:compile
 |  \- com.stuartsierra:dependency:jar:1.0.0:compile
@@ -249,11 +246,11 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- org.apache.kafka:kafka-clients:jar:1.0.0:compile
 |     +- org.lz4:lz4-java:jar:1.4:compile
 |     \- org.xerial.snappy:snappy-java:jar:1.1.4:compile
-+- com.fasterxml.jackson.core:jackson-core:jar:2.13.4:compile
-+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.13.4:compile
-+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.13.4:compile
-+- com.fasterxml.jackson.core:jackson-databind:jar:2.13.4.2:compile
-|  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.4:compile
++- com.fasterxml.jackson.core:jackson-core:jar:2.15.2:compile
++- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.15.2:compile
++- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.15.2:compile
++- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
+|  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
 +- zookeeper-clj:zookeeper-clj:jar:0.9.4:compile
 +- software.amazon.awssdk:firehose:jar:2.17.232:compile
 |  +- software.amazon.awssdk:aws-json-protocol:jar:2.17.232:compile
@@ -280,7 +277,11 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- org.antlr:antlr4-runtime:jar:4.7.2:compile
 |  +- com.graphql-java:java-dataloader:jar:2.0.2:compile
 |  \- org.reactivestreams:reactive-streams:jar:1.0.2:compile
-+- org.slf4j:log4j-over-slf4j:jar:1.7.20:compile
++- org.slf4j:log4j-over-slf4j:jar:2.0.13:compile
++- org.slf4j:slf4j-api:jar:2.0.13:compile
++- net.logstash.logback:logstash-logback-encoder:jar:7.4:compile
++- ch.qos.logback:logback-classic:jar:1.5.6:compile
++- ch.qos.logback:logback-core:jar:1.5.6:compile
 +- puppetlabs:trapperkeeper:jar:test:3.2.0:test
 +- puppetlabs:kitchensink:jar:test:3.2.0:test
 +- org.clojure:test.check:jar:1.1.1:test

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -1513,7 +1513,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.4</version>
+      <version>2.15.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -1536,7 +1536,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-smile</artifactId>
-      <version>2.13.4</version>
+      <version>2.15.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -1559,7 +1559,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-cbor</artifactId>
-      <version>2.13.4</version>
+      <version>2.15.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -1582,7 +1582,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.4.2</version>
+      <version>2.15.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -1780,7 +1780,99 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.20</version>
+      <version>2.0.13</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.13</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+      <version>7.4</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.6</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>1.5.6</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (def cheshire-version "5.10.2")
 (def clj-http-fake-version "1.0.3")
 (def clj-version "1.11.2")
-(def jackson-version "2.13.4")
-(def jackson-databind-version "2.13.4.2")
+(def jackson-version "2.15.2")
+(def jackson-databind-version "2.15.2")
 (def metrics-clojure-version "2.10.0")
 (def netty-version "4.1.75.Final")
 (def perforate-version "0.3.4")
@@ -186,7 +186,11 @@
                  [com.graphql-java/graphql-java "9.7"]
 
                  ;; Logging
-                 [org.slf4j/log4j-over-slf4j "1.7.20"]]
+                 [org.slf4j/log4j-over-slf4j "2.0.13"]
+                 [org.slf4j/slf4j-api "2.0.13"]
+                 [net.logstash.logback/logstash-logback-encoder "7.4"]
+                 [ch.qos.logback/logback-classic "1.5.6"]
+                 [ch.qos.logback/logback-core "1.5.6"]]
 
   :resource-paths ["resources"]
   :classpath ".:resources"


### PR DESCRIPTION
This PR add [logback encder](https://github.com/logfellow/logstash-logback-encoder) dependency. This provides [logback](http://logback.qos.ch/) encoders, layouts, and appenders to log in JSON and [other formats supported by Jackson](https://github.com/logfellow/logstash-logback-encoder#data-format).

This PR also upgrade SLF4J to version 2.0.13 and Jackson to version 2.15.2.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: upgrade SLF4J to version 2.0.13 and Jackson to version 2.15.2
public: add [logback encoder](https://github.com/logfellow/logstash-logback-encoder)
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

