### PR TITLE
fix(access-control): apply write filter to delete-search (XFV-120)

### DIFF
--- a/src/ctia/entity/feed.clj
+++ b/src/ctia/entity/feed.clj
@@ -396,16 +396,16 @@
                  (if (empty? query)
                    (forbidden {:error "you must provide at least one of from, to, query or any field filter."})
                    (ok
-                    (if (:REALLY_DELETE_ALL_THESE_ENTITIES params)
-                      (-> (get-store :feed)
-                          (delete-search
-                           query
-                           identity-map
-                           {:wait_for_completion (boolean (:wait_for params))}))
-                      (-> (get-store :feed)
-                          (query-string-count
-                           query
-                           identity-map))))))))
+                    ;; Both the dry-run count and the destructive delete go
+                    ;; through delete-search so the reported count reflects the
+                    ;; write access-control filter that an actual delete would
+                    ;; apply (XFV-120), not the broader read visibility.
+                    (-> (get-store :feed)
+                        (delete-search
+                         query
+                         identity-map
+                         {:wait_for_completion (boolean (:wait_for params))
+                          :really-delete? (boolean (:REALLY_DELETE_ALL_THESE_ENTITIES params))})))))))
 
      (let [capabilities :read-feed]
        (GET "/:id" []

--- a/src/ctia/http/routes/crud.clj
+++ b/src/ctia/http/routes/crud.clj
@@ -415,16 +415,16 @@
                (if (empty? query)
                  (forbidden {:error "you must provide at least one of from, to, query or any field filter."})
                  (ok
-                  (if (:REALLY_DELETE_ALL_THESE_ENTITIES params)
-                    (-> (get-store entity)
-                        (store/delete-search
-                          query
-                          identity-map
-                          {:wait_for_completion (boolean (:wait_for params))}))
-                    (-> (get-store entity)
-                        (store/query-string-count
-                          query
-                          identity-map))))))))))
+                  ;; Both the dry-run count and the destructive delete go through
+                  ;; delete-search so the reported count reflects the write
+                  ;; access-control filter that an actual delete would apply
+                  ;; (XFV-120), not the broader read visibility.
+                  (-> (get-store entity)
+                      (store/delete-search
+                        query
+                        identity-map
+                        {:wait_for_completion (boolean (:wait_for params))
+                         :really-delete? (boolean (:REALLY_DELETE_ALL_THESE_ENTITIES params))})))))))))
      (when can-aggregate?
        (let [capabilities search-capabilities]
          (context "/metric" []

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -32,7 +32,16 @@
   (query-string-search [this args #_#_:- QueryStringSearchArgs])
   (query-string-count [this search-query ident])
   (aggregate [this search-query agg-query ident])
-  (delete-search [this search-query ident params]))
+  (delete-search [this search-query ident params]
+    "Delete documents matching `search-query` under the write access-control
+     filter (a caller may only delete what it can write, not merely read;
+     XFV-120), and return a nat-int count.
+
+     Deletion only happens when `params` carries `:really-delete? true`.
+     Without it the call is a dry run: nothing is deleted and the count of
+     matching (deletable) documents is returned as a preview. Callers relying
+     on an always-deletes contract must pass `:really-delete? true` explicitly,
+     otherwise they get a plausible non-zero count with nothing removed."))
 
 (defprotocol IPaginateableStore
   "Protocol that can implement lazy iteration over some number of calls to impure

--- a/src/ctia/store.clj
+++ b/src/ctia/store.clj
@@ -37,7 +37,7 @@
      filter (a caller may only delete what it can write, not merely read;
      XFV-120), and return a nat-int count.
 
-     Deletion only happens when `params` carries `:really-delete? true`.
+     Deletion only happens when `params` carries a truthy `:really-delete?`.
      Without it the call is a dry run: nothing is deleted and the count of
      matching (deletable) documents is returned as a preview. Callers relying
      on an always-deletes contract must pass `:really-delete? true` explicitly,

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -597,17 +597,23 @@ It returns the documents with full hits meta data including the real index in wh
   ([es-conn-state :- ESConnState
     search-query :- SearchQuery
     ident
-    {:keys [extra-filters]}]
+    {:keys [extra-filters access-control]
+     :or {access-control :read}}]
    (let [{:keys [services]} es-conn-state
          {{:keys [get-in-config]} :ConfigService} services
          {:keys [filter-map range full-text]} search-query
          range-query (when range
                        {:range range})
+         ;; Delete operations must use the write access-control filter so a
+         ;; caller can only remove documents it is allowed to write (XFV-120).
+         restriction-query-part (case access-control
+                                  :write (es.query/find-write-restriction-query-part ident)
+                                  (es.query/find-restriction-query-part ident get-in-config))
          filter-terms (-> (ensure-document-id-in-map filter-map)
                           q/prepare-terms)]
      {:bool
       {:filter
-       (cond-> [(es.query/find-restriction-query-part ident get-in-config)]
+       (cond-> [restriction-query-part]
          true (into extra-filters)
          (seq filter-map) (into filter-terms)
          (seq range)      (conj range-query)
@@ -646,24 +652,36 @@ It returns the documents with full hits meta data including the real index in wh
                                       get-in-config)))))))
 
 (s/defn handle-delete-search
-  "ES delete by query handler"
+  "ES delete by query handler.
+
+   Builds the `_delete_by_query` body with the write access-control filter so a
+   caller can only delete documents it is allowed to write (XFV-120), rather
+   than every document it can read.
+
+   When `es-params` does not carry `:really-delete? true` no deletion is
+   performed: the number of matching (deletable) documents is returned as a
+   dry-run preview, computed with the same write filter so the preview matches
+   what an actual delete would remove."
   [{:keys [conn index] :as es-conn-state} :- ESConnState
    search-query :- SearchQuery
    ident
    es-params]
-  (let [query (make-search-query es-conn-state search-query ident)
+  (let [query (make-search-query es-conn-state search-query ident {:access-control :write})
         opts (select-keys es-params [:wait_for_completion :refresh])
-        nb-deleted (ductile.doc/count-docs conn index query)]
-    (log/info (format "deleting %s documents in %s (%s)"
-                      nb-deleted
-                      index
-                      (pr-str query)))
-    (:deleted
-     (ductile.doc/delete-by-query conn
-                                  [index]
-                                  query
-                                  opts)
-     nb-deleted)))
+        nb-matched (ductile.doc/count-docs conn index query)]
+    (if (:really-delete? es-params)
+      (do
+        (log/info (format "deleting %s documents in %s (%s)"
+                          nb-matched
+                          index
+                          (pr-str query)))
+        (:deleted
+         (ductile.doc/delete-by-query conn
+                                      [index]
+                                      query
+                                      opts)
+         nb-matched))
+      nb-matched)))
 
 (s/defn handle-query-string-count :- (s/pred nat-int?)
   "ES count handler"

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -593,22 +593,25 @@ It returns the documents with full hits meta data including the real index in wh
   ([es-conn-state :- ESConnState
     search-query :- SearchQuery
     ident]
-   (make-search-query es-conn-state search-query ident {}))
+   (make-search-query es-conn-state search-query ident {:access-control :read}))
   ([es-conn-state :- ESConnState
     search-query :- SearchQuery
     ident
-    {:keys [extra-filters access-control]
-     :or {access-control :read}}]
+    {:keys [extra-filters access-control]}]
    (let [{:keys [services]} es-conn-state
          {{:keys [get-in-config]} :ConfigService} services
          {:keys [filter-map range full-text]} search-query
          range-query (when range
                        {:range range})
-         ;; Delete operations must use the write access-control filter so a
-         ;; caller can only remove documents it is allowed to write (XFV-120).
-         ;; Fail closed: only the explicit :read/:write values are accepted.
-         ;; An unknown value (typo, wrong type, nil) throws rather than
-         ;; silently widening a delete to the broader read filter (XFV-120).
+         ;; Access-control filter selection is mandatory and fail-closed: the
+         ;; caller MUST pass an explicit :read or :write. There is no default --
+         ;; an omitted key leaves `access-control` nil and the `case` below
+         ;; throws, so a future destructive path that forgets :access-control
+         ;; fails loudly instead of silently widening a delete to the broader
+         ;; read filter. An unknown value (typo, wrong type) throws for the same
+         ;; reason. Delete operations pass :write so a caller can only remove
+         ;; documents it is allowed to write; read/count/aggregate pass :read
+         ;; (XFV-120).
          restriction-query-part (case access-control
                                   :write (es.query/find-write-restriction-query-part ident)
                                   :read  (es.query/find-restriction-query-part ident get-in-config))
@@ -766,7 +769,8 @@ It returns the documents with full hits meta data including the real index in wh
    {:keys [agg-type] :as agg-query} :- AggQuery
    ident]
   (let [agg-query (assoc agg-query :agg-key :metric)
-        query (make-search-query es-conn-state search-query ident {:extra-filters (aggregation-filters agg-query)})
+        query (make-search-query es-conn-state search-query ident {:access-control :read
+                                                                    :extra-filters (aggregation-filters agg-query)})
         agg (make-aggregation agg-query)
         es-res (ductile.doc/query conn
                                   index

--- a/src/ctia/stores/es/crud.clj
+++ b/src/ctia/stores/es/crud.clj
@@ -606,9 +606,12 @@ It returns the documents with full hits meta data including the real index in wh
                        {:range range})
          ;; Delete operations must use the write access-control filter so a
          ;; caller can only remove documents it is allowed to write (XFV-120).
+         ;; Fail closed: only the explicit :read/:write values are accepted.
+         ;; An unknown value (typo, wrong type, nil) throws rather than
+         ;; silently widening a delete to the broader read filter (XFV-120).
          restriction-query-part (case access-control
                                   :write (es.query/find-write-restriction-query-part ident)
-                                  (es.query/find-restriction-query-part ident get-in-config))
+                                  :read  (es.query/find-restriction-query-part ident get-in-config))
          filter-terms (-> (ensure-document-id-in-map filter-map)
                           q/prepare-terms)]
      {:bool
@@ -651,7 +654,7 @@ It returns the documents with full hits meta data including the real index in wh
                                       ident
                                       get-in-config)))))))
 
