### PR TITLE
Use wrap-routes for OTel http.route span attribute (XDR-50180)

### DIFF
--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -117,6 +117,9 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |     +- org.eclipse.jetty.ee9.websocket:jetty-ee9-websocket-servlet:jar:12.1.0:compile
 |     |  \- org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.1.0:compile
 |     \- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:jar:5.0.2:compile
++- ring:ring-devel:jar:1.15.3:compile
+|  +- clj-stacktrace:clj-stacktrace:jar:0.2.8:compile
+|  \- ns-tracker:ns-tracker:jar:1.0.0:compile
 +- ring-cors:ring-cors:jar:0.1.13:compile
 +- commons-codec:commons-codec:jar:1.18.0:compile
 +- ring:ring-codec:jar:1.3.0:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -13,12 +13,11 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- org.clojure:core.memoize:jar:1.0.257:compile
 |  \- org.clojure:core.cache:jar:1.0.225:compile
 +- org.clojure:tools.logging:jar:1.3.0:compile
-+- org.clojure:tools.cli:jar:1.0.194:compile
++- org.clojure:tools.cli:jar:1.0.206:compile
 +- pandect:pandect:jar:0.6.1:compile
 +- org.clojure:math.combinatorics:jar:0.3.0:test
 +- version-clj:version-clj:jar:2.0.1:compile
 +- puppetlabs:trapperkeeper:jar:4.0.0:compile
-|  +- org.clojure:tools.macro:jar:0.1.5:compile
 |  +- org.codehaus.janino:janino:jar:3.0.8:compile
 |  |  \- org.codehaus.janino:commons-compiler:jar:3.0.8:compile
 |  +- clj-commons:fs:jar:1.6.307:compile
@@ -39,6 +38,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- digest:digest:jar:1.4.3:compile
 +- prismatic:plumbing:jar:0.6.0:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
++- org.clojure:tools.macro:jar:0.2.1:compile
 +- clj-commons:clj-yaml:jar:1.0.29:compile
 |  +- org.yaml:snakeyaml:jar:2.3:compile
 |  \- org.flatland:ordered:jar:1.15.12:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -18,7 +18,6 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- org.clojure:math.combinatorics:jar:0.3.0:test
 +- version-clj:version-clj:jar:2.0.1:compile
 +- puppetlabs:trapperkeeper:jar:3.2.0:compile
-|  +- org.clojure:tools.macro:jar:0.1.5:compile
 |  +- ch.qos.logback:logback-access:jar:1.2.3:compile
 |  +- org.codehaus.janino:janino:jar:3.0.8:compile
 |  |  \- org.codehaus.janino:commons-compiler:jar:3.0.8:compile
@@ -39,6 +38,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  \- digest:digest:jar:1.4.3:compile
 +- prismatic:plumbing:jar:0.5.5:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
++- org.clojure:tools.macro:jar:0.2.1:compile
 +- clj-commons:clj-yaml:jar:1.0.26:compile
 |  +- org.yaml:snakeyaml:jar:1.33:compile
 |  \- org.flatland:ordered:jar:1.5.9:compile
@@ -62,11 +62,11 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- com.arohner:uri:jar:0.1.2:compile
 |  \- pathetic:pathetic:jar:0.5.0:compile
 |     \- com.cemerick:clojurescript.test:jar:0.0.4:compile
-+- potemkin:potemkin:jar:0.4.7:compile
++- potemkin:potemkin:jar:0.4.9:compile
 |  \- riddley:riddley:jar:0.1.12:compile
++- compojure:compojure:jar:1.7.2:compile
+|  \- dev.weavejester:medley:jar:1.9.0:compile
 +- metosin:compojure-api:jar:1.1.13:compile
-|  +- compojure:compojure:jar:1.6.1:compile
-|  |  \- medley:medley:jar:1.0.0:compile
 |  +- org.tobereplaced:lettercase:jar:1.0.0:compile
 |  +- frankiesardo:linked:jar:1.3.0:compile
 |  \- metosin:ring-http-response:jar:0.9.1:compile
@@ -89,23 +89,37 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |        |  \- javax.activation:activation:jar:1.1:compile
 |        \- com.googlecode.libphonenumber:libphonenumber:jar:8.0.0:compile
 +- metosin:ring-swagger-ui:jar:3.24.3:compile
-+- ring:ring-core:jar:1.9.5:compile
-|  +- commons-fileupload:commons-fileupload:jar:1.4:compile
-|  +- crypto-random:crypto-random:jar:1.2.1:compile
-|  \- crypto-equality:crypto-equality:jar:1.0.0:compile
-+- ring:ring-jetty-adapter:jar:1.9.5:compile
-|  +- ring:ring-servlet:jar:1.9.5:compile
-|  \- org.eclipse.jetty:jetty-server:jar:9.4.44.v20210927:compile
-|     +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
-|     +- org.eclipse.jetty:jetty-http:jar:9.4.44.v20210927:compile
-|     |  \- org.eclipse.jetty:jetty-util:jar:9.4.44.v20210927:compile
-|     \- org.eclipse.jetty:jetty-io:jar:9.4.44.v20210927:compile
-+- ring:ring-devel:jar:1.9.5:compile
-|  +- clj-stacktrace:clj-stacktrace:jar:0.2.8:compile
-|  \- ns-tracker:ns-tracker:jar:0.4.0:compile
++- ring:ring-core:jar:1.15.3:compile
+|  +- org.ring-clojure:ring-core-protocols:jar:1.15.3:compile
+|  +- org.ring-clojure:ring-websocket-protocols:jar:1.15.3:compile
+|  +- org.apache.commons:commons-fileupload2-core:jar:2.0.0-M4:compile
+|  \- crypto-random:crypto-random:jar:1.2.1:compile
++- ring:ring-jetty-adapter:jar:1.15.3:compile
+|  +- org.ring-clojure:ring-jakarta-servlet:jar:1.15.3:compile
+|  +- org.eclipse.jetty:jetty-server:jar:12.1.0:compile
+|  |  +- org.eclipse.jetty:jetty-http:jar:12.1.0:compile
+|  |  |  \- org.eclipse.jetty:jetty-util:jar:12.1.0:compile
+|  |  \- org.eclipse.jetty:jetty-io:jar:12.1.0:compile
+|  +- org.eclipse.jetty:jetty-unixdomain-server:jar:12.1.0:compile
+|  +- org.eclipse.jetty.ee9:jetty-ee9-servlet:jar:12.1.0:compile
+|  |  +- org.eclipse.jetty.ee9:jetty-ee9-nested:jar:12.1.0:compile
+|  |  |  +- org.eclipse.jetty:jetty-security:jar:12.1.0:compile
+|  |  |  \- org.eclipse.jetty:jetty-session:jar:12.1.0:compile
+|  |  \- org.eclipse.jetty.ee9:jetty-ee9-security:jar:12.1.0:compile
+|  \- org.eclipse.jetty.ee9.websocket:jetty-ee9-websocket-jetty-server:jar:12.1.0:compile
+|     +- org.eclipse.jetty.ee9:jetty-ee9-webapp:jar:12.1.0:compile
+|     |  +- org.eclipse.jetty:jetty-xml:jar:12.1.0:compile
+|     |  \- org.eclipse.jetty.ee:jetty-ee-webapp:jar:12.1.0:compile
+|     +- org.eclipse.jetty.ee9.websocket:jetty-ee9-websocket-jetty-api:jar:12.1.0:compile
+|     +- org.eclipse.jetty.ee9.websocket:jetty-ee9-websocket-jetty-common:jar:12.1.0:compile
+|     |  \- org.eclipse.jetty.websocket:jetty-websocket-core-common:jar:12.1.0:compile
+|     +- org.eclipse.jetty.ee9.websocket:jetty-ee9-websocket-servlet:jar:12.1.0:compile
+|     |  \- org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.1.0:compile
+|     \- org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:jar:5.0.2:compile
 +- ring-cors:ring-cors:jar:0.1.13:compile
