### PR TITLE
Fix ILM template Migration

### DIFF
--- a/test/ctia/test_helpers/es.clj
+++ b/test/ctia/test_helpers/es.clj
@@ -262,7 +262,8 @@
   (es-index/delete! conn index-pattern)
   (es-index/delete-template! conn index-pattern)
   (es-index/delete-index-template! conn index-pattern)
-  (es-index/delete-policy! conn index-pattern))
+  ;; delete policy does not work with wildcard, try real index
+  (es-index/delete-policy! conn (string/replace index-pattern "*" "")))
 
 (defmacro for-each-es-version
   "for each given ES version:


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #XDR-6078
> Related https://github.com/threatgrid/ctia/pull/1440

This PR fixes the ILM migration and explicitly set update index state parameters to false to ensure the expected configuration conditions (it was set in another part which biased test and hid the bug)

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

