### PR TITLE
feat(auth): expose :specify-id via private-intel scope

### DIFF
--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -310,9 +310,6 @@
         "import-bundle" (if (contains? (:access scope-repr) :write)
                           #{:import-bundle}
                           #{})
-        "specify-id" (if (contains? (:access scope-repr) :write)
-                       #{:specify-id}
-                       #{})
         (let [entity (get (all-entities)
                           (-> scope-repr
                               :path
@@ -327,7 +324,7 @@
            (map #(gen-capabilities-for-entity-and-accesses % (:access scope-repr)))
            unionize
            (set/union (if (contains? (:access scope-repr) :write)
-                        #{:import-bundle}
+                        #{:import-bundle :specify-id}
                         #{})))
     #{}))
 

--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -291,6 +291,9 @@
 (defn assets-root-scope [get-in-config]
   (get-in-config [:ctia :auth :assets :scope] "asset"))
 
+(defn specify-id-root-scope [get-in-config]
+  (get-in-config [:ctia :auth :specify-id :scope] "ctia-specify-id"))
+
 (defn claim-prefix [get-in-config]
   (get-in-config [:ctia :http :jwt :claim-prefix]
                  "https://schemas.cisco.com/iroh/identity/claims"))
@@ -310,9 +313,6 @@
         "import-bundle" (if (contains? (:access scope-repr) :write)
                           #{:import-bundle}
                           #{})
-        "specify-id" (if (contains? (:access scope-repr) :write)
-                       #{:specify-id}
-                       #{})
         (let [entity (get (all-entities)
                           (-> scope-repr
                               :path
@@ -327,7 +327,7 @@
            (map #(gen-capabilities-for-entity-and-accesses % (:access scope-repr)))
            unionize
            (set/union (if (contains? (:access scope-repr) :write)
-                        #{:import-bundle :specify-id}
+                        #{:import-bundle}
                         #{})))
     #{}))
 
@@ -349,14 +349,25 @@
               % (:access scope-repr)))
        unionize))
 
+(defn gen-specify-id-capabilities
+  "Dedicated single-capability scope conferring only :specify-id when the
+  scope is exactly `<root>:write`. The bare scope and `<root>:read` confer
+  nothing."
+  [scope-repr]
+  (if (and (= 1 (count (:path scope-repr)))
+           (= #{:write} (:access scope-repr)))
+    #{:specify-id}
+    #{}))
+
 (defn scope-to-capabilities
   "given a scope generate capabilities"
   [scope get-in-config]
   (let [scope-repr (scopula/to-scope-repr scope)]
     (condp = (first (:path scope-repr))
-      (entity-root-scope get-in-config)   (gen-entity-capabilities scope-repr)
-      (casebook-root-scope get-in-config) (gen-casebook-capabilities scope-repr)
-      (assets-root-scope get-in-config)   (gen-assets-capabilities scope-repr)
+      (entity-root-scope get-in-config)     (gen-entity-capabilities scope-repr)
+      (casebook-root-scope get-in-config)   (gen-casebook-capabilities scope-repr)
+      (assets-root-scope get-in-config)     (gen-assets-capabilities scope-repr)
+      (specify-id-root-scope get-in-config) (gen-specify-id-capabilities scope-repr)
       #{})))
 
 (defn scopes-to-capabilities

--- a/src/ctia/auth/jwt.clj
+++ b/src/ctia/auth/jwt.clj
@@ -310,6 +310,9 @@
         "import-bundle" (if (contains? (:access scope-repr) :write)
                           #{:import-bundle}
                           #{})
+        "specify-id" (if (contains? (:access scope-repr) :write)
+                       #{:specify-id}
+                       #{})
         (let [entity (get (all-entities)
                           (-> scope-repr
                               :path

--- a/src/ctia/bulk/core.clj
+++ b/src/ctia/bulk/core.clj
@@ -58,6 +58,8 @@
     {:data EntitiesResult
      (s/optional-key :tempids) TempIDs}))
 
+(declare read-entities)
+
 (s/defn create-entities :- EnvelopedEntities+TempIDs
   "Create many entities provided their type and returns a list of ids"
   [new-entities :- flows/Entities
@@ -67,12 +69,14 @@
    params
    services :- APIHandlerServices]
   (when (seq new-entities)
-    (let [{:keys [realize-fn new-spec]} (get (all-entities) entity-type)]
+    (let [{:keys [realize-fn new-spec]} (get (all-entities) entity-type)
+          get-fn #(read-entities % entity-type auth-identity services)]
       (update (flows/create-flow
                 :services services
                 :entity-type entity-type
                 :realize-fn realize-fn
                 :store-fn (create-fn entity-type auth-identity params services)
+                :get-fn get-fn
                 :long-id-fn #(with-long-id % services)
                 :enveloped-result? true
                 :identity auth-identity

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -161,6 +161,47 @@
                entities)]
     (update fm :tempids (fnil into {}) newtempids)))
 
+(defn- normalize-id-for-dedup
+  "Normalize a caller-supplied :id to its short-id form so two distinct
+   encodings (long vs short) for the same entity are detected as a
+   duplicate. Returns nil for missing or transient IDs (those get fresh
+   server-minted ids and cannot collide intra-batch). Falls back to the
+   raw id if normalization fails so it still participates in equality."
+  [id]
+  (when (and (seq id)
+             (not (schemas/transient-id? id)))
+    (try
+      (if (id/long-id? id)
+        (:short-id (id/long-id->id id))
+        (id/str->short-id id))
+      (catch Exception _ id))))
+
+(s/defn detect-duplicate-ids :- FlowMap
+  "Fast-fail intra-batch duplicate caller-supplied :id detection.
+   `get-prev-entity` pre-fetches existing docs once at flow start, so
+   two entities in the same batch sharing a fresh caller-supplied :id
+   would both pass the collision guard in find-create-entity-id and let
+   the ES upsert last-write-wins. This stage rejects any entity whose
+   normalized :id appears more than once in the same create batch."
+  [{:keys [entities] :as fm} :- FlowMap]
+  (let [duplicates (->> entities
+                        (keep #(normalize-id-for-dedup (:id %)))
+                        frequencies
+                        (keep (fn [[k v]] (when (< 1 v) k)))
+                        set)]
+    (cond-> fm
+      (seq duplicates)
+      (assoc :entities
+             (mapv (fn [{:keys [id] :as entity}]
+                     (let [short (normalize-id-for-dedup id)]
+                       (if (contains? duplicates short)
+                         {:error (format "Duplicate caller-supplied :id %s in batch"
+                                         short)
+                          :type :id-collision-error
+                          :entity entity}
+                         entity)))
+                   entities)))))
+
 (s/defn ^:private realize-entities :- FlowMap
   [{:keys [entities
            flow-type
@@ -465,6 +506,7 @@
                                         (remove schemas/transient-id?)))))
       validate-entities
       create-ids-from-transient
+      detect-duplicate-ids
       realize-entities
       throw-validation-error
       apply-before-hooks

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -444,25 +444,25 @@
              enveloped-result?
              get-fn
              get-success-entities]}]
-  (-> {:flow-type :create
-       :services services
-       :entity-type entity-type
-       :entities (map #(dissoc % :schema_version) entities)
-       :tempids tempids
-       :identity identity
-       :long-id-fn long-id-fn
-       :spec spec
-       :realize-fn realize-fn
-       :find-entity-id (find-create-entity-id services)
-       :store-fn store-fn
-       :create-event-fn to-create-event
-       :enveloped-result? enveloped-result?
-       :get-prev-entity (when get-fn
-                          (prev-entity get-fn
-                                       (->> entities
-                                            (keep :id)
-                                            (remove schemas/transient-id?))))
-       :get-success-entities (or get-success-entities default-success-entities)}
+  (-> (cond-> {:flow-type :create
+               :services services
+               :entity-type entity-type
+               :entities (map #(dissoc % :schema_version) entities)
+               :tempids tempids
+               :identity identity
+               :long-id-fn long-id-fn
+               :spec spec
+               :realize-fn realize-fn
+               :find-entity-id (find-create-entity-id services)
+               :store-fn store-fn
+               :create-event-fn to-create-event
+               :enveloped-result? enveloped-result?
+               :get-success-entities (or get-success-entities default-success-entities)}
+        get-fn (assoc :get-prev-entity
+                      (prev-entity get-fn
+                                   (->> entities
+                                        (keep :id)
+                                        (remove schemas/transient-id?)))))
       validate-entities
       create-ids-from-transient
       realize-entities

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -76,7 +76,7 @@
 (s/defn find-create-entity-id
   [services :- HTTPShowServices]
   (s/fn [{identity-obj :identity
-          :keys [entity-type tempids]} :- FlowMap
+          :keys [entity-type tempids get-prev-entity]} :- FlowMap
          entity] :- s/Str
     (or
      (get tempids (:id entity))
@@ -85,10 +85,23 @@
          (http-response/forbidden!
           {:error "Missing capability to specify entity ID"
            :entity entity}))
-       (if (id/valid-short-id? entity-id)
-         entity-id
+       (cond
+         (not (id/valid-short-id? entity-id))
          {:error (format "Invalid entity ID: %s" entity-id)
-          :entity entity}))
+          :entity entity}
+         ;; Reject caller-supplied :id that collides with an existing
+         ;; document. handle-create at the ES layer is an upsert (no
+         ;; pre-existence check), so without this guard a holder of the
+         ;; :specify-id capability could overwrite any existing record by
+         ;; reusing its id - including documents owned by another org.
+         ;; Updates have their own endpoint (PUT /:id), gated by
+         ;; allow-write? in handle-update; the create path should not
+         ;; double as an update path.
+         (and get-prev-entity (get-prev-entity entity-id))
+         {:error (format "An entity with ID %s already exists" entity-id)
+          :type :id-collision-error
+          :entity entity}
+         :else entity-id))
      (make-id entity-type))))
 
 (s/defn ^:private find-existing-entity-id
@@ -400,6 +413,18 @@
                        (patch-entity patch-fn prev-entity)))]
     (assoc fm :entities patched)))
 
+(defn prev-entity
+  [get-fn ids]
+  (let [indexed (into {}
+                      (comp
+                       (filter seq)
+                       (map (fn [e]
+                              [(id/str->short-id (:id e)) e])))
+                      (get-fn ids))]
+    (fn [id]
+      (when (seq id)
+        (get indexed (id/str->short-id id))))))
+
 (defn create-flow
   "This function centralizes the create workflow.
   It is helpful to easily add new hooks name
@@ -417,6 +442,7 @@
              spec
              services
              enveloped-result?
+             get-fn
              get-success-entities]}]
   (-> {:flow-type :create
        :services services
@@ -431,6 +457,11 @@
        :store-fn store-fn
        :create-event-fn to-create-event
        :enveloped-result? enveloped-result?
+       :get-prev-entity (when get-fn
+                          (prev-entity get-fn
+                                       (->> entities
+                                            (keep :id)
+                                            (remove schemas/transient-id?))))
        :get-success-entities (or get-success-entities default-success-entities)}
       validate-entities
       create-ids-from-transient
@@ -444,18 +475,6 @@
       apply-event-hooks
       apply-after-hooks
       make-create-result))
-
-(defn prev-entity
-  [get-fn ids]
-  (let [indexed (into {}
-                      (comp
-                       (filter seq)
-                       (map (fn [e]
-                              [(id/str->short-id (:id e)) e])))
-                      (get-fn ids))]
-    (fn [id]
-      (when (seq id)
-        (get indexed (id/str->short-id id))))))
 
 (s/defn make-update-result
   [{:keys [make-result results long-id-fn] :as fm} :- FlowMap]

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -281,6 +281,7 @@
                                      %
                                      identity-map
                                      (wait_for->refresh wait_for)))
+                    :get-fn (get-by-ids-fn identity-map)
                     :long-id-fn #(with-long-id % services)
                     :entity-type entity
                     :identity identity

--- a/src/ctia/properties.clj
+++ b/src/ctia/properties.clj
@@ -80,6 +80,7 @@
                       "ctia.auth.entities.scope" s/Str
                       "ctia.auth.assets.scope" s/Str
                       "ctia.auth.casebook.scope" s/Str
+                      "ctia.auth.specify-id.scope" s/Str
                       "ctia.auth.threatgrid.whoami-url" s/Str
                       "ctia.auth.static.secret" s/Str
                       "ctia.auth.static.name" s/Str

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -72,7 +72,7 @@
              :delete-casebook}
            (sut/scope-to-capabilities (sut/casebook-root-scope get-in-config) get-in-config))
         "Check the casebook capabilities from the casebook scope")
-    (is (= #{:developer}
+    (is (= #{:developer :specify-id}
            (set/difference (caps/all-capabilities)
                            (sut/scopes-to-capabilities #{(sut/entity-root-scope get-in-config)
                                                          (sut/casebook-root-scope get-in-config)}
@@ -103,22 +103,31 @@
                         :import-bundle)))
     (is (= #{:specify-id}
            (sut/scopes-to-capabilities
-            #{(str (sut/entity-root-scope get-in-config) "/specify-id")}
+            #{(str (sut/specify-id-root-scope get-in-config) ":write")}
             get-in-config))
-        "narrow specify-id sub-scope confers only :specify-id")
+        "ctia-specify-id:write confers exactly #{:specify-id}")
     (is (= #{}
            (sut/scopes-to-capabilities
-            #{(str (sut/entity-root-scope get-in-config) "/specify-id:read")}
+            #{(sut/specify-id-root-scope get-in-config)}
             get-in-config))
-        "specify-id sub-scope with :read confers nothing")
-    (is (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":write")}
-                                               get-in-config)
-                   :specify-id)
-        "broad entity scope with :write confers :specify-id")
-    (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
-                                                    get-in-config)
+        "ctia-specify-id alone (no access suffix) confers nothing")
+    (is (= #{}
+           (sut/scopes-to-capabilities
+            #{(str (sut/specify-id-root-scope get-in-config) ":read")}
+            get-in-config))
+        "ctia-specify-id:read confers nothing")
+    (is (not (contains? (sut/scopes-to-capabilities
+                         #{(str (sut/entity-root-scope get-in-config) ":write")}
+                         get-in-config)
                         :specify-id))
-        "broad entity scope with :read does NOT confer :specify-id")
+        "private-intel:write does NOT confer :specify-id (decoupled from broad write scope)")
+    (is (not (contains? (try
+                          (sut/scopes-to-capabilities
+                           #{(str (sut/entity-root-scope get-in-config) "/specify-id:write")}
+                           get-in-config)
+                          (catch Exception _ #{}))
+                        :specify-id))
+        "private-intel/specify-id:write does NOT confer :specify-id (namespace path is not a grant)")
     (is (= #{:read-sighting :list-sightings :search-sighting :create-sighting
              :delete-sighting}
            (sut/scopes-to-capabilities

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -101,6 +101,25 @@
     (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
                                                     get-in-config)
                         :import-bundle)))
+    (is (= #{:specify-id}
+           (sut/scopes-to-capabilities
+            #{(str (sut/entity-root-scope get-in-config) "/specify-id")}
+            get-in-config))
+        "specify-id sub-scope grants the :specify-id capability")
+    (is (= #{:specify-id}
+           (sut/scopes-to-capabilities
+            #{(str (sut/entity-root-scope get-in-config) "/specify-id:write")}
+            get-in-config))
+        "specify-id sub-scope with explicit :write grants the :specify-id capability")
+    (is (= #{}
+           (sut/scopes-to-capabilities
+            #{(str (sut/entity-root-scope get-in-config) "/specify-id:read")}
+            get-in-config))
+        "specify-id sub-scope with :read grants nothing")
+    (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":write")}
+                                                    get-in-config)
+                        :specify-id))
+        "broad entity scope with :write does NOT confer :specify-id")
     (is (= #{:read-sighting :list-sightings :search-sighting :create-sighting
              :delete-sighting}
            (sut/scopes-to-capabilities

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -101,14 +101,24 @@
     (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
                                                     get-in-config)
                         :import-bundle)))
+    (is (= #{:specify-id}
+           (sut/scopes-to-capabilities
+            #{(str (sut/entity-root-scope get-in-config) "/specify-id")}
+            get-in-config))
+        "narrow specify-id sub-scope confers only :specify-id")
+    (is (= #{}
+           (sut/scopes-to-capabilities
+            #{(str (sut/entity-root-scope get-in-config) "/specify-id:read")}
+            get-in-config))
+        "specify-id sub-scope with :read confers nothing")
     (is (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":write")}
                                                get-in-config)
                    :specify-id)
-        "entity scope with :write confers :specify-id")
+        "broad entity scope with :write confers :specify-id")
     (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
                                                     get-in-config)
                         :specify-id))