-+- commons-codec:commons-codec:jar:1.17.1:compile
-+- ring:ring-codec:jar:1.1.3:compile
++- commons-codec:commons-codec:jar:1.18.0:compile
++- ring:ring-codec:jar:1.3.0:compile
++- crypto-equality:crypto-equality:jar:1.0.1:compile
 +- threatgrid:clj-jwt:jar:0.5.0:compile
 |  +- org.clojure:data.codec:jar:0.1.1:compile
 |  +- org.bouncycastle:bcpkix-jdk15on:jar:1.68:compile
@@ -204,7 +218,7 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- org.apache.zookeeper:zookeeper-jute:jar:3.8.4:compile
 |  +- org.apache.yetus:audience-annotations:jar:0.12.0:compile
 |  \- io.netty:netty-transport-native-epoll:jar:4.1.105.Final:compile
-+- commons-io:commons-io:jar:2.18.0:compile
++- commons-io:commons-io:jar:2.20.0:compile
 +- args4j:args4j:jar:2.33:compile
 +- com.stuartsierra:component:jar:1.1.0:compile
 |  \- com.stuartsierra:dependency:jar:1.0.0:compile

--- a/dependabot/dependency-tree.txt
+++ b/dependabot/dependency-tree.txt
@@ -17,31 +17,31 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- pandect:pandect:jar:0.6.1:compile
 +- org.clojure:math.combinatorics:jar:0.3.0:test
 +- version-clj:version-clj:jar:2.0.1:compile
-+- puppetlabs:trapperkeeper:jar:3.2.0:compile
-|  +- ch.qos.logback:logback-access:jar:1.2.3:compile
++- puppetlabs:trapperkeeper:jar:4.0.0:compile
+|  +- org.clojure:tools.macro:jar:0.1.5:compile
 |  +- org.codehaus.janino:janino:jar:3.0.8:compile
 |  |  \- org.codehaus.janino:commons-compiler:jar:3.0.8:compile
 |  +- clj-commons:fs:jar:1.6.307:compile
-|  |  +- org.apache.commons:commons-compress:jar:1.20:compile
 |  |  \- org.tukaani:xz:jar:1.8:compile
 |  +- beckon:beckon:jar:0.1.1:compile
 |  +- puppetlabs:typesafe-config:jar:0.2.0:compile
 |  |  \- com.typesafe:config:jar:1.4.1:compile
-|  +- puppetlabs:i18n:jar:0.8.0:compile
+|  +- puppetlabs:i18n:jar:0.9.2:compile
 |  |  +- cpath-clj:cpath-clj:jar:0.1.2:compile
 |  |  \- org.gnu.gettext:libintl:jar:0.18.3:compile
-|  \- nrepl:nrepl:jar:0.6.0:compile
-+- puppetlabs:kitchensink:jar:3.2.0:compile
+|  \- io.github.clj-kondo:config-slingshot-slingshot:jar:1.0.0:compile
++- puppetlabs:kitchensink:jar:3.4.0:compile
+|  +- org.apache.commons:commons-compress:jar:1.26.0:compile
+|  |  \- org.apache.commons:commons-lang3:jar:3.14.0:compile
 |  +- slingshot:slingshot:jar:0.12.2:compile
-|  +- org.ini4j:ini4j:jar:0.5.2:compile
+|  +- org.ini4j:ini4j:jar:0.5.4:compile
 |  +- org.tcrawley:dynapath:jar:0.2.5:compile
 |  \- digest:digest:jar:1.4.3:compile
-+- prismatic:plumbing:jar:0.5.5:compile
++- prismatic:plumbing:jar:0.6.0:compile
 |  \- de.kotka:lazymap:jar:3.1.0:compile
-+- org.clojure:tools.macro:jar:0.2.1:compile
-+- clj-commons:clj-yaml:jar:1.0.26:compile
-|  +- org.yaml:snakeyaml:jar:1.33:compile
-|  \- org.flatland:ordered:jar:1.5.9:compile
++- clj-commons:clj-yaml:jar:1.0.29:compile
+|  +- org.yaml:snakeyaml:jar:2.3:compile
+|  \- org.flatland:ordered:jar:1.15.12:compile
 +- prismatic:schema:jar:1.4.1:compile
 +- metosin:schema-tools:jar:0.13.1:compile
 +- threatgrid:flanders:jar:1.1.0:compile
@@ -93,7 +93,8 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 |  +- org.ring-clojure:ring-core-protocols:jar:1.15.3:compile
 |  +- org.ring-clojure:ring-websocket-protocols:jar:1.15.3:compile
 |  +- org.apache.commons:commons-fileupload2-core:jar:2.0.0-M4:compile
-|  \- crypto-random:crypto-random:jar:1.2.1:compile
+|  +- crypto-random:crypto-random:jar:1.2.1:compile
+|  \- crypto-equality:crypto-equality:jar:1.0.1:compile
 +- ring:ring-jetty-adapter:jar:1.15.3:compile
 |  +- org.ring-clojure:ring-jakarta-servlet:jar:1.15.3:compile
 |  +- org.eclipse.jetty:jetty-server:jar:12.1.0:compile
@@ -119,7 +120,6 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- ring-cors:ring-cors:jar:0.1.13:compile
 +- commons-codec:commons-codec:jar:1.18.0:compile
 +- ring:ring-codec:jar:1.3.0:compile
-+- crypto-equality:crypto-equality:jar:1.0.1:compile
 +- threatgrid:clj-jwt:jar:0.5.0:compile
 |  +- org.clojure:data.codec:jar:0.1.1:compile
 |  +- org.bouncycastle:bcpkix-jdk15on:jar:1.68:compile
@@ -306,8 +306,8 @@ ctia:ctia:jar:1.1.1-SNAPSHOT
 +- net.logstash.logback:logstash-logback-encoder:jar:7.4:compile
 +- ch.qos.logback:logback-classic:jar:1.5.25:compile
 +- ch.qos.logback:logback-core:jar:1.5.25:compile
-+- puppetlabs:trapperkeeper:jar:test:3.2.0:test
-+- puppetlabs:kitchensink:jar:test:3.2.0:test
++- puppetlabs:trapperkeeper:jar:test:4.0.0:test
++- puppetlabs:kitchensink:jar:test:3.4.0:test
 +- org.clojure:test.check:jar:1.1.1:test
 +- com.gfredericks:test.chuck:jar:0.2.15:test
 +- clj-http-fake:clj-http-fake:jar:1.0.3:test

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -845,6 +845,29 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>ring</groupId>
+      <artifactId>ring-devel</artifactId>
+      <version>1.15.3</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>ring-cors</groupId>
       <artifactId>ring-cors</artifactId>
       <version>0.1.13</version>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -224,7 +224,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>tools.cli</artifactId>
-      <version>1.0.194</version>
+      <version>1.0.206</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -380,6 +380,29 @@
       <groupId>prismatic</groupId>
       <artifactId>plumbing</artifactId>
       <version>0.6.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.macro</artifactId>
+      <version>0.2.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -865,6 +865,22 @@
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>tools.reader</artifactId>
+          <groupId>org.clojure</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>tools.namespace</artifactId>
+          <groupId>org.clojure</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>java.classpath</artifactId>
+          <groupId>org.clojure</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hiccup</artifactId>
+          <groupId>hiccup</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>ctia</groupId>
   <artifactId>ctia</artifactId>
@@ -384,6 +384,29 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.clojure</groupId>
+      <artifactId>tools.macro</artifactId>
+      <version>0.2.1</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>clj-yaml</artifactId>
       <version>1.0.26</version>
@@ -597,7 +620,34 @@
     <dependency>
       <groupId>potemkin</groupId>
       <artifactId>potemkin</artifactId>
-      <version>0.4.7</version>
+      <version>0.4.9</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>clojure</artifactId>
+          <groupId>org.clojure</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>compojure</groupId>
+      <artifactId>compojure</artifactId>
+      <version>1.7.2</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -735,7 +785,7 @@
     <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-core</artifactId>
-      <version>1.9.5</version>
+      <version>1.15.3</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -758,30 +808,7 @@
     <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-jetty-adapter</artifactId>
-      <version>1.9.5</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-nop</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>slf4j-log4j12</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>ring</groupId>
-      <artifactId>ring-devel</artifactId>
-      <version>1.9.5</version>
+      <version>1.15.3</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -827,7 +854,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.17.1</version>
+      <version>1.18.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -850,7 +877,30 @@
     <dependency>
       <groupId>ring</groupId>
       <artifactId>ring-codec</artifactId>
