### PR TITLE
chore: remove Datadog Java tracer from deploy Dockerfile

### DIFF
--- a/build/deploy-actions.sh
+++ b/build/deploy-actions.sh
@@ -56,8 +56,7 @@ RUN apk update && \
 WORKDIR /ctia
 
 ADD ctia.jar /ctia/
-ADD 'https://dtdg.co/latest-java-tracer' /ctia/dd-java-agent.jar
-RUN chmod 644 /ctia/ctia.jar /ctia/dd-java-agent.jar
+RUN chmod 644 /ctia/ctia.jar
 USER nobody
 ENTRYPOINT ["/sbin/tini", "--"]
 EOF


### PR DESCRIPTION
## Summary
- Remove `dd-java-agent.jar` download from inline Dockerfile in `build/deploy-actions.sh`
- Splunk autoinstrumentation (pod-level injection) replaces the DD agent — no application-level tracer needed

## Changes
- Removed `ADD 'https://dtdg.co/latest-java-tracer' /ctia/dd-java-agent.jar` from heredoc Dockerfile
- Simplified `chmod` to only cover `ctia.jar`

## Test plan
- [ ] Verify Docker image builds successfully in CI/CD pipeline
- [ ] Confirm Splunk traces still appear after deployment (autoinstrumentation is pod-level, unaffected)