-        "entity scope with :read does NOT confer :specify-id")
+        "broad entity scope with :read does NOT confer :specify-id")
     (is (= #{:read-sighting :list-sightings :search-sighting :create-sighting
              :delete-sighting}
            (sut/scopes-to-capabilities

--- a/test/ctia/auth/jwt_test.clj
+++ b/test/ctia/auth/jwt_test.clj
@@ -72,7 +72,7 @@
              :delete-casebook}
            (sut/scope-to-capabilities (sut/casebook-root-scope get-in-config) get-in-config))
         "Check the casebook capabilities from the casebook scope")
-    (is (= #{:developer :specify-id}
+    (is (= #{:developer}
            (set/difference (caps/all-capabilities)
                            (sut/scopes-to-capabilities #{(sut/entity-root-scope get-in-config)
                                                          (sut/casebook-root-scope get-in-config)}
@@ -101,25 +101,14 @@
     (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
                                                     get-in-config)
                         :import-bundle)))
-    (is (= #{:specify-id}
-           (sut/scopes-to-capabilities
-            #{(str (sut/entity-root-scope get-in-config) "/specify-id")}
-            get-in-config))
-        "specify-id sub-scope grants the :specify-id capability")
-    (is (= #{:specify-id}
-           (sut/scopes-to-capabilities
-            #{(str (sut/entity-root-scope get-in-config) "/specify-id:write")}
-            get-in-config))
-        "specify-id sub-scope with explicit :write grants the :specify-id capability")
-    (is (= #{}
-           (sut/scopes-to-capabilities
-            #{(str (sut/entity-root-scope get-in-config) "/specify-id:read")}
-            get-in-config))
-        "specify-id sub-scope with :read grants nothing")
-    (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":write")}
+    (is (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":write")}
+                                               get-in-config)
+                   :specify-id)
+        "entity scope with :write confers :specify-id")
+    (is (not (contains? (sut/scopes-to-capabilities #{(str (sut/entity-root-scope get-in-config) ":read")}
                                                     get-in-config)
                         :specify-id))
-        "broad entity scope with :write does NOT confer :specify-id")
+        "entity scope with :read does NOT confer :specify-id")
     (is (= #{:read-sighting :list-sightings :search-sighting :create-sighting
              :delete-sighting}
            (sut/scopes-to-capabilities

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -211,22 +211,15 @@
                (is (= [expected-get-res] (map #(dissoc % :created :modified) (:parsed-body matched))))
                (is (= [] (:parsed-body not-matched)))))
 
-           (testing "Holders of private-intel:write are allowed to set ids during creation."
-             ;; The JWT under test claims the `private-intel` scope, which
-             ;; confers the :specify-id capability alongside :import-bundle.
-             ;; The hostname in the supplied :id must match this server's;
-             ;; otherwise CTIA rejects with 400 Bad Request.
-             (let [host (str "http://localhost:" (helpers/get-http-port app))
-                   supplied-id (str host "/ctia/judgement/judgement-00001111-0000-1111-2222-000011112222")
-                   response
+           (testing "Normal users are not allowed to set the ids during creation."
+             (let [response
                    (POST app
                          "ctia/judgement"
-                         :body (assoc new-judgement-1 :id supplied-id)
+                         :body (assoc new-judgement-1
+                                      :id "http://localhost:3001/ctia/judgement/judgement-00001111-0000-1111-2222-000011112222")
                          :headers {"Authorization" bearer
                                    "origin" "http://external.cisco.com"})]
-               (is (= 201 (:status response)))
-               (is (= supplied-id (-> response :parsed-body :id))
-                   "the caller-supplied :id is honored")))
+               (is (= 403 (:status response)))))
 
            (testing "POST /ctia/judgement/:id with bad JWT Authorization header"
              (let [response
@@ -237,71 +230,75 @@
                                    "origin" "http://external.cisco.com"})]
                (is (= 401 (:status response))))))))))))
 