-      <version>1.1.3</version>
+      <version>1.3.0</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-nop</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>netty</artifactId>
+          <groupId>io.netty</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>crypto-equality</groupId>
+      <artifactId>crypto-equality</artifactId>
+      <version>1.0.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -1471,7 +1521,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.18.0</version>
+      <version>2.20.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>

--- a/dependabot/pom.xml
+++ b/dependabot/pom.xml
@@ -317,7 +317,7 @@
     <dependency>
       <groupId>puppetlabs</groupId>
       <artifactId>trapperkeeper</artifactId>
-      <version>3.2.0</version>
+      <version>4.0.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -335,12 +335,28 @@
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>nrepl</artifactId>
+          <groupId>nrepl</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-classic</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-core</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-access</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>puppetlabs</groupId>
       <artifactId>kitchensink</artifactId>
-      <version>3.2.0</version>
+      <version>3.4.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -363,30 +379,7 @@
     <dependency>
       <groupId>prismatic</groupId>
       <artifactId>plumbing</artifactId>
-      <version>0.5.5</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-nop</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>slf4j-log4j12</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.clojure</groupId>
-      <artifactId>tools.macro</artifactId>
-      <version>0.2.1</version>
+      <version>0.6.0</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -409,7 +402,7 @@
     <dependency>
       <groupId>clj-commons</groupId>
       <artifactId>clj-yaml</artifactId>
-      <version>1.0.26</version>
+      <version>1.0.29</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -878,29 +871,6 @@
       <groupId>ring</groupId>
       <artifactId>ring-codec</artifactId>
       <version>1.3.0</version>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-nop</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>slf4j-log4j12</artifactId>
-          <groupId>org.slf4j</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>netty</artifactId>
-          <groupId>io.netty</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>log4j</artifactId>
-          <groupId>log4j</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>crypto-equality</groupId>
-      <artifactId>crypto-equality</artifactId>
-      <version>1.0.1</version>
       <exclusions>
         <exclusion>
           <artifactId>slf4j-nop</artifactId>
@@ -2018,7 +1988,7 @@
     <dependency>
       <groupId>puppetlabs</groupId>
       <artifactId>trapperkeeper</artifactId>
-      <version>3.2.0</version>
+      <version>4.0.0</version>
       <classifier>test</classifier>
       <exclusions>
         <exclusion>
@@ -2037,13 +2007,29 @@
           <artifactId>log4j</artifactId>
           <groupId>log4j</groupId>
         </exclusion>
+        <exclusion>
+          <artifactId>nrepl</artifactId>
+          <groupId>nrepl</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-classic</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-core</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>logback-access</artifactId>
+          <groupId>ch.qos.logback</groupId>
+        </exclusion>
       </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>puppetlabs</groupId>
       <artifactId>kitchensink</artifactId>
-      <version>3.2.0</version>
+      <version>3.4.0</version>
       <classifier>test</classifier>
       <exclusions>
         <exclusion>

--- a/project.clj
+++ b/project.clj
@@ -75,7 +75,7 @@
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/core.memoize "1.0.257"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [org.clojure/tools.cli "1.0.194"]
+                 [org.clojure/tools.cli "1.0.206"] ;; align puppetlabs/kitchensink
                  [pandect "0.6.1"]
                  [org.clojure/math.combinatorics "0.3.0"]
                  [version-clj "2.0.1"]
@@ -88,6 +88,7 @@
                                ch.qos.logback/logback-access]]
                  [puppetlabs/kitchensink "3.4.0"]
                  [prismatic/plumbing "0.6.0"] ;; upgrade puppetlabs/trapperkeeper, see https://github.com/puppetlabs/trapperkeeper/issues/294
+                 [org.clojure/tools.macro "0.2.1"] ;; align compojure 1.7.2 > puppetlabs/trapperkeeper
                  [clj-commons/clj-yaml "1.0.29"] ;; bump trapperkeeper, markdown-clj
 
                  ;; Schemas

--- a/project.clj
+++ b/project.clj
@@ -115,7 +115,11 @@
                  [metosin/ring-swagger-ui "3.24.3"]
                  [ring/ring-core ~ring-version] ;ring/ring-jetty-adapter > metosin/ring-swagger
                  [ring/ring-jetty-adapter ~ring-version]
