### PR TITLE
Fix kafka docs

### DIFF
--- a/dev/ctia/dev/split_tests.clj
+++ b/dev/ctia/dev/split_tests.clj
@@ -222,7 +222,7 @@
                  (str "set +e; "
                       "SECONDS=0; "
                       "until echo dump | nc 127.0.0.1 2181 | grep brokers; do sleep 1; " exit-if-too-long " ; done"))
-          (assert-sh "Error connecting to kafaka"))
+          (assert-sh "Error connecting to kafka"))
       (println "[ctia.dev.split-tests] Docker initialized."))))
 
 ;Derived from https://github.com/circleci/circleci.test/blob/master/src/circleci/test.clj

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -204,11 +204,11 @@ Rate limit related configuration
 
 | Property                                   | Description                         | Possible values |
 |--------------------------------------------+-------------------------------------+-----------------|
-| ctia.hook.kafa.request-size                | set the Kafa max request size       | number          |
-| ctia.hook.kafa.zk.address                  | Zookeeper address                   | string          |
-| ctia.hook.kafa.topic.name                  | The topic name to push messages to  | string          |
-| ctia.hook.kafa.topic.num-partitions        | Setup the topic partition countDown | string          |
-| ctia.hook.kafa.topic.replication-factor    | Setup the topic replication-factor  | string          |
+| ctia.hook.kafka.request-size                | set the Kafa max request size       | number          |
+| ctia.hook.kafka.zk.address                  | Zookeeper address                   | string          |
+| ctia.hook.kafka.topic.name                  | The topic name to push messages to  | string          |
+| ctia.hook.kafka.topic.num-partitions        | Setup the topic partition countDown | string          |
+| ctia.hook.kafka.topic.replication-factor    | Setup the topic replication-factor  | string          |
 | ctia.hook.kafka.ssl.enabled                | Configure SSL Transport             | Boolean         |
 | ctia.hook.kafka.ssl.truststore.location    | SSL truststore location             | String          |
 | ctia.hook.kafka.ssl.truststore.password    | SSL truststore password             | string          |


### PR DESCRIPTION
Trivial typos.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================

<!--
Describe the steps to test your PR.

1.
2.
3.

Or if no QA is needed keep it as is.
 -->
No QA is needed.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="ops">[§](#ops)</a> Ops
===============================

  Specify Ops related issues and documentation
- Config change needed: threatgrid/tenzin#
- Migration needed: threatgrid/tenzin#
- How to enable/disable that feature: (ex remove service from `bootstrap.cfg`, add scope to org)
-->

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="documentation">[§](#documentation)</a> Documentation
=============================================================

  Public Facing documentation section;
- Public documentation updated needed: threatgrid/iroh-ui#
  See internal [doc file](./services/iroh-auth/doc/public-doc.org)
 -->

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

<!-- REMOVE UNUSED LINES -->

```
intern: one-line description for internal eyes only.
public: one line description for public release notes.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