-(defn gen-jwts []
-  (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
-        priv-key-1 (jwt-key/private-key "resources/cert/ctia-jwt.key")
-        priv-key-2 (jwt-key/private-key "resources/cert/ctia-jwt-2.key")
-        now (t/now)
-        in-one-hour (t/plus now (t/hours 1))
-        claims-1
-        {:exp in-one-hour
-         :iat now
-         :iss "IROH Auth",
-         :email "gbuisson+qa_sdc_iroh@cisco.com",
-         :nbf now
-         "sub" "56bb5f8c-cc4e-4ed3-a91a-c6604287fe32"
-         :jti "a268ae7a3-09c9-4149-b495-b98c8c5de666",
-         (clm "oauth/client/id") "iroh-ui",
-         (clm "oauth/client/name") "iroh-ui",
-         (clm "oauth/kind") "session-token",
-         (clm "org/id") "63489cf9-561c-4958-a13d-6d84b7ef09d4",
-         (clm "org/name") "IROH Testing",
-         (clm "scopes") ["casebook","global-intel","private-intel","collect",
-                         "enrich","inspect","integration","iroh-auth",
-                         "response","ui-settings"],
-         (clm "user/email") "gbuisson+qa_sdc_iroh@cisco.com",
-         (clm "user/id") "56bb5f8c-cc4e-4ed3-a91a-c6604287fe32",
-         (clm "user/idp/id") "amp",
-         (clm "user/nick") "gbuisson+qa_sdc_iroh@cisco.com",
-         (clm "version") "1"}
-        claims-2 (assoc claims-1 :iss "IROH Auth TEST")]
-    {:jwt-1 (-> claims-1 jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)
-     :bad-iss-jwt-1 (-> claims-1 (assoc :iss "IROH Auth TEST") jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)
-     :jwt-2 (-> claims-2 jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)
-     :bad-iss-jwt-2 (-> claims-2 (assoc :iss "IROH Auth") jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)}))
+(def default-jwt-scopes
+  ["casebook" "global-intel" "private-intel" "collect"
+   "enrich" "inspect" "integration" "iroh-auth"
+   "response" "ui-settings"])
+
+(defn gen-jwts
+  ([] (gen-jwts default-jwt-scopes))
+  ([scopes]
+   (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
+         priv-key-1 (jwt-key/private-key "resources/cert/ctia-jwt.key")
+         priv-key-2 (jwt-key/private-key "resources/cert/ctia-jwt-2.key")
+         now (t/now)
+         in-one-hour (t/plus now (t/hours 1))
+         claims-1
+         {:exp in-one-hour
+          :iat now
+          :iss "IROH Auth",
+          :email "gbuisson+qa_sdc_iroh@cisco.com",
+          :nbf now
+          "sub" "56bb5f8c-cc4e-4ed3-a91a-c6604287fe32"
+          :jti "a268ae7a3-09c9-4149-b495-b98c8c5de666",
+          (clm "oauth/client/id") "iroh-ui",
+          (clm "oauth/client/name") "iroh-ui",
+          (clm "oauth/kind") "session-token",
+          (clm "org/id") "63489cf9-561c-4958-a13d-6d84b7ef09d4",
+          (clm "org/name") "IROH Testing",
+          (clm "scopes") (vec scopes),
+          (clm "user/email") "gbuisson+qa_sdc_iroh@cisco.com",
+          (clm "user/id") "56bb5f8c-cc4e-4ed3-a91a-c6604287fe32",
+          (clm "user/idp/id") "amp",
+          (clm "user/nick") "gbuisson+qa_sdc_iroh@cisco.com",
+          (clm "version") "1"}
+         claims-2 (assoc claims-1 :iss "IROH Auth TEST")]
+     {:jwt-1 (-> claims-1 jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)
+      :bad-iss-jwt-1 (-> claims-1 (assoc :iss "IROH Auth TEST") jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)
+      :jwt-2 (-> claims-2 jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)
+      :bad-iss-jwt-2 (-> claims-2 (assoc :iss "IROH Auth") jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)})))
 
 (defn jwt-for-org
   "Signs a JWT identical to gen-jwts/jwt-1 but with a different org/id claim
   and a distinct user id. Used to assert that a caller from another org
   cannot overwrite documents owned by the original org."
-  [org-id]
-  (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
-        priv-key-1 (jwt-key/private-key "resources/cert/ctia-jwt.key")
-        now (t/now)
-        in-one-hour (t/plus now (t/hours 1))
-        other-user-id "deadbeef-dead-beef-dead-beefdeadbeef"
-        claims
-        {:exp in-one-hour
-         :iat now
-         :iss "IROH Auth"
-         :email "other-org@example.com"
-         :nbf now
-         "sub" other-user-id
-         :jti "00000000-0000-0000-0000-000000000001"
-         (clm "oauth/client/id") "iroh-ui"
-         (clm "oauth/client/name") "iroh-ui"
-         (clm "oauth/kind") "session-token"
-         (clm "org/id") org-id
-         (clm "org/name") "Other Org"
-         (clm "scopes") ["casebook" "global-intel" "private-intel" "collect"
-                         "enrich" "inspect" "integration" "iroh-auth"
-                         "response" "ui-settings"]
-         (clm "user/email") "other-org@example.com"
-         (clm "user/id") other-user-id
-         (clm "user/idp/id") "amp"
-         (clm "user/nick") "other-org@example.com"
-         (clm "version") "1"}]
-    (-> claims jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)))
+  ([org-id] (jwt-for-org org-id default-jwt-scopes))
+  ([org-id scopes]
+   (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
+         priv-key-1 (jwt-key/private-key "resources/cert/ctia-jwt.key")
+         now (t/now)
+         in-one-hour (t/plus now (t/hours 1))
+         other-user-id "deadbeef-dead-beef-dead-beefdeadbeef"
+         claims
+         {:exp in-one-hour
+          :iat now
+          :iss "IROH Auth"
+          :email "other-org@example.com"
+          :nbf now
+          "sub" other-user-id
+          :jti "00000000-0000-0000-0000-000000000001"
+          (clm "oauth/client/id") "iroh-ui"
+          (clm "oauth/client/name") "iroh-ui"
+          (clm "oauth/kind") "session-token"
+          (clm "org/id") org-id
+          (clm "org/name") "Other Org"
+          (clm "scopes") (vec scopes)
+          (clm "user/email") "other-org@example.com"
+          (clm "user/id") other-user-id
+          (clm "user/idp/id") "amp"
+          (clm "user/nick") "other-org@example.com"
+          (clm "version") "1"}]
+     (-> claims jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str))))
 
 (s/defn apply-fixtures-with-app
   [properties f-with-app :- (s/=> s/Any (s/=> s/Any (s/named s/Any 'app)))]
@@ -553,16 +550,17 @@
 ))
 
 (deftest bundle-import-with-jwt-specify-id-test
-  ;; End-to-end check that a JWT carrying the `private-intel` scope can
-  ;; supply entity ids on POST /ctia/bundle/import. The scope confers the
-  ;; :specify-id capability via the mapping in ctia.auth.jwt; the flow-layer
+  ;; End-to-end check that a JWT carrying the dedicated `ctia-specify-id:write`
+  ;; scope can supply entity ids on POST /ctia/bundle/import. The scope confers
+  ;; the :specify-id capability via the mapping in ctia.auth.jwt; the flow-layer
   ;; gate in ctia.flows.crud/find-create-entity-id then permits the caller-
   ;; supplied id rather than minting a fresh UUID.
   (test-for-each-store-with-app
    (fn [app]
      (helpers/fixture-with-fixed-time (tc/to-date (time/date-time 2017 02 15 14 15 10))
        (fn []
-         (let [{:keys [jwt-1]} (gen-jwts)
+         (let [scopes (conj default-jwt-scopes "ctia-specify-id:write")
+               {:keys [jwt-1]} (gen-jwts scopes)
                bearer (str "Bearer " jwt-1)
                host (str "http://localhost:" (helpers/get-http-port app))
                supplied-short-id "sighting-00112233-4455-6677-8899-aabbccddeeff"
@@ -585,7 +583,7 @@
                      :body bundle
                      :headers {"Authorization" bearer})]
            (is (= 200 status)
-               "bundle import succeeds when caller supplies :id with private-intel scope")
+               "bundle import succeeds when caller supplies :id with ctia-specify-id:write scope")
            (let [sighting-result (first (filter #(= :sighting (:type %))
                                                 (:results parsed-body)))]
              (is (= "created" (:result sighting-result))
@@ -611,7 +609,7 @@
                ;;
                ;; This test asserts the safe outcome and SHOULD FAIL until a
                ;; flow-layer pre-existence + allow-write? guard is added.
-               (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-ffffffffffff")
+               (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-ffffffffffff" scopes)
                      other-bearer (str "Bearer " other-org-jwt)
                      attack-bundle (-> bundle
                                        (assoc-in [:sightings 0 :description]
@@ -690,7 +688,8 @@
    (fn [app]
      (helpers/fixture-with-fixed-time (tc/to-date (time/date-time 2017 02 15 14 15 10))
        (fn []
-         (let [{:keys [jwt-1]} (gen-jwts)
+         (let [scopes (conj default-jwt-scopes "ctia-specify-id:write")
+               {:keys [jwt-1]} (gen-jwts scopes)
                bearer (str "Bearer " jwt-1)
                host (str "http://localhost:" (helpers/get-http-port app))
                supplied-short-id "sighting-aa112233-4455-6677-8899-aabbccddee01"
@@ -726,7 +725,7 @@
                (is (= "original" (-> get-after :parsed-body :description))
                    "the original record is not overwritten by the second POST")))
            (testing "cross-org POST with another org's :id is rejected"
-             (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-fffffffffff0")
+             (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-fffffffffff0" scopes)
                    other-bearer (str "Bearer " other-org-jwt)
                    attack-resp (POST app
                                      "ctia/sighting"

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -634,5 +634,109 @@
                         (-> get-after :parsed-body :description))
                      "Org A's original description is intact")
                  (is (not= "created" (:result attack-result))
-                     "the cross-org import of an :id owned by another org must NOT be reported as a successful create"))))))))))
+                     "the cross-org import of an :id owned by another org must NOT be reported as a successful create")))
+             (testing "same-org caller reusing their own :id is rejected on the create path"
+               ;; Updates have their own endpoint (PUT /ctia/:entity/:id), gated
+               ;; by allow-write? in handle-update. The create path should not
+               ;; double as an update path: a second create with an existing
+               ;; :id must surface a conflict, not silently upsert.
+               (let [reuse-bundle (-> bundle
+                                      (assoc-in [:sightings 0 :description]
+                                                "SAME-ORG SECOND CREATE")
+                                      (assoc-in [:sightings 0 :external_ids]
+                                                ["specify-id-jwt-test/sighting/reuse"]))
+                     reuse-response (POST app
+                                          "ctia/bundle/import"
+                                          :body reuse-bundle
+                                          :headers {"Authorization" bearer})
+                     reuse-result (first (filter #(= :sighting (:type %))
+                                                 (-> reuse-response :parsed-body :results)))
+                     get-after (GET app
+                                    (str "ctia/sighting/" supplied-short-id)
+                                    :headers {"Authorization" bearer})]
+                 (is (not= "created" (:result reuse-result))
+                     "a same-org second create on an existing :id must NOT be reported as created")
+                 (is (= "caller-supplied id"
+                        (-> get-after :parsed-body :description))
+                     "the original same-org record is not overwritten by a second create")))
+             (testing "brand-new caller-supplied :id still succeeds (regression)"
+               ;; Sanity: the collision guard must not break the happy path of
+               ;; caller-supplied ids on a fresh id.
+               (let [fresh-short-id "sighting-99887766-5544-3322-1100-ffeeddccbbaa"
+                     fresh-id (str host "/ctia/sighting/" fresh-short-id)
+                     fresh-bundle (-> bundle
+                                      (assoc-in [:sightings 0 :id] fresh-id)
+                                      (assoc-in [:sightings 0 :external_ids]
+                                                ["specify-id-jwt-test/sighting/fresh"]))
+                     fresh-response (POST app
+                                          "ctia/bundle/import"
+                                          :body fresh-bundle
+                                          :headers {"Authorization" bearer})
+                     fresh-result (first (filter #(= :sighting (:type %))
+                                                 (-> fresh-response :parsed-body :results)))]
+                 (is (= "created" (:result fresh-result))
+                     "a brand-new caller-supplied :id on the create path still succeeds")
+                 (is (= fresh-id (:id fresh-result))
+                     "the fresh caller-supplied :id is honored"))))))))))
+
+(deftest single-entity-post-with-caller-supplied-id-test
+  ;; Same safety properties as bundle-import-with-jwt-specify-id-test, but
+  ;; routed through the single-entity POST /ctia/:entity path. Both routes
+  ;; share ctia.flows.crud/create-flow, so a fix at the flow layer should
+  ;; protect both. This direct test pins the property at the single-entity
+  ;; surface so a future refactor that bypasses the flow layer here can't
+  ;; silently regress.
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/fixture-with-fixed-time (tc/to-date (time/date-time 2017 02 15 14 15 10))
+       (fn []
+         (let [{:keys [jwt-1]} (gen-jwts)
+               bearer (str "Bearer " jwt-1)
+               host (str "http://localhost:" (helpers/get-http-port app))
+               supplied-short-id "sighting-aa112233-4455-6677-8899-aabbccddee01"
+               supplied-id (str host "/ctia/sighting/" supplied-short-id)
+               new-sighting {:id supplied-id
+                             :external_ids ["single-post-test/sighting/1"]
+                             :description "original"
+                             :timestamp #inst "2017-02-15T14:15:10.000Z"
+                             :observed_time {:start_time #inst "2017-02-15T14:15:10.000Z"}
+                             :schema_version schema-version
+                             :count 1
+                             :source "single-post-test"
+                             :sensor "endpoint.sensor"
+                             :confidence "High"}
+               first-resp (POST app
+                                "ctia/sighting"
+                                :body new-sighting
+                                :headers {"Authorization" bearer})]
+           (is (= 201 (:status first-resp))
+               "first POST with caller-supplied :id succeeds")
+           (is (= supplied-id (-> first-resp :parsed-body :id))
+               "the caller-supplied :id is honored")
+           (testing "same-org second POST with the same :id is rejected (no silent upsert)"
+             (let [reuse-resp (POST app
+                                    "ctia/sighting"
+                                    :body (assoc new-sighting :description "OVERWRITE ATTEMPT")
+                                    :headers {"Authorization" bearer})
+                   get-after (GET app
+                                  (str "ctia/sighting/" supplied-short-id)
+                                  :headers {"Authorization" bearer})]
+               (is (not= 201 (:status reuse-resp))
+                   "second POST with same caller-supplied :id must NOT report 201 Created")
+               (is (= "original" (-> get-after :parsed-body :description))
+                   "the original record is not overwritten by the second POST")))
+           (testing "cross-org POST with another org's :id is rejected"
+             (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-fffffffffff0")
+                   other-bearer (str "Bearer " other-org-jwt)
+                   attack-resp (POST app
+                                     "ctia/sighting"
+                                     :body (assoc new-sighting :description "CROSS-ORG OVERWRITE")
+                                     :headers {"Authorization" other-bearer})
+                   get-after (GET app
+                                  (str "ctia/sighting/" supplied-short-id)
+                                  :headers {"Authorization" bearer})]
+               (is (not= 201 (:status attack-resp))
+                   "cross-org POST with an :id owned by another org must NOT report 201 Created")
+               (is (= "original" (-> get-after :parsed-body :description))
+                   "Org A's original record is not overwritten by Org B's POST")))))))))
 

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -270,6 +270,39 @@
      :jwt-2 (-> claims-2 jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)
      :bad-iss-jwt-2 (-> claims-2 (assoc :iss "IROH Auth") jwt/jwt (jwt/sign :RS256 priv-key-2) jwt/to-str)}))
 
