### PR TITLE
Enable auth in migration params schema

### DIFF
--- a/src/ctia/task/migration/store.clj
+++ b/src/ctia/task/migration/store.clj
@@ -20,7 +20,8 @@
              [conn :as conn]
              [document :as ductile.doc]
              [index :as ductile.index]
-             [query :as ductile.query]]
+             [query :as ductile.query]
+             [schemas :refer [AuthParams]]]
             [ductile.schemas :refer [ESConn ESQuery Refresh]]
             [schema-tools.core :as st]
             [schema.core :as s]))
@@ -41,7 +42,8 @@
     :aliased  s/Bool
     :default_operator (s/enum "OR" "AND")
     :timeout s/Num
-    :version s/Num}))
+    :version s/Num
+    :auth AuthParams}))
 
 (s/defschema MigrationParams
   {:migration-id s/Str

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -159,8 +159,11 @@
         (with-each-fixtures #(-> %
                                  (assoc-in [:ctia :store :es :investigation :indexname]
                                            investigation-indexname)
-                                 (assoc-in [:malware 0 :state :props :indexname]
-                                           malware-indexname))
+                                 (assoc-in [:malware 0 :state :props]
+                                           {:indexname malware-indexname
+                                            :auth {:type "basic"
+                                                   :params {:user "basic"
+                                                            :pwd "ductile"}}}))
           app
           (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
             (let [v (get-in-config [:ctia :store :es :investigation :indexname])]


### PR DESCRIPTION
Fix CTIA migration configuraiton schema to accept authentication

```
2024-06-25T14:53:45.274Z INFO (main) [ctia.task.migration.migrate-es-stores] - migration started {:buffer-size 3, :store {:es {:default {:protocol :https, :host "int-es7-storage.es.vpce.us-east-1.aws.elastic-cloud.com", :auth {:params {:pwd "zGHz6L5gf1PsMxf86LAxIkWG", :user "elastic"}, :type :basic-auth}, :port 443, :version 7}, :migration {:indexname "ctia_migration"}}}, :migration-id "elastic-migration", :restart? nil, :prefix "2.0.0", :store-keys (:actor :attack-pattern :campaign :coa :feed :feedback :indicator :judgement :malware :relationship :sighting :tool :vulnerability :weakness), :migrations (:identity), :confirm? true, :batch-size 6000}
2024-06-25T14:53:45.280Z ERROR (main) [ctia.task.migration.migrate-es-stores] - Unexpected error during migration
clojure.lang.ExceptionInfo: Input to check-migration-params does not match schema:

           [(named {:store {:es {:default {:auth disallowed-key}}}} arg0) nil]


        at ctia.task.migration.migrate_es_stores$eval100649$check_migration_params__100654.invoke(migrate_es_stores.clj:283)
        at ctia.task.migration.migrate_es_stores$eval100709$run_migration__100714$fn__100715.invoke(migrate_es_stores.clj:325)
        at ctia.task.migration.migrate_es_stores$eval100709$run_migration__100714.invoke(migrate_es_stores.clj:310)
        at ctia.task.migration.migrate_es_stores$_main.invokeStatic(migrate_es_stores.clj:357)
        at ctia.task.migration.migrate_es_stores$_main.doInvoke(migrate_es_stores.clj:345)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.main$main_opt.invokeStatic(main.clj:514)
        at clojure.main$main_opt.invoke(main.clj:510)
        at clojure.main$main.invokeStatic(main.clj:664)
        at clojure.main$main.doInvoke(main.clj:616)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.main.main(main.java:40) 
```

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