-(s/defn handle-delete-search
+(s/defn handle-delete-search :- (s/pred nat-int?)
   "ES delete by query handler.
 
    Builds the `_delete_by_query` body with the write access-control filter so a

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -64,7 +64,11 @@
   "Access-control filter for write/delete operations. Mirrors the disjuncts of
    `ctia.domain.access-control/allow-write?`. Unlike `find-restriction-query-part`
    it never adds the `max-record-visibility=everyone` public-TLP clause, so a
-   caller cannot match another group's TLP white/green records. See XFV-120."
+   caller cannot reach another group's TLP white/green records by blanket
+   visibility alone. It can still match a foreign group's record when that
+   record explicitly grants the caller via `authorized_users`/`authorized_groups`
+   — that is intended, since `allow-write?` grants write on the same basis.
+   See XFV-120."
   [ident]
   (let [{:keys [login groups]} (normalize-ident ident)]
     {:bool

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -7,35 +7,59 @@
    [schema-tools.core :as st]
    [schema.core :as s]))
 
-(defn find-restriction-query-part
-  [{:keys [login groups]} get-in-config]
+(defn- normalize-ident
   ;; TODO do we really want to discard case on that?
-  (let [login (str/lower-case login)
-        groups (map str/lower-case groups)]
+  [{:keys [login groups]}]
+  {:login (str/lower-case login)
+   :groups (map str/lower-case groups)})
+
+(defn- write-restriction-should-clauses
+  "The should-clauses shared by the read and write access-control filters.
+   These mirror the disjuncts of `ctia.domain.access-control/allow-write?`:
+   document owner, `authorized_users`, `authorized_groups`, same-group records
+   at TLP amber or below, and same-group owner records at TLP red."
+  [login groups]
+  [;; Document Owner
+   {:bool {:filter [{:term {"owner" login}}
+                    {:terms {"groups" groups}}]}}
+
+   ;; or if user is listed in authorized_users or authorized_groups field
+   {:term {"authorized_users" login}}
+   {:terms {"authorized_groups" groups}}
+
+   ;; CTIM records with TLP equal or below amber that are owned by org BAR
+   {:bool {:must [{:terms {"tlp" (conj ac/public-tlps "amber")}}
+                  {:terms {"groups" groups}}]}}
+
+   ;; CTIM records with TLP red that is owned by user FOO
+   {:bool {:must [{:term {"tlp" "red"}}
+                  {:term {"owner" login}}
+                  {:terms {"groups" groups}}]}}])
+
+(defn find-restriction-query-part
+  "Access-control filter for read operations. In addition to the write
+   disjuncts, when `ctia.access-control.max-record-visibility` is `everyone`
+   it also matches any TLP white/green document regardless of owner/groups."
+  [ident get-in-config]
+  (let [{:keys [login groups]} (normalize-ident ident)]
     {:bool
      {:minimum_should_match 1
       :should
-      (cond->>
-       [;; Document Owner
-        {:bool {:filter [{:term {"owner" login}}
-                         {:terms {"groups" groups}}]}}
-
-           ;; or if user is listed in authorized_users or authorized_groups field
-        {:term {"authorized_users" login}}
-        {:terms {"authorized_groups" groups}}
-
-           ;; CTIM records with TLP equal or below amber that are owned by org BAR
-        {:bool {:must [{:terms {"tlp" (conj ac/public-tlps "amber")}}
-                       {:terms {"groups" groups}}]}}
-
-           ;; CTIM records with TLP red that is owned by user FOO
-        {:bool {:must [{:term {"tlp" "red"}}
-                       {:term {"owner" login}}
-                       {:terms {"groups" groups}}]}}]
-
+      (cond->> (write-restriction-should-clauses login groups)
         ;; Any Green/White TLP if max-visibility is set to `everyone`
         (ac/max-record-visibility-everyone? get-in-config)
         (cons {:terms {"tlp" ac/public-tlps}}))}}))
+
+(defn find-write-restriction-query-part
+  "Access-control filter for write/delete operations. Mirrors the disjuncts of
+   `ctia.domain.access-control/allow-write?`. Unlike `find-restriction-query-part`
+   it never adds the `max-record-visibility=everyone` public-TLP clause, so a
+   caller cannot match another group's TLP white/green records. See XFV-120."
+  [ident]
+  (let [{:keys [login groups]} (normalize-ident ident)]
+    {:bool
+     {:minimum_should_match 1
+      :should (write-restriction-should-clauses login groups)}}))
 
 
 (s/defn make-date-range-query :- search-schemas/RangeQuery

--- a/src/ctia/stores/es/query.clj
+++ b/src/ctia/stores/es/query.clj
@@ -16,8 +16,15 @@
 (defn- write-restriction-should-clauses
   "The should-clauses shared by the read and write access-control filters.
    These mirror the disjuncts of `ctia.domain.access-control/allow-write?`:
-   document owner, `authorized_users`, `authorized_groups`, same-group records
-   at TLP amber or below, and same-group owner records at TLP red."
+   document owner (TLP-independent), `authorized_users`, `authorized_groups`,
+   and same-group records at TLP amber or below.
+
+   The trailing TLP-red owner clause is redundant: `allow-write?` has no red
+   branch, and its owner rule matches at any TLP, so the owner should-clause
+   above already covers same-group owner records at TLP red. It is kept
+   unchanged only so `find-restriction-query-part` (read) emits the exact same
+   query body as before these clauses were factored out — the read filter must
+   stay byte-identical (see XFV-120)."
   [login groups]
   [;; Document Owner
    {:bool {:filter [{:term {"owner" login}}
@@ -31,7 +38,10 @@
    {:bool {:must [{:terms {"tlp" (conj ac/public-tlps "amber")}}
                   {:terms {"groups" groups}}]}}
 
-   ;; CTIM records with TLP red that is owned by user FOO
+   ;; CTIM records with TLP red owned by user FOO. Redundant with the owner
+   ;; clause above (which is TLP-independent, matching owner+group at any TLP);
+   ;; retained only to keep the read filter byte-identical to its pre-refactor
+   ;; form. See the fn docstring and XFV-120.
    {:bool {:must [{:term {"tlp" "red"}}
                   {:term {"owner" login}}
                   {:terms {"groups" groups}}]}}])

--- a/test/ctia/entity/incident_test.clj
+++ b/test/ctia/entity/incident_test.clj
@@ -19,6 +19,7 @@
             [ctia.test-helpers.fake-whoami-service :as whoami-helpers]
             [ctia.test-helpers.search :as search-th]
             [ctia.test-helpers.store :refer [test-for-each-store-with-app]]
+            [ctia.store :as store]
             [ctim.domain.id :as id]
             [ctim.examples.bundles :refer [new-bundle-minimal]]
             [ctim.examples.incidents
@@ -886,19 +887,32 @@
          (assoc :title (str (java.util.UUID/randomUUID))
                 :revision (or order 0))))))
 
+;; Incidents in these tests are created (via create-incidents) owned by this
+;; identity, regardless of the HTTP auth mode a given deftest uses.
+(def ^:private incident-owner-ident
+  (auth/map->Identity {:login "foouser"
+                       :groups ["foogroup"]}))
+
 (s/defn create-incidents [app incidents :- (s/pred set?)]
   (bundle/import-bundle
     (-> new-bundle-minimal
         (dissoc :id)
         (assoc :incidents incidents))
     nil    ;; external-key-prefixes
-    (auth/map->Identity {:login "foouser"
-                         :groups ["foogroup"]})
+    incident-owner-ident
     (app/service-graph app)))
 
 (defn purge-incidents! [app]
-  (search-th/delete-search app :incident {:query "*"
-                                          :REALLY_DELETE_ALL_THESE_ENTITIES true})
+  ;; Delete at the store level with the owning identity (foouser/foogroup), the
+  ;; same identity create-incidents uses. Since XFV-120, delete-search enforces
+  ;; the write access-control filter, so an allow-all HTTP caller (login
+  ;; "Unknown", group "Administrators") can no longer delete another group's
+  ;; records. Going through the store with the owner identity purges the
+  ;; incidents in every auth mode these tests run under.
+  (store/delete-search (helpers/get-store app :incident)
+                       {:full-text [{:query "*" :query_mode :query_string}]}
+                       incident-owner-ident
+                       {:really-delete? true :refresh "true"})
   ;;FIXME ideally we pass wait_for=true to the delete search, but it yields a coercion error in ES.
   ;; instead, we query GET /incident/search/count until it is zero as a workaround
   (loop [tries 0]

--- a/test/ctia/stores/es/crud_test.clj
+++ b/test/ctia/stores/es/crud_test.clj
@@ -5,6 +5,7 @@
             [clojure.test :as t
              :refer
              [are deftest is testing use-fixtures]]
+            [ctia.domain.access-control :as cdac]
             [ctia.entity.sighting.schemas :as ss]
             [ctia.flows.crud :refer [gen-random-uuid]]
             [ctia.stores.es.crud :as sut]
@@ -841,6 +842,7 @@
                                      query
                                      ident
                                      {:wait_for_completion wait_for_completion
+                                      :really-delete? true
                                       :refresh "true"}))
                                  "the number of deleted entities shall be equal to the number of matched")
                              (let [remaining (count-fn es-conn-state query ident)]
@@ -892,6 +894,61 @@
               :deleted? true
               :wait_for_completion false})
             )))))
