### PR TITLE
XDR-19630 XDR-19632 Fix interval logic for new statuses.

### DIFF
--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -29,8 +29,7 @@
             [puppetlabs.trapperkeeper.app :as app]
             [schema-tools.core :as st]
             [schema.core :as s]
-            [clojure.string :as string]
-            [ctia.entity.incident :as incident]))
+            [clojure.string :as string]))
 
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
@@ -780,20 +779,20 @@
                 incident (-> incident (assoc :incident_time {:opened later :closed earlier}))]
             (is (= incident (sut/compute-intervals prev incident)))))))))
 
-(s/defn create-incident-at-time
+(s/defn create-incident-at-time :- s/Str
   [app
    time :- s/Inst
    incident :- sut/NewIncident]
   (let [time (jt/java-date time)
-        {[created-incident] :results}
+        {[{incident-id :id}] :results :as results}
         (helpers/fixture-with-fixed-time
           time
           #(create-incidents app #{incident}))
-        resp (get-incident app (:id created-incident))
+        resp (get-incident app incident-id)
         created (-> resp :parsed-body :timestamp)]
     (assert (= time created)
             [time created])
-    created-incident))
+    incident-id))
 
 (deftest incident-average-metrics-test
   (test-for-each-store-with-app
@@ -801,90 +800,87 @@
       (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
       (whoami-helpers/set-whoami-response app "45c1f5e3f05d0" "foouser" "foogroup" "user")
       (try (let [epoch (jt/instant)
-                 [first-created second-created third-created] [0 10 20]
-                 incident-specs [{:title "incident1"
-                                  :new-status "New"
-                                  :open-status "Open"
-                                  :closed-status "Closed"
-                                  :create-at first-created
-                                  :open-at 100
-                                  :close-at 250}
-                                 {:title "incident2"
-                                  :new-status "New: Presented"
-                                  :open-status "Open: Investigating"
-                                  :closed-status "Closed: Merged"
-                                  :create-at second-created
-                                  :open-at 210
-                                  :close-at 460}
-                                 {:title "incident3"
-                                  :new-status "New: Processing"
-                                  :open-status "Open: Investigating"
-                                  :closed-status "Closed: False Positive"
-                                  :create-at third-created
-                                  :open-at 520
-                                  :close-at 1070}]
-                 incident-specs (->> incident-specs
-                                     (mapv (fn [{:keys [create-at open-at close-at] :as incident}]
-                                             (assoc incident
-                                               :new-to-open (- open-at create-at)
-                                               :open-to-close (- close-at open-at)))))
+                 first-created 0 ;;offsets in seconds from epoch to created
+                 second-created 10
+                 third-created 20
+                 first-new_to_opened 100 ;;offsets in seconds from created to opened
+                 second-new_to_opened 200
+                 third-new_to_opened 500
+                 first-opened_to_closed 150 ;;offsets in seconds from opened to closed
+                 second-opened_to_closed 250
+                 third-opened_to_closed 550
+                 incident->status-changes (take 3 [[(assoc (gen-new-incident) :status "New" :title "incident1")
+                                                    {:created first-created
+                                                     :new_to_opened first-new_to_opened
+                                                     :opened-status "Open"
+                                                     :opened_to_closed first-opened_to_closed
+                                                     :closed-status "Closed"}]
+                                                   [(assoc (gen-new-incident) :status "New: Processing" :title "incident2")
+                                                    {:created second-created
+                                                     :new_to_opened second-new_to_opened
+                                                     :opened-status "Open: Reported"
+                                                     :opened_to_closed second-opened_to_closed
+                                                     :closed-status "Closed: False Positive"}]
+                                                   [(assoc (gen-new-incident) :status "New: Presented" :title "incident3")
+                                                    {:created third-created
+                                                     :new_to_opened third-new_to_opened
+                                                     :opened-status "Open: Investigating"
+                                                     :opened_to_closed third-opened_to_closed
+                                                     :closed-status "Closed: Merged"}]])
                  +sec #(jt/plus epoch (jt/seconds %))
-                 specs-with-incidents  (->> incident-specs
-                                            (mapv (fn [{:keys [new-status create-at] :as spec}]
-                                                    (assoc spec
-                                                      :created-incident
-                                                      (create-incident-at-time app
-                                                                               (jt/java-date (+sec create-at))
-                                                                               (assoc (gen-new-incident)
-                                                                                 :status new-status))))))
-                 ;; Create some extra incidents that will not be updated and should be irrelevant for interval computation.
-                 _ (doseq [create-at [0 5 10 20 50]]
-                     (create-incident-at-time app (jt/java-date (+sec create-at)) (gen-new-incident)))
+                 incident-ids (mapv (fn [[incident {:keys [created]}]]
+                                      ;; create extra incidents whose statuses are never changed to simulate a real environment
+                                      (second
+                                        (repeatedly
+                                          2
+                                          #(create-incident-at-time app (jt/java-date (+sec created)) incident))))
+                                    incident->status-changes)
+                 incident-id->incident+intervals (map vector incident-ids incident->status-changes)
+                 _ (assert (= (count incident-id->incident+intervals) (count incident->status-changes))
+                           incident-ids)
                  _ (testing "populate intervals"
-                     (doseq [{:keys [created-incident open-at close-at open-status closed-status]}
-                             specs-with-incidents]
-                       (let [open-resp (helpers/fixture-with-fixed-time (jt/java-date (+sec open-at))
-                                                                        #(post-status app (uri/uri-encode (:id created-incident)) open-status))
-                             close-resp (helpers/fixture-with-fixed-time (jt/java-date (+sec close-at))
-                                                                         #(post-status app (uri/uri-encode (:id created-incident)) closed-status))]
-                         (assert (= 200 (:status open-resp) (:status close-resp))
-                                 "expect status updates to succeed"))))]
+                     (doseq [[incident-id [incident {:keys [created new_to_opened opened-status opened_to_closed closed-status]}]] incident-id->incident+intervals
+                             [new-status next-time] [[opened-status (+sec (+ created new_to_opened))]
+                                                     [closed-status (+sec (+ created new_to_opened opened_to_closed))]]]
+                       (testing (pr-str [new-status incident])
+                         (let [response (helpers/fixture-with-fixed-time
+                                          (jt/java-date next-time)
+                                          #(post-status app (uri/uri-encode incident-id) new-status))]
+                           (assert (= 200 (:status response))
+                                   (pr-str response))))))
+                 avg #(quot (apply + %&) (count %&))]
              (testing "average aggregation"
                (helpers/fixture-with-fixed-time
                  (jt/java-date (jt/plus epoch (jt/days 1))) ;;default `to` query param
                  (fn []
                    ;; the average of intervals.<field> should involve <expected-count> incidents and
                    ;; have value <expected-average> between time window <from> and <to> (latter is optional).
-                   (let [avg (fn [xs]
-                               (long (/ (apply + xs) (count xs))))
-                         ;; Add a time after the last incident was created to exercise null case.
-                         test-boundries [first-created second-created third-created (inc third-created)]]
-                     (doseq [from test-boundries  
-                             to (mapv inc test-boundries)
-                             interval-type [:new-to-open :open-to-close]
-                             :when (<= from to)]
-                       (testing (pr-str interval-type " - " from ":" to)
-                         (let [incidents-in-interval (->> incident-specs
-                                                          (filter (fn [{:keys [create-at]}]
-                                                                    (<= from create-at (dec to)))))
-                               expected-count (count incidents-in-interval)
-                               expected-avg (->> incidents-in-interval
-                                                 (map interval-type)
-                                                 avg)
-                               agg-field (case interval-type
-                                           :new-to-open "new_to_opened"
-                                           :open-to-close "opened_to_closed")
-                               {:keys [parsed-body] :as raw} (GET app "ctia/incident/metric/average"
-                                                               :headers {"Authorization" "45c1f5e3f05d0"}
-                                                               :query-params (cond-> {:aggregate-on (str "intervals." agg-field)
-                                                                                      :from (+sec from)}
-                                                                               to (assoc :to (+sec to))))]
-                           (and (is (= 200 (:status raw)) (pr-str raw))
-                                (is (= expected-count (some-> (get-in raw [:headers "X-Total-Hits"]) Integer/parseInt))
-                                    raw)
-                                (is (= expected-avg
-                                       (some-> (get-in parsed-body [:data :intervals (keyword agg-field)]) Math/floor long))
-                                    (pr-str parsed-body)))))))))))
+                   (doseq [[field expected-count expected-average from to :as test-case]
+                           [["new_to_opened" 3 (avg first-new_to_opened second-new_to_opened third-new_to_opened) first-created]
+                            ["new_to_opened" 2 (avg second-new_to_opened third-new_to_opened) second-created]
+                            ["new_to_opened" 2 (avg first-new_to_opened second-new_to_opened) first-created (inc second-created)]
+                            ["new_to_opened" 1 first-new_to_opened first-created (inc first-created)]
+                            ["new_to_opened" 1 second-new_to_opened second-created (inc second-created)]
+                            ["new_to_opened" 1 third-new_to_opened third-created (inc third-created)]
+                            ["new_to_opened" 1 third-new_to_opened third-created]
+                            ["new_to_opened" 0 nil (inc third-created)]
+                            ["opened_to_closed" 3 (avg first-opened_to_closed second-opened_to_closed third-opened_to_closed) first-created]
+                            ["opened_to_closed" 2 (avg second-opened_to_closed third-opened_to_closed) second-created]
+                            ["opened_to_closed" 1 third-opened_to_closed third-created]
+                            ["opened_to_closed" 0 nil (inc third-created)]]]
+                     (testing (pr-str test-case)
+                       (let [{:keys [parsed-body] :as raw} (GET app "ctia/incident/metric/average"
+                                                                :headers {"Authorization" "45c1f5e3f05d0"}
+                                                                :query-params (cond-> {:aggregate-on (str "intervals." field)
+                                                                                       :from (+sec from)}
+                                                                                to (assoc :to (+sec to))))]
+
+                         (and (is (= 200 (:status raw)) (pr-str raw))
+                              (is (= expected-count (some-> (get-in raw [:headers "X-Total-Hits"]) Integer/parseInt))
+                                  raw)
+                              (is (= expected-average
+                                     (some-> (get-in parsed-body [:data :intervals (keyword field)]) Math/floor long))
+                                  (pr-str parsed-body))))))))))
            (finally (purge-incidents! app))))))
 
 (deftest incident-realize-timestamp-test


### PR DESCRIPTION
This is an amendment to a previous change. In my previous PR I had missed that the logic for recording the new status changes in `:incident_time` was also needed (and necessary for interval computation).

See the main PR for details: https://github.com/threatgrid/ctia/pull/1467

I also took the opportunity to make a change suggested by @ereteog in the previous PR to use regex's instead of sets to recognize 'New', 'Open', and 'Closed' statuses. 