### PR TITLE
Enable same indexname for different target cluster

### DIFF
--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -300,7 +300,7 @@
                  (nil? (:host target-store))
                  (nil? (:indexname target-store)))
         (throw (AssertionError.
-                (format "The migration was misconfigured.\nThe source and target indices are identical: %s\n%s\n."
+                (format "The migration setup is misconfigured.\nThe source and target indices are identical: %s\n%s\n."
                         (pr-str params)
                         (pr-str origin-store)
                         (pr-str target-store)))))))


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->
Ops uses the migration task to migrate to the new cluster, but they would like to preserve the same indices name.
This PR relaxes the migration params check constraints.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
