### PR TITLE
Change regex pattern to find ambiguous index name

### DIFF
--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -128,7 +128,7 @@
   (let [existing (-> (index/get conn (str index "*"))
                      keys
                      set)
-        index-pattern (re-pattern (str index "(-\\d{4}.\\d{2}.\\d{2}.*)?"))
+        index-pattern (re-pattern (str index "(-\\d{4}.\\d{2}.\\d{2}(?!-\\d{6}).*)"))
         matching (filter #(re-matches index-pattern (name %))
                          existing)
         ambiguous (difference existing (set matching))]


### PR DESCRIPTION
we need to remove from match indices which ends on `000001` (can be any number in the same format)

because we have indices created by elastic ILM policy and rollover step which looks like this:
`partial-v2.0.0_ctia_identities-2024.07.11-000001`
and its valid index name 

current regex should match indices which ends on date but ignore if ends on `-6 dights`



