### PR TITLE
Enable "partial-" and "restored-" prefixes

### DIFF
--- a/src/ctia/stores/es/init.clj
+++ b/src/ctia/stores/es/init.clj
@@ -157,14 +157,12 @@
 
 (defn ambiguous-indices
   [existing index]
-  (let [existing-k (set (keys existing))
-        index-pattern (re-pattern (str "((partial|restored)-)?"
-                                       index
-                                       "(-\\d{4}.\\d{2}.\\d{2}.*)?"))
-        matching (filter #(re-matches index-pattern (name %))
-                         existing-k)
-        ambiguous (difference existing-k (set matching))]
-    ambiguous))
+  (let [index-pattern (re-pattern (str "((partial|restored)-)?"
+                                       (java.util.regex.Pattern/quote index)
+                                       "(-\\d{4}.\\d{2}.\\d{2}.*)?"))]
+    (into #{}
+          (remove #(re-matches index-pattern (name %)))
+          (keys existing))))
 
 (defn get-existing-indices
   [conn index]

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -175,6 +175,23 @@
                    false
                    nil))))))
 
+(deftest ambiguous-indices-test
+  (let [test-cases [{:message "partial and restored should not match the ambiguous index names"
+                     :existing {:v2.0.0_ctia_sighting-2022.07.07-000001 {}
+                                :partial-v2.0.0_ctia_sighting-2022.07.07-000001 {}
+                                :restored-v2.0.0_ctia_sighting-2022.07.07-000001 {}}
+                     :index "v2.0.0_ctia_sighting"
+                     :expected #{}}
+                    {:message "ambiguous names with unknown prefix should be detected"
+                     :existing {:v2.0.0_ctia_sighting-2022.07.07-000001 {}
+                                :prefix-v2.0.0_ctia_sighting-2022.07.07-000001 {}}
+                     :index "v2.0.0_ctia_sighting"
+                     :expected #{:prefix-v2.0.0_ctia_sighting-2022.07.07-000001}}]]
+    (doseq [{:keys [message existing index expected]} test-cases]
+      (is (= expected
+             (sut/ambiguous-indices existing index))
+          message))))
+
 (deftest init-es-conn!-test
   (helpers/with-config-transformer
     #(assoc-in % [:ctia :task :ctia.task.update-index-state] true)
@@ -483,8 +500,7 @@
                                          :update-mappings false
                                          :update-settings false
                                          :refresh-mappings false
-                                         :rollover {:max_docs 1}
-                                         )
+                                         :rollover {:max_docs 1})
               {:keys [conn index props] :as store-conn}
               (sut/init-es-conn! ilm-migration-props services)]
           (check-ilm-migration store-conn)

--- a/test/ctia/stores/es/init_test.clj
+++ b/test/ctia/stores/es/init_test.clj
@@ -186,7 +186,15 @@
                      :existing {:v2.0.0_ctia_sighting-2022.07.07-000001 {}
                                 :prefix-v2.0.0_ctia_sighting-2022.07.07-000001 {}}
                      :index "v2.0.0_ctia_sighting"
-                     :expected #{:prefix-v2.0.0_ctia_sighting-2022.07.07-000001}}]]
+                     :expected #{:prefix-v2.0.0_ctia_sighting-2022.07.07-000001}}
+                    {:message "regular expression characters are correctly escaped"
+                     :existing {:v2x0x0_ctia_sighting-2022.07.07-000001 {}
+                                :v2.0.0_ctia_sighting-2022.07.07-000001 {}
+                                :partial-v2x0x0_ctia_sighting-2022.07.07-000001 {}
+                                :partial-v2.0.0_ctia_sighting-2022.07.07-000001 {}}
+                     :index "v2.0.0_ctia_sighting"
+                     :expected #{:v2x0x0_ctia_sighting-2022.07.07-000001
+                                 :partial-v2x0x0_ctia_sighting-2022.07.07-000001}}]]
     (doseq [{:keys [message existing index expected]} test-cases]
       (is (= expected
              (sut/ambiguous-indices existing index))


### PR DESCRIPTION
> Related https://cisco-sbg.atlassian.net/browse/XDR-13581

This PR exclude "restored-" and "partial-" prefixes from the ambiguous index names detection.

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.