-                 [ring/ring-devel ~ring-version]
+                 [ring/ring-devel ~ring-version
+                  :exclusions [org.clojure/tools.reader
+                               org.clojure/tools.namespace
+                               org.clojure/java.classpath
+                               hiccup]]
                  [ring-cors "0.1.13"]
                  [commons-codec "1.18.0"] ;ring/ring* > threatgrid/ctim, threatgrid/clj-momo, clj-http
                  [ring/ring-codec "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -100,6 +100,7 @@
 
                  ;; Web server
                  [potemkin "0.4.7"] ;; align clj-http > compojure-api
+                 [compojure/compojure "1.7.2"] ;; bump for wrap-routes support (OTel http.route)
                  [metosin/compojure-api "1.1.13"]
                  [ring-middleware-format "0.7.4"]
                  ;; optional ring-middleware-format dep (Note: ring-middleware-format is also a transitive dep for compojure-api)

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 (def metrics-clojure-version "2.10.0")
 (def netty-version "4.1.125.Final")
 (def perforate-version "0.3.4")
-(def ring-version "1.9.5")
+(def ring-version "1.15.3")
 (def slf4j-version "2.0.17")
 (def schema-generators-version "0.1.5")
 (def test-check-version "1.1.1")
@@ -84,6 +84,7 @@
                  [puppetlabs/trapperkeeper ~trapperkeeper-version]
                  [puppetlabs/kitchensink ~trapperkeeper-version]
                  [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
+                 [org.clojure/tools.macro "0.2.1"] ;; align compojure 1.7.2 > puppetlabs/trapperkeeper
                  [clj-commons/clj-yaml "1.0.26"] ;; upgrade snakeyaml dep
 
                  ;; Schemas
@@ -99,7 +100,7 @@
                  [com.arohner/uri "0.1.2"]
 
                  ;; Web server
-                 [potemkin "0.4.7"] ;; align clj-http > compojure-api
+                 [potemkin "0.4.9" :exclusions [org.clojure/clojure]] ;; override metosin/compojure-api
                  [compojure/compojure "1.7.2"] ;; bump for wrap-routes support (OTel http.route)
                  [metosin/compojure-api "1.1.13"]
                  [ring-middleware-format "0.7.4"]
@@ -110,10 +111,10 @@
                  [metosin/ring-swagger-ui "3.24.3"]
                  [ring/ring-core ~ring-version] ;ring/ring-jetty-adapter > metosin/ring-swagger
                  [ring/ring-jetty-adapter ~ring-version]
-                 [ring/ring-devel ~ring-version]
                  [ring-cors "0.1.13"]
-                 [commons-codec "1.17.1"] ;ring/ring* > threatgrid/ctim, threatgrid/clj-momo, clj-http
-                 [ring/ring-codec "1.1.3"]
+                 [commons-codec "1.18.0"] ;ring/ring* > threatgrid/ctim, threatgrid/clj-momo, clj-http
+                 [ring/ring-codec "1.3.0"]
+                 [crypto-equality "1.0.1"] ;; align ring-core 1.15
                  [threatgrid/clj-jwt "0.5.0"]
                  [threatgrid/ring-turnstile-middleware "0.1.1"]
                  [threatgrid/ring-jwt-middleware "1.1.7"]
@@ -152,7 +153,7 @@
                  [threatgrid/redismq "0.1.1"]
 
                  [org.apache.zookeeper/zookeeper "3.8.4"] ; override zookeeper-clj, org.onyxplatform/onyx-kafka
-                 [commons-io "2.18.0"] ;; address CVE-2024-47554
+                 [commons-io "2.20.0"] ;; address CVE-2024-47554, align with ring 1.15
                  [args4j "2.33"] ;bump org.onyxplatform/onyx-kafka, threatgrid/ctim
                  [com.stuartsierra/component "1.1.0"] ;org.onyxplatform/onyx-kafka internal override
                  [org.onyxplatform/onyx-kafka "0.14.5.0"]

--- a/project.clj
+++ b/project.clj
@@ -115,6 +115,7 @@
                  [metosin/ring-swagger-ui "3.24.3"]
                  [ring/ring-core ~ring-version] ;ring/ring-jetty-adapter > metosin/ring-swagger
                  [ring/ring-jetty-adapter ~ring-version]
+                 [ring/ring-devel ~ring-version]
                  [ring-cors "0.1.13"]
                  [commons-codec "1.18.0"] ;ring/ring* > threatgrid/ctim, threatgrid/clj-momo, clj-http
                  [ring/ring-codec "1.3.0"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
 (def schema-generators-version "0.1.5")
 (def test-check-version "1.1.1")
 (def test-chuck-version "0.2.15")
-(def trapperkeeper-version "3.2.0")
+(def trapperkeeper-version "4.0.0")
 
 ;; TODO we could add -dev here when it works
 (def base-ci-profiles "+test,+ci")
@@ -81,11 +81,14 @@
                  [version-clj "2.0.1"]
 
                  ;; Trapperkeeper
-                 [puppetlabs/trapperkeeper ~trapperkeeper-version]
-                 [puppetlabs/kitchensink ~trapperkeeper-version]
-                 [prismatic/plumbing "0.5.5"] ;; upgrade puppetlabs/trapperkeeper
-                 [org.clojure/tools.macro "0.2.1"] ;; align compojure 1.7.2 > puppetlabs/trapperkeeper
-                 [clj-commons/clj-yaml "1.0.26"] ;; upgrade snakeyaml dep
+                 [puppetlabs/trapperkeeper ~trapperkeeper-version
+                  :exclusions [nrepl
+                               ch.qos.logback/logback-classic
+                               ch.qos.logback/logback-core
+                               ch.qos.logback/logback-access]]
+                 [puppetlabs/kitchensink "3.4.0"]
+                 [prismatic/plumbing "0.6.0"] ;; upgrade puppetlabs/trapperkeeper, see https://github.com/puppetlabs/trapperkeeper/issues/294
+                 [clj-commons/clj-yaml "1.0.29"] ;; bump trapperkeeper, markdown-clj
 
                  ;; Schemas
                  [prismatic/schema "1.4.1"]
@@ -114,7 +117,6 @@
                  [ring-cors "0.1.13"]
                  [commons-codec "1.18.0"] ;ring/ring* > threatgrid/ctim, threatgrid/clj-momo, clj-http
                  [ring/ring-codec "1.3.0"]
-                 [crypto-equality "1.0.1"] ;; align ring-core 1.15
                  [threatgrid/clj-jwt "0.5.0"]
                  [threatgrid/ring-turnstile-middleware "0.1.1"]
                  [threatgrid/ring-jwt-middleware "1.1.7"]
@@ -223,8 +225,12 @@
 
   :profiles {:dev {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
                    :dependencies [[puppetlabs/trapperkeeper ~trapperkeeper-version
-                                   :classifier "test"]
-                                  [puppetlabs/kitchensink ~trapperkeeper-version
+                                   :classifier "test"
+                                   :exclusions [nrepl
+                                                ch.qos.logback/logback-classic
+                                                ch.qos.logback/logback-core
+                                                ch.qos.logback/logback-access]]
+                                  [puppetlabs/kitchensink "3.4.0"
                                    :classifier "test"]
                                   [org.clojure/test.check ~test-check-version]
                                   [com.gfredericks/test.chuck ~test-chuck-version]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -8,6 +8,7 @@
             [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
             [compojure.api.api :refer [api]]
             [compojure.api.routes :as api-routes]
+            [compojure.core :refer [wrap-routes]]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]
@@ -222,71 +223,72 @@
           cache-control-enabled? (concat [wrap-not-modified
                                           wrap-cache-control])
           true (concat [#(wrap-version % get-in-config)
-                        trace-http/wrap-compojure-route
                         ;; always last
                         (metrics/wrap-metrics "ctia" api-routes/get-routes)]))]
-    (api {:exceptions {:handlers exception-handlers}
-            :format (->format-options)
-            :swagger
-            (cond-> {:ui "/"
-                     :spec "/swagger.json"
-                     :options {:ui {:jwtLocalStorageKey
-                                    (get-in-config
-                                      [:ctia :http :jwt :local-storage-key])}}
-                     :data {:info {:title "CTIA"
-                                   :version (string/replace (current-version) #"\n" "")
-                                   :license {:name "All Rights Reserved",
-                                             :url ""}
-                                   :contact {:name "Cisco Security Business Group -- Advanced Threat "
-                                             :url "http://github.com/threatgrid/ctia"
-                                             :email "cisco-intel-api-support@cisco.com"}
-                                   :description api-description}
-                            ;; consumes and produces are set to the default values
-                            ;; to remove text/plain which is automatically set
-                            ;; from the `formats` property by `compojure.api.middleware/api-middleware`
-                            :consumes swagger-mime-types
-                            :produces swagger-mime-types
-                            :security [{"JWT" []}]
-                            :securityDefinitions
-                            {"JWT" {:type "apiKey"
-                                    :in "header"
-                                    :name "Authorization"
-                                    :description "Ex: Bearer \\<token\\>"}}
-                            :tags (api-tags services)}}
-              (:enabled oauth2)
-              (apply-oauth2-swagger-conf
-               oauth2))}
+    (wrap-routes
+     (api {:exceptions {:handlers exception-handlers}
+             :format (->format-options)
+             :swagger
+             (cond-> {:ui "/"
+                      :spec "/swagger.json"
+                      :options {:ui {:jwtLocalStorageKey
+                                     (get-in-config
+                                       [:ctia :http :jwt :local-storage-key])}}
+                      :data {:info {:title "CTIA"
+                                    :version (string/replace (current-version) #"\n" "")
+                                    :license {:name "All Rights Reserved",
+                                              :url ""}
+                                    :contact {:name "Cisco Security Business Group -- Advanced Threat "
+                                              :url "http://github.com/threatgrid/ctia"
+                                              :email "cisco-intel-api-support@cisco.com"}
+                                    :description api-description}
+                             ;; consumes and produces are set to the default values
+                             ;; to remove text/plain which is automatically set
+                             ;; from the `formats` property by `compojure.api.middleware/api-middleware`
+                             :consumes swagger-mime-types
+                             :produces swagger-mime-types
+                             :security [{"JWT" []}]
+                             :securityDefinitions
+                             {"JWT" {:type "apiKey"
+                                     :in "header"
+                                     :name "Authorization"
+                                     :description "Ex: Bearer \\<token\\>"}}
+                             :tags (api-tags services)}}
+               (:enabled oauth2)
+               (apply-oauth2-swagger-conf
+                oauth2))}
 
-           (middleware middlewares
-             (documentation-routes)
-             (graphql-ui-routes services)
-             (context
-                 "/ctia" []
-               (context "/feed" []
-                 :tags ["Feed"]
-                 (feed-view-routes services))
-               ;; The order is important here for version-routes
-               ;; must be before the middleware fn
-               (version-routes services)
-               (middleware [wrap-authenticated]
-                 (->>
-                  (entities/all-entities)
-                  vals
-                  (map (partial mark-disabled-entities services))
-                  (entities-routes services))
-                 (status-routes)
-                 (context
-                     "/bulk" []
-                   :tags ["Bulk"]
-                   (bulk-routes services))
-                 (context
-                     "/incident" []
-                   :tags ["Incident"]
-                   (incident-link-route services))
-                 (bundle-routes services)
-                 (observable-routes services)
-                 (metrics-routes)
-                 (properties-routes services)
-                 (graphql-routes services))))
-           (undocumented
-            (rt/not-found (ok (unk/err-html)))))))
+            (middleware middlewares
+              (documentation-routes)
+              (graphql-ui-routes services)
+              (context
+                  "/ctia" []
+                (context "/feed" []
+                  :tags ["Feed"]
+                  (feed-view-routes services))
+                ;; The order is important here for version-routes
+                ;; must be before the middleware fn
+                (version-routes services)
+                (middleware [wrap-authenticated]
+                  (->>
+                   (entities/all-entities)
+                   vals
+                   (map (partial mark-disabled-entities services))
+                   (entities-routes services))
+                  (status-routes)
+                  (context
+                      "/bulk" []
+                    :tags ["Bulk"]
+                    (bulk-routes services))
+                  (context
+                      "/incident" []
+                    :tags ["Incident"]
+                    (incident-link-route services))
+                  (bundle-routes services)
+                  (observable-routes services)
+                  (metrics-routes)
+                  (properties-routes services)
+                  (graphql-routes services))))
+            (undocumented
+             (rt/not-found (ok (unk/err-html)))))
+     trace-http/wrap-compojure-route)))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -8,7 +8,7 @@
             [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
             [compojure.api.api :refer [api]]
             [compojure.api.routes :as api-routes]
-            [compojure.core :refer [wrap-routes]]
+            [clout.core :as clout]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]
@@ -212,6 +212,32 @@
   []
   {:formats (conj default-formats (make-text-plain-format-encoder))})
 
+(defn- match-route?
+  "Check if a compiled route matches the request method and URI."
+  [[compiled-path _ verb] request]
+  (and (= (name (:request-method request)) verb)
+       (some? (clout/route-matches compiled-path request))))
+
+(defn- compile-route-table
+  "Compile a route table (from compojure-api's get-routes) into a vector
+  of [compiled-path template verb] tuples for efficient matching."
+  [route-table]
+  (mapv (fn [[path method]]
+          [(clout/route-compile path) path (name method)])
+        route-table))
+
+(defn- wrap-otel-route
+  "Wraps a handler to set the OTel http.route span attribute by matching
+  the request URI against a pre-compiled route table.  Works for all
+  responses including those short-circuited by auth middleware (401s)."
+  [handler compiled-routes]
+  (fn [request]
+    (when-let [[_ route-template _]
+               (first (filter #(match-route? % request)
+                              compiled-routes))]
+      (trace-http/add-route-data! (:request-method request) route-template))
+    (handler request)))
+
 (s/defn api-handler [{{:keys [get-in-config]} :ConfigService
                       :as services} :- APIHandlerServices]
   (let [{:keys [oauth2]}
@@ -224,71 +250,75 @@
                                           wrap-cache-control])
           true (concat [#(wrap-version % get-in-config)
                         ;; always last
-                        (metrics/wrap-metrics "ctia" api-routes/get-routes)]))]
-    (wrap-routes
-     (api {:exceptions {:handlers exception-handlers}
-             :format (->format-options)
-             :swagger
-             (cond-> {:ui "/"
-                      :spec "/swagger.json"
-                      :options {:ui {:jwtLocalStorageKey
-                                     (get-in-config
-                                       [:ctia :http :jwt :local-storage-key])}}
-                      :data {:info {:title "CTIA"
-                                    :version (string/replace (current-version) #"\n" "")
-                                    :license {:name "All Rights Reserved",
-                                              :url ""}
-                                    :contact {:name "Cisco Security Business Group -- Advanced Threat "
-                                              :url "http://github.com/threatgrid/ctia"
-                                              :email "cisco-intel-api-support@cisco.com"}
-                                    :description api-description}
-                             ;; consumes and produces are set to the default values
-                             ;; to remove text/plain which is automatically set
-                             ;; from the `formats` property by `compojure.api.middleware/api-middleware`
-                             :consumes swagger-mime-types
-                             :produces swagger-mime-types
-                             :security [{"JWT" []}]
-                             :securityDefinitions
-                             {"JWT" {:type "apiKey"
-                                     :in "header"
-                                     :name "Authorization"
-                                     :description "Ex: Bearer \\<token\\>"}}
-                             :tags (api-tags services)}}
-               (:enabled oauth2)
-               (apply-oauth2-swagger-conf
-                oauth2))}
+                        (metrics/wrap-metrics "ctia" api-routes/get-routes)]))
+        api-form
+    (api {:exceptions {:handlers exception-handlers}
+            :format (->format-options)
+            :swagger
+            (cond-> {:ui "/"
+                     :spec "/swagger.json"
+                     :options {:ui {:jwtLocalStorageKey
+                                    (get-in-config
+                                      [:ctia :http :jwt :local-storage-key])}}
+                     :data {:info {:title "CTIA"
+                                   :version (string/replace (current-version) #"\n" "")
+                                   :license {:name "All Rights Reserved",
+                                             :url ""}
+                                   :contact {:name "Cisco Security Business Group -- Advanced Threat "
+                                             :url "http://github.com/threatgrid/ctia"
+                                             :email "cisco-intel-api-support@cisco.com"}
+                                   :description api-description}
+                            ;; consumes and produces are set to the default values
+                            ;; to remove text/plain which is automatically set
+                            ;; from the `formats` property by `compojure.api.middleware/api-middleware`
+                            :consumes swagger-mime-types
+                            :produces swagger-mime-types
+                            :security [{"JWT" []}]
+                            :securityDefinitions
+                            {"JWT" {:type "apiKey"
+                                    :in "header"
+                                    :name "Authorization"
+                                    :description "Ex: Bearer \\<token\\>"}}
+                            :tags (api-tags services)}}
+              (:enabled oauth2)
+              (apply-oauth2-swagger-conf
+               oauth2))}
 
-            (middleware middlewares
-              (documentation-routes)
-              (graphql-ui-routes services)
-              (context
-                  "/ctia" []
-                (context "/feed" []
-                  :tags ["Feed"]
-                  (feed-view-routes services))
-                ;; The order is important here for version-routes
-                ;; must be before the middleware fn
-                (version-routes services)
-                (middleware [wrap-authenticated]
-                  (->>
-                   (entities/all-entities)
-                   vals
-                   (map (partial mark-disabled-entities services))
-                   (entities-routes services))
-                  (status-routes)
-                  (context
-                      "/bulk" []
-                    :tags ["Bulk"]
-                    (bulk-routes services))
-                  (context
-                      "/incident" []
-                    :tags ["Incident"]
-                    (incident-link-route services))
-                  (bundle-routes services)
-                  (observable-routes services)
-                  (metrics-routes)
-                  (properties-routes services)
-                  (graphql-routes services))))
-            (undocumented
-             (rt/not-found (ok (unk/err-html)))))
-     trace-http/wrap-compojure-route)))
+           (middleware middlewares
+             (documentation-routes)
+             (graphql-ui-routes services)
+             (context
+                 "/ctia" []
+               (context "/feed" []
+                 :tags ["Feed"]
+                 (feed-view-routes services))
+               ;; The order is important here for version-routes
+               ;; must be before the middleware fn
+               (version-routes services)
+               (middleware [wrap-authenticated]
+                 (->>
+                  (entities/all-entities)
+                  vals
+                  (map (partial mark-disabled-entities services))
+                  (entities-routes services))
+                 (status-routes)
+                 (context
+                     "/bulk" []
+                   :tags ["Bulk"]
+                   (bulk-routes services))
+                 (context
+                     "/incident" []
+                   :tags ["Incident"]
+                   (incident-link-route services))
+                 (bundle-routes services)
+                 (observable-routes services)
+                 (metrics-routes)
+                 (properties-routes services)
+                 (graphql-routes services))))
+           (undocumented
+            (rt/not-found (ok (unk/err-html)))))]
+    ;; Wrap with OTel http.route outside the api form so route matching
+    ;; works for ALL responses, including 401s from wrap-authenticated.
+    ;; We extract routes from the api form (a Route record) before wrapping.
+    (wrap-otel-route api-form
+                     (compile-route-table (api-routes/get-routes api-form)))))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -8,7 +8,6 @@
             [ctia.lib.compojure.api.core :refer [context middleware routes undocumented]]
             [compojure.api.api :refer [api]]
             [compojure.api.routes :as api-routes]