+(defn jwt-for-org
+  "Signs a JWT identical to gen-jwts/jwt-1 but with a different org/id claim
+  and a distinct user id. Used to assert that a caller from another org
+  cannot overwrite documents owned by the original org."
+  [org-id]
+  (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
+        priv-key-1 (jwt-key/private-key "resources/cert/ctia-jwt.key")
+        now (t/now)
+        in-one-hour (t/plus now (t/hours 1))
+        other-user-id "deadbeef-dead-beef-dead-beefdeadbeef"
+        claims
+        {:exp in-one-hour
+         :iat now
+         :iss "IROH Auth"
+         :email "other-org@example.com"
+         :nbf now
+         "sub" other-user-id
+         :jti "00000000-0000-0000-0000-000000000001"
+         (clm "oauth/client/id") "iroh-ui"
+         (clm "oauth/client/name") "iroh-ui"
+         (clm "oauth/kind") "session-token"
+         (clm "org/id") org-id
+         (clm "org/name") "Other Org"
+         (clm "scopes") ["casebook" "global-intel" "private-intel" "collect"
+                         "enrich" "inspect" "integration" "iroh-auth"
+                         "response" "ui-settings"]
+         (clm "user/email") "other-org@example.com"
+         (clm "user/id") other-user-id
+         (clm "user/idp/id") "amp"
+         (clm "user/nick") "other-org@example.com"
+         (clm "version") "1"}]
+    (-> claims jwt/jwt (jwt/sign :RS256 priv-key-1) jwt/to-str)))
+
 (s/defn apply-fixtures-with-app
   [properties f-with-app :- (s/=> s/Any (s/=> s/Any (s/named s/Any 'app)))]
   (let [fixture-fn
@@ -565,32 +598,41 @@
                                        :headers {"Authorization" bearer})]
                  (is (= 200 (:status get-response)))
                  (is (= supplied-id (-> get-response :parsed-body :id)))))
-             (testing "KNOWN UNSAFE: a second import reusing the same :id silently overwrites"
-               ;; Documents a collision gap in the ES store create path: the
-               ;; underlying call (ctia.stores.es.crud/handle-create →
-               ;; ductile.doc/bulk-index-docs) is an upsert and there is no
-               ;; pre-existence guard at the flow layer. A second POST with the
-               ;; same caller-supplied :id silently replaces the first record
-               ;; and the caller sees "created" again. This test pins that
-               ;; behavior so any future change that adds a collision guard
-               ;; will surface here and we can flip the assertions.
-               (let [second-bundle (-> bundle
+             (testing "RED: cross-org overwrite via caller-supplied :id MUST be prevented"
+               ;; Safety property: one org must never be able to mutate a
+               ;; document owned by another org. The JWT's org/id claim
+               ;; populates the entity's :groups; access control on update is
+               ;; enforced by allow-write? against owner/groups (see
+               ;; ctia.stores.es.crud/handle-update). The create path does NOT
+               ;; perform that check (handle-create ignores _ident and writes
+               ;; via ductile.doc/bulk-index-docs, an upsert), so a second
+               ;; caller from another org can replace the original record by
+               ;; reusing its :id.
+               ;;
+               ;; This test asserts the safe outcome and SHOULD FAIL until a
+               ;; flow-layer pre-existence + allow-write? guard is added.
+               (let [other-org-jwt (jwt-for-org "ffffffff-ffff-ffff-ffff-ffffffffffff")
+                     other-bearer (str "Bearer " other-org-jwt)
+                     attack-bundle (-> bundle
                                        (assoc-in [:sightings 0 :description]
                                                  "OVERWRITE ATTEMPT")
                                        (assoc-in [:sightings 0 :external_ids]
-                                                 ["specify-id-jwt-test/sighting/2"]))
-                     second-response (POST app
+                                                 ["specify-id-jwt-test/sighting/from-other-org"]))
+                     attack-response (POST app
                                            "ctia/bundle/import"
-                                           :body second-bundle
-                                           :headers {"Authorization" bearer})
+                                           :body attack-bundle
+                                           :headers {"Authorization" other-bearer})
                      get-after (GET app
                                     (str "ctia/sighting/" supplied-short-id)
                                     :headers {"Authorization" bearer})
-                     second-sighting-result (first (filter #(= :sighting (:type %))
-                                                           (-> second-response :parsed-body :results)))]
-                 (is (= "OVERWRITE ATTEMPT"
+                     attack-result (first (filter #(= :sighting (:type %))
+                                                  (-> attack-response :parsed-body :results)))]
+                 (is (not= "OVERWRITE ATTEMPT"
+                           (-> get-after :parsed-body :description))
+                     "Org A's record must NOT be modified by another org")
+                 (is (= "caller-supplied id"
                         (-> get-after :parsed-body :description))
-                     "the second import overwrites the original — pre-existence guard missing")
-                 (is (= "created" (:result second-sighting-result))
-                     "the second import is reported as a successful create — no conflict surfaced"))))))))))
+                     "Org A's original description is intact")
+                 (is (not= "created" (:result attack-result))
+                     "the cross-org import of an :id owned by another org must NOT be reported as a successful create"))))))))))
 

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -564,5 +564,33 @@
                                        (str "ctia/sighting/" supplied-short-id)
                                        :headers {"Authorization" bearer})]
                  (is (= 200 (:status get-response)))
