### PR TITLE
Upgrade CTIM to 1.3.30

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -46,7 +46,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.1.0:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.29:compile
++- threatgrid:ctim:jar:1.3.30:compile
 |  +- org.mozilla:rhino:jar:1.8.0:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.5:compile
 |     \- org.clojure:clojurescript:jar:1.11.132:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.29</version>
+      <version>1.3.30</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -90,7 +90,7 @@
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
                  [threatgrid/flanders "1.1.0"]
-                 [threatgrid/ctim "1.3.29"
+                 [threatgrid/ctim "1.3.30"
                   :exclusions [com.cognitect/transit-java]] ;; ring-middleware-format takes precedence
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.4.1"]

--- a/test/data/incident.graphql
+++ b/test/data/incident.graphql
@@ -108,6 +108,7 @@ fragment incidentFields on Incident {
   groups
   assignees
   promotion_method
+  detection_status
   severity
   tactics
   techniques


### PR DESCRIPTION
This PR bumps the version of CTIM from 1.3.29 to 1.3.30. The underlying change to CTIM introduces a new optional `detection_status` field on incidents. See: https://github.com/threatgrid/ctim/pull/481