### PR TITLE
Fix trailing-slash and ANY route matching in OTel middleware (XDR-50180)

### DIFF
--- a/src/ctia/http/middleware/otel.clj
+++ b/src/ctia/http/middleware/otel.clj
@@ -10,9 +10,11 @@
 
 (defn compile-route-table
   "Compile a route table (from compojure-api's get-routes) into a map
-  of HTTP verb to vector of [compiled-path template] tuples."
+  of HTTP verb (or :any for nil-method ANY routes) to vector of
+  [compiled-path template] tuples."
   [route-table]
-  (-> (group-by (fn [[_ method]] (name method)) route-table)
+  (-> (filter (fn [[path]] (and path (not= "*" path))) route-table)
+      (->> (group-by (fn [[_ method]] (if method (name method) :any))))
       (update-vals (fn [entries]
                      (mapv (fn [[path _]] [(clout/route-compile path) path])
                            entries)))))
@@ -40,7 +42,8 @@
                               routes))]
       (or (match-route (get compiled-routes method-name))
           (when (= "head" method-name)
-            (match-route (get compiled-routes "get")))))))
+            (match-route (get compiled-routes "get")))
+          (match-route (get compiled-routes :any))))))
 
 (defn wrap-otel-route
   "Wraps a handler to set the OTel http.route span attribute.

--- a/src/ctia/http/middleware/otel.clj
+++ b/src/ctia/http/middleware/otel.clj
@@ -17,12 +17,22 @@
                      (mapv (fn [[path _]] [(clout/route-compile path) path])
                            entries)))))
 
+(defn ->path
+  "Normalize a request URI to match route templates produced by
+  compojure-api's get-routes: strips trailing slash (unless the path
+  is just \"/\")."
+  [uri]
+  (if (and uri (> (count uri) 1) (.endsWith ^String uri "/"))
+    (subs uri 0 (dec (count uri)))
+    uri))
+
 (defn find-route-template
   "Return the route template matching `request`, or nil if none matches.
   Falls back to GET routes for HEAD requests, matching Compojure's behavior."
   [compiled-routes request]
   (when-let [method (:request-method request)]
-    (let [method-name (name method)
+    (let [request (update request :uri ->path)
+          method-name (name method)
           match-route (fn [routes]
                         (some (fn [[compiled-path template]]
                                 (when (clout/route-matches compiled-path request)

--- a/test/ctia/http/middleware/otel_test.clj
+++ b/test/ctia/http/middleware/otel_test.clj
@@ -13,7 +13,8 @@
    ["/ctia/indicator/:id" :delete]
    ["/ctia/sighting/:id" :get]
    ["/ctia/entity/:id/sub/:sub-id" :get]
-   ["/ctia/version" :get]])
+   ["/ctia/version" :get]
+   ["/ctia/proxy/*" nil]])
 
 (defn ok-handler [_request] {:status 200})
 
@@ -124,3 +125,40 @@
            (find-route-template compiled
                                 {:request-method :get
                                  :uri "/ctia/entity/ent-1/sub/sub-2/"})))))
+
+;; --- ANY route tests ---
+
+(deftest compile-route-table-groups-any-routes
+  (let [compiled (compile-route-table sample-route-table)]
+    (is (seq (get compiled :any))
+        "nil-method routes are grouped under :any")))
+
+(deftest any-route-matches-get
+  (with-mock-span captured
+    (let [handler (make-handler)]
+      (handler {:request-method :get
+                :uri "/ctia/proxy/foo/bar"})
+      (is (= "/ctia/proxy/*" (get @captured "http.route"))))))
+
+(deftest any-route-matches-post
+  (with-mock-span captured
+    (let [handler (make-handler)]
+      (handler {:request-method :post
+                :uri "/ctia/proxy/foo/bar"})
+      (is (= "/ctia/proxy/*" (get @captured "http.route"))))))
+
+(deftest any-route-matches-delete
+  (with-mock-span captured
+    (let [handler (make-handler)]
+      (handler {:request-method :delete
+                :uri "/ctia/proxy/foo/bar"})
+      (is (= "/ctia/proxy/*" (get @captured "http.route"))))))
+
+(deftest specific-method-takes-priority-over-any
+  (let [compiled (compile-route-table (conj sample-route-table
+                                            ["/ctia/indicator/:id" nil]))]
+    (is (= "/ctia/indicator/:id"
+           (find-route-template compiled
+                                {:request-method :get
+                                 :uri "/ctia/indicator/indicator-123"}))
+        "GET-specific route wins over ANY")))

--- a/test/ctia/http/middleware/otel_test.clj
+++ b/test/ctia/http/middleware/otel_test.clj
@@ -2,7 +2,8 @@
   "Unit tests for the OTel http.route middleware."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ctia.http.middleware.otel :refer [wrap-otel-route]]
+   [ctia.http.middleware.otel :refer [->path compile-route-table
+                                         find-route-template wrap-otel-route]]
    [ctia.test-helpers.otel :refer [with-mock-span]]))
 
 (def ^:private sample-route-table
@@ -86,3 +87,40 @@
               (handler {:request-method :get
                         :uri "/ctia/indicator/indicator-123"})))
         (is (= "/ctia/indicator/:id" (get @captured "http.route")))))))