-                 (is (= supplied-id (-> get-response :parsed-body :id))))))))))))
+                 (is (= supplied-id (-> get-response :parsed-body :id)))))
+             (testing "KNOWN UNSAFE: a second import reusing the same :id silently overwrites"
+               ;; Documents a collision gap in the ES store create path: the
+               ;; underlying call (ctia.stores.es.crud/handle-create →
+               ;; ductile.doc/bulk-index-docs) is an upsert and there is no
+               ;; pre-existence guard at the flow layer. A second POST with the
+               ;; same caller-supplied :id silently replaces the first record
+               ;; and the caller sees "created" again. This test pins that
+               ;; behavior so any future change that adds a collision guard
+               ;; will surface here and we can flip the assertions.
+               (let [second-bundle (-> bundle
+                                       (assoc-in [:sightings 0 :description]
+                                                 "OVERWRITE ATTEMPT")
+                                       (assoc-in [:sightings 0 :external_ids]
+                                                 ["specify-id-jwt-test/sighting/2"]))
+                     second-response (POST app
+                                           "ctia/bundle/import"
+                                           :body second-bundle
+                                           :headers {"Authorization" bearer})
+                     get-after (GET app
+                                    (str "ctia/sighting/" supplied-short-id)
+                                    :headers {"Authorization" bearer})
+                     second-sighting-result (first (filter #(= :sighting (:type %))
+                                                           (-> second-response :parsed-body :results)))]
+                 (is (= "OVERWRITE ATTEMPT"
+                        (-> get-after :parsed-body :description))
+                     "the second import overwrites the original — pre-existence guard missing")
+                 (is (= "created" (:result second-sighting-result))
+                     "the second import is reported as a successful create — no conflict surfaced"))))))))))
 

