### PR TITLE
Set http.route span attribute on OTel spans for Splunk APM (XDR-49687)

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -278,6 +278,15 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- com.graphql-java:java-dataloader:jar:5.0.3:compile
 |  +- org.reactivestreams:reactive-streams:jar:1.0.3:compile
 |  \- org.jspecify:jspecify:jar:1.0.0:compile
++- com.github.steffan-westcott:clj-otel-api:jar:0.2.10:compile
+|  +- io.opentelemetry.semconv:opentelemetry-semconv:jar:1.37.0:compile
+|  +- io.opentelemetry:opentelemetry-api:jar:1.54.1:compile
+|  |  \- io.opentelemetry:opentelemetry-context:jar:1.54.1:compile
+|  |     \- io.opentelemetry:opentelemetry-common:jar:1.54.1:compile
+|  +- io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:jar:2.20.1:compile
+|  |  \- io.opentelemetry:opentelemetry-api-incubator:jar:1.54.1-alpha:runtime
+|  +- io.opentelemetry.semconv:opentelemetry-semconv-incubating:jar:1.37.0-alpha:compile
+|  \- camel-snake-kebab:camel-snake-kebab:jar:0.4.3:compile
 +- org.slf4j:log4j-over-slf4j:jar:2.0.17:compile
 +- org.slf4j:slf4j-api:jar:2.0.17:compile
 +- net.logstash.logback:logstash-logback-encoder:jar:7.4:compile

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -1828,6 +1828,29 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.github.steffan-westcott</groupId>
+      <artifactId>clj-otel-api</artifactId>
+      <version>0.2.10</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <version>2.0.17</version>

--- a/project.clj
+++ b/project.clj
@@ -191,6 +191,9 @@
                  [threatgrid/ring-graphql-ui "0.1.1"]
                  [com.graphql-java/graphql-java "24.3"]
 
+                 ;; OpenTelemetry
+                 [com.github.steffan-westcott/clj-otel-api "0.2.10"]
+
                  ;; Logging
                  [org.slf4j/log4j-over-slf4j ~slf4j-version]
                  [org.slf4j/slf4j-api ~slf4j-version]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -8,7 +8,6 @@
             [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
             [compojure.api.api :refer [api]]
             [compojure.api.routes :as api-routes]
-            [compojure.core :refer [wrap-routes]]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]
@@ -223,10 +222,10 @@
           cache-control-enabled? (concat [wrap-not-modified
                                           wrap-cache-control])
           true (concat [#(wrap-version % get-in-config)
+                        trace-http/wrap-compojure-route
                         ;; always last
                         (metrics/wrap-metrics "ctia" api-routes/get-routes)]))]
-    (wrap-routes
-      (api {:exceptions {:handlers exception-handlers}
+    (api {:exceptions {:handlers exception-handlers}
             :format (->format-options)
             :swagger
             (cond-> {:ui "/"
@@ -290,5 +289,4 @@
                  (properties-routes services)
                  (graphql-routes services))))
            (undocumented
-            (rt/not-found (ok (unk/err-html)))))
-      trace-http/wrap-compojure-route)))
+            (rt/not-found (ok (unk/err-html)))))))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -8,6 +8,7 @@
             [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
             [compojure.api.api :refer [api]]
             [compojure.api.routes :as api-routes]
+            [compojure.core :refer [wrap-routes]]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]
@@ -33,7 +34,8 @@
             [ring.util.http-response :refer [ok]]
             [schema.core :as s]
             [compojure.api.middleware :refer [->mime-types api-middleware-defaults]]
-            [ring.middleware.format-response :refer [make-encoder]]))
+            [ring.middleware.format-response :refer [make-encoder]]
+            [steffan-westcott.clj-otel.api.trace.http :as trace-http]))
 
 (def api-description
   "A Threat Intelligence API service
@@ -223,68 +225,70 @@
           true (concat [#(wrap-version % get-in-config)
                         ;; always last
                         (metrics/wrap-metrics "ctia" api-routes/get-routes)]))]