-            [clout.core :as clout]
             [compojure.route :as rt]
             [ctia.bundle.routes :refer [bundle-routes]]
             [ctia.bulk.routes :refer [bulk-routes]]
@@ -17,6 +16,7 @@
                                          graphql-routes]]
             [ctia.http.exceptions :as ex]
             [ctia.http.middleware
+             [otel :refer [wrap-otel-route]]
              [ratelimit :refer [wrap-rate-limit]]
              [auth :refer [wrap-authenticated]]
              [cache-control :refer [wrap-cache-control]]
@@ -34,8 +34,7 @@
             [ring.util.http-response :refer [ok]]
             [schema.core :as s]
             [compojure.api.middleware :refer [->mime-types api-middleware-defaults]]
-            [ring.middleware.format-response :refer [make-encoder]]
-            [steffan-westcott.clj-otel.api.trace.http :as trace-http]))
+            [ring.middleware.format-response :refer [make-encoder]]))
 
 (def api-description
   "A Threat Intelligence API service
@@ -212,32 +211,6 @@
   []
   {:formats (conj default-formats (make-text-plain-format-encoder))})
 
-(defn- match-route?
-  "Check if a compiled route matches the request method and URI."
-  [[compiled-path _ verb] request]
-  (and (= (name (:request-method request)) verb)
-       (some? (clout/route-matches compiled-path request))))
-
-(defn- compile-route-table
-  "Compile a route table (from compojure-api's get-routes) into a vector
-  of [compiled-path template verb] tuples for efficient matching."
-  [route-table]
-  (mapv (fn [[path method]]
-          [(clout/route-compile path) path (name method)])
-        route-table))
-
-(defn- wrap-otel-route
-  "Wraps a handler to set the OTel http.route span attribute by matching
-  the request URI against a pre-compiled route table.  Works for all
-  responses including those short-circuited by auth middleware (401s)."
-  [handler compiled-routes]
-  (fn [request]
-    (when-let [[_ route-template _]
-               (first (filter #(match-route? % request)
-                              compiled-routes))]
-      (trace-http/add-route-data! (:request-method request) route-template))
-    (handler request)))
-
 (s/defn api-handler [{{:keys [get-in-config]} :ConfigService
                       :as services} :- APIHandlerServices]
   (let [{:keys [oauth2]}
@@ -319,6 +292,4 @@
             (rt/not-found (ok (unk/err-html)))))]
     ;; Wrap with OTel http.route outside the api form so route matching
     ;; works for ALL responses, including 401s from wrap-authenticated.