--- a/test/ctia/entity/web_test.clj
+++ b/test/ctia/entity/web_test.clj
@@ -211,15 +211,22 @@
                (is (= [expected-get-res] (map #(dissoc % :created :modified) (:parsed-body matched))))
                (is (= [] (:parsed-body not-matched)))))
 
-           (testing "Normal users are not allowed to set the ids during creation."
-             (let [response
+           (testing "Holders of private-intel:write are allowed to set ids during creation."
+             ;; The JWT under test claims the `private-intel` scope, which
+             ;; confers the :specify-id capability alongside :import-bundle.
+             ;; The hostname in the supplied :id must match this server's;
+             ;; otherwise CTIA rejects with 400 Bad Request.
+             (let [host (str "http://localhost:" (helpers/get-http-port app))
+                   supplied-id (str host "/ctia/judgement/judgement-00001111-0000-1111-2222-000011112222")
+                   response
                    (POST app
                          "ctia/judgement"
-                         :body (assoc new-judgement-1
-                                      :id "http://localhost:3001/ctia/judgement/judgement-00001111-0000-1111-2222-000011112222")
+                         :body (assoc new-judgement-1 :id supplied-id)
                          :headers {"Authorization" bearer
                                    "origin" "http://external.cisco.com"})]
-               (is (= 403 (:status response)))))
+               (is (= 201 (:status response)))
+               (is (= supplied-id (-> response :parsed-body :id))
+                   "the caller-supplied :id is honored")))
 
            (testing "POST /ctia/judgement/:id with bad JWT Authorization header"
              (let [response
@@ -229,7 +236,6 @@
                          :headers {"Authorization" "Bearer 45c1f5e3f05d0"
                                    "origin" "http://external.cisco.com"})]
                (is (= 401 (:status response))))))))))))