-    (api {:exceptions {:handlers exception-handlers}
-          :format (->format-options)
-          :swagger
-          (cond-> {:ui "/"
-                   :spec "/swagger.json"
-                   :options {:ui {:jwtLocalStorageKey
-                                  (get-in-config
-                                    [:ctia :http :jwt :local-storage-key])}}
-                   :data {:info {:title "CTIA"
-                                 :version (string/replace (current-version) #"\n" "")
-                                 :license {:name "All Rights Reserved",
-                                           :url ""}
-                                 :contact {:name "Cisco Security Business Group -- Advanced Threat "
-                                           :url "http://github.com/threatgrid/ctia"
-                                           :email "cisco-intel-api-support@cisco.com"}
-                                 :description api-description}
-                          ;; consumes and produces are set to the default values
-                          ;; to remove text/plain which is automatically set
-                          ;; from the `formats` property by `compojure.api.middleware/api-middleware`
-                          :consumes swagger-mime-types
-                          :produces swagger-mime-types
-                          :security [{"JWT" []}]
-                          :securityDefinitions
-                          {"JWT" {:type "apiKey"
-                                  :in "header"
-                                  :name "Authorization"
-                                  :description "Ex: Bearer \\<token\\>"}}
-                          :tags (api-tags services)}}
-            (:enabled oauth2)
-            (apply-oauth2-swagger-conf
-             oauth2))}
+    (wrap-routes
+      (api {:exceptions {:handlers exception-handlers}
+            :format (->format-options)
+            :swagger
+            (cond-> {:ui "/"
+                     :spec "/swagger.json"
+                     :options {:ui {:jwtLocalStorageKey
+                                    (get-in-config
+                                      [:ctia :http :jwt :local-storage-key])}}
+                     :data {:info {:title "CTIA"
+                                   :version (string/replace (current-version) #"\n" "")
+                                   :license {:name "All Rights Reserved",
+                                             :url ""}
+                                   :contact {:name "Cisco Security Business Group -- Advanced Threat "
+                                             :url "http://github.com/threatgrid/ctia"
+                                             :email "cisco-intel-api-support@cisco.com"}
+                                   :description api-description}
+                            ;; consumes and produces are set to the default values
+                            ;; to remove text/plain which is automatically set
+                            ;; from the `formats` property by `compojure.api.middleware/api-middleware`
+                            :consumes swagger-mime-types
+                            :produces swagger-mime-types
+                            :security [{"JWT" []}]
+                            :securityDefinitions
+                            {"JWT" {:type "apiKey"
+                                    :in "header"
+                                    :name "Authorization"
+                                    :description "Ex: Bearer \\<token\\>"}}
+                            :tags (api-tags services)}}
+              (:enabled oauth2)
+              (apply-oauth2-swagger-conf
+               oauth2))}
 
-         (middleware middlewares
-           (documentation-routes)
-           (graphql-ui-routes services)
-           (context
-               "/ctia" []
-             (context "/feed" []
-               :tags ["Feed"]
-               (feed-view-routes services))
-             ;; The order is important here for version-routes
-             ;; must be before the middleware fn
-             (version-routes services)
-             (middleware [wrap-authenticated]
-               (->>
-                (entities/all-entities)
-                vals
-                (map (partial mark-disabled-entities services))
-                (entities-routes services))
-               (status-routes)
-               (context
-                   "/bulk" []
-                 :tags ["Bulk"]
-                 (bulk-routes services))
-               (context
-                   "/incident" []
-                 :tags ["Incident"]
-                 (incident-link-route services))
-               (bundle-routes services)
-               (observable-routes services)
-               (metrics-routes)
-               (properties-routes services)
-               (graphql-routes services))))
-         (undocumented
-          (rt/not-found (ok (unk/err-html)))))))
+           (middleware middlewares
+             (documentation-routes)
+             (graphql-ui-routes services)
+             (context
+                 "/ctia" []
+               (context "/feed" []
+                 :tags ["Feed"]
+                 (feed-view-routes services))
+               ;; The order is important here for version-routes
+               ;; must be before the middleware fn
+               (version-routes services)
+               (middleware [wrap-authenticated]
+                 (->>
+                  (entities/all-entities)
+                  vals
+                  (map (partial mark-disabled-entities services))
+                  (entities-routes services))
+                 (status-routes)
+                 (context
+                     "/bulk" []
+                   :tags ["Bulk"]
+                   (bulk-routes services))
+                 (context
+                     "/incident" []
+                   :tags ["Incident"]
+                   (incident-link-route services))
+                 (bundle-routes services)
+                 (observable-routes services)
+                 (metrics-routes)
+                 (properties-routes services)
+                 (graphql-routes services))))
+           (undocumented
+            (rt/not-found (ok (unk/err-html)))))
+      trace-http/wrap-compojure-route)))


### PR DESCRIPTION
[XDR-49687](https://cisco-sbg.atlassian.net/browse/XDR-49687)

## Summary

After switching CTIA to Splunk APM via OTel auto-instrumentation, span names only show HTTP method (GET/POST) without route information. This adds `http.route` span attributes with low-cardinality route templates.

**Changes:**
- Add `clj-otel-api 0.2.10` dependency
- Wrap Compojure API handler with `wrap-compojure-route` from `steffan-westcott.clj-otel.api.trace.http`

This sets `http.route` on OTel spans (e.g., `/ctia/indicator/:id` instead of `/ctia/indicator/indicator-abc123`), matching the approach used in iroh (advthreat/iroh#10443).

## QA

No QA needed — this only adds span metadata when an OTel Java agent is present. No-op without the agent.

## Affected Tests Timings

No tests affected.

[XDR-49687]: https://cisco-sbg.atlassian.net/browse/XDR-49687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