+
+(deftest handle-delete-search-write-access-control-test
+  ;; Regression test for XFV-120: delete-search must apply the write
+  ;; access-control filter, not the read filter. Under the default
+  ;; max-record-visibility=everyone, a TLP green/white document is READABLE by
+  ;; any group, but only WRITABLE (deletable) by its owning group. delete-search
+  ;; must therefore refuse to delete another group's green/white records.
+  (es-helpers/for-each-es-version
+      "handle-delete-search shall apply write access control, not read visibility"
+      [7]
+      #(es-index/delete! % "ctia_*")
+    (helpers/fixture-ctia-with-app
+        (fn [app]
+          (let [es-conn-state (get-conn-state app :sighting)
+                owner-ident {:login "johndoe"
+                             :groups ["group1"]}
+                foreign-ident {:login "janedoe"
+                               :groups ["group2"]}
+                green-data (map (fn [doc] (assoc doc :tlp "green"))
+                                high-t1-title1)
+                query {:full-text [{:query "title1"}]
+                       :filter-map {:confidence "High"}}
+                get-in-config (helpers/current-get-in-config-fn app)]
+            (is (cdac/max-record-visibility-everyone? get-in-config)
+                "test assumes the default max-record-visibility=everyone")
+            (create-fn es-conn-state green-data owner-ident {:refresh "true"})
+
+            (testing "a foreign group can READ the owner's green records"
+              (is (= (count green-data)
+                     (count-fn es-conn-state query foreign-ident))
+                  "read visibility exposes green records across groups under `everyone`"))
+
+            (testing "delete-search dry-run for a foreign group matches nothing (write ACL)"
+              (is (zero?
+                   (sut/handle-delete-search
+                    es-conn-state query foreign-ident
+                    {:really-delete? false :refresh "true"}))
+                  "the foreign group cannot write the owner's green records"))
+
+            (testing "destructive delete-search by a foreign group removes nothing"
+              (is (zero?
+                   (sut/handle-delete-search
+                    es-conn-state query foreign-ident
+                    {:really-delete? true :wait_for_completion true :refresh "true"}))
+                  "no foreign green records shall be deleted")
+              (is (= (count green-data)
+                     (count-fn es-conn-state query owner-ident))
+                  "the owner's records survive a foreign delete-search"))
+
+            (testing "the owner can still delete its own green records"
+              (is (= (count green-data)
+                     (sut/handle-delete-search
+                      es-conn-state query owner-ident
+                      {:really-delete? true :wait_for_completion true :refresh "true"})))
+              (is (zero? (count-fn es-conn-state query owner-ident)))))))))
 
 (deftest docs-with-indices-test
   (es-helpers/for-each-es-version

--- a/test/ctia/stores/es/query_test.clj
+++ b/test/ctia/stores/es/query_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.stores.es.query-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ctia.domain.access-control :as ac]
    [ctia.entity.entities :as entities]
    [ctia.test-helpers.core :as helpers]
    [ctia.test-helpers.es :as es-helpers]
@@ -107,6 +108,41 @@
                                assoc :type "text" :fields {:ignored-and-sad {:type "text"}}))]
           (is (= expected-result
                  (select-keys (digest-searchable-map es-mappings) [:incident :vulnerability]))))))))
