### PR TITLE
remove update-tenzin gh actionjob

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,7 +77,7 @@ jobs:
           CTIA_COMMIT_MESSAGE: ${{steps.gh-project-context.outputs.commitMsg}}
       # Retreive previous timing information
       # actions/cache/restore is used to avoid a 2m slowdown due to actions/cache deciding
-      # whether to save a cache, which is not useful here. 
+      # whether to save a cache, which is not useful here.
       # https://github.com/actions/cache?tab=readme-ov-file#using-a-combination-of-restore-and-save-actions
       - name: Timing Cache
         id: get-timing
@@ -367,9 +367,6 @@ jobs:
       - run: echo "All tests pass!"
   deploy:
     runs-on: "ubuntu-22.04"
-    outputs:
-      build_version: ${{ steps.deploy.outputs.build_version }}
-      build_type: ${{ steps.deploy.outputs.build_type }}
     needs: [all-pr-checks]
     # see on.push.branches for which branches are built on push
     if: github.event_name == 'push' && github.repository == 'threatgrid/ctia'
@@ -427,39 +424,3 @@ jobs:
           # offline to catch issues where `lein warm-ci-deps` doesn't download all
           # dependencies we need to deploy.
           LEIN_OFFLINE: true
-
-  update-tenzin:
-    runs-on: ubuntu-22.04
-    needs: deploy
-    if: ${{ needs.deploy.outputs.build_type == 'int' }}
-    steps:
-    - name: Setup Git user
-      run: |
-       git config --global user.email "github-actions[bot]@users.noreply.github.com"
-       git config --global user.name "GitHub Actions Bot"
-    - name: Checkout tenzin
-      uses: actions/checkout@v4
-      with:
-        repository: advthreat/tenzin
-        ssh-key: ${{ secrets.TENZIN_PRIVATE_SSH }}
-        path: tenzin
-        ref: master
-    - name: update ctia image tag
-      env:
-        BUILD_VERSION: ctia-${{ needs.deploy.outputs.build_version }}
-      run: |
-        cd tenzin/applications/ctia/kustomize/overlays/ctr-int-eks
-        yq -i '.images[0].newTag = env(BUILD_VERSION)' kustomization.yaml
-        git add kustomization.yaml
-    - name: Commit and push changes if any
-      env:
-       BUILD_VERSION: ctia-${{ needs.deploy.outputs.build_version }}
-      run: |
-        cd tenzin
-        if ! git diff --cached --quiet
-        then
-          git commit -m "Update ctia image tag to ${BUILD_VERSION}"
-          git push
-        else
-          echo "No changes to commit"
-        fi

--- a/build/deploy-actions.sh
+++ b/build/deploy-actions.sh
@@ -102,9 +102,6 @@ EOF
     docker tag "$docker_registry/$docker_nomad_repository:$build_version" "$prod_apjc_registry/$prod_nomad_repository:$build_version"
     docker push "$prod_apjc_registry/$prod_nomad_repository:$build_version"
   fi
-
-  echo "build_version=$build_version" >> "$GITHUB_OUTPUT"
-  echo "build_type=$build_type" >> "$GITHUB_OUTPUT"
 }
 
 function build-and-publish-package {


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** #
> Close #
> Related #

update-tenzin job is replaced by an app that read docker repo push events

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