-
 
 (defn gen-jwts []
   (let [clm (fn [k] (str "https://schemas.cisco.com/iroh/identity/claims/" k))
@@ -512,3 +518,51 @@
                (is (= 3 @counter)
                    "After the cache-ttl we should make a new call for the same JWT")))))))))))))
 ))
+
+(deftest bundle-import-with-jwt-specify-id-test
+  ;; End-to-end check that a JWT carrying the `private-intel` scope can
+  ;; supply entity ids on POST /ctia/bundle/import. The scope confers the
+  ;; :specify-id capability via the mapping in ctia.auth.jwt; the flow-layer
+  ;; gate in ctia.flows.crud/find-create-entity-id then permits the caller-
+  ;; supplied id rather than minting a fresh UUID.
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/fixture-with-fixed-time (tc/to-date (time/date-time 2017 02 15 14 15 10))
+       (fn []
+         (let [{:keys [jwt-1]} (gen-jwts)
+               bearer (str "Bearer " jwt-1)
+               host (str "http://localhost:" (helpers/get-http-port app))
+               supplied-short-id "sighting-00112233-4455-6677-8899-aabbccddeeff"
+               supplied-id (str host "/ctia/sighting/" supplied-short-id)
+               bundle {:type "bundle"
+                       :source "specify-id-jwt-test"
+                       :sightings [{:id supplied-id
+                                    :external_ids ["specify-id-jwt-test/sighting/1"]
+                                    :description "caller-supplied id"
+                                    :timestamp #inst "2017-02-15T14:15:10.000Z"
+                                    :observed_time {:start_time #inst "2017-02-15T14:15:10.000Z"}
+                                    :schema_version schema-version
+                                    :count 1
+                                    :source "specify-id-jwt-test"
+                                    :sensor "endpoint.sensor"
+                                    :confidence "High"}]}
+               {:keys [status parsed-body]}
+               (POST app
+                     "ctia/bundle/import"
+                     :body bundle
+                     :headers {"Authorization" bearer})]
+           (is (= 200 status)
+               "bundle import succeeds when caller supplies :id with private-intel scope")
+           (let [sighting-result (first (filter #(= :sighting (:type %))
+                                                (:results parsed-body)))]
+             (is (= "created" (:result sighting-result))
+                 "sighting was created")
+             (is (= supplied-id (:id sighting-result))
+                 "the caller-supplied :id is honored")
+             (testing "the entity is retrievable by the supplied short-id"
+               (let [get-response (GET app
+                                       (str "ctia/sighting/" supplied-short-id)
+                                       :headers {"Authorization" bearer})]
+                 (is (= 200 (:status get-response)))
+                 (is (= supplied-id (-> get-response :parsed-body :id))))))))))))
+

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -357,3 +357,59 @@
            expected (assoc patch-flow-map :entities expected-entities)]
        (is (= expected
               (flows.crud/patch-entities patch-flow-map)))))))
