### PR TITLE
XDR-27079 Add new_to_contained interval to incident.

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.0.2:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.25:compile
++- threatgrid:ctim:jar:1.3.26:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.0.2:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.24:compile
++- threatgrid:ctim:jar:1.3.25:compile
 |  +- org.mozilla:rhino:jar:1.7.7.1:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.3:compile
 |     \- org.clojure:clojurescript:jar:1.7.122:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.24</version>
+      <version>1.3.25</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.25</version>
+      <version>1.3.26</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [threatgrid/flanders "1.0.2"]
-                 [threatgrid/ctim "1.3.25"]
+                 [threatgrid/ctim "1.3.26"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -88,7 +88,7 @@
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [threatgrid/flanders "1.0.2"]
-                 [threatgrid/ctim "1.3.24"]
+                 [threatgrid/ctim "1.3.25"]
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.3.5"]
                  [threatgrid/ductile "0.5.0"]

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -39,7 +39,6 @@
    [schema-tools.core :as st]
    [schema.core :as s]))
 
-(def incident-bundle-default-limit 1000)
 
 (s/defschema Incident
   (st/merge
@@ -72,7 +71,8 @@
 ;;NOTE: changing this requires a ES mapping refresh
 (def incident-intervals
   [:new_to_opened
-   :opened_to_closed])
+   :opened_to_closed
+   :new_to_contained])
 
 (def-stored-schema StoredIncident Incident)
 
@@ -119,27 +119,32 @@
 (defn open-status? [status]
    (some? (re-matches #"Open(: .+)?" status)))
 
+(defn contained-status? [status]
+  (= status "Open: Contained"))
+
 (defn closed-status? [status]
   (some? (re-matches #"Closed(: .+)?" status)))
 
 (defn make-status-update
   [{:keys [status]}]
   (let [t (time/internal-now)
-        verb (or (case status
-                   "New" nil
-                   "Stalled" nil
-                   "Hold" nil
-                   ;; Note: GitHub syntax highlighting doesn't like lists with strings
-                   "Containment Achieved" :remediated
-                   "Restoration Achieved" :remediated
-                   "Rejected" :rejected
-                   "Incident Reported" :reported
-                   nil)
-                 (cond
-                   (open-status? status) :opened
-                   (closed-status? status) :closed))]
+        verbs (case status
+                "New" nil
+                "Stalled" nil
+                "Hold" nil
+                ;; Note: GitHub syntax highlighting doesn't like lists with strings
+                "Containment Achieved" [:remediated]
+                "Restoration Achieved" [:remediated]
+                "Rejected" [:rejected]
+                "Incident Reported" [:reported]
+                "Open: Contained" [:opened :contained]
+                (cond
+                  (open-status? status) [:opened]
+                  (closed-status? status) [:closed]))]
     (cond-> {:status status}
-      verb (assoc :incident_time {verb t}))))
+      verbs (assoc :incident_time (into {}
+                                        (map (fn [verb] [verb t]))
+                                        verbs)))))
 
 (s/defn ^:private update-interval :- ESStoredIncident
   [{:keys [intervals] :as incident} :- ESStoredIncident
@@ -178,7 +183,13 @@
                        ;; we assume this was updated by the status route on Open. will be garbage if status was updated
                        ;; in any other way.
                        (get-in prev [:incident_time :opened])
-                       (get-in incident [:incident_time :closed])))))
+                       (get-in incident [:incident_time :closed]))
+
+      (and (new-status? old-status)
+           (contained-status? new-status))
+      (update-interval :new_to_contained
+                       (:created prev)
+                       (get-in incident [:incident_time :contained])))))
 
 (s/defn un-store-incident :- PartialStoredIncident
   [{:keys [doc]} :- {:doc ESPartialStoredIncident
@@ -283,6 +294,7 @@
            :incident_time.remediated
            :incident_time.closed
            :incident_time.rejected
+           :incident_time.contained
            :discovery_method
            :intended_effect
            :assignees
@@ -371,12 +383,14 @@
    :incident_time.reported
    :incident_time.remediated
    :incident_time.closed
-   :incident_time.rejected])
+   :incident_time.rejected
+   :incident_time.contained])
 
 (def incident-average-fields
   {;; restrict to entities _created_ within from/to interval.
    :intervals.new_to_opened {:date-field :created}
-   :intervals.opened_to_closed {:date-field :created}})
+   :intervals.opened_to_closed {:date-field :created}
+   :intervals.new_to_contained {:date-field :created}})
 
 (s/defschema IncidentFieldsParam
   {(s/optional-key :fields) [(apply s/enum incident-fields)]})

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -185,7 +185,7 @@
                        (get-in prev [:incident_time :opened])
                        (get-in incident [:incident_time :closed]))
 
