### PR TITLE
Parallelize bulk operations across entity types

### DIFF
--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -255,14 +255,13 @@
   [func bulk & args]
   (try
     (into {}
-          (comp
-           (remove (comp empty? second))
-           (map (fn [[bulk-k entities]]
-                  [bulk-k (apply func
-                                 entities
-                                 (entity-type-from-bulk-key bulk-k)
-                                 args)])))
-          bulk)
+          (->> bulk
+               (remove (comp empty? second))
+               (pmap (fn [[bulk-k entities]]
+                       [bulk-k (apply func
+                                      entities
+                                      (entity-type-from-bulk-key bulk-k)
+                                      args)]))))
     (catch java.util.concurrent.ExecutionException e
       (throw (.getCause e)))))
 

--- a/src/ctia/bundle/core.clj
+++ b/src/ctia/bundle/core.clj
@@ -228,12 +228,16 @@
    external-key-prefixes
    auth-identity :- auth/AuthIdentity
    services :- APIHandlerServices]
-  (map-kv (fn [k v]
-            (let [entity-type (bulk/entity-type-from-bulk-key k)]
-              (-> v
-                  (init-import-data entity-type external-key-prefixes)
-                  (with-existing-entities entity-type auth-identity services))))
-          bundle-entities))
+  (try
+    (into {}
+          (->> bundle-entities
+               (pmap (fn [[k v]]
+                       (let [entity-type (bulk/entity-type-from-bulk-key k)]
+                         [k (-> v
+                                (init-import-data entity-type external-key-prefixes)
+                                (with-existing-entities entity-type auth-identity services))])))))
+    (catch java.util.concurrent.ExecutionException e
+      (throw (.getCause e)))))
 
 (s/defn create? :- s/Bool
   "Whether the provided entity should be created or not"


### PR DESCRIPTION
> Related: Performance optimization

## Description

Use `pmap` instead of sequential `map` in `gen-bulk-from-fn` and `prepare-import` to process independent entity types concurrently, reducing ES round-trip wait time during bulk and bundle operations.

### What changed

**`src/ctia/bulk/core.clj` — `gen-bulk-from-fn`**

This is the central dispatcher for all bulk operations (create, read, update, delete, patch). It iterates over entity types in the bulk map and applies the operation to each. Previously sequential — now uses `pmap` to process entity types in parallel.

Affects: `POST /ctia/bulk`, `GET /ctia/bulk`, `PUT /ctia/bulk`, `PATCH /ctia/bulk`, `DELETE /ctia/bulk`, and bundle export (`fetch-relationship-targets`).

**`src/ctia/bundle/core.clj` — `prepare-import`**

The deduplication step of bundle import that looks up existing entities by external IDs. Each entity type does an independent ES query via `list-records`. Previously sequential — now uses `pmap` to run lookups concurrently.

Affects: `POST /ctia/bundle/import`.

### Why this is safe

- Each entity type writes to a **different ES index** with an **independent store instance**
- No data dependencies between entity types within the same processing pass (cross-type dependencies like transient IDs are handled by the 3-pass structure in `import-bulks-with`)
- `pmap` is already used safely in `export-bundle` (`bundle/core.clj:534`)
- The existing `ExecutionException` catch in `gen-bulk-from-fn` already handles `pmap` error propagation

### Expected impact

For a bundle import with N entity types, ES wait time is reduced from `N × round-trip` to `~1 × round-trip` per processing pass. For a typical bundle with 5-6 entity types and ~10ms per ES round-trip, this saves ~50-100ms per request.

<a name="qa">[§](#qa)</a> QA
============================

Verify that existing bulk and bundle routes still behave correctly:

1. `POST /ctia/bulk` — create a bulk with multiple entity types (e.g., indicators + sightings + relationships), verify all entities are created and transient IDs are resolved
2. `GET /ctia/bulk` — fetch entities across multiple types by ID, verify all are returned
3. `PUT /ctia/bulk` — bulk update entities across multiple types, verify updates are applied
4. `PATCH /ctia/bulk` — bulk patch entities, verify partial updates
5. `DELETE /ctia/bulk` — bulk delete across types, verify deletions
6. `POST /ctia/bundle/import` — import a bundle with external IDs, verify deduplication works (re-import should return "exists" for already-imported entities)
7. `GET /ctia/bundle/export` — export a bundle by ID, verify relationships and targets are fetched

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Parallelize bulk/bundle operations across entity types for reduced ES wait time.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

019ceae6 Parallelize bulk operations across entity types

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)