### PR TITLE
change: update incident_time.closed and opened_to_closed interval on re-close (XDR-42815)

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -148,7 +148,7 @@
           new-status (:status new-obj)
           status-update (make-status-update {:status new-status})
           ;; Merge the incident_time updates from status change logic
-          ;; Explicitly provided values (current-incident-time) take precedence over auto-generated ones
+          ;; Existing values take precedence (set-once semantics for opened, contained, etc.)
           incident-time-updates (get status-update :incident_time {})
           current-incident-time (get new-obj :incident_time {})
           ;; If transitioning from closed to closed, preserve the original closed date
@@ -159,9 +159,16 @@
           prev-opened-date (when (and (open-status? old-status)
                                       (open-status? new-status))
                              (get-in prev-obj [:incident_time :opened]))
+          ;; On re-close (non-closed → closed), update closed date for time-to-resolution
+          new-closed-date (when (and (closed-status? new-status)
+                                     (not (closed-status? old-status)))
+                            (get-in status-update [:incident_time :closed]))
+          ;; prev-closed-date and new-closed-date are mutually exclusive:
+          ;; prev-closed-date requires old-status to be closed, new-closed-date requires it not to be.
           merged-incident-time (cond-> (merge incident-time-updates current-incident-time)
                                  prev-closed-date (assoc :closed prev-closed-date)
-                                 prev-opened-date (assoc :opened prev-opened-date))]
+                                 prev-opened-date (assoc :opened prev-opened-date)
+                                 new-closed-date (assoc :closed new-closed-date))]
       (cond-> new-obj
         (seq merged-incident-time) (assoc :incident_time merged-incident-time)))
     ;; No status change or no previous object, return as-is
@@ -200,11 +207,19 @@
   that also computes any relevant intervals that are missing from the updated incident."
   [{old-status :status :as prev} :- ESStoredIncident
    {new-status :status :as incident} :- StoredIncident]