-      (and (new-status? old-status)
+      (and (or (open-status? old-status) (new-status? old-status))
            (contained-status? new-status))
       (update-interval :new_to_contained
                        (:created prev)

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -142,9 +142,7 @@
                   (open-status? status) [:opened]
                   (closed-status? status) [:closed]))]
     (cond-> {:status status}
-      verbs (assoc :incident_time (into {}
-                                        (map (fn [verb] [verb t]))
-                                        verbs)))))
+      verbs (assoc :incident_time (zipmap verbs (repeat t))))))
 
 (s/defn ^:private update-interval :- ESStoredIncident
   [{:keys [intervals] :as incident} :- ESStoredIncident

--- a/src/ctia/stores/es/mapping.clj
+++ b/src/ctia/stores/es/mapping.clj
@@ -166,7 +166,8 @@
     :reported ts
     :remediated ts
     :closed ts
-    :rejected ts}})
+    :rejected ts
+    :contained ts}})
 
 (def action-type
   {:properties

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -780,7 +780,8 @@
             (is (= incident (sut/compute-intervals prev incident)))))))
     (testing "updating new_to_contained"
       (let [prev (assoc prev :status "New: Presented")
-            incident (assoc prev :status "Open: Contained" :incident_time {:contained later})]
+            incident (-> (assoc prev :status "Open: Contained")
+                         (assoc-in [:incident_time :contained] later))]
         (testing "if prev does not already have a :new_to_contained interval, compute interval and include in update"
           (is (= (assoc incident :intervals {:new_to_contained computed-interval})
                  (sut/compute-intervals prev incident))))
@@ -794,7 +795,8 @@
               (is (= incident (sut/compute-intervals (assoc prev :status stored-status) incident))))))
         (testing "if :created is after the updated :incident_time.contained, elide interval from update"
           (let [prev (assoc prev :created later)
-                incident (assoc prev :status "Open: Contained" :incident_time {:contained earlier})]
+                incident (-> (assoc prev :status "Open: Contained")
+                             (assoc-in [:incident_time :contained] earlier))]
             (is (= incident
                    (sut/compute-intervals prev incident)))))))))
 

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -852,13 +852,13 @@
                                                    [(assoc (gen-new-incident) :status "New: Processing" :title "incident2")
                                                     {:created i2-created
                                                      :new_to_opened i2-new_to_opened
-                                                     :opened-status "Open: Contained"
+                                                     :opened-status "Open: Investigating"
                                                      :opened_to_closed i2-opened_to_closed
                                                      :closed-status "Closed: False Positive"}]
                                                    [(assoc (gen-new-incident) :status "New: Presented" :title "incident3")
                                                     {:created i3-created
                                                      :new_to_opened i3-new_to_contained
-                                                     :opened-status "Open: Investigating"
+                                                     :opened-status "Open: Contained"
                                                      :opened_to_closed i3-opened_to_closed
                                                      :closed-status "Closed: Merged"}]])
                  +sec #(jt/plus epoch (jt/seconds %))

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -327,7 +327,8 @@
                          :reported #inst "2010-01-01T00:00:06.129-00:00",
                          :remediated #inst "2010-01-01T00:02:07.145-00:00",
                          :closed #inst "2010-01-01T00:00:02.349-00:00",
-                         :rejected #inst "2010-01-01T00:00:00.327-00:00"},
+                         :rejected #inst "2010-01-01T00:00:00.327-00:00"
+                         :contained #inst "2010-01-01T00:00:00.327-00:00"},
                         :status "New",
                         :confidence "High"}
                        {:description "desc",

--- a/test/ctia/http/generative/fulltext_search_test.clj
+++ b/test/ctia/http/generative/fulltext_search_test.clj
@@ -344,7 +344,8 @@
                          :reported #inst "2010-01-01T00:00:06.129-00:00",
                          :remediated #inst "2010-01-01T00:02:07.145-00:00",
                          :closed #inst "2010-01-01T00:00:02.349-00:00",
-                         :rejected #inst "2010-01-01T00:00:00.327-00:00"},
+                         :rejected #inst "2010-01-01T00:00:00.327-00:00"
+                         :contained #inst "2010-01-01T00:00:00.327-00:00"},
                         :status "New",
                         :confidence "High"}]}
             ignore-ks  [:created :groups :id :incident_time :modified :owner :timestamp]]

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -73,6 +73,7 @@ fragment incidentTimeFields on IncidentTime {
   remediated
   closed
   rejected
+  contained
 }
 
 fragment incidentFields on Incident {


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> **Epic** [XDR-18637](https://cisco-sbg.atlassian.net/browse/XDR-18637)
> Close [XDR-27079](https://cisco-sbg.atlassian.net/browse/XDR-27079)
> Related [XDR-21512](https://cisco-sbg.atlassian.net/browse/XDR-21512)

This PR adds a new_to_contained interval Incident to support a new Mean Time dashboard tile. 'Contained' refers to the status 'Open: Contained'. To support this interval, a new `incident_time` type, `contained` was added to CTIM. 

<a name="QA">[§](#ops)</a> QA


1. Create some incidents, record the time for each creation. Optionally, move some of them to an Open status other than 'Open: Contained' such as 'Open: Investigating'. The interval should eventually be recorded regardless of whether or not there were intermediate 'Open' statuses .
2. Update status(es) to `Opened: Contained` using the `/ctia/incident/{id}/status` endpoint, recording the time for each status change. 
3. Use `incident/metric/histogram` and `aggregate-on=incident_time.contained`, expecting to see values corresponding to the times you recorded above. 
4. Use `incident/metric/average` to retrieve the average value of time elapsed between Incident creation and status change. Set `aggregate-on` to `intervals.new_to_contained`. Set `from` and `to` to various times based on the times recorded above. Any incident _created_ within the `from`-`to` window will be included. Expect the correct averages for time elapsed.
<a name="ops">[§](#ops)</a> Ops

Requires an ES mapping migration. @ereteog indicated that he will coordinate with ops during business hours in France.


<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

public: Add new metric type to `incident/metric/average`: `intervals.new_to_contained`. Add new field to incident object `incident_time.contained` and a corresponding metric to `/ctia/incident/metric/histogram`.

[XDR-18637]: https://cisco-sbg.atlassian.net/browse/XDR-18637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[XDR-27079]: https://cisco-sbg.atlassian.net/browse/XDR-27079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[XDR-21512]: https://cisco-sbg.atlassian.net/browse/XDR-21512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