### PR TITLE
#XDR-15766 CTIM 1.3.21

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.0.2:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.20:compile
++- threatgrid:ctim:jar:1.3.21:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.0.2:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.21-SNAPSHOT:compile
++- threatgrid:ctim:jar:1.3.21:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.0.2:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.21:compile
++- threatgrid:ctim:jar:1.3.21-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.20</version>
+      <version>1.3.21</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.21</version>
+      <version>1.3.21-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.21-SNAPSHOT</version>
+      <version>1.3.21</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [threatgrid/flanders "1.0.2"]
-                 [threatgrid/ctim "1.3.21-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.21"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [threatgrid/flanders "1.0.2"]
-                 [threatgrid/ctim "1.3.20"]
+                 [threatgrid/ctim "1.3.21-SNAPSHOT"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.5.0"]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -240,6 +240,7 @@
       :discovery_method   em/token
       :intended_effect    em/token
       :assignees          em/token
+      :detection_sources  em/token
       :promotion_method   em/token
       :severity           em/token
       :tactics            em/token
@@ -275,6 +276,7 @@
            :discovery_method
            :intended_effect
            :assignees
+           :detection_sources
            :promotion_method
            :severity
            :tactics
@@ -339,6 +341,7 @@
 
 (def incident-enumerable-fields
   [:assignees
+   :detection_sources
    :categories
    :confidence
    :discovery_method
@@ -384,6 +387,7 @@
      :categories         s/Str
      :sort_by            (incident-sort-fields services)
      :assignees          s/Str
+     :detection_sources  s/Str
      :promotion_method   s/Str
      :severity           s/Str
      :tactics            [s/Str]

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -617,27 +617,27 @@
         (fn [app]
           ;(helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
           ;(whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
-          (try (let [incident1 (assoc (gen-new-incident) :detection_sources ["TA0002" "TA0043" "TA0006"])
-                     incident2 (assoc (gen-new-incident) :detection_sources ["TA0004" "TA0043" "TA0008"])
-                     incident3 (assoc (gen-new-incident) :detection_sources ["TA0008" "TA0043" "TA0006" "TA8888"])
+          (try (let [incident1 (assoc (gen-new-incident) :detection_sources ["Crowdstrike for Endpoint" "Cisco XDR Detections" "TA0006"])
+                     incident2 (assoc (gen-new-incident) :detection_sources ["TA0004" "Cisco XDR Detections" "TA0008"])
+                     incident3 (assoc (gen-new-incident) :detection_sources ["TA0008" "Cisco XDR Detections" "TA0006" "Talnos, which is like Talos but weird"])
                      normalize (fn [incidents]
                                  (->> incidents
                                       (map #(select-keys % [:title :tactics]))
                                       (sort-by :tactics)))]
                  (create-incidents app #{incident1 incident2 incident3})
                  (testing "incident1"
-                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"TA0002\")"})]
+                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"Crowdstrike for Endpoint\")"})]
                      (and (is (= 200 (:status raw)) (pr-str raw))
                           (is (= (normalize [incident1])
                                  (normalize parsed-body))
                               (pr-str parsed-body)))))
                  (testing "incident1+2+3"
-                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"TA0043\")"})]
+                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"Cisco XDR Detections\")"})]
                      (and (is (= 200 (:status raw)) (pr-str raw))
                           (is (= (normalize [incident1 incident2 incident3])
                                  (normalize parsed-body))))))
                  (testing "incident1+3 multi"
-                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"TA0002\" || \"TA8888\")"}) ]
+                   (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"Crowdstrike for Endpoint\" || \"Talnos, which is like Talos but weird\")"}) ]
                      (and (is (= 200 (:status raw)) (pr-str raw))
                           (is (= (normalize [incident1 incident3])
                                  (normalize parsed-body)))))))

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -622,8 +622,8 @@
                      incident3 (assoc (gen-new-incident) :detection_sources ["TA0008" "Cisco XDR Detections" "TA0006" "Talnos, which is like Talos but weird"])
                      normalize (fn [incidents]
                                  (->> incidents
-                                      (map #(select-keys % [:title :tactics]))
-                                      (sort-by :tactics)))]
+                                      (map #(select-keys % [:title :detection_sources]))
+                                      (sort-by :detection_sources)))]
                  (create-incidents app #{incident1 incident2 incident3})
                  (testing "incident1"
                    (let [{:keys [parsed-body] :as raw} (search-th/search-raw app :incident {:query "detection_sources:(\"Crowdstrike for Endpoint\")"})]

--- a/test/ctia/http/routes/graphql/incident_test.clj
+++ b/test/ctia/http/routes/graphql/incident_test.clj
@@ -19,7 +19,7 @@
 (def external-ref "http://external.com/ctia/incident/incident-ab053333-2ad2-41d0-a445-31e9b9c38caf")
 
 (defn init-graph-data [app]
-  (let [base-incident (dissoc new-incident-maximal :id :scores :meta)
+  (let [base-incident (dissoc new-incident-maximal :id :scores :meta :detection_sources)
         ap1 (gh/create-object
              app
              "incident"


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** https://cisco-sbg.atlassian.net/browse/XDR-13590
> Close https://cisco-sbg.atlassian.net/browse/XDR-15766
> Related https://cisco-sbg.atlassian.net/browse/XDR-15694

<!--
🚨 NOT YET READY FOR REVIEW. PR FOR CI, PLEASE DISREGARD UNTIL THIS NOTICE IS REMOVED 🚨 
Bumps to CTIM version 1.3.21, which adds the new `detection_sources` field to incidents. Includes tests for searching this field.
-->


<a name="qa">[§](#qa)</a> QA
============================

QA from Conure.


<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: updates CTIM to 1.3.21, containing new incdent `detection_sources` field
public: updates CTIM to latest version
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

