### PR TITLE
Apply status change logic to PATCH route and support Hold →    Closed transitions

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -144,7 +144,7 @@
     ;; Status has changed, apply status update logic
     (let [status-update (make-status-update {:status (:status new-obj)})
           ;; Merge the incident_time updates from status change logic
-          ;; Only update incident_time fields that aren't already explicitly set
+          ;; Explicitly provided values (current-incident-time) take precedence over auto-generated ones
           incident-time-updates (get status-update :incident_time {})
           current-incident-time (get new-obj :incident_time {})
           merged-incident-time (merge incident-time-updates current-incident-time)]

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -54,11 +54,39 @@
   (GET app (str "ctia/incident/" (uri/uri-encode id))
        :headers {"Authorization" "45c1f5e3f05d0"}))
 
+(defn create-test-incident
+  "Creates a fresh incident with status 'New' for testing. Returns the incident ID."
+  [app]
+  (let [incident-to-create (-> new-incident-minimal
+                                (dissoc :id :severity :incident_time)
+                                (assoc :title (str "Test Incident " (java.util.UUID/randomUUID))
+                                       :status "New"
+                                       ;; incident_time is required and must have :opened
+                                       :incident_time {:opened (t/internal-now)}))
+        response (POST app
+                       "ctia/incident"
+                       :body incident-to-create
+                       :headers {"Authorization" "45c1f5e3f05d0"})
+        incident (:parsed-body response)]
+    (assert (= 201 (:status response)) (str "Failed to create incident: " response))
+    (:id incident)))
+
+(defn delete-incident
+  "Deletes an incident by ID."
+  [app incident-id]
+  (helpers/DELETE app
+                  (str "ctia/incident/" (uri/uri-encode incident-id))
+                  :headers {"Authorization" "45c1f5e3f05d0"}))
+
 (defn additional-tests [app incident-id incident]
-  (let [fixed-now (t/internal-now)]
-    (helpers/fixture-with-fixed-time
-     fixed-now
-     (fn []
+  (let [fixed-now (t/internal-now)
+        ;; Track test incidents for cleanup
+        test-incidents (atom [])]
+    (try
+      (helpers/fixture-with-fixed-time
+       fixed-now
+       (fn []
+       ;; Keep the original POST status tests with the shared incident
        (testing "Incident status update: test setup"
          (let [response (PATCH app
                                (str "ctia/incident/" (:short-id incident-id))
@@ -103,9 +131,12 @@
            (is (= (get-in updated-incident [:incident_time :contained])
                   (tc/to-date fixed-now)))))
 
+       ;; PATCH tests with fresh incidents for each test
        (testing "PATCH /ctia/incident/:id with status change to Open"
-         (let [response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               response (PATCH app
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:status "Open"}
                                :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
@@ -115,8 +146,16 @@
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id with status change to Closed"
-         (let [response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               ;; First set to Open to have a valid transition
+               _ (PATCH app
+                        (str "ctia/incident/" (uri/uri-encode test-id))
+                        :body {:status "Open"}
+                        :headers {"Authorization" "45c1f5e3f05d0"})
+               ;; Then test New -> Closed transition
+               response (PATCH app
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:status "Closed"}
                                :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
@@ -126,8 +165,10 @@
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id with status change to Containment Achieved"
-         (let [response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               response (PATCH app
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:status "Containment Achieved"}
                                :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
@@ -137,24 +178,35 @@
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id with status change to Open: Contained"
-         (let [response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               response (PATCH app
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:status "Open: Contained"}
                                :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
            (is (= 200 (:status response)))
            (is (= "Open: Contained" (:status updated-incident)))
            (is (= (get-in updated-incident [:incident_time :contained])
+                  (tc/to-date fixed-now)))
+           (is (= (get-in updated-incident [:incident_time :opened])
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id without status change does not update incident_time"
-         (let [;; Get current incident
-               current (get-incident app (:id incident))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               ;; First, set a status to establish incident_time
+               _ (PATCH app
+                        (str "ctia/incident/" (uri/uri-encode test-id))
+                        :body {:status "Open"}
+                        :headers {"Authorization" "45c1f5e3f05d0"})
+               ;; Get current incident
+               current (get-incident app test-id)
                current-incident (:parsed-body current)
                current-incident-time (:incident_time current-incident)
                ;; Update something other than status
                response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:description "Updated description"}
                                :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body response)]
@@ -164,9 +216,11 @@
            (is (= current-incident-time (:incident_time updated-incident)))))
 
        (testing "PATCH /ctia/incident/:id preserves explicitly set incident_time fields"
-         (let [custom-time (tc/to-date (t/plus fixed-now (t/hours 2)))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               custom-time (tc/to-date (t/plus fixed-now (t/hours 2)))
                response (PATCH app
-                               (str "ctia/incident/" (:short-id incident-id))
+                               (str "ctia/incident/" (uri/uri-encode test-id))
                                :body {:status "Open"
                                       :incident_time {:opened custom-time}}
                                :headers {"Authorization" "45c1f5e3f05d0"})
@@ -177,12 +231,14 @@
            (is (= custom-time (get-in updated-incident [:incident_time :opened])))))
 
        (testing "POST /ctia/incident/:id/status Hold to Closed transition"
-         ;; First set status to Hold
-         (let [hold-response (post-status app (:short-id incident-id) "Hold")
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               ;; First set status to Hold
+               hold-response (post-status app (uri/uri-encode test-id) "Hold")
                _ (is (= 200 (:status hold-response)))
                _ (is (= "Hold" (:status (:parsed-body hold-response))))
                ;; Then transition to Closed
-               closed-response (post-status app (:short-id incident-id) "Closed")
+               closed-response (post-status app (uri/uri-encode test-id) "Closed")
                updated-incident (:parsed-body closed-response)]
            (is (= 200 (:status closed-response)))
            (is (= "Closed" (:status updated-incident)))
@@ -190,16 +246,18 @@
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id with status change from Hold to Closed"
-         ;; First set status to Hold
-         (let [hold-response (PATCH app
-                                    (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               ;; First set status to Hold
+               hold-response (PATCH app
+                                    (str "ctia/incident/" (uri/uri-encode test-id))
                                     :body {:status "Hold"}
                                     :headers {"Authorization" "45c1f5e3f05d0"})
                _ (is (= 200 (:status hold-response)))
                _ (is (= "Hold" (:status (:parsed-body hold-response))))
                ;; Then transition to Closed via PATCH
                closed-response (PATCH app
-                                      (str "ctia/incident/" (:short-id incident-id))
+                                      (str "ctia/incident/" (uri/uri-encode test-id))
                                       :body {:status "Closed"}
                                       :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body closed-response)]
@@ -209,24 +267,29 @@
                   (tc/to-date fixed-now)))))
 
        (testing "PATCH /ctia/incident/:id with status change from Hold: Internal to Closed: Other"
-         ;; First set status to Hold: Internal
-         (let [hold-response (PATCH app
-                                    (str "ctia/incident/" (:short-id incident-id))
+         (let [test-id (create-test-incident app)
+               _ (swap! test-incidents conj test-id)
+               ;; First set status to Hold: Internal
+               hold-response (PATCH app
+                                    (str "ctia/incident/" (uri/uri-encode test-id))
                                     :body {:status "Hold: Internal"}
                                     :headers {"Authorization" "45c1f5e3f05d0"})
                _ (is (= 200 (:status hold-response)))
                _ (is (= "Hold: Internal" (:status (:parsed-body hold-response))))
                ;; Then transition to Closed: Other via PATCH
                closed-response (PATCH app
-                                      (str "ctia/incident/" (:short-id incident-id))
+                                      (str "ctia/incident/" (uri/uri-encode test-id))
                                       :body {:status "Closed: Other"}
                                       :headers {"Authorization" "45c1f5e3f05d0"})
                updated-incident (:parsed-body closed-response)]
            (is (= 200 (:status closed-response)))
            (is (= "Closed: Other" (:status updated-incident)))
            (is (= (get-in updated-incident [:incident_time :closed])
-                  (tc/to-date fixed-now)))))))))
-
+                  (tc/to-date fixed-now)))))))
+      (finally
+        ;; Clean up test incidents
+        (doseq [test-id @test-incidents]
+          (delete-incident app test-id))))))
 
 (deftest test-incident-crud-routes
   (test-for-each-store-with-app


### PR DESCRIPTION
<!-- Specify linked issues and REMOVE THE UNUSED LINES -->

> Related #https://cisco-sbg.atlassian.net/browse/XDR-35708

### Overview
     1. Updates PATCH `/ctia/incident/{id}` to automatically detect
   status changes and apply the same logic as POST
   `/ctia/incident/{id}/status`, resolving the frequent error of
   using PATCH for status updates without triggering `incident_time`
   field updates.
     2. Extends Hold → Closed transitions to trigger
   `opened_to_closed` interval calculation (similar to Open →
   Closed), enabling proper time tracking for incidents placed on
   hold.

### Changes
     - Added `apply-status-update-logic` function to detect status
   changes and apply `make-status-update` logic before realization
     - Modified `realize-incident` to call status update logic when
   status changes are detected
     - Explicitly provided `incident_time` values take precedence
   over auto-generated ones
     - `compute-intervals` already supports Hold → Closed via
   `hold-status?` function (no code changes needed, just tests)

### Backwards Compatibility
     Fully backwards compatible. POST route unchanged, PATCH now
   provides consistent behavior, explicit overrides still work.

<!-- UNCOMMENT THIS SECTION IF NEEDED
<a name="iroh-services-clients">[§](#iroh-services-clients)</a> IROH Services Clients
=====================================================================================

Put all informations that need to be communicated to IROH Services Clients.
Typically IROH-UI, ATS Integration, Orbital, etc...
 -->

<a name="qa">[§](#qa)</a> QA
============================
  Setup

     - Create a test incident with status "New"
     - Note the incident ID for use in all tests below

   Test Cases

   1. PATCH Status Change to Open

     PATCH /ctia/incident/{id}
     Body: {"status": "Open"}

   Expected: Response includes incident_time.opened with current
   timestamp

   2. PATCH Status Change from Hold to Closed

     # First, set to Hold
     PATCH /ctia/incident/{id}
     Body: {"status": "Hold"}

     # Then, transition to Closed
     PATCH /ctia/incident/{id}
     Body: {"status": "Closed"}

   Expected: Response includes incident_time.closed with current
   timestamp

   3. PATCH with Hold Substatus to Closed Substatus

     # Set to Hold: Internal
     PATCH /ctia/incident/{id}
     Body: {"status": "Hold: Internal"}

     # Transition to Closed: Other
     PATCH /ctia/incident/{id}
     Body: {"status": "Closed: Other"}

   Expected: Response includes incident_time.closed with current
   timestamp

   4. PATCH Without Status Change

     PATCH /ctia/incident/{id}
     Body: {"description": "Updated description"}

   Expected: incident_time fields remain unchanged from previous
   state

   5. PATCH with Explicit incident_time Override

     PATCH /ctia/incident/{id}
     Body: {
       "status": "Open",
       "incident_time": {"opened": "2024-01-01T00:00:00.000Z"}
     }

   Expected: incident_time.opened uses the provided timestamp, not
   current time

   6. Verify POST Route Still Works

     POST /ctia/incident/{id}/status
     Body: {"status": "Closed"}

   Expected: Behavior unchanged from before, incident_time.closed set
    correctly

   Validation

     - All status transitions should set appropriate incident_time
   fields
     - PATCH and POST routes should produce identical results for
   status changes
     - Hold → Closed transitions should work like Open → Closed
   transitions

