### PR TITLE
Consider migration default es store

### DIFF
--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -293,10 +293,12 @@
     (assert (seq migrations) "Please provide the migrations' ids to apply"))
   (doseq [store-key store-keys]
     (let [origin-store (get-in-config [:ctia :store :es store-key])
+          default-target-store (get-in store [:es :default])
           target-store (get-in store [:es store-key])
           origin-indexname (:indexname origin-store)]
       (when (and (= (mst/prefixed-index origin-indexname prefix)
                     origin-indexname)
+                 (nil? (:host default-target-store))
                  (nil? (:host target-store))
                  (nil? (:indexname target-store)))
         (throw (AssertionError.

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -188,16 +188,20 @@
 
       (testing "different target cluster same indexname"
         (let [malware-indexname (str "v1.2.0_ctia_malware" (UUID/randomUUID))
-              malware-target-store {:host "another-host-cluster"
-                                    :auth {:type :basic-auth
-                                           :params {:user "basic"
-                                                    :pwd "ductile"}}}]
+              target-store {:host "another-host-cluster"
+                            :auth {:type :basic-auth
+                                   :params {:user "basic"
+                                            :pwd "ductile"}}}]
           (with-each-fixtures #(assoc-in % [:ctia :store :es :malware :indexname] malware-indexname)
             app
             (let [{:keys [get-in-config]} (helpers/get-service-map app :ConfigService)]
               (is (sut/check-migration-params (assoc (assoc migration-params :store-keys [:malware])
-                                                     :store {:es {:malware malware-target-store}})
-                                              get-in-config))))))))
+                                                     :store {:es {:malware target-store}})
+                                              get-in-config))
+              (is (sut/check-migration-params (assoc (assoc migration-params :store-keys [:malware])
+                                                     :store {:es {:default target-store}})
+                                              get-in-config)
+                  "configured default target store shall be considered")))))))
 
 (deftest prepare-params-test
   (let [migration-props {:buffer-size 3,


### PR DESCRIPTION
> Related [XDR-5272](https://cisco-sbg.atlassian.net/browse/XDR-5272)

Consider the default configured store for targeted migration cluster checks.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.


[XDR-5272]: https://cisco-sbg.atlassian.net/browse/XDR-5272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