### PR TITLE
Make entity ids mandatory in Bulk update/patch requests

### DIFF
--- a/src/ctia/bulk/routes.clj
+++ b/src/ctia/bulk/routes.clj
@@ -53,7 +53,7 @@
          :responses {200 {:schema (s/maybe (bulk.schemas/BulkActionsRefs services))}}
          :summary "UPDATE many entities at once"
          :query-params [{wait_for :- (describe s/Bool "wait for updated entities to be available for search") nil}]
-         :body [bulk (describe (bulk.schemas/BulkUpdate services) "a new Bulk Update object")]
+         :body [bulk (describe (bulk.schemas/BulkUpdate services) "a Bulk Update object")]
          :description (common/capabilities->description capabilities)
          :capabilities capabilities
          :auth-identity auth-identity

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -25,26 +25,34 @@
             s/Keyword s/Any})])
 
 (defn entity-schema
-  [{:keys [plural] :as entity} sch services]
-  (let [bulk-schema
-        (if (keyword? sch)
-          [(s/maybe
-            (let [ent-schema (get entity sch)]
-              (if (fn? ent-schema) (ent-schema services) ent-schema)))]
-          sch)]
-    {(-> plural
-         name
-         (str/replace #"-" "_")
-         keyword)
-     bulk-schema}))
+  ([entity sch services]
+   (entity-schema entity sch services {}))
+  ([{:keys [plural] :as entity} sch services {:keys [required-ids?]}]
+   (let [bulk-schema
+         (if (keyword? sch)
+           [(s/maybe
+             (let [ent-schema (get entity sch)]
+               (cond-> (if (fn? ent-schema)
+                         (ent-schema services) ent-schema)
+                 required-ids? (st/required-keys [:id]))))]
+           (if required-ids?
+             (st/required-keys sch :id)
+             sch))]
+     {(-> plural
+          name
+          (str/replace #"-" "_")
+          keyword)
+      bulk-schema})))
 
 (defn entities-bulk-schema
-  [entities sch services]
-  (st/optional-keys
-   (->> (vals entities)
-        (remove :no-bulk?)
-        (map #(entity-schema % sch services))
-        (apply merge {}))))
+  ([entities sch services]
+   (entities-bulk-schema entities sch services {}))
+  ([entities sch services opts]
+   (st/optional-keys
+    (->> (vals entities)
+         (remove :no-bulk?)
+         (map #(entity-schema % sch services opts))
+         (apply merge {})))))
 
 (s/defschema EntityError
   "Error related to one entity of the bulk"
@@ -74,7 +82,7 @@
   (let [patchable-entities (into {}
                                  (filter #(:can-patch? (second %)))
                                  (get-entities services))]
-    (entities-bulk-schema patchable-entities :partial-schema services)))
+    (entities-bulk-schema patchable-entities :partial-schema services {:required-ids? true})))
 
 (s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- GetEntitiesServices]
@@ -91,7 +99,13 @@
   [services :- GetEntitiesServices]
   (entities-bulk-schema (get-entities services) :new-schema services))
 
-(def BulkUpdate NewBulk)
+(s/defn BulkUpdate :- (s/protocol s/Schema)
+  "Returns NewBulk schema without disabled entities and required ids"
+  [services :- GetEntitiesServices]
+  (entities-bulk-schema (get-entities services)
+                        :new-schema
+                        services
+                        {:required-ids? true}))
 
 (def NewBulkDelete BulkRefs)
 

--- a/src/ctia/bulk/schemas.clj
+++ b/src/ctia/bulk/schemas.clj
@@ -82,7 +82,10 @@
   (let [patchable-entities (into {}
                                  (filter #(:can-patch? (second %)))
                                  (get-entities services))]
-    (entities-bulk-schema patchable-entities :partial-schema services {:required-ids? true})))
+    (entities-bulk-schema patchable-entities
+                          :partial-schema
+                          services
+                          {:required-ids? true})))
 
 (s/defn BulkRefs :- (s/protocol s/Schema)
   [services :- GetEntitiesServices]

--- a/test/ctia/bulk/routes_test.clj
+++ b/test/ctia/bulk/routes_test.clj
@@ -439,6 +439,15 @@
                             :headers {"Authorization" "45c1f5e3f05d0"})))
                  "only entities with patch-bulk? set to true can be submitted to PATCH bulk")))
 
+         (testing "PATCH /ctia/bulk without ids"
+           (let [patch-bulk {:incidents (repeat 5 (hash-map :source "patched"))}
+                 {:keys [status parsed-body]} (PATCH app
+                                                     bulk-url
+                                                     :form-params patch-bulk
+                                                     :headers {"Authorization" "45c1f5e3f05d0"})]
+             (is (= 400 status))
+             (is (= parsed-body {:errors {:incidents (repeat 5 {:id 'missing-required-key})}}))))
+
          (testing "DELETE /ctia/bulk"
            ;; edge cases are tested in bulk/core-test
            (let [delete-bulk-query (into {}


### PR DESCRIPTION
Fix a bug in the Bulk update/patch routes by enforcing the ids in the document updates as mandatory in the request schemas

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================


Describe the steps to test your PR.

1. issue a bulk update request without supplying ids in the entities
2. the request should fail with an appropriate 400 response
3. profit



<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
public: harden the bulk update schemas
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

