### PR TITLE
XDR-19630 XDR-19632 Update incident interval for new statuses.

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -143,6 +143,13 @@
     (assoc-in [:intervals interval]
               (jt/time-between (jt/instant earlier) (jt/instant later) :seconds))))
 
+(def new-status-set #{"New" "New: Processing" "New: Presented"})
+
+(def open-status-set #{"Open" "Open: Investigating" "Open: Reported" "Open: Contained" "Open: Recovered"})
+
+(def closed-status-set #{"Closed" "Closed: Under Review" "Closed: Confirmed Threat" "Closed: Suspected"
+                         "Closed: False Positive" "Closed: Near-Miss" "Closed: Other" "Closed: Merged"})
+
 (s/defn compute-intervals :- ESStoredIncident
   "Given the currently stored (raw) incident and the incident to update it to, return a new update
   that also computes any relevant intervals that are missing from the updated incident."
@@ -156,14 +163,14 @@
     (cond-> incident
       ;; the duration between the time at which the incident changed from New to Open and the incident creation time
       ;; https://github.com/advthreat/iroh/issues/7622#issuecomment-1496374419
-      (and (= "New" old-status)
-           (= "Open" new-status))
+      (and (new-status-set old-status)
+           (open-status-set new-status))
       (update-interval :new_to_opened
                        (:created prev)
                        (get-in incident [:incident_time :opened]))
 
-      (and (= "Open" old-status)
-           (= "Closed" new-status))
+      (and (open-status-set old-status)
+           (closed-status-set new-status))
       (update-interval :opened_to_closed
                        ;; we assume this was updated by the status route on Open. will be garbage if status was updated
                        ;; in any other way.


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->
> **Epic** XDR-18637
> Close XDR-19630, XDR-19632
<!--
Describe your PR for reviewers.
Don't forget to set correct labels (User Facing / Beta / Feature Flag)
If there is UI change please add a screen capture.
-->
This PR updates incident interval (new_to_opened, opened_to_closed) computation to recognize the new statuses. Note that since these intervals are computed at status update time, the `incident/metric/average` endpoint will only be guaranteed to reflect this new logic for time windows that are after the time this is deployed.

I went back and forth on whether to base the logic on the set of statuses that exist at this time vs. any status that matches a prefix (e.g. 'Open: '). In the end I used the current set and added an assertion in the test file that will fail if new statuses with prefixes 'Open', 'Closed', or 'New' are added in the future. Happy to change that though.


Since the Jira issues are about the Mean Time Tile, we should probably verify there.

1. Generate new incidents.
2. Keeping track of the creation times, update incident statuses to Open, using a variety of the new statuses that begin `Open: `
3. Keeping track of the incident open times, update the incident statuses to Closed, using a variety of the new statuses that begin with `Closed: `.
4. Verify that the values reported by the Mean Time tile agree with what you did (probably using the last 24 hour filter?).

```
intern: Update interval computations for `incident/metric/average` so that new statuses are recognized.
public: 
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

