### PR TITLE
Fix jackson command line args parsing

### DIFF
--- a/src/ctia/task/migration/migrate_es_stores.clj
+++ b/src/ctia/task/migration/migrate_es_stores.clj
@@ -366,9 +366,12 @@
   ;; An option with a required argument
   [["-c" "--confirm" "really do the migration?"]
    ["-r" "--restart" "restart ongoing migration?"]
-   [nil "--jackson-maxNestingDepth" "Sets the maximum nesting depth. Corresponds to jackson's StreamReadConstraints$Builder/maxNestingDepth"]
-   [nil "--jackson-maxStringLength" "Sets the maximum string length (in chars or bytes, depending on input context). Corresponds to jackson's StreamReadConstraints$Builder/.maxStringLength"]
-   [nil "--jackson-maxNumberLength" "Sets the maximum number length (in chars or bytes, depending on input context). Corresponds to jackson's StreamReadConstraints$Builder/.maxNumberLength"]
+   [nil "--jackson-maxNestingDepth INT" "Sets the maximum nesting depth. Corresponds to jackson's StreamReadConstraints$Builder/.maxNestingDepth"
+    :parse-fn Integer/parseInt]
+   [nil "--jackson-maxStringLength INT" "Sets the maximum string length (in chars or bytes, depending on input context). Corresponds to jackson's StreamReadConstraints$Builder/.maxStringLength"
+    :parse-fn Integer/parseInt]
+   [nil "--jackson-maxNumberLength INT" "Sets the maximum number length (in chars or bytes, depending on input context). Corresponds to jackson's StreamReadConstraints$Builder/.maxNumberLength"
+    :parse-fn Integer/parseInt]
    ["-h" "--help"]])
 
 (s/defn extract-jackson-config :- (s/maybe mst/JacksonConfig)
@@ -380,19 +383,24 @@
       (update-keys #(keyword (subs (name %) (count "jackson-"))))
       not-empty))
 
-(defn -main [& args]
+(defn prep-run-migration-options [args]
   (let [{:keys [options errors summary]} (parse-opts args cli-options)
         {:keys [restart confirm]} options
         jackson-config (extract-jackson-config options)]
-    (when errors
-      (binding  [*out* *err*]
-        (println (string/join "\n" errors))
-        (println summary))
-      (System/exit 1))
-    (when (:help options)
-      (println summary)
-      (System/exit 0))
-    (pp/pprint options)
-    (run-migration (cond-> {:confirm? confirm
-                            :restart? restart}
-                     jackson-config (assoc :jackson-config jackson-config)))))
+    (cond
+      errors (binding [*out* *err*]
+               (println (string/join "\n" errors))
+               (println summary)
+               1)
+      (:help options) (do (println summary)
+                          0)
+      :else (do (pp/pprint options)
+                (cond-> {:confirm? confirm
+                         :restart? restart}
+                  jackson-config (assoc :jackson-config jackson-config))))))
+
+(defn -main [& args]
+  (let [options-or-exit (prep-run-migration-options args)]
+    (if (integer? options-or-exit)
+      (System/exit options-or-exit)
+      (run-migration options-or-exit))))

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -882,6 +882,19 @@
             :jackson-maxNumberLength 11
             :jackson-maxNestingDepth 12}))))
 
