### PR TITLE
return 413 when entities exceed collection size limits

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -44,9 +44,9 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- org.flatland:ordered:jar:1.5.9:compile
 +- prismatic:schema:jar:1.4.1:compile
 +- metosin:schema-tools:jar:0.13.1:compile
-+- threatgrid:flanders:jar:1.1.0:compile
++- threatgrid:flanders:jar:1.1.1-SNAPSHOT:compile
 |  \- org.clojure:core.match:jar:1.0.0:compile
-+- threatgrid:ctim:jar:1.3.30:compile
++- threatgrid:ctim:jar:1.3.30-SNAPSHOT:compile
 |  +- org.mozilla:rhino:jar:1.8.0:compile
 |  \- kovacnica:clojure.network.ip:jar:0.1.5:compile
 |     \- org.clojure:clojurescript:jar:1.11.132:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -455,7 +455,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>flanders</artifactId>
-      <version>1.1.0</version>
+      <version>1.1.1-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -478,7 +478,7 @@
     <dependency>
       <groupId>threatgrid</groupId>
       <artifactId>ctim</artifactId>
-      <version>1.3.30</version>
+      <version>1.3.30-SNAPSHOT</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/project.clj
+++ b/project.clj
@@ -89,8 +89,8 @@
                  ;; Schemas
                  [prismatic/schema "1.4.1"]
                  [metosin/schema-tools "0.13.1"]
-                 [threatgrid/flanders "1.1.0"]
-                 [threatgrid/ctim "1.3.30"
+                 [threatgrid/flanders "1.1.1-SNAPSHOT"]
+                 [threatgrid/ctim "1.3.30-SNAPSHOT"
                   :exclusions [com.cognitect/transit-java]] ;; ring-middleware-format takes precedence
                  [instaparse "1.4.10"] ;; com.gfredericks/test.chuck > threatgrid/ctim
                  [threatgrid/clj-momo "0.4.1"]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -99,17 +99,40 @@
       (id/str->short-id id)
       id)))
 
+(defn- size-limit-violation?
+  "Returns true if any of the spec problems are caused by a max-len predicate."
+  [explain-data]
+  (some (fn [{:keys [pred]}]
+          (when (fn? pred)
+            (:max-len (meta pred))))
+        (:clojure.spec.alpha/problems explain-data)))
+
+(defn- describe-size-violations
+  "Builds a human-readable message listing which fields exceeded their size limits."
+  [explain-data]
+  (->> (:clojure.spec.alpha/problems explain-data)
+       (keep (fn [{:keys [pred val in]}]
+               (when-let [max-len (and (fn? pred) (:max-len (meta pred)))]
+                 (format "field %s has %d elements (max %d)"
+                         (pr-str in) (count val) max-len))))
+       (str/join "; ")))
+
 (defn- check-spec [entity spec]
-  (if (and spec
-           (not (cs/valid? spec
-                           ;; the spec enforce long id for the API
-                           ;; while we store short ids
-                           (dissoc entity :id))))
-    {:msg (cs/explain-str spec entity)
-     :error "Entity validation Error"
-     :type :spec-validation-error
-     :entity entity}
-    entity))
+  (if-not spec
+    entity
+    (let [entity-no-id (dissoc entity :id)
+          explain-data (cs/explain-data spec entity-no-id)]
+      (if-not explain-data
+        entity
+        (if (size-limit-violation? explain-data)
+          {:msg (str "Entity too large: " (describe-size-violations explain-data))
+           :error "Entity too large"
+           :type :entity-too-large-error
+           :entity entity}
+          {:msg (cs/explain-str spec entity)
+           :error "Entity validation Error"
+           :type :spec-validation-error
+           :entity entity})))))
 
 (defn tlp-check
   [{:keys [tlp] :as entity} get-in-config]

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -7,7 +7,8 @@
             [compojure.api.impl.logging :as logging]
             [ring.util.http-response :refer [internal-server-error
                                              bad-request
-                                             forbidden]]
+                                             forbidden
+                                             request-entity-too-large]]
             [clojure.data.json :as json]))
 
 (defn ex-message-and-data [^Exception e]
@@ -80,6 +81,18 @@
    (let [entity (:entity (ex-data e))]
      {:error "Spec Validation Client Error"
       :type "Invalid Entity Error"
+      :message (.getMessage e)
+      :entity entity
+      :class (.getName (class e))})))
+
+(defn entity-too-large-error-handler
+  "Handle entity too large error (413)"
+  [^Exception e _data _request]
+  (logging/log! :info e (ex-message-and-data e))
+  (request-entity-too-large
+   (let [entity (:entity (ex-data e))]
+     {:error "Entity Too Large"
+      :type "Entity Size Limit Error"
       :message (.getMessage e)
       :entity entity
       :class (.getName (class e))})))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -113,6 +113,7 @@
    :invalid-tlp-error ex/invalid-tlp-error-handler
    :realize-entity-error ex/realize-entity-error-handler
    :spec-validation-error ex/spec-validation-error-handler