+
+(deftest find-write-restriction-query-part-test
+  ;; Pin the exact clause set emitted by the write/delete access-control
+  ;; filter. `write-restriction-should-clauses` is the single source shared by
+  ;; both the read and the write filters (XFV-120), and nothing else in the
+  ;; code distinguishes which disjuncts belong to which policy. This test forces
+  ;; any edit to that shared vector to be acknowledged on the write side: a
+  ;; read-side widening (e.g. a new public-visibility disjunct) that landed
+  ;; silently on the delete path would break this assertion.
+  (let [ident {:login "Foo" :groups ["Bar"]}
+        expected {:bool
+                  {:minimum_should_match 1
+                   :should [;; document owner (TLP-independent)
+                            {:bool {:filter [{:term {"owner" "foo"}}
+                                             {:terms {"groups" ["bar"]}}]}}
+                            ;; explicit grants
+                            {:term {"authorized_users" "foo"}}
+                            {:terms {"authorized_groups" ["bar"]}}
+                            ;; same-group records at TLP amber or below
+                            {:bool {:must [{:terms {"tlp" (conj ac/public-tlps "amber")}}
+                                           {:terms {"groups" ["bar"]}}]}}
+                            ;; same-group owner records at TLP red (redundant
+                            ;; with the owner clause; kept for read parity)
+                            {:bool {:must [{:term {"tlp" "red"}}
+                                           {:term {"owner" "foo"}}
+                                           {:terms {"groups" ["bar"]}}]}}]}}]
+    (testing "emitted write filter matches the pinned clause set, login/groups lower-cased"
+      (is (= expected (sut/find-write-restriction-query-part ident))))
+    (testing "the write filter never grants blanket public-TLP visibility"
+      ;; The security property of XFV-120: unlike the read filter under
+      ;; max-record-visibility=everyone, the write filter must not contain a
+      ;; disjunct that matches any white/green document regardless of owner.
+      (let [should (get-in (sut/find-write-restriction-query-part ident)
+                           [:bool :should])]
+        (is (not (some #{{:terms {"tlp" ac/public-tlps}}} should)))))))
 
 (deftest rename-search-fields-map-test
   (doseq [es-version [7]]

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -55,14 +55,25 @@
           (:groups entity-2))))
 
 (defn search-access-control-test
-  "test search access control"
+  "test search access control.
+
+   `player-2-expected-delete-list` is the subset of records that player-2 is
+   allowed to *delete* via delete-search (the write access-control filter). It
+   defaults to `player-2-expected-entity-list` (what player-2 can *read*). The
+   two diverge under `max-record-visibility=everyone`, where a foreign group's
+   TLP white/green records are readable but not deletable (XFV-120)."
   [{:keys [app
            entity
            list-query
            player-1-expected-entity-list
            player-2-expected-entity-list
-           player-3-expected-entity-list]}]
-  (let [;; searches
+           player-3-expected-entity-list
+           player-2-expected-delete-list]
+    :or {player-2-expected-delete-list :unset}}]
+  (let [player-2-expected-delete-list (if (= :unset player-2-expected-delete-list)
+                                         player-2-expected-entity-list
+                                         player-2-expected-delete-list)
+        ;; searches
         search (fn [token]
                  (:parsed-body
                   (GET app
@@ -116,18 +127,22 @@
       (is (= (count player-3-expected-entity-list)
              player-3-entity-count-1)))
 
-    (testing "delete-search should only match and delete visible entities"
-      (is (= (str (count player-2-expected-entity-list))
+    (testing "delete-search should only match and delete entities the caller may write"
+      (is (= (str (count player-2-expected-delete-list))
               player-2-entity-delete-search))
 
-      ;; check second count
-      (is (zero? player-2-entity-count-2))
+      ;; check second count: only the records player-2 could write are gone,
+      ;; the rest of each player's visible set remains readable.
+      (is (= (-> (set player-2-expected-entity-list)
+                 (set/difference (set player-2-expected-delete-list))
+                 count)
+             player-2-entity-count-2))
       (is (= (-> (set player-1-expected-entity-list)
-                 (set/difference player-2-expected-entity-list)
+                 (set/difference (set player-2-expected-delete-list))
                  count)
              player-1-entity-count-2))
       (is (= (-> (set player-3-expected-entity-list)
-                 (set/difference player-2-expected-entity-list)
+                 (set/difference (set player-2-expected-delete-list))
                  count)
              player-3-entity-count-2)))))
 
@@ -550,6 +565,12 @@
                                                 player-3-entity-search]
                 :player-3-expected-entity-list [player-1-entity-search
                                                 player-2-entity-search
+                                                player-3-entity-search]
+                ;; XFV-120: under max-record-visibility=everyone player-2
+                ;; (bargroup) can read every green record but may only delete
+                ;; its own group's records (its own + player-3's), never
+                ;; player-1's (foogroup) green record.
+                :player-2-expected-delete-list [player-2-entity-search
                                                 player-3-entity-search]}))))))
 
 (defn test-access-control-entity-tlp-amber

--- a/test/ctia/test_helpers/access_control.clj
+++ b/test/ctia/test_helpers/access_control.clj
@@ -96,6 +96,18 @@
         player-3-entity-count-1 (search-count "player-3-token")
 
 
+        ;; dry-run delete-search: REALLY_DELETE_ALL_THESE_ENTITIES is not set,
+        ;; so nothing is deleted and the returned preview count must be the
+        ;; write-filtered (deletable) count, not the broader read count. This
+        ;; guards the route's dry-run path end-to-end: reverting it to a
+        ;; read-filtered count would make this diverge under `everyone`
+        ;; (XFV-120).
+        {player-2-entity-dry-run-delete :body}
+        (DELETE app
+                (format "ctia/%s/search" entity)
+                :query-params {:query list-query}
+                :headers {"Authorization" "player-2-token"})
+
         ;; delete-searches
        {player-2-entity-delete-search :body}
        (DELETE app
@@ -128,6 +140,12 @@
              player-3-entity-count-1)))
 
     (testing "delete-search should only match and delete entities the caller may write"
+      ;; dry run: preview count is the write-filtered (deletable) count, and
+      ;; nothing was deleted (the destructive delete below still removes the
+      ;; full deletable set, which would be impossible had the dry run deleted).
+      (is (= (str (count player-2-expected-delete-list))
+             player-2-entity-dry-run-delete))
+
       (is (= (str (count player-2-expected-delete-list))
               player-2-entity-delete-search))
 


### PR DESCRIPTION
## Summary

`delete-search` (ES `_delete_by_query`) built its query body with the **read**
access-control filter (`find-restriction-query-part`). Under the default
`ctia.access-control.max-record-visibility=everyone`, that filter also matches
any TLP white/green document regardless of owner or group. As a result a caller
could **delete another group's TLP green/white records that it was only
permitted to read, not write** — a cross-tenant authorization bypass on the
bulk delete endpoint.

Related: XFV-120

## Fix

- Add `find-write-restriction-query-part` (src/ctia/stores/es/query.clj). It
  mirrors the disjuncts of `ctia.domain.access-control/allow-write?` (owner,
  `authorized_users`, `authorized_groups`, same-group TLP amber-or-below,
  same-group owner TLP red) and **omits** the `everyone`/public-TLP clause that
  the read filter adds. The shared disjuncts are factored into a private
  `write-restriction-should-clauses`, so the read filter is byte-identical to
  before (it still `cons`es the public-TLP clause under `everyone`).
- Thread an `:access-control` option through `make-search-query`
  (src/ctia/stores/es/crud.clj); `handle-delete-search` now requests
  `:write`. The dry-run count is computed with the **same** write filter, so
  the preview matches what an actual delete would remove.
- The `DELETE /search` routes (generic crud + feed) always go through
  `delete-search`, passing `:really-delete?` derived from
  `REALLY_DELETE_ALL_THESE_ENTITIES`. The non-destructive request returns the
  write-filtered match count instead of the broader read count.

The new write filter is a **strict subset** of the old read filter, so the
change can only ever delete *fewer* documents — it cannot widen access.

## Tests

- New `handle-delete-search-write-access-control-test`
  (test/ctia/stores/es/crud_test.clj): under `everyone`, a foreign group can
  READ another group's green records but its `delete-search` (dry-run and
  destructive) matches/deletes **0**, the owner's docs survive, and the owner
  can still delete its own.
- `search-access-control-test` gains an optional `player-2-expected-delete-list`
  (defaults to the read list; diverges only under `everyone`), with the
  TLP-green case asserting a foreign group can read but not delete a third
  group's green record.

Local ES7 suite (all green):
- `ctia.stores.es.crud-test` — 664 assertions, 0 failures
- `ctia.entity.sighting-test` — 292 assertions, 0 failures
- `ctia.entity.feed-test` — 176 assertions, 0 failures
- `ctia.domain.access-control-test` — 120 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Rejected findings

Adjudication of ereteog's review (2026-08-25). Applied findings are listed in
the review-response summary comment; the items below were not applied as
suggested, with reasoning.

- **[doc/O1] — drop the TLP-red should-clause: NOT DROPPED (docstring fixed
  instead).** The red clause lives in the shared `write-restriction-should-clauses`
  and master's read filter includes it, so dropping it changes the read filter's
  emitted query body and breaks the byte-identical-read-filter property this PR
  is built on (and that the reviewer verified). The real concern — a maintainer
  misreading the docstring's "TLP red" as an `allow-write?` disjunct — is fixed
  by correcting the docstring/comment to state the owner rule is TLP-independent
  and the red clause is redundant (subsumed by the owner clause), retained only
  for read byte-identity. Write match set unchanged either way (red ⊆ owner).
- **[observability] LOW — dropped `_delete_by_query` `:failures`/`:version_conflicts`
  and async pre-count: OUT OF SCOPE.** Pre-existing behavior not introduced by
  this PR; tracked as a separate follow-up rather than expanding this PR's scope.
- **[tests] LOW — remaining coverage follow-ups: PARTIALLY DEFERRED.** The main
  gap (T1, dry-run write-filter count unguarded end-to-end) is now closed with a
  foreign-caller dry-run assertion. The remaining suggestions (feed DELETE /search
  route currently `:delete-search-tests? false`, a direct unit test for
  `find-write-restriction-query-part`) are noted as optional follow-ups; the
  write-vs-read divergence is already regression-tested at the route level
  (green/everyone) and the store level (`handle-delete-search-write-access-control-test`).


### Second-review adjudication (ereteog, 2026-09-03; addressed in 4f244c79)

- **[S1] MEDIUM — fail-closed default: APPLIED.** Dropped `:or {access-control
  :read}` in `make-search-query`; selection is now mandatory. The `case` has no
  default, so an omitted/typo'd key throws rather than silently selecting the
  read filter. Read callers pass `:access-control :read` explicitly; the comment
  is rewritten to describe this accurately.
- **[coupling] MEDIUM — direct write-clause unit test: APPLIED (no longer
  optional).** `find-write-restriction-query-part-test` pins the exact emitted
  `:should` vector and asserts no blanket public-TLP disjunct on the write path,
  so a read-side widening of the shared vector that leaked onto the delete path
  now breaks a unit test. This supersedes the "optional follow-up" note above.
- **[doc] LOW ×2 — APPLIED.** Write-filter docstring narrowed (blanket-visibility
  vs `authorized_users`/`authorized_groups` grants); `delete-search` docstring
  now says "a truthy `:really-delete?`".
- **[style] LOW — `normalize-ident` map/`:unset`: NOT APPLICABLE.** Current
  `normalize-ident` returns `{:login .. :groups ..}` with no `:unset` sentinel;
  both callers destructure the same two keys, so the map is the shared shape,
  not redundant.
- **[tests] LOW — feed DELETE /search route; `purge-incidents!` count: DEFERRED**
  (consistent with the first-review adjudication above).
