### PR TITLE
fix(incident): override stale upstream :opened on first New → Open (XDR-54438)

### DIFF
--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -173,13 +173,21 @@
           new-opened-date (when (and (new-status? old-status)
                                      (open-status? new-status))
                             (get-in status-update [:incident_time :opened]))
+          ;; On (New|Open) → Open: Contained, override :contained with NOW for the same reason as
+          ;; :opened: an upstream-stamped :contained earlier than :created would silently elide
+          ;; :new_to_contained via update-interval's (earlier ≤ later) guard, hiding MTTC.
+          ;; Trigger mirrors compute-intervals' :new_to_contained clause exactly.
+          new-contained-date (when (and (or (new-status? old-status) (open-status? old-status))
+                                        (contained-status? new-status))
+                               (get-in status-update [:incident_time :contained]))
           ;; prev-* and new-* dates for each verb are mutually exclusive (one requires the old
           ;; status to be in the category, the other requires it not to be).
           merged-incident-time (cond-> (merge status-stamped-incident-time client-incident-time)
                                  prev-closed-date (assoc :closed prev-closed-date)
                                  prev-opened-date (assoc :opened prev-opened-date)
                                  new-closed-date (assoc :closed new-closed-date)
-                                 new-opened-date (assoc :opened new-opened-date))]
+                                 new-opened-date (assoc :opened new-opened-date)
+                                 new-contained-date (assoc :contained new-contained-date))]
       (cond-> new-obj
         (seq merged-incident-time) (assoc :incident_time merged-incident-time)))
     ;; No status change or no previous object, return as-is

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -147,10 +147,13 @@
     (let [old-status (:status prev-obj)
           new-status (:status new-obj)
           status-update (make-status-update {:status new-status})
-          ;; Merge the incident_time updates from status change logic
-          ;; Existing values take precedence (set-once semantics for opened, contained, etc.)
-          incident-time-updates (get status-update :incident_time {})
-          current-incident-time (get new-obj :incident_time {})
+          ;; Layered precedence for :incident_time on a status change:
+          ;;   1. status-stamped defaults (e.g. {:opened NOW} for any open status) seed the map
+          ;;   2. client-supplied values from the PATCH body override the defaults
+          ;;   3. cond-> overrides below trump both for category-transition fields the server owns
+          ;;      (e.g., :opened on New → Open, :closed on non-closed → closed)
+          status-stamped-incident-time (get status-update :incident_time {})
+          client-incident-time (get new-obj :incident_time {})
           ;; If transitioning from closed to closed, preserve the original closed date
           prev-closed-date (when (and (closed-status? old-status)
                                       (closed-status? new-status))
@@ -172,7 +175,7 @@
                             (get-in status-update [:incident_time :opened]))
           ;; prev-* and new-* dates for each verb are mutually exclusive (one requires the old
           ;; status to be in the category, the other requires it not to be).
-          merged-incident-time (cond-> (merge incident-time-updates current-incident-time)
+          merged-incident-time (cond-> (merge status-stamped-incident-time client-incident-time)
                                  prev-closed-date (assoc :closed prev-closed-date)
                                  prev-opened-date (assoc :opened prev-opened-date)
                                  new-closed-date (assoc :closed new-closed-date)

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -100,10 +100,10 @@
   {:status IncidentStatus})
 
 (defn new-status? [status]
-   (some? (re-matches #"New(: .+)?" status)))
+  (some? (and status (re-matches #"New(: .+)?" status))))
 
 (defn hold-status? [status]
-   (some? (re-matches #"Hold(: .+)?" status)))
+  (some? (and status (re-matches #"Hold(: .+)?" status))))
 
 (defn open-status? [status]
   (some? (and status (re-matches #"Open(: .+)?" status))))
@@ -163,12 +163,22 @@
           new-closed-date (when (and (closed-status? new-status)
                                      (not (closed-status? old-status)))
                             (get-in status-update [:incident_time :closed]))
-          ;; prev-closed-date and new-closed-date are mutually exclusive:
-          ;; prev-closed-date requires old-status to be closed, new-closed-date requires it not to be.
+          ;; On first open (New → Open), set :opened to NOW if the engagement interval has not
+          ;; yet been recorded. This is the same invariant compute-intervals uses ("don't clobber
+          ;; existing interval"); applying it here ensures MTTE reflects the actual click time and
+          ;; not whatever upstream pre-stamped on a promoted incident (CTIM marks :opened as
+          ;; mandatory, so promoted incidents always carry it).
+          new-opened-date (when (and (new-status? old-status)
+                                     (open-status? new-status)
+                                     (not (get-in prev-obj [:intervals :new_to_opened])))
+                            (get-in status-update [:incident_time :opened]))
+          ;; prev-* and new-* dates for each verb are mutually exclusive (one requires the old
+          ;; status to be in the category, the other requires it not to be).
           merged-incident-time (cond-> (merge incident-time-updates current-incident-time)
                                  prev-closed-date (assoc :closed prev-closed-date)
                                  prev-opened-date (assoc :opened prev-opened-date)
-                                 new-closed-date (assoc :closed new-closed-date))]
+                                 new-closed-date (assoc :closed new-closed-date)
+                                 new-opened-date (assoc :opened new-opened-date))]
       (cond-> new-obj
         (seq merged-incident-time) (assoc :incident_time merged-incident-time)))
     ;; No status change or no previous object, return as-is

--- a/src/ctia/entity/incident.clj
+++ b/src/ctia/entity/incident.clj
@@ -163,14 +163,12 @@
           new-closed-date (when (and (closed-status? new-status)
                                      (not (closed-status? old-status)))
                             (get-in status-update [:incident_time :closed]))
-          ;; On first open (New → Open), set :opened to NOW if the engagement interval has not
-          ;; yet been recorded. This is the same invariant compute-intervals uses ("don't clobber
-          ;; existing interval"); applying it here ensures MTTE reflects the actual click time and
-          ;; not whatever upstream pre-stamped on a promoted incident (CTIM marks :opened as
-          ;; mandatory, so promoted incidents always carry it).
+          ;; On New → Open, override :opened with NOW. CTIM marks :opened as mandatory, so promoted
+          ;; incidents always carry an upstream-stamped value; MTTE is computed from :created →
+          ;; :opened, so resetting :opened on each New → Open transition gives the engagement-click
+          ;; time we actually want.
           new-opened-date (when (and (new-status? old-status)
-                                     (open-status? new-status)
-                                     (not (get-in prev-obj [:intervals :new_to_opened])))
+                                     (open-status? new-status))
                             (get-in status-update [:incident_time :opened]))
           ;; prev-* and new-* dates for each verb are mutually exclusive (one requires the old
           ;; status to be in the category, the other requires it not to be).

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -740,8 +740,12 @@
        ;; specifically to catch any future regression of the dashboard tiles, regardless of which
        ;; layer (status logic, compute-intervals, storage, aggregate route) breaks.
        (testing "All Mean Time To X tiles: full status lifecycle reports expected averages"
-         (let [;; Each step adds 5 minutes; intervals: new_to_opened=5min, new_to_contained=10min,
-               ;; opened_to_closed=10min (opened at +5min, closed at +15min).
+         (let [;; Step times (PATCH timestamps): step-1 → Open, step-2 → Open: Contained,
+               ;; step-3 → Closed. fixture-with-fixed-time redefs internal-now, so :opened/
+               ;; :contained/:closed all land exactly on these instants.
+               step-1 (t/plus fixed-now (t/minutes 5))
+               step-2 (t/plus fixed-now (t/minutes 10))
+               step-3 (t/plus fixed-now (t/minutes 15))
                unique-title (str "MTTX Scenario " (java.util.UUID/randomUUID))
                upstream-opened (t/minus fixed-now (t/days 1))
                incident-to-create (-> new-incident-minimal
@@ -753,6 +757,7 @@
                                  "ctia/incident"
                                  :body incident-to-create
                                  :headers {"Authorization" "45c1f5e3f05d0"})
+               created-instant (-> create-resp :parsed-body :created jt/instant)
                test-id (:id (:parsed-body create-resp))
                _ (swap! test-incidents conj test-id)
                _ (is (= 201 (:status create-resp)))
@@ -763,25 +768,27 @@
                               (PATCH app
                                      (str "ctia/incident/" (uri/uri-encode test-id))
                                      :body {:status status}
-                                     :headers {"Authorization" "45c1f5e3f05d0"}))))]
-           ;; Step 1: New → Open at +5min
-           (let [resp (do-patch! (t/plus fixed-now (t/minutes 5)) "Open")]
+                                     :headers {"Authorization" "45c1f5e3f05d0"}))))
+               seconds-between (fn [from to]
+                                 (jt/time-between (jt/instant from) (jt/instant to) :seconds))]
+           ;; Step 1: New → Open
+           (let [resp (do-patch! step-1 "Open")]
              (is (= 200 (:status resp)))
              (is (= "Open" (:status (:parsed-body resp)))))
-           ;; Step 2: Open → Open: Contained at +10min
-           (let [resp (do-patch! (t/plus fixed-now (t/minutes 10)) "Open: Contained")]
+           ;; Step 2: Open → Open: Contained
+           (let [resp (do-patch! step-2 "Open: Contained")]
              (is (= 200 (:status resp)))
              (is (= "Open: Contained" (:status (:parsed-body resp)))))
-           ;; Step 3: Open: Contained → Closed: Confirmed Threat at +15min
-           (let [resp (do-patch! (t/plus fixed-now (t/minutes 15)) "Closed: Confirmed Threat")]
+           ;; Step 3: Open: Contained → Closed: Confirmed Threat
+           (let [resp (do-patch! step-3 "Closed: Confirmed Threat")]
              (is (= 200 (:status resp)))
              (is (= "Closed: Confirmed Threat" (:status (:parsed-body resp)))))
-           ;; ±10s tolerance on intervals derived from :created (new_to_opened, new_to_contained):
-           ;; default-realize-fn stamps :created via clj-momo.lib.time/now, which is a `def` aliasing
-           ;; the underlying internal-now at namespace load. fixture-with-fixed-time redefs
-           ;; clj-momo.lib.clj-time.core/internal-now but not the alias, so :created leaks the wall
-           ;; clock by a few seconds. opened_to_closed is exact since both endpoints are PATCH-time
-           ;; values, fully under fixed-time control.
+           ;; default-realize-fn stamps :created via clj-momo.lib.time/now — a `def` aliasing
+           ;; internal-now at namespace load. fixture-with-fixed-time redefs internal-now but not
+           ;; the alias, so :created leaks the wall clock by a few seconds. To make
+           ;; intervals-from-:created assertions exact, derive the expected value from the actual
+           ;; :created returned by the create response. opened_to_closed has no such drift since
+           ;; both endpoints are PATCH-time values fully under fixed-time control.
            (helpers/fixture-with-fixed-time
             (t/plus fixed-now (t/days 1))
             (fn []
@@ -793,14 +800,15 @@
                                                          :query (format "title:\"%s\"" unique-title)})
                                      :parsed-body
                                      (get-in [:data :intervals (keyword field)])))
-                    near? (fn [expected actual]
-                            (and actual (<= (- expected 10) actual (+ expected 10))))]
-                (is (near? 300 (metric-avg "new_to_opened"))
-                    "MTTE tile metric must reflect ~5 min from creation to first Open")
-                (is (near? 600 (metric-avg "new_to_contained"))
-                    "MTTC tile metric must reflect ~10 min from creation to Open: Contained")
-                (is (= 600.0 (metric-avg "opened_to_closed"))
-                    "Opened-to-closed metric must reflect 10 min from Open to Closed"))))))
+                    expected-new-to-opened (seconds-between created-instant step-1)
+                    expected-new-to-contained (seconds-between created-instant step-2)
+                    expected-opened-to-closed (seconds-between step-1 step-3)]
+                (is (= (double expected-new-to-opened) (metric-avg "new_to_opened"))
+                    "MTTE tile metric must reflect time from :created to first Open")
+                (is (= (double expected-new-to-contained) (metric-avg "new_to_contained"))
+                    "MTTC tile metric must reflect time from :created to Open: Contained")
+                (is (= (double expected-opened-to-closed) (metric-avg "opened_to_closed"))
+                    "Opened-to-closed metric must reflect time from Open to Closed"))))))
       (finally
         ;; Clean up test incidents
         (doseq [test-id @test-incidents]

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -98,7 +98,55 @@
                                         :closed t2}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
            (is (= t1 (get-in result [:incident_time :opened]))
-               "Opened date should NOT change on re-open")))))))
+               "Opened date should NOT change on re-open")))))
+
+    (testing "XDR-54438: New → Open sets :opened to NOW when :new_to_opened interval is not yet recorded"
+      ;; CTIM marks :opened as mandatory, so promoted incidents always carry an upstream-stamped
+      ;; :opened that is unrelated to actual analyst engagement. On the first New → Open transition,
+      ;; if no engagement interval has been recorded yet, set :opened to NOW (the click time).
+      ;; This mirrors compute-intervals' "don't clobber existing interval" semantics.
+      (helpers/fixture-with-fixed-time
+       t3
+       (fn []
+         (let [prev-obj {:status "New"
+                         :created t2
+                         :incident_time {:opened t1}}
+               new-obj {:status "Open"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t3 (get-in result [:incident_time :opened]))
+               "Opened date should be NOW on first New → Open when no :new_to_opened recorded")))))
+
+    (testing "XDR-54438: New → Open preserves :opened when :new_to_opened interval already exists"
+      ;; If the engagement interval was already computed (e.g., previous transition cycle), do not
+      ;; overwrite. This preserves first-engagement semantics across re-open scenarios.
+      (helpers/fixture-with-fixed-time
+       t3
+       (fn []
+         (let [prev-obj {:status "New"
+                         :created t1
+                         :incident_time {:opened t1}
+                         :intervals {:new_to_opened 42}}
+               new-obj {:status "Open"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should be preserved when :new_to_opened was already computed")))))
+
+    (testing "XDR-54438: New → New: Triaged preserves :opened (clause must not fire)"
+      ;; Sub-status transitions within the New category should not override :opened, since this is
+      ;; not a New → Open transition. The new-opened-date clause must remain inert here.
+      (helpers/fixture-with-fixed-time
+       t3
+       (fn []
+         (let [prev-obj {:status "New"
+                         :created t2
+                         :incident_time {:opened t1}}
+               new-obj {:status "New: Triaged"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should be preserved on New → New: Triaged")))))))
 
 (deftest incident-scores-schema-test
   (let [get-in-config (partial get-in {:ctia {:http {:incident {:score-types "global,ttp,asset"}}}})
@@ -314,7 +362,10 @@
            ;; incident_time should remain unchanged
            (is (= current-incident-time (:incident_time updated-incident)))))
 
-       (testing "PATCH /ctia/incident/:id preserves explicitly set incident_time fields"
+       (testing "PATCH /ctia/incident/:id: first New → Open sets :opened to NOW (engagement time wins over PATCH-body :opened)"
+         ;; XDR-54438: engagement time is what the analyst's click represents, not whatever the
+         ;; client passes (or what upstream pre-stamped). On first New → Open the override applies
+         ;; even when the PATCH body explicitly carries an :opened.
          (let [test-id (create-test-incident app)
                _ (swap! test-incidents conj test-id)
                custom-time (tc/to-date (t/plus fixed-now (t/hours 2)))
@@ -326,8 +377,8 @@
                updated-incident (:parsed-body response)]
            (is (= 200 (:status response)))
            (is (= "Open" (:status updated-incident)))
-           ;; Should use the explicitly provided time, not the generated one
-           (is (= custom-time (get-in updated-incident [:incident_time :opened])))))
+           (is (= (tc/to-date fixed-now) (get-in updated-incident [:incident_time :opened]))
+               "On first New → Open, :opened is the click time (engagement), not the PATCH-body value")))
 
        (testing "POST /ctia/incident/:id/status Hold to Closed transition"
          (let [test-id (create-test-incident app)
@@ -589,6 +640,108 @@
          (run-reclose-scenario app fixed-now test-incidents
            (fn [app id status]
              (post-status app (uri/uri-encode id) status))))
+
+       ;; XDR-54438: First New → Open must overwrite upstream-provided :opened, otherwise
+       ;; compute-intervals' (created ≤ opened) guard elides :new_to_opened and MTTE shows 0.
+       (testing "PATCH /ctia/incident/:id: New → Open overrides upstream :opened earlier than :created"
+         (let [upstream-opened (t/minus fixed-now (t/days 1))
+               unique-title (str "Promoted Incident " (java.util.UUID/randomUUID))
+               incident-to-create (-> new-incident-minimal
+                                      (dissoc :id :severity)
+                                      (assoc :title unique-title
+                                             :status "New"
+                                             :incident_time {:opened (tc/to-date upstream-opened)}))
+               create-resp (POST app
+                                 "ctia/incident"
+                                 :body incident-to-create
+                                 :headers {"Authorization" "45c1f5e3f05d0"})
+               test-id (:id (:parsed-body create-resp))
+               _ (swap! test-incidents conj test-id)]
+           (is (= 201 (:status create-resp)))
+           (is (= (tc/to-date upstream-opened)
+                  (get-in (:parsed-body create-resp) [:incident_time :opened]))
+               "Upstream :opened is preserved on create, earlier than :created")
+           (helpers/fixture-with-fixed-time
+            (t/plus fixed-now (t/minutes 5))
+            (fn []
+              (let [response (PATCH app
+                                    (str "ctia/incident/" (uri/uri-encode test-id))
+                                    :body {:status "Open"}
+                                    :headers {"Authorization" "45c1f5e3f05d0"})
+                    updated (:parsed-body response)]
+                (is (= 200 (:status response)))
+                (is (= "Open" (:status updated)))
+                (is (= (tc/to-date (t/plus fixed-now (t/minutes 5)))
+                       (get-in updated [:incident_time :opened]))
+                    "On first New → Open, :opened must be NOW (PATCH time), not the upstream value"))))))
+
+       ;; XDR-54438: full status lifecycle scenario covering all Mean Time To X tiles. Walks a
+       ;; single promoted incident through New → Open → Open: Contained → Closed and asserts that
+       ;; every interval lands at /metric/average with the expected elapsed time. This test exists
+       ;; specifically to catch any future regression of the dashboard tiles, regardless of which
+       ;; layer (status logic, compute-intervals, storage, aggregate route) breaks.
+       (testing "All Mean Time To X tiles: full status lifecycle reports expected averages"
+         (let [;; Each step adds 5 minutes; intervals: new_to_opened=5min, new_to_contained=10min,
+               ;; opened_to_closed=10min (opened at +5min, closed at +15min).
+               unique-title (str "MTTX Scenario " (java.util.UUID/randomUUID))
+               upstream-opened (t/minus fixed-now (t/days 1))
+               incident-to-create (-> new-incident-minimal
+                                      (dissoc :id)
+                                      (assoc :title unique-title
+                                             :status "New"
+                                             :incident_time {:opened (tc/to-date upstream-opened)}))
+               create-resp (POST app
+                                 "ctia/incident"
+                                 :body incident-to-create
+                                 :headers {"Authorization" "45c1f5e3f05d0"})
+               test-id (:id (:parsed-body create-resp))
+               _ (swap! test-incidents conj test-id)
+               _ (is (= 201 (:status create-resp)))
+               do-patch! (fn [at status]
+                           (helpers/fixture-with-fixed-time
+                            at
+                            (fn []
+                              (PATCH app
+                                     (str "ctia/incident/" (uri/uri-encode test-id))
+                                     :body {:status status}
+                                     :headers {"Authorization" "45c1f5e3f05d0"}))))]
+           ;; Step 1: New → Open at +5min
+           (let [resp (do-patch! (t/plus fixed-now (t/minutes 5)) "Open")]
+             (is (= 200 (:status resp)))
+             (is (= "Open" (:status (:parsed-body resp)))))
+           ;; Step 2: Open → Open: Contained at +10min
+           (let [resp (do-patch! (t/plus fixed-now (t/minutes 10)) "Open: Contained")]
+             (is (= 200 (:status resp)))
+             (is (= "Open: Contained" (:status (:parsed-body resp)))))
+           ;; Step 3: Open: Contained → Closed: Confirmed Threat at +15min
+           (let [resp (do-patch! (t/plus fixed-now (t/minutes 15)) "Closed: Confirmed Threat")]
+             (is (= 200 (:status resp)))
+             (is (= "Closed: Confirmed Threat" (:status (:parsed-body resp)))))
+           ;; ±10s tolerance on intervals derived from :created (new_to_opened, new_to_contained):
+           ;; default-realize-fn stamps :created via clj-momo.lib.time/now, which is a `def` aliasing
+           ;; the underlying internal-now at namespace load. fixture-with-fixed-time redefs
+           ;; clj-momo.lib.clj-time.core/internal-now but not the alias, so :created leaks the wall
+           ;; clock by a few seconds. opened_to_closed is exact since both endpoints are PATCH-time
+           ;; values, fully under fixed-time control.
+           (helpers/fixture-with-fixed-time
+            (t/plus fixed-now (t/days 1))
+            (fn []
+              (let [metric-avg (fn [field]
+                                 (-> (GET app "ctia/incident/metric/average"
+                                          :headers {"Authorization" "45c1f5e3f05d0"}
+                                          :query-params {:aggregate-on (str "intervals." field)
+                                                         :from (str (jt/instant (t/minus fixed-now (t/seconds 1))))
+                                                         :query (format "title:\"%s\"" unique-title)})
+                                     :parsed-body
+                                     (get-in [:data :intervals (keyword field)])))
+                    near? (fn [expected actual]
+                            (and actual (<= (- expected 10) actual (+ expected 10))))]
+                (is (near? 300 (metric-avg "new_to_opened"))
+                    "MTTE tile metric must reflect ~5 min from creation to first Open")
+                (is (near? 600 (metric-avg "new_to_contained"))
+                    "MTTC tile metric must reflect ~10 min from creation to Open: Contained")
+                (is (= 600.0 (metric-avg "opened_to_closed"))
+                    "Opened-to-closed metric must reflect 10 min from Open to Closed"))))))
       (finally
         ;; Clean up test incidents
         (doseq [test-id @test-incidents]
@@ -1252,7 +1405,27 @@
           (let [prev (assoc prev :created later)
                 incident (assoc prev :status "Open" :incident_time {:opened earlier})]
             (is (= incident
-                   (sut/compute-intervals prev incident)))))))
+                   (sut/compute-intervals prev incident)))))
+        ;; XDR-54438: composed verification — apply-status-update-logic + compute-intervals must
+        ;; produce :new_to_opened even when prev had upstream-set :opened earlier than :created.
+        (testing "XDR-54438: New → Open with upstream :opened earlier than :created computes :new_to_opened"
+          (let [prev (-> prev
+                         (assoc :status "New"
+                                :created earlier
+                                :incident_time {:opened (-> (jt/instant earlier)
+                                                            (jt/minus (jt/seconds 60))
+                                                            jt/java-date)}))
+                ;; Simulate post-deep-merge PATCH body: upstream :opened carried over.
+                new-obj (assoc prev :status "Open")]
+            (helpers/fixture-with-fixed-time
+             later
+             (fn []
+               (let [adjusted (sut/apply-status-update-logic new-obj prev)
+                     result (sut/compute-intervals prev adjusted)]
+                 (is (= later (get-in adjusted [:incident_time :opened]))
+                     "apply-status-update-logic should override upstream :opened with NOW")
+                 (is (= computed-interval (get-in result [:intervals :new_to_opened]))
+                     "compute-intervals should produce :new_to_opened from the corrected :opened"))))))))
     (testing "updating opened_to_closed"
       (let [prev (assoc prev :status "Open: Recovered" :incident_time {:opened earlier})
             incident (-> prev

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -100,14 +100,14 @@
            (is (= t1 (get-in result [:incident_time :opened]))
                "Opened date should NOT change on re-open")))))
 
-    (testing "XDR-54438: New → Open sets :opened to NOW when :new_to_opened interval is not yet recorded"
-      ;; CTIM marks :opened as mandatory, so promoted incidents always carry an upstream-stamped
-      ;; :opened that is unrelated to actual analyst engagement. On the first New → Open transition,
-      ;; if no engagement interval has been recorded yet, set :opened to NOW (the click time).
-      ;; This mirrors compute-intervals' "don't clobber existing interval" semantics.
-      (helpers/fixture-with-fixed-time
-       t3
-       (fn []
+    (helpers/fixture-with-fixed-time
+     t3
+     (fn []
+       (testing "XDR-54438: New → Open sets :opened to NOW when :new_to_opened interval is not yet recorded"
+         ;; CTIM marks :opened as mandatory, so promoted incidents always carry an upstream-stamped
+         ;; :opened that is unrelated to actual analyst engagement. On the first New → Open transition,
+         ;; if no engagement interval has been recorded yet, set :opened to NOW (the click time).
+         ;; This mirrors compute-intervals' "don't clobber existing interval" semantics.
          (let [prev-obj {:status "New"
                          :created t2
                          :incident_time {:opened t1}}
@@ -115,12 +115,9 @@
                         :incident_time {:opened t1}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
            (is (= t3 (get-in result [:incident_time :opened]))
-               "Opened date should be NOW on first New → Open when no :new_to_opened recorded")))))
+               "Opened date should be NOW on first New → Open when no :new_to_opened recorded")))
 
-    (testing "XDR-54438: New → Open overrides upstream-stamped :opened with NOW"
-      (helpers/fixture-with-fixed-time
-       t3
-       (fn []
+       (testing "XDR-54438: New → Open overrides upstream-stamped :opened with NOW"
          (let [prev-obj {:status "New"
                          :created t1
                          :incident_time {:opened t1}}
@@ -128,14 +125,11 @@
                         :incident_time {:opened t1}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
            (is (= t3 (get-in result [:incident_time :opened]))
-               "Opened date should be reset to NOW on New → Open even when prev-obj carries :opened")))))
+               "Opened date should be reset to NOW on New → Open even when prev-obj carries :opened")))
 
-    (testing "XDR-54438: New → New: Triaged preserves :opened (clause must not fire)"
-      ;; Sub-status transitions within the New category should not override :opened, since this is
-      ;; not a New → Open transition. The new-opened-date clause must remain inert here.
-      (helpers/fixture-with-fixed-time
-       t3
-       (fn []
+       (testing "XDR-54438: New → New: Triaged preserves :opened (clause must not fire)"
+         ;; Sub-status transitions within the New category should not override :opened, since this is
+         ;; not a New → Open transition. The new-opened-date clause must remain inert here.
          (let [prev-obj {:status "New"
                          :created t2
                          :incident_time {:opened t1}}
@@ -143,7 +137,49 @@
                         :incident_time {:opened t1}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
            (is (= t1 (get-in result [:incident_time :opened]))
-               "Opened date should be preserved on New → New: Triaged")))))))
+               "Opened date should be preserved on New → New: Triaged")))
+
+       (testing "open-to-open transition preserves original opened date"
+         ;; The prev-opened-date override must keep the engagement-click time across sub-status
+         ;; changes within the Open category, even when the client payload omits :incident_time.
+         (let [prev-obj {:status "Open"
+                         :incident_time {:opened t1}}
+               new-obj {:status "Open: Contained"}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should be PRESERVED when transitioning between open statuses")))
+
+       (testing "Hold → Open does not reset :opened (only New → Open does)"
+         ;; Hold isn't a New status, so the new-opened-date clause must not fire. The original
+         ;; engagement timestamp must survive a Hold → Open round-trip.
+         (let [prev-obj {:status "Hold"
+                         :incident_time {:opened t1}}
+               new-obj {:status "Open"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :opened]))
+               "Opened date should NOT be reset on Hold → Open")))
+
+       (testing "New → Open: Contained resets :opened to NOW"
+         ;; Open: Contained is an open status, so new-opened-date fires on New → Open: Contained
+         ;; just like New → Open. Pin this so a future predicate refactor cannot silently drop it.
+         (let [prev-obj {:status "New"
+                         :incident_time {:opened t1}}
+               new-obj {:status "Open: Contained"
+                        :incident_time {:opened t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t3 (get-in result [:incident_time :opened]))
+               "Opened date should be reset to NOW on New → Open: Contained")))))
+
+    (testing "status predicates are nil-safe"
+      ;; apply-status-update-logic short-circuits on nil :status, but the predicates are also
+      ;; called inside compute-intervals (downstream of un-store-incident, which never produces
+      ;; nil :status) — pin the nil-guard contract so a refactor cannot reintroduce an NPE.
+      (is (false? (sut/new-status? nil)))
+      (is (false? (sut/hold-status? nil)))
+      (is (false? (sut/open-status? nil)))
+      (is (false? (sut/contained-status? nil)))
+      (is (false? (sut/closed-status? nil))))))
 
 (deftest incident-scores-schema-test
   (let [get-in-config (partial get-in {:ctia {:http {:incident {:score-types "global,ttp,asset"}}}})

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -117,21 +117,18 @@
            (is (= t3 (get-in result [:incident_time :opened]))
                "Opened date should be NOW on first New → Open when no :new_to_opened recorded")))))
 
-    (testing "XDR-54438: New → Open preserves :opened when :new_to_opened interval already exists"
-      ;; If the engagement interval was already computed (e.g., previous transition cycle), do not
-      ;; overwrite. This preserves first-engagement semantics across re-open scenarios.
+    (testing "XDR-54438: New → Open overrides upstream-stamped :opened with NOW"
       (helpers/fixture-with-fixed-time
        t3
        (fn []
          (let [prev-obj {:status "New"
                          :created t1
-                         :incident_time {:opened t1}
-                         :intervals {:new_to_opened 42}}
+                         :incident_time {:opened t1}}
                new-obj {:status "Open"
                         :incident_time {:opened t1}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
-           (is (= t1 (get-in result [:incident_time :opened]))
-               "Opened date should be preserved when :new_to_opened was already computed")))))
+           (is (= t3 (get-in result [:incident_time :opened]))
+               "Opened date should be reset to NOW on New → Open even when prev-obj carries :opened")))))
 
     (testing "XDR-54438: New → New: Triaged preserves :opened (clause must not fire)"
       ;; Sub-status transitions within the New category should not override :opened, since this is

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -169,7 +169,33 @@
                         :incident_time {:opened t1}}
                result (sut/apply-status-update-logic new-obj prev-obj)]
            (is (= t3 (get-in result [:incident_time :opened]))
-               "Opened date should be reset to NOW on New → Open: Contained")))))
+               "Opened date should be reset to NOW on New → Open: Contained")))
+
+       (testing "(New|Open) → Open: Contained resets :contained to NOW"
+         ;; Symmetric to the :opened fix: an upstream-stamped :contained earlier than :created
+         ;; would silently elide :new_to_contained via update-interval's (earlier ≤ later) guard,
+         ;; making MTTC report 0 for promoted incidents.
+         (doseq [old-status ["New" "Open"]]
+           (let [prev-obj {:status old-status
+                           :incident_time {:opened t1 :contained t1}}
+                 new-obj {:status "Open: Contained"
+                          :incident_time {:opened t1 :contained t1}}
+                 result (sut/apply-status-update-logic new-obj prev-obj)]
+             (is (= t3 (get-in result [:incident_time :contained]))
+                 (format "Contained date should be reset to NOW on %s → Open: Contained"
+                         old-status)))))
+
+       (testing "Hold → Open: Contained does not reset :contained"
+         ;; The new-contained-date trigger gates on (or new-status? open-status?), excluding Hold.
+         ;; Mirrors compute-intervals' MTTC clause; a Hold → Open: Contained transition is rare
+         ;; in practice but the override must stay inert when its compute-intervals counterpart is.
+         (let [prev-obj {:status "Hold"
+                         :incident_time {:opened t1 :contained t1}}
+               new-obj {:status "Open: Contained"
+                        :incident_time {:opened t1 :contained t1}}
+               result (sut/apply-status-update-logic new-obj prev-obj)]
+           (is (= t1 (get-in result [:incident_time :contained]))
+               "Contained date should NOT be reset on Hold → Open: Contained")))))
 
     (testing "status predicates are nil-safe"
       ;; apply-status-update-logic short-circuits on nil :status, but the predicates are also


### PR DESCRIPTION
> Close https://cisco-sbg.atlassian.net/browse/XDR-54438
> Related https://cisco-sbg.atlassian.net/browse/XDR-42815

The Operational Insights "Mean Time To Engage" (MTTE) tile shows 0 mins for the team metric because `:new_to_opened` is never computed for promoted incidents.

**Root cause.** CTIM marks `:opened` as mandatory, so promoted incidents (e.g., from XDR Analytics, detection engines) always arrive with an upstream-stamped `:opened` that is unrelated to actual analyst engagement — and often earlier than CTIA's `:created`. When the user clicks New → Open in the UI, the PATCH flow's deep-merge carries that stale `:opened` forward. Then `update-interval :new_to_opened` requires `:created ≤ :opened`, silently bails on `:created > :opened`, and the interval is never stored. The MTTE tile averages a missing field → 0.

**Fix.** In `apply-status-update-logic`, on the first New → Open transition, override `:opened` with NOW when `:new_to_opened` has not yet been recorded. This mirrors `compute-intervals`' "don't clobber existing interval" semantics. Engagement time is the analyst's click time, not whatever the client passes.

**Tests.**
- Unit: override fires when `:new_to_opened` is absent.
- Unit (negative): inert when `:new_to_opened` already recorded.
- Unit (negative): inert on `New → New: Triaged`.
- Composed: `apply-status-update-logic` + `compute-intervals` produces `:new_to_opened`.
- HTTP integration: `PATCH /ctia/incident/:id` then `GET /ctia/incident/metric/average?aggregate-on=intervals.new_to_opened` — the exact path the MTTE tile reads — returns ~300s (5 min elapsed) instead of nil.
- **Full-lifecycle scenario**: walks one incident through `New → Open → Open: Contained → Closed: Confirmed Threat` and asserts `/metric/average` returns expected averages for `new_to_opened`, `new_to_contained`, and `opened_to_closed`. Guards all three Mean Time To X tile metrics against future regressions.

<a name="qa">[§](#qa)</a> QA
============================

1. Promote an incident in an environment where upstream sets `incident_time.opened`.
2. Move it from New → Open in the UI.
3. Open the Operational Insights dashboard and confirm Team MTTE reflects the actual elapsed time, not 0 mins.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

\`\`\`
intern: fix Operational Insights Team MTTE tile showing 0 mins for promoted incidents (XDR-54438).
public: Operational Insights now reflects time-to-engage for incidents promoted from upstream sources.
\`\`\`