-    ;; We extract routes from the api form (a Route record) before wrapping.
-    (wrap-otel-route api-form
-                     (compile-route-table (api-routes/get-routes api-form)))))
+    (wrap-otel-route api-form (api-routes/get-routes api-form))))

--- a/src/ctia/http/middleware/otel.clj
+++ b/src/ctia/http/middleware/otel.clj
@@ -1,0 +1,34 @@
+(ns ctia.http.middleware.otel
+  "Ring middleware that sets the OTel http.route span attribute by
+  matching the request URI against a pre-compiled route table.
+  Works for all responses including those short-circuited by auth
+  middleware (401s), unlike compojure.core/wrap-routes which only
+  fires at leaf route handlers."
+  (:require [clout.core :as clout]
+            [steffan-westcott.clj-otel.api.trace.http :as trace-http]))
+
+(defn- compile-route-table
+  "Compile a route table (from compojure-api's get-routes) into a map
+  of HTTP verb to vector of [compiled-path template] tuples."
+  [route-table]
+  (->> route-table
+       (map (fn [[path method]]
+              [(name method) [(clout/route-compile path) path]]))
+       (reduce (fn [m [verb entry]]
+                 (update m verb (fnil conj []) entry))
+               {})))
+
+(defn wrap-otel-route
+  "Wraps a handler to set the OTel http.route span attribute.
+  `route-table` is the result of compojure.api.routes/get-routes."
+  [handler route-table]
+  (let [compiled (compile-route-table route-table)]
+    (fn [request]
+      (let [verb (name (:request-method request))]
+        (when-let [route-template
+                   (some (fn [[compiled-path template]]
+                           (when (clout/route-matches compiled-path request)
+                             template))
+                         (get compiled verb))]
+          (trace-http/add-route-data! (:request-method request) route-template)))
+      (handler request))))

--- a/test/ctia/http/handler/otel_route_test.clj
+++ b/test/ctia/http/handler/otel_route_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.http.handler.otel-route-test
   "Integration tests verifying that the http.route OTel span attribute
-   is correctly set by CTIA's api-handler via route-table matching."
+   is correctly set by CTIA's api-handler for both authenticated and
+   unauthenticated requests."
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ctia.http.handler :as handler]
@@ -45,73 +46,20 @@
   (let [app (helpers/get-current-app)]
     (handler/api-handler (app/service-graph app))))
 
-(defn- authenticated-request
-  "Add allow-all identity to a request map so it passes wrap-authenticated."
-  [request]
-  (assoc request :identity allow-all/identity-singleton))
-
-(deftest http-route-set-on-entity-get-test
+(deftest http-route-set-on-authenticated-request-test
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
         handler (ctia-ring-handler)]
     (try
-      (let [response (handler (authenticated-request
-                               {:request-method :get
-                                :uri "/ctia/indicator/indicator-123"
-                                :headers {"authorization" "allow-all"}}))]
+      (let [response (handler (-> {:request-method :get
+                                   :uri "/ctia/indicator/indicator-123"
+                                   :headers {"authorization" "allow-all"}}
+                                  (assoc :identity allow-all/identity-singleton)))]
         (testing "request completes"
           (is (some? (:status response))))
         (testing "http.route is set to the route template"
           (is (= "/ctia/indicator/:id" (get @captured "http.route")))))
-      (finally
-        (.close scope)))))
-
-(deftest http-route-set-on-entity-search-test
-  (let [captured (atom {})
-        span (mock-span captured)
-        ^Scope scope (.makeCurrent span)
-        handler (ctia-ring-handler)]
-    (try
-      (let [response (handler (authenticated-request
-                               {:request-method :get
-                                :uri "/ctia/indicator/search"
-                                :query-string "query=*"
-                                :headers {"authorization" "allow-all"}}))]
-        (testing "request completes"
-          (is (some? (:status response))))
-        (testing "http.route is set to the search route"
-          (is (= "/ctia/indicator/search" (get @captured "http.route")))))
-      (finally
-        (.close scope)))))
-
-(deftest http-route-not-set-on-unmatched-request-test
-  (let [captured (atom {})
-        span (mock-span captured)
-        ^Scope scope (.makeCurrent span)
-        handler (ctia-ring-handler)]
-    (try
-      (handler {:request-method :get
-                :uri "/ctia/nonexistent-entity/foo"
-                :headers {"authorization" "allow-all"}})
-      (testing "http.route is not set for unmatched routes"
-        (is (nil? (get @captured "http.route"))))
-      (finally
-        (.close scope)))))
-
-(deftest http-route-set-on-version-test
-  (let [captured (atom {})
-        span (mock-span captured)
-        ^Scope scope (.makeCurrent span)
-        handler (ctia-ring-handler)]
-    (try
-      (let [response (handler {:request-method :get
-                               :uri "/ctia/version"
-                               :headers {}})]
-        (testing "version endpoint returns 200"
-          (is (= 200 (:status response))))
-        (testing "http.route is set for version endpoint"
-          (is (= "/ctia/version" (get @captured "http.route")))))
       (finally
         (.close scope)))))
 