+   :entity-too-large-error ex/entity-too-large-error-handler
    :compojure.api.exception/default ex/default-error-handler})
 
 (s/defn api-tags

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -10,7 +10,9 @@
             [ctim.examples.sightings :refer [sighting-minimal]]
             [ctia.domain.entities :refer [short-id->long-id]]
             [java-time.api :as jt]
-            [puppetlabs.trapperkeeper.app :as app]))
+            [puppetlabs.trapperkeeper.app :as app]
+            [ctim.schemas.common :as ctim-common]
+            [ctim.schemas.sighting :as sighting-schema]))
 
 (deftest deep-merge-with-add-colls-test
   (let [fixture {:foo {:bar ["one" "two" "three"]
@@ -304,6 +306,45 @@
                       {sighting-id-1 false sighting-id-2 false})
          (delete-flow "delete flow deletes entities and creates events only for existing entities when some are not found"
                       {sighting-id-3 true missing-id-1 false missing-id-2 false}))))))
+
+(deftest check-spec-test
+  (let [check-spec #'flows.crud/check-spec
+        valid-sighting {:type "sighting"
+                        :confidence "High"
+                        :count 1
+                        :observed_time {:start_time #inst "2024-01-01T00:00:00.000Z"}
+                        :schema_version ctim-common/ctim-schema-version}]
+    (testing "valid entity passes through unchanged"
+      (is (= valid-sighting
+             (check-spec valid-sighting :new-sighting/map))))
+    (testing "nil spec passes through unchanged"
+      (is (= valid-sighting
+             (check-spec valid-sighting nil))))
+    (testing "oversized observables returns entity-too-large-error"
+      (let [entity (assoc valid-sighting
+                          :observables
+                          (vec (repeat (inc sighting-schema/max-sighting-observables)
+                                       {:type "ip" :value "1.2.3.4"})))
+            result (check-spec entity :new-sighting/map)]
+        (is (= :entity-too-large-error (:type result)))
+        (is (= "Entity too large" (:error result)))
+        (is (re-find #"max 5000" (:msg result)))))
+    (testing "oversized relations returns entity-too-large-error"
+      (let [entity (assoc valid-sighting
+                          :relations
+                          (vec (repeat (inc sighting-schema/max-sighting-relations)
+                                       {:origin "test"
+                                        :relation "Connected_To"
+                                        :source {:type "ip" :value "1.2.3.4"}
+                                        :related {:type "ip" :value "5.6.7.8"}})))
+            result (check-spec entity :new-sighting/map)]
+        (is (= :entity-too-large-error (:type result)))
+        (is (re-find #"max 10000" (:msg result)))))
+    (testing "non-size spec failure returns spec-validation-error"
+      (let [entity (assoc valid-sighting :confidence "INVALID")
+            result (check-spec entity :new-sighting/map)]
+        (is (= :spec-validation-error (:type result)))
+        (is (= "Entity validation Error" (:error result)))))))
 
 (defn mk-fake-store
   [entity size]


### PR DESCRIPTION
> **Epic** [XDR-46972](https://cisco-sbg.atlassian.net/browse/XDR-46972)
> Related [ctim#483](https://github.com/threatgrid/ctim/pull/483)
> Related [flanders#58](https://github.com/threatgrid/flanders/pull/58)

- update ctim to 1.3.30-SNAPSHOT, flanders to 1.1.1-SNAPSHOT
- check-spec detects collection limit violations via pred metadata
- add entity-too-large-error handler returning 413 with field details
- add check-spec-test covering valid, invalid, and limit scenarios

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
intern: Return 413 when entities exceed collection size limits defined in CTIM.
```

<a name="squashed-commits">[§](#squashed-commits)</a> Squashed Commits
======================================================================

[XDR-46972]: https://cisco-sbg.atlassian.net/browse/XDR-46972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