-  (let [incident (into incident (select-keys prev [:intervals]))]
+  (let [incident (into incident (select-keys prev [:intervals]))
+        ;; On re-close (non-closed → closed), clear stale opened_to_closed so it gets recomputed.
+        ;; This dissoc is necessary because update-interval has a "don't clobber" guard
+        ;; that skips intervals already present.
+        incident (cond-> incident
+                   (and (not (closed-status? old-status))
+                        (closed-status? new-status)
+                        (get-in incident [:intervals :opened_to_closed]))
+                   (update :intervals dissoc :opened_to_closed))]
     ;; note: incident_time.opened is a required field, so its presence is meaningless.
     ;; note: intervals are independent. they can be triggered in any order and only one can be calculated per change.
     ;; e.g., :opened_to_closed does not backfill :new_to_opened, nor prevents :new_to_opened from being filled later.
-    ;; note: each interval is calculated at most once per incident.
+    ;; note: each interval is calculated at most once per incident, except opened_to_closed which is recomputed on re-close.
     (cond-> incident
       ;; the duration between the time at which the incident changed from New to Open and the incident creation time
       ;; https://github.com/advthreat/iroh/issues/7622#issuecomment-1496374419

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -34,6 +34,72 @@
 (use-fixtures :once (join-fixtures [mth/fixture-schema-validation
                                     whoami-helpers/fixture-server]))
 
+(deftest apply-status-update-logic-test
+  (let [t1 #inst "2026-01-01T00:00:00.000Z"
+        t2 #inst "2026-01-02T00:00:00.000Z"
+        t3 #inst "2026-01-03T00:00:00.000Z"]
+
+    (testing "re-close scenario: Closed → Open → Closed updates closed timestamp"
+      ;; Simulate: incident was closed at t1, reopened at t2, re-closed at t3
+      ;; After the reopen, prev-obj has status "Open" and incident_time includes {:closed t1, :opened t2}
+      ;; The PATCH body is {:status "Closed"}, which after deep-merge with prev becomes:
+      ;; {:status "Closed", :incident_time {:closed t1, :opened t2}} (old incident_time preserved)
+      (helpers/fixture-with-fixed-time
+       t3
+       (fn []
+         (let [prev-obj {:status "Open"
+                         :incident_time {:opened t2
+                                         :closed t1}}
+               new-obj {:status "Closed"
+                        :incident_time {:opened t2
+                                        :closed t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= "Closed" (:status result)))
+           (is (= t3 (get-in result [:incident_time :closed]))
+               "Closed date should be updated to NOW on re-close, not preserved from first close")
+           (is (= t2 (get-in result [:incident_time :opened]))
+               "Opened date should be preserved")))))
+
+    (testing "first close: Open → Closed sets closed timestamp"
+      (helpers/fixture-with-fixed-time
+       t2
+       (fn []
+         (let [prev-obj {:status "Open"
+                         :incident_time {:opened t1}}
+               new-obj {:status "Closed"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t2 (get-in result [:incident_time :closed]))
+               "Closed date should be set on first close")
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should be preserved")))))
+
+    (testing "closed-to-closed transition preserves original closed date"
+      (helpers/fixture-with-fixed-time
+       t2
+       (fn []
+         (let [prev-obj {:status "Closed: False Positive"
+                         :incident_time {:closed t1}}
+               new-obj {:status "Closed: Confirmed Threat"
+                        :incident_time {:closed t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :closed]))
+               "Closed date should be PRESERVED when transitioning between closed statuses")))))
+
+    (testing "re-open does not update opened date (set-once semantics)"
+      (helpers/fixture-with-fixed-time
+       t3
+       (fn []
+         (let [prev-obj {:status "Closed"
+                         :incident_time {:opened t1
+                                         :closed t2}}
+               new-obj {:status "Open"
+                        :incident_time {:opened t1
+                                        :closed t2}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should NOT change on re-open")))))))
+
 (deftest incident-scores-schema-test
   (let [get-in-config (partial get-in {:ctia {:http {:incident {:score-types "global,ttp,asset"}}}})
         fake-services {:ConfigService {:get-in-config get-in-config}}
@@ -77,6 +143,39 @@
   (helpers/DELETE app
                   (str "ctia/incident/" (uri/uri-encode incident-id))
                   :headers {"Authorization" "45c1f5e3f05d0"}))
+
+(defn run-reclose-scenario
+  "Executes a close → reopen → reclose scenario and verifies
+   that the closed date is updated on re-close."
+  [app fixed-now test-incidents transition-fn]
+  (let [test-id (create-test-incident app)
+        _ (swap! test-incidents conj test-id)
+        ;; Step 1: Close the incident
+        first-response (transition-fn app test-id "Closed")
+        first-closed-date (get-in (:parsed-body first-response) [:incident_time :closed])]
+    (is (= 200 (:status first-response)))
+    (is (= "Closed" (:status (:parsed-body first-response))))
+    (is (some? first-closed-date) "First closed date should be set")
+    ;; Step 2: Re-open (5 min later)
+    (helpers/fixture-with-fixed-time
+     (t/plus fixed-now (t/minutes 5))
+     (fn []
+       (let [reopen-response (transition-fn app test-id "Open")]
+         (is (= 200 (:status reopen-response)))
+         (is (= "Open" (:status (:parsed-body reopen-response))))
+         ;; Step 3: Re-close (10 min later)
+         (helpers/fixture-with-fixed-time
+          (t/plus fixed-now (t/minutes 10))
+          (fn []
+            (let [reclose-response (transition-fn app test-id "Closed")
+                  second-closed-date (get-in (:parsed-body reclose-response) [:incident_time :closed])]
+              (is (= 200 (:status reclose-response)))
+              (is (= "Closed" (:status (:parsed-body reclose-response))))
+              (is (some? second-closed-date) "Second closed date should be set")
+              (is (not= first-closed-date second-closed-date)
+                  "Closed date should be UPDATED on re-close, not preserved from first close")
+              (is (= (tc/to-date (t/plus fixed-now (t/minutes 10))) second-closed-date)
+                  "Closed date should reflect the time of the re-close")))))))))
 
 (defn additional-tests [app incident-id incident]
   (let [fixed-now (t/internal-now)
@@ -474,6 +573,22 @@
                     "Contained date should be DIFFERENT from opened date")
                 (is (= (tc/to-date (t/plus fixed-now (t/minutes 5))) contained-date)
                     "Contained date should be the time of transition to Open: Contained"))))))
+
+       ;; XDR-42815: Re-close tests (Closed → Open → Closed)
+       ;; Note: interval recomputation (opened_to_closed) is verified at unit level only,
+       ;; as un-store-incident strips :intervals from API responses.
+       (testing "PATCH /ctia/incident/:id: Closed date updated on re-close (Closed → Open → Closed)"
+         (run-reclose-scenario app fixed-now test-incidents
+           (fn [app id status]
+             (PATCH app
+                    (str "ctia/incident/" (uri/uri-encode id))
+                    :body {:status status}
+                    :headers {"Authorization" "45c1f5e3f05d0"}))))
+
+       (testing "POST /ctia/incident/:id/status: Closed date updated on re-close (Closed → Open → Closed)"
+         (run-reclose-scenario app fixed-now test-incidents
+           (fn [app id status]
+             (post-status app (uri/uri-encode id) status))))
       (finally
         ;; Clean up test incidents
         (doseq [test-id @test-incidents]
@@ -1165,14 +1280,27 @@
         (testing "if :stored-incident does not already have an :opened_to_closed interval, compute it"
           (is (= (assoc-in incident [:intervals :opened_to_closed] computed-interval)
                  (sut/compute-intervals prev incident))))
-        (testing "if :stored-incident already has an :opened_to_closed interval, don't add it to the update"
-          (let [prev (assoc prev :intervals {:opened_to_closed (* 2 (rand-int (inc computed-interval)))})]
-            (is (= (assoc incident :intervals (:intervals prev))
-                   (sut/compute-intervals prev incident)))))
+        (testing "if :stored-incident already has an :opened_to_closed interval, recompute on re-close (non-closed → closed)"
+          (let [prev (assoc prev :intervals {:opened_to_closed (* 2 computed-interval)})]
+            (is (= (assoc incident :intervals {:opened_to_closed computed-interval})
+                   (sut/compute-intervals prev incident))
+                "opened_to_closed should be recomputed on re-close, not preserved from first close")))
         (testing "if :incident_time.opened is after the updated :incident_time.closed, elide interval from update"
           (let [prev (assoc prev :incident_time {:opened later})
                 incident (-> incident (assoc :incident_time {:opened later :closed earlier}))]
-            (is (= incident (sut/compute-intervals prev incident)))))))
+            (is (= incident (sut/compute-intervals prev incident)))))
+        (testing "XDR-42815: on re-close, opened_to_closed is recomputed with fresh closed date"
+          (let [reclose-later (-> (jt/instant earlier) (jt/plus (jt/seconds (* 2 computed-interval))) jt/java-date)
+                prev (assoc prev
+                            :status "Open"
+                            :incident_time {:opened earlier :closed later}
+                            :intervals {:opened_to_closed computed-interval})
+                incident (-> (dissoc prev :intervals)
+                             (assoc :status "Closed")
+                             (assoc-in [:incident_time :closed] reclose-later))]
+            (is (= (assoc incident :intervals {:opened_to_closed (* 2 computed-interval)})
+                   (sut/compute-intervals prev incident))
+                "opened_to_closed should be recomputed on re-close, not preserved from first close")))))
     (testing "updating new_to_contained"
       (let [prev (assoc prev :status "New: Presented")
             incident (-> (assoc prev :status "Open: Contained")


### PR DESCRIPTION
> Related https://cisco-sbg.atlassian.net/browse/XDR-42815

## Summary

Previously, `incident_time.closed` was set once and never updated — by design. This change updates the behavior so that re-closing an incident (Closed → Open → Closed) refreshes both the `incident_time.closed` timestamp and the `intervals.opened_to_closed` metric to reflect the actual resolution time.

### What changed

**`apply-status-update-logic`** (`src/ctia/entity/incident.clj`):
- On non-closed → closed transitions, force the new closed date from `make-status-update`, overriding the stale value preserved by `patch-entity` deep-merge.
- Closed → closed (sub-status changes) still preserves the original closed date.
- All other timestamps (opened, contained, etc.) keep set-once semantics.

**`compute-intervals`** (`src/ctia/entity/incident.clj`):
- On non-closed → closed transitions, clear stale `opened_to_closed` interval so it gets recomputed with the fresh closed date.
- Ensures time-to-resolution metrics reflect the actual re-close time.

### Why

When a status change goes through `PATCH /ctia/incident/{id}` (the path used by Conure/UI), `patch-entity` deep-merges the partial update with the stored entity, preserving old `incident_time`. Then `apply-status-update-logic` merges auto-generated timestamps with existing ones, but existing values took precedence — so the old `:closed` date was never updated on re-close.

### Tests

- Unit tests for `apply-status-update-logic`: re-close, first close, closed-to-closed, re-open (opened preserved)
- Unit test for `compute-intervals`: `opened_to_closed` recomputed on re-close
- Integration tests for both `PATCH /ctia/incident/:id` and `POST /ctia/incident/:id/status` re-close scenarios

<a name="qa">[§](#qa)</a> QA
============================

1. Create an incident, set status to Closed → verify `incident_time.closed` is set
2. Re-open the incident (status → Open)
3. Re-close the incident (status → Closed) → verify `incident_time.closed` is **updated** to the new close time
4. Change closed sub-status (e.g. Closed: False Positive → Closed: Confirmed Threat) → verify `incident_time.closed` is **preserved**

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Update incident_time.closed and opened_to_closed interval on re-close (Closed → Open → Closed).
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

🤖 Generated with [Claude Code](https://claude.com/claude-code)