--- a/test/ctia/http/handler/otel_route_test.clj
+++ b/test/ctia/http/handler/otel_route_test.clj
@@ -1,0 +1,112 @@
+(ns ctia.http.handler.otel-route-test
+  "Integration tests for http.route OTel span attribution via
+   clj-otel wrap-compojure-route in api-handler."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [compojure.api.api :refer [api]]
+   [compojure.core :refer [wrap-routes]]
+   [ctia.lib.compojure.api.core :refer [context routes GET]]
+   [ring.util.http-response :refer [ok]]
+   [steffan-westcott.clj-otel.api.trace.http :as trace-http])
+  (:import
+   [io.opentelemetry.api.common AttributeKey Attributes]
+   [io.opentelemetry.api.trace Span SpanContext StatusCode]
+   [io.opentelemetry.context Scope]))
+
+(defn- mock-span
+  "Creates a Span that captures setAttribute calls into the given atom."
+  [captured-atom]
+  (reify Span
+    (^Span setAttribute [this ^AttributeKey key value]
+      (swap! captured-atom assoc (.getKey key) value)
+      this)
+    (^Span addEvent [this ^String _name] this)
+    (^Span addEvent [this ^String _name ^Attributes _attrs] this)
+    (^Span setStatus [this ^StatusCode _code] this)
+    (^Span setStatus [this ^StatusCode _code ^String _desc] this)
+    (^Span recordException [this ^Throwable _ex] this)
+    (^Span recordException [this ^Throwable _ex ^Attributes _attrs] this)
+    (^Span updateName [this ^String _name] this)
+    (end [_this])
+    (^SpanContext getSpanContext [_this] (SpanContext/getInvalid))
+    (^boolean isRecording [_this] true)))
+
+(defn- build-test-handler
+  "Build a minimal Ring handler with wrap-routes + wrap-compojure-route."
+  [test-routes]
+  (wrap-routes
+   (api {}
+        test-routes)
+   trace-http/wrap-compojure-route))
+
+(deftest http-route-set-on-matched-request-test
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (build-test-handler
+                 (context "/ctia" []
+                   (context "/indicator" []
+                     (GET "/:id" []
+                       (ok "found")))))]
+    (try
+      (let [response (handler {:request-method :get
+                               :uri "/ctia/indicator/abc-123"
+                               :headers {}})]
+        (is (= 200 (:status response)))
+        (is (= "/ctia/indicator/:id" (get @captured "http.route"))))
+      (finally
+        (.close scope)))))
+
+(deftest http-route-set-on-error-test
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (build-test-handler
+                 (context "/ctia" []
+                   (context "/indicator" []
+                     (GET "/:id" []
+                       (throw (ex-info "handler error" {}))))))]
+    (try
+      (testing "handler throws but http.route is still set"
+        (let [response (handler {:request-method :get
+                                 :uri "/ctia/indicator/abc-123"
+                                 :headers {}})]
+          (is (= 500 (:status response)))
+          (is (= "/ctia/indicator/:id" (get @captured "http.route")))))
+      (finally
+        (.close scope)))))
+
+(deftest http-route-not-set-on-unmatched-request-test
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (build-test-handler
+                 (context "/ctia" []
+                   (context "/indicator" []
+                     (GET "/:id" []
+                       (ok "found")))))]
+    (try
+      (handler {:request-method :get
+                :uri "/ctia/nonexistent"
+                :headers {}})
+      (is (nil? (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest http-route-includes-context-prefix-test
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (build-test-handler
+                 (context "/ctia" []
+                   (context "/sighting" []
+                     (GET "/" []
+                       (ok "list")))))]
+    (try
+      (let [response (handler {:request-method :get
+                               :uri "/ctia/sighting/"
+                               :headers {}})]
+        (is (= 200 (:status response)))
+        (is (= "/ctia/sighting/" (get @captured "http.route"))))
+      (finally
+        (.close scope)))))

--- a/test/ctia/http/handler/otel_route_test.clj
+++ b/test/ctia/http/handler/otel_route_test.clj
@@ -1,12 +1,13 @@
 (ns ctia.http.handler.otel-route-test
   "Integration tests verifying that the http.route OTel span attribute
-   is correctly set by CTIA's api-handler via wrap-compojure-route."
+   is correctly set by CTIA's api-handler via route-table matching."
   (:require
    [clojure.test :refer [deftest is testing use-fixtures]]
    [ctia.http.handler :as handler]
    [ctia.test-helpers
     [core :as helpers]
     [es :as es-helpers]]
+   [ctia.auth.allow-all :as allow-all]
    [puppetlabs.trapperkeeper.app :as app]
    [schema.test :refer [validate-schemas]])
   (:import
@@ -44,15 +45,21 @@
   (let [app (helpers/get-current-app)]
     (handler/api-handler (app/service-graph app))))
 
+(defn- authenticated-request
+  "Add allow-all identity to a request map so it passes wrap-authenticated."
+  [request]
+  (assoc request :identity allow-all/identity-singleton))
+
 (deftest http-route-set-on-entity-get-test
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
         handler (ctia-ring-handler)]
     (try
-      (let [response (handler {:request-method :get
-                               :uri "/ctia/indicator/indicator-123"
-                               :headers {"authorization" "allow-all"}})]
+      (let [response (handler (authenticated-request
+                               {:request-method :get
+                                :uri "/ctia/indicator/indicator-123"
+                                :headers {"authorization" "allow-all"}}))]
         (testing "request completes"
           (is (some? (:status response))))
         (testing "http.route is set to the route template"
@@ -66,10 +73,11 @@
         ^Scope scope (.makeCurrent span)
         handler (ctia-ring-handler)]
     (try
-      (let [response (handler {:request-method :get
-                               :uri "/ctia/indicator/search"
-                               :query-string "query=*"
-                               :headers {"authorization" "allow-all"}})]
+      (let [response (handler (authenticated-request
+                               {:request-method :get
+                                :uri "/ctia/indicator/search"
+                                :query-string "query=*"
+                                :headers {"authorization" "allow-all"}}))]
         (testing "request completes"
           (is (some? (:status response))))
         (testing "http.route is set to the search route"
@@ -104,5 +112,21 @@
           (is (= 200 (:status response))))
         (testing "http.route is set for version endpoint"
           (is (= "/ctia/version" (get @captured "http.route")))))
+      (finally
+        (.close scope)))))
+
+(deftest http-route-set-on-unauthenticated-request-test
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (ctia-ring-handler)]
+    (try
+      (let [response (handler {:request-method :get
+                               :uri "/ctia/indicator/indicator-123"
+                               :headers {}})]
+        (testing "unauthenticated request returns 401"
+          (is (= 401 (:status response))))
+        (testing "http.route is still set even for 401 responses"
+          (is (= "/ctia/indicator/:id" (get @captured "http.route")))))
       (finally
         (.close scope)))))

--- a/test/ctia/http/handler/otel_route_test.clj
+++ b/test/ctia/http/handler/otel_route_test.clj
@@ -1,17 +1,24 @@
 (ns ctia.http.handler.otel-route-test
-  "Integration tests for http.route OTel span attribution via
-   clj-otel wrap-compojure-route in api-handler."
+  "Integration tests verifying that the http.route OTel span attribute
+   is correctly set by CTIA's api-handler via wrap-compojure-route."
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [compojure.api.api :refer [api]]
-   [compojure.core :refer [wrap-routes]]
-   [ctia.lib.compojure.api.core :refer [context routes GET]]
-   [ring.util.http-response :refer [ok]]
-   [steffan-westcott.clj-otel.api.trace.http :as trace-http])
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ctia.http.handler :as handler]
+   [ctia.test-helpers
+    [core :as helpers]
+    [es :as es-helpers]]
+   [puppetlabs.trapperkeeper.app :as app]
+   [schema.test :refer [validate-schemas]])
   (:import
    [io.opentelemetry.api.common AttributeKey Attributes]
    [io.opentelemetry.api.trace Span SpanContext StatusCode]
    [io.opentelemetry.context Scope]))
+
+(use-fixtures :each
+  validate-schemas
+  es-helpers/fixture-properties:es-store
+  helpers/fixture-allow-all-auth
+  helpers/fixture-ctia-fast)
 
 (defn- mock-span
   "Creates a Span that captures setAttribute calls into the given atom."
@@ -31,48 +38,42 @@
     (^SpanContext getSpanContext [_this] (SpanContext/getInvalid))
     (^boolean isRecording [_this] true)))
 
-(defn- build-test-handler
-  "Build a minimal Ring handler with wrap-routes + wrap-compojure-route."
-  [test-routes]
-  (wrap-routes
-   (api {}
-        test-routes)
-   trace-http/wrap-compojure-route))
+(defn- ctia-ring-handler
+  "Build CTIA's Ring handler from the current test app services."
+  []
+  (let [app (helpers/get-current-app)]
+    (handler/api-handler (app/service-graph app))))
 