+(deftest prep-run-migration-options-test
+  (is (= 0
+         (sut/prep-run-migration-options ["--help"])
+         (sut/prep-run-migration-options ["-h"])))
+  (is (= 1 (sut/prep-run-migration-options ["--jackson-maxStringLength"])))
+  (is (= 1 (sut/prep-run-migration-options ["--jackson-maxStringLength" "true"])))
+  (is (= {:confirm? nil,
+          :restart? nil,
+          :jackson-config {:maxNestingDepth 10, :maxNumberLength 500, :maxStringLength 250000}}
+         (sut/prep-run-migration-options ["--jackson-maxNestingDepth" "10"
+                                          "--jackson-maxStringLength" "250000"
+                                          "--jackson-maxNumberLength" "500"]))))
+
 ;;(deftest ^:integration minimal-load-test
 ;; (with-each-fixtures identity app
 ;;  (testing "load testing with minimal entities"

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -900,14 +900,33 @@
                                           "--jackson-maxNumberLength" "500"]))))
 
 (deftest wrap-jackson-config-test
-  (is (= "123456789"
-         ((sut/wrap-jackson-config json/parse-stream-strict
-                                   {:maxStringLength 10})
-          (java.io.StringReader. (pr-str "123456789")))))
-  (is (thrown? Exception
-               ((sut/wrap-jackson-config json/parse-stream-strict
-                                         {:maxStringLength 5})
-                (java.io.StringReader. (pr-str "123456789"))))))
+  (testing "maxStringLength"
+    (is (= "123456789"
+           ((sut/wrap-jackson-config json/parse-stream-strict
+                                     {:maxStringLength 10})
+            (java.io.StringReader. (pr-str "123456789")))))
+    (is (thrown? Exception
+                 ((sut/wrap-jackson-config json/parse-stream-strict
+                                           {:maxStringLength 5})
+                  (java.io.StringReader. (pr-str "123456789"))))))
+  (testing "maxNumberLength"
+    (is (= 123456789
+           ((sut/wrap-jackson-config json/parse-stream-strict
+                                     {:maxNumberLength 10})
+            (java.io.StringReader. "123456789"))))
+    (is (thrown? Exception
+                 ((sut/wrap-jackson-config json/parse-stream-strict
+                                           {:maxNumberLength 5})
+                  (java.io.StringReader. "123456789")))))
+  (testing "maxNestingDepth"
+    (is (= [[[[[1]]]]]
+           ((sut/wrap-jackson-config json/parse-stream-strict
+                                     {:maxNestingDepth 10})
+            (java.io.StringReader. "[[[[[1]]]]]"))))
+    (is (thrown? Exception
+                 ((sut/wrap-jackson-config json/parse-stream-strict
+                                           {:maxNestingDepth 3})
+                  (java.io.StringReader. "[[[[[1]]]]]"))))))
 
 ;;(deftest ^:integration minimal-load-test
 ;; (with-each-fixtures identity app

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -886,12 +886,15 @@
   (is (= 0
          (sut/prep-run-migration-options ["--help"])
          (sut/prep-run-migration-options ["-h"])))
+  (is (= {:confirm? nil :restart? nil} (sut/prep-run-migration-options [])))
   (is (= 1 (sut/prep-run-migration-options ["--jackson-maxStringLength"])))
   (is (= 1 (sut/prep-run-migration-options ["--jackson-maxStringLength" "true"])))
-  (is (= {:confirm? nil,
-          :restart? nil,
+  (is (= {:confirm? true,
+          :restart? true,
           :jackson-config {:maxNestingDepth 10, :maxNumberLength 500, :maxStringLength 250000}}
-         (sut/prep-run-migration-options ["--jackson-maxNestingDepth" "10"
+         (sut/prep-run-migration-options ["--confirm"
+                                          "--restart"
+                                          "--jackson-maxNestingDepth" "10"
                                           "--jackson-maxStringLength" "250000"
                                           "--jackson-maxNumberLength" "500"]))))
 

--- a/test/ctia/task/migration/migrate_es_stores_test.clj
+++ b/test/ctia/task/migration/migrate_es_stores_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.task.migration.migrate-es-stores-test
   (:require [clj-momo.lib.clj-time.coerce :as time-coerce]
             [clj-momo.test-helpers.core :as mth]
+            [cheshire.core :as json]
             [clojure.data :refer [diff]]
             [clojure.java.io :as io]
             [clojure.set :as set]
@@ -897,6 +898,16 @@
                                           "--jackson-maxNestingDepth" "10"
                                           "--jackson-maxStringLength" "250000"
                                           "--jackson-maxNumberLength" "500"]))))
+
+(deftest wrap-jackson-config-test
+  (is (= "123456789"
+         ((sut/wrap-jackson-config json/parse-stream-strict
+                                   {:maxStringLength 10})
+          (java.io.StringReader. (pr-str "123456789")))))
+  (is (thrown? Exception
+               ((sut/wrap-jackson-config json/parse-stream-strict
+                                         {:maxStringLength 5})
+                (java.io.StringReader. (pr-str "123456789"))))))
 
 ;;(deftest ^:integration minimal-load-test
 ;; (with-each-fixtures identity app


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

Related https://cisco-sbg.atlassian.net/browse/XDR-15852

Adds missing tests and fixes some bugs in initial implementation.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: Fix jackson command line args parsing
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