+
+(deftest find-create-entity-id-collision-test
+  ;; Unit-level coverage for the caller-supplied :id pre-existence guard.
+  ;; The integration coverage lives in ctia.entity.web-test
+  ;; (bundle-import-with-jwt-specify-id-test and
+  ;; single-entity-post-with-caller-supplied-id-test) — this test pins the
+  ;; pure logic so a future refactor of the flow layer cannot silently drop
+  ;; the guard without a tightly-scoped test failure.
+  (let [host "http://localhost:3000"
+        services {:ConfigService {:get-in-config
+                                  (fn [path]
+                                    (when (= path [:ctia :http :show])
+                                      {:hostname "localhost"
+                                       :protocol "http"
+                                       :port 3000}))}
+                  :CTIAHTTPServerService {:get-port (constantly 3000)}}
+        capable-ident (map->Identity {:login "owner"
+                                      :groups ["g1"]
+                                      :capabilities #{:specify-id}})
+        existing-short-id "sighting-deadbeef-1111-2222-3333-444455556666"
+        existing-long-id (str host "/ctia/sighting/" existing-short-id)
+        existing-doc {:id existing-long-id :owner "owner" :groups ["g1"]}
+        fresh-short-id "sighting-12345678-1111-2222-3333-444455556666"
+        fresh-long-id (str host "/ctia/sighting/" fresh-short-id)
+        get-prev (fn [id] (when (= id existing-short-id) existing-doc))
+        find-fn (flows.crud/find-create-entity-id services)]
+    (testing "no get-prev-entity in flow map ⇒ caller-supplied :id is accepted (legacy behavior)"
+      (is (= existing-short-id
+             (find-fn {:identity capable-ident
+                       :entity-type :sighting
+                       :tempids nil}
+                      {:id existing-long-id}))))
+    (testing "caller-supplied :id that collides with an existing doc ⇒ :id-collision-error"
+      (let [result (find-fn {:identity capable-ident
+                             :entity-type :sighting
+                             :tempids nil
+                             :get-prev-entity get-prev}
+                            {:id existing-long-id})]
+        (is (map? result) "collision returns an error map, not a short-id")
+        (is (= :id-collision-error (:type result)))
+        (is (string? (:error result)))))
+    (testing "brand-new caller-supplied :id ⇒ short-id is returned"
+      (is (= fresh-short-id
+             (find-fn {:identity capable-ident
+                       :entity-type :sighting
+                       :tempids nil
+                       :get-prev-entity get-prev}
+                      {:id fresh-long-id}))))
+    (testing "no caller-supplied :id ⇒ a fresh id is minted (no collision check)"
+      (let [result (find-fn {:identity capable-ident
+                             :entity-type :sighting
+                             :tempids nil
+                             :get-prev-entity get-prev}
+                            {})]
+        (is (string? result))
+        (is (.startsWith result "sighting-"))))))

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -413,3 +413,37 @@
                             {})]
         (is (string? result))
         (is (.startsWith result "sighting-"))))))
+
+(deftest detect-duplicate-ids-test
+  ;; Intra-batch duplicate caller-supplied :id detection. find-create-entity-id
+  ;; uses a pre-fetched get-prev-entity that resolves to nil for fresh IDs, so
+  ;; two entities in the same batch sharing the same fresh :id both pass the
+  ;; existing collision guard. This stage rejects them before the store write.
+  (let [host "http://localhost:3000"
+        short-a "sighting-aaaaaaaa-1111-2222-3333-444455556666"
+        long-a  (str host "/ctia/sighting/" short-a)
+        short-b "sighting-bbbbbbbb-1111-2222-3333-444455556666"]
+    (testing "no duplicates ⇒ entities are returned unchanged"
+      (let [entities [{:id long-a :data 1} {:id short-b :data 2} {:data 3}]
+            fm {:entities entities}]
+        (is (= fm (flows.crud/detect-duplicate-ids fm)))))
+    (testing "two entities share the same caller-supplied :id ⇒ both flagged"
+      (let [entities [{:id long-a :data 1} {:id short-b :data 2} {:id long-a :data 3}]
+            result (flows.crud/detect-duplicate-ids {:entities entities})
+            errors (filter :error (:entities result))]
+        (is (= 2 (count errors)))
+        (is (every? #(= :id-collision-error (:type %)) errors))
+        (is (= {:id short-b :data 2}
+               (->> result :entities (remove :error) first)))))
+    (testing "long and short encodings of the same id are detected as a duplicate"
+      (let [entities [{:id long-a :data 1} {:id short-a :data 2}]
+            result (flows.crud/detect-duplicate-ids {:entities entities})]
+        (is (= 2 (count (filter :error (:entities result)))))))
+    (testing "transient ids do not count as duplicates (they get fresh server ids)"
+      (let [entities [{:id "transient:foo" :data 1} {:id "transient:foo" :data 2}]
+            fm {:entities entities}]
+        (is (= fm (flows.crud/detect-duplicate-ids fm)))))
+    (testing "entities without :id are ignored"
+      (let [entities [{:data 1} {:data 2} {:data 3}]
+            fm {:entities entities}]
+        (is (= fm (flows.crud/detect-duplicate-ids fm)))))))


### PR DESCRIPTION
> Related https://cisco-sbg.atlassian.net/browse/XDR-52722

## Summary

Exposes the `:specify-id` capability through a dedicated top-level OAuth2 scope and closes the cross-tenant overwrite gap that surfaces when caller-supplied IDs become reachable outside the static admin role.

## What changes

### Dedicated `ctia-specify-id` scope

A new sibling root scope is added in `src/ctia/auth/jwt.clj`:

- `ctia-specify-id:write` — confers `#{:specify-id}` and nothing else
- `ctia-specify-id` (no access) — confers nothing
- `ctia-specify-id:read` — confers nothing

The scope is intentionally NOT a subscope of `private-intel` (or any entity-root scope), so granting `private-intel:write` does not implicitly carry `:specify-id`. Least-privilege provisioning: a client that should be able to specify entity IDs holds exactly this one scope, and gains no entity read/write/delete authority from it.

Scope name is configurable via `ctia.auth.specify-id.scope` (default `"ctia-specify-id"`), following the same pattern as `entity-root-scope` / `casebook-root-scope` / `assets-root-scope`.

### Flow-layer collision check on caller-supplied `:id`

`:specify-id` only gates the *capability* to name an entity at create time. It does not by itself protect against a caller supplying an ID that already exists and belongs to another org — `handle-create` writes via an ES upsert and does not check the existing document's ACL.

`src/ctia/flows/crud.clj` `find-create-entity-id` now performs a pre-existence lookup whenever a caller supplies `:id`. If the ID resolves to an existing document, the flow rejects the create with `:id-collision-error`. The same `prev-entity` + `:get-fn` plumbing `update-flow` already uses is reused; both `POST /ctia/{entity}` and `POST /ctia/bundle/import` traverse the new check.

## Why

Today `:specify-id` is reachable only via the static admin role — no OAuth2 scope maps to it. A dedicated narrow scope lets operators grant just this capability without conferring full admin identity or any entity-level write authority.

## Trade-offs

- The flow-layer check costs one additional store read per caller-supplied `:id` on the create path. Bundle imports without `:id` (the common case) are unaffected.
- The check uses the same access-controlled read as the existing flow; if a TLP=red document owned by another org is unreadable to the caller, the collision is currently not detected. This is a residual gap consistent with the existing ACL posture and is called out as a known limitation, not a regression introduced here.

## Out of scope

- `valid-short-id?` validates format only; it does not bind IDs to a tenant or hostname.
- Operator documentation and changelog beyond what is in this PR.

<a name="qa"></a> QA
============================
No QA is needed. Covered by `scopes-to-capabilities-test` and `find-create-entity-id-collision-test`, plus end-to-end JWT integration coverage in `ctia.entity.web-test/bundle-import-with-jwt-specify-id-test` and `single-entity-post-with-caller-supplied-id-test`.

<a name="release-notes"></a> Release Notes
=============================================================

```
intern: :specify-id is now conferred by the dedicated ctia-specify-id:write OAuth2 scope (previously admin-only). Caller-supplied :id on create is now rejected when it collides with an existing document the caller is not authorized to write.
```