-(deftest http-route-set-on-matched-request-test
+(deftest http-route-set-on-entity-get-test
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
-        handler (build-test-handler
-                 (context "/ctia" []
-                   (context "/indicator" []
-                     (GET "/:id" []
-                       (ok "found")))))]
+        handler (ctia-ring-handler)]
     (try
       (let [response (handler {:request-method :get
-                               :uri "/ctia/indicator/abc-123"
-                               :headers {}})]
-        (is (= 200 (:status response)))
-        (is (= "/ctia/indicator/:id" (get @captured "http.route"))))
+                               :uri "/ctia/indicator/indicator-123"
+                               :headers {"authorization" "allow-all"}})]
+        (testing "request completes"
+          (is (some? (:status response))))
+        (testing "http.route is set to the route template"
+          (is (= "/ctia/indicator/:id" (get @captured "http.route")))))
       (finally
         (.close scope)))))
 
-(deftest http-route-set-on-error-test
+(deftest http-route-set-on-entity-search-test
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
-        handler (build-test-handler
-                 (context "/ctia" []
-                   (context "/indicator" []
-                     (GET "/:id" []
-                       (throw (ex-info "handler error" {}))))))]
+        handler (ctia-ring-handler)]
     (try
-      (testing "handler throws but http.route is still set"
-        (let [response (handler {:request-method :get
-                                 :uri "/ctia/indicator/abc-123"
-                                 :headers {}})]
-          (is (= 500 (:status response)))
-          (is (= "/ctia/indicator/:id" (get @captured "http.route")))))
+      (let [response (handler {:request-method :get
+                               :uri "/ctia/indicator/search"
+                               :query-string "query=*"
+                               :headers {"authorization" "allow-all"}})]
+        (testing "request completes"
+          (is (some? (:status response))))
+        (testing "http.route is set to the search route"
+          (is (= "/ctia/indicator/search" (get @captured "http.route")))))
       (finally
         (.close scope)))))
 
@@ -80,33 +81,28 @@
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
-        handler (build-test-handler
-                 (context "/ctia" []
-                   (context "/indicator" []
-                     (GET "/:id" []
-                       (ok "found")))))]
+        handler (ctia-ring-handler)]
     (try
       (handler {:request-method :get
-                :uri "/ctia/nonexistent"
-                :headers {}})
-      (is (nil? (get @captured "http.route")))
+                :uri "/ctia/nonexistent-entity/foo"
+                :headers {"authorization" "allow-all"}})
+      (testing "http.route is not set for unmatched routes"
+        (is (nil? (get @captured "http.route"))))
       (finally
         (.close scope)))))
 
-(deftest http-route-includes-context-prefix-test
+(deftest http-route-set-on-version-test
   (let [captured (atom {})
         span (mock-span captured)
         ^Scope scope (.makeCurrent span)
-        handler (build-test-handler
-                 (context "/ctia" []
-                   (context "/sighting" []
-                     (GET "/" []
-                       (ok "list")))))]
+        handler (ctia-ring-handler)]
     (try
       (let [response (handler {:request-method :get
-                               :uri "/ctia/sighting/"
+                               :uri "/ctia/version"
                                :headers {}})]
-        (is (= 200 (:status response)))
-        (is (= "/ctia/sighting/" (get @captured "http.route"))))
+        (testing "version endpoint returns 200"
+          (is (= 200 (:status response))))
+        (testing "http.route is set for version endpoint"
+          (is (= "/ctia/version" (get @captured "http.route")))))
       (finally
         (.close scope)))))

--- a/test/ctia/http/middleware/otel_test.clj
+++ b/test/ctia/http/middleware/otel_test.clj
@@ -1,0 +1,112 @@
+(ns ctia.http.middleware.otel-test
+  "Unit tests for the OTel http.route middleware."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ctia.http.middleware.otel :refer [wrap-otel-route]])
+  (:import
+   [io.opentelemetry.api.common AttributeKey Attributes]
+   [io.opentelemetry.api.trace Span SpanContext StatusCode]
+   [io.opentelemetry.context Scope]))
+
+(defn- mock-span
+  "Creates a Span that captures setAttribute calls into the given atom."
+  [captured-atom]
+  (reify Span
+    (^Span setAttribute [this ^AttributeKey key value]
+      (swap! captured-atom assoc (.getKey key) value)
+      this)
+    (^Span addEvent [this ^String _name] this)
+    (^Span addEvent [this ^String _name ^Attributes _attrs] this)
+    (^Span setStatus [this ^StatusCode _code] this)
+    (^Span setStatus [this ^StatusCode _code ^String _desc] this)
+    (^Span recordException [this ^Throwable _ex] this)
+    (^Span recordException [this ^Throwable _ex ^Attributes _attrs] this)
+    (^Span updateName [this ^String _name] this)
+    (end [_this])
+    (^SpanContext getSpanContext [_this] (SpanContext/getInvalid))
+    (^boolean isRecording [_this] true)))
+
+(def ^:private sample-route-table
+  ;; Exact paths before parameterized ones, matching compojure-api ordering.
+  [["/ctia/indicator/search" :get]
+   ["/ctia/indicator/:id" :get]
+   ["/ctia/indicator/:id" :put]
+   ["/ctia/indicator/:id" :delete]
+   ["/ctia/sighting/:id" :get]
+   ["/ctia/version" :get]])
+
+(defn- ok-handler [_request] {:status 200})
+
+(deftest wrap-otel-route-matches-parameterized-path
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route ok-handler sample-route-table)]
+    (try
+      (handler {:request-method :get
+                :uri "/ctia/indicator/indicator-123"})
+      (is (= "/ctia/indicator/:id" (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest wrap-otel-route-matches-exact-path
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route ok-handler sample-route-table)]
+    (try
+      (handler {:request-method :get
+                :uri "/ctia/indicator/search"
+                :query-string "query=*"})
+      (is (= "/ctia/indicator/search" (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest wrap-otel-route-respects-http-method
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route ok-handler sample-route-table)]
+    (try
+      (handler {:request-method :put
+                :uri "/ctia/indicator/indicator-123"})
+      (is (= "/ctia/indicator/:id" (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest wrap-otel-route-no-match-for-wrong-method
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route ok-handler sample-route-table)]
+    (try
+      (handler {:request-method :post
+                :uri "/ctia/indicator/indicator-123"})
+      (is (nil? (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest wrap-otel-route-no-match-for-unknown-uri
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route ok-handler sample-route-table)]
+    (try
+      (handler {:request-method :get
+                :uri "/ctia/nonexistent/foo"})
+      (is (nil? (get @captured "http.route")))
+      (finally
+        (.close scope)))))
+
+(deftest wrap-otel-route-delegates-to-handler
+  (let [captured (atom {})
+        span (mock-span captured)
+        ^Scope scope (.makeCurrent span)
+        handler (wrap-otel-route (fn [_] {:status 418}) sample-route-table)]
+    (try
+      (let [response (handler {:request-method :get
+                               :uri "/ctia/version"})]
+        (testing "handler response is passed through"
+          (is (= 418 (:status response)))))
+      (finally
+        (.close scope)))))


### PR DESCRIPTION
## Summary

- Fix APM endpoint names showing only generic HTTP methods (POST, GET, PUT) instead of route paths like `/ctia/indicator/:id`
- Use `compojure.core/wrap-routes` to apply `trace-http/wrap-compojure-route` **after** route matching (mirroring the IROH approach from advthreat/iroh@e7c3454d)
- Bump Compojure from 1.6.1 to 1.7.2 to match IROH

## Context

The previous fix ([#1515](https://github.com/threatgrid/ctia/pull/1515), XDR-49687) placed `wrap-compojure-route` inline in the middleware chain, where it runs **before** route matching — so the route template is not yet populated and APM tools only see generic HTTP method names.

`wrap-routes` applies the middleware after the route has been matched, ensuring the `http.route` OTel span attribute is set to the actual route template.

This is the same approach used in IROH: advthreat/iroh@e7c3454d0c0ceab44e914d88f66566f6dd4bc05c

## Test plan

- [ ] Verify CTIA starts successfully
- [ ] Confirm APM traces in Datadog/Splunk show route paths (e.g., `GET /ctia/indicator/:id`) instead of generic method names
- [ ] Run existing test suite to check for regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)