+
+;; --- ->path unit tests ---
+
+(deftest ->path-strips-trailing-slash
+  (is (= "/things" (->path "/things/"))))
+
+(deftest ->path-preserves-root
+  (is (= "/" (->path "/"))))
+
+(deftest ->path-preserves-no-trailing-slash
+  (is (= "/items/:id" (->path "/items/:id"))))
+
+(deftest ->path-handles-nil
+  (is (nil? (->path nil))))
+
+;; --- find-route-template trailing-slash tests ---
+
+(deftest find-route-template-trailing-slash-exact
+  (let [compiled (compile-route-table sample-route-table)]
+    (is (= "/ctia/indicator/search"
+           (find-route-template compiled
+                                {:request-method :get
+                                 :uri "/ctia/indicator/search/"})))))
+
+(deftest find-route-template-trailing-slash-parameterized
+  (let [compiled (compile-route-table sample-route-table)]
+    (is (= "/ctia/indicator/:id"
+           (find-route-template compiled
+                                {:request-method :get
+                                 :uri "/ctia/indicator/indicator-123/"})))))
+
+(deftest find-route-template-trailing-slash-multi-param
+  (let [compiled (compile-route-table sample-route-table)]
+    (is (= "/ctia/entity/:id/sub/:sub-id"
+           (find-route-template compiled
+                                {:request-method :get
+                                 :uri "/ctia/entity/ent-1/sub/sub-2/"})))))


### PR DESCRIPTION
## Summary
- Add `->path` to normalize request URIs by stripping trailing slashes before route matching, fixing a mismatch where `get-routes` strips trailing slashes from templates but request URIs are not normalized
- Support ANY routes (nil method from `get-routes`): `compile-route-table` groups them under `:any`, `find-route-template` falls back to `:any` after method-specific and HEAD→GET lookups
- Aligns with iroh-web.otel's implementation (iroh PR #10452)

Follow-up: [XDR-50316](https://cisco-sbg.atlassian.net/browse/XDR-50316) — extract OTel route matching into a shared Clojars library

## Test plan
- [x] Unit tests for `->path`: strips trailing slash, preserves `/`, preserves paths without trailing slash, handles nil
- [x] Unit tests for `find-route-template` with trailing-slash URIs: exact, parameterized, and multi-param paths
- [x] `compile-route-table` groups nil-method routes under `:any`
- [x] ANY routes match GET, POST, and DELETE requests
- [x] Specific method routes take priority over ANY
- [x] All 21 tests pass (`lein test :only ctia.http.middleware.otel-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[XDR-50316]: https://cisco-sbg.atlassian.net/browse/XDR-50316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