### PR TITLE
fix(flows): reject dangerous URL schemes on ingest (XFV-135)

### DIFF
--- a/src/ctia/domain/url_safety.clj
+++ b/src/ctia/domain/url_safety.clj
@@ -191,7 +191,17 @@
                  ;; intentionally not flagged, as CTIM URI fields are string-
                  ;; typed; the recursion only re-flags string values that again
                  ;; sit directly under a url-typed key.
-                 (for [item (if (coll? v) v [v])
+                 ;; `tree-seq` over the sequential/set nesting scans a value under a
+                 ;; url-typed key at ANY list depth: the earlier `(if (coll? v) v [v])`
+                 ;; unwrapped exactly one level, so `{:url [["javascript:.."]]}` slipped
+                 ;; through (the inner vector is a non-string, nil-guarded away, and the
+                 ;; recursion below then descends into a value no longer under a
+                 ;; url-typed key). Maps are deliberately NOT a branch here (only
+                 ;; `sequential?`/`set?`), so a nested Identity map under a url-typed key
+                 ;; is still handled only by the recursion, not flagged as a string here;
+                 ;; sets stay in scope (a set-valued url field is flagged as before).
+                 (for [item (tree-seq (some-fn sequential? set?) seq v)
+                       :when (string? item)
                        :let [scheme (unsafe-url-scheme item)]
                        :when scheme]
                    {:field k :scheme scheme :value item}))

--- a/src/ctia/domain/url_safety.clj
+++ b/src/ctia/domain/url_safety.clj
@@ -1,0 +1,201 @@
+(ns ctia.domain.url-safety
+  "Pure predicates backing the ingest URL-scheme gate (XFV-135), extracted from
+   ctia.flows.crud so the flow keeps only the thin `url-scheme-check` wrapper and
+   the security logic is unit-testable in isolation (mirroring how tlp/access-
+   control checks delegate to ctia.domain.access-control).
+
+   Defense-in-depth against stored XSS (CWE-79/CWE-116) via threat-intel URL
+   fields: a value in a URL-typed field whose scheme is not http(s) is reported
+   so the flow can reject it before it reaches a UI render sink. The primary XSS
+   control remains output-encoding at that sink, owned by the UI team; this is
+   the storage-layer backstop."
+  (:require
+   [clojure.string :as str]
+   [ctia.schemas.core :as schemas])
+  (:import
+   java.util.Locale))
+
+(def safe-url-schemes
+  "Allowlist of URL schemes permitted in URL-typed fields on ingest. Any other
+   scheme (javascript:, data:, vbscript:, ...) is rejected as defense-in-depth
+   against stored XSS via threat-intel URL fields (XFV-135). A value is
+   scheme-checked only when its prefix matches the RFC 3986 scheme grammar
+   (see `url-scheme-re`); truly scheme-less / relative values (e.g. \"/a/b\",
+   \"example.com/a\") carry no scheme and pass. An ambiguous bare authority such
+   as \"example.com:8080/path\" matches the RFC 3986 scheme grammar with scheme
+   \"example.com\" (java.net.URI/create accepts it as an absolute URI) and is
+   rejected as an unknown scheme, which is acceptable: CTIM URI-typed fields
+   carry absolute http(s) URLs, not bare host:port authorities."
+  #{"http" "https"})
+
+(def url-typed-keys
+  "Entity keys whose values may be CTIM URI-typed and are rendered as clickable
+   hyperlinks by downstream UIs. Kept in sync with the URI-typed entries across
+   CTIM schemas (:url, :source_uri, :origin_uri, :reason_uri). `:identity` is
+   included defensively: it is URI-typed only in RelatedIdentity (:identity a
+   URI ref) and is a nested map elsewhere (actor.cljc, identity_assertion.cljc);
+   a non-string :identity value is recursed into, not flagged (see
+   `collect-unsafe-url-fields`). This is a cross-schema hand-curation, not the
+   key set of a single schema.
+   These are the render-sinks reachable by an attacker via CTIA writes; free-text
+   fields and observable IOC values (which legitimately carry malicious URLs) are
+   intentionally NOT in this set. Matching is by key name at any nesting depth,
+   which assumes every field so named in a CTIM object is a URI-typed http(s)
+   field; a future same-named free-text field would need adding here."
+  #{:url :source_uri :origin_uri :reason_uri :identity})
+
+;; RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by ":"
+(def url-scheme-re #"(?i)^([a-z][a-z0-9+.\-]*):")
+
+(defn code-point->str
+  "Unicode code point -> String, or nil when out of range."
+  [n]
+  (when (<= 0 n 0x10FFFF)
+    (String. (Character/toChars n))))
+
+(def scheme-relevant-named-entities
+  "The HTML named character references that can help reconstruct a URL scheme at
+   the render sink, mapped to the character they decode to:
+     - \"amp\"     -> \"&\"  the entity-delimiter itself: `&amp;` is the canonical
+                             encoding of `&`, so `javascript&amp;colon;alert(1)`
+                             HTML-decodes to `javascript&colon;alert(1)` and then
+                             to `javascript:alert(1)`. Including it lets the
+                             fixed-point loop (see `decode-html-entities`) unmask
+                             this double-encoded delimiter, closing the gap its
+                             numeric twin `&#38;colon;` already covered.
+     - \"colon\"   -> \":\"  the scheme delimiter, the one structural char with a
+                             named reference: `javascript&colon;alert(1)`.
+     - \"tab\"     -> \"\\t\" and
+     - \"newline\" -> \"\\n\" whitespace the WHATWG URL parser strips from anywhere
+                             in a URL, so `java&NewLine;script:...` -> `javascript:`.
+   No HTML5 named reference decodes to a single ASCII *letter* usable to spell a
+   scheme name (the sole ASCII-letter-producing entity, &fjlig; -> \"fj\", cannot
+   form any executable scheme), so an attacker can only hide the `&`/`:` delimiters
+   or insert tab/newline between the letters -- this closed, scheme-relevant set is
+   what the gate decodes. Named references that decode to a non-scheme, non-parser-
+   stripped character (e.g. &ZeroWidthSpace; -> U+200B, which the WHATWG URL parser
+   does NOT strip from a scheme) cannot reconstruct an executable scheme and are
+   deliberately left encoded. Matched case-insensitively since over-decoding can
+   only reveal a scheme, never create a false positive on a legitimate http(s) URL."
+  {"amp" "&" "colon" ":" "tab" "\t" "newline" "\n"})
+
+(defn decode-html-entities
+  "Decodes the HTML character references an attacker could use to obfuscate a URL
+   scheme, so the scheme is unmasked before extraction: numeric (&#NN;), hex
+   (&#xHH;), and the scheme-relevant NAMED references (&amp; &colon; &Tab;
+   &NewLine;; see `scheme-relevant-named-entities`). Decoding can only *reveal* a
+   scheme (e.g. \"javascript&colon;...\" -> \"javascript:...\"); it never turns a
+   legitimate http(s) URL into a dangerous one -- the scheme sits at the front and
+   is extracted first, so a decoded `&amp;`/`&colon;` in a query string cannot
+   change it. It CAN surface a scheme on a *scheme-less* value that encoded a colon
+   (e.g. a filename \"report&#58;final.pdf\" -> \"report:final.pdf\", rejected as a
+   non-http(s) scheme); URI-typed fields are expected to carry absolute http(s)
+   URLs, so that rejection is acceptable rather than a false positive on a URL.
+   Downstream HTML output-encoding remains the primary XSS control.
+
+   Decoding is iterated to a fixed point under a bounded loop so a reference that
+   only becomes visible after an *outer* reference is decoded is still unmasked:
+   \"javascript&#38;colon;alert(1)\" -> \"javascript&colon;alert(1)\" ->
+   \"javascript:alert(1)\". Each pass peels one encoding layer (a decoded entity
+   collapses to a single character, shortening the string) or leaves it byte-
+   identical (an unparseable / oversized numeric entity is left untouched, which is
+   the loop's exit condition), so it always converges. The budget is load-bearing,
+   not merely a safety net: it caps the peel depth, so a value nested deeper than
+   the budget (9+ stacked `&#38;`) is left partially-encoded -- which fails safe,
+   since a partially-encoded value does not present an http(s)-or-dangerous scheme
+   and a browser HTML-decodes only one layer per render, never reaching the payload
+   in a single hop."
+  [s]
+  (letfn [(num-ref [m digits radix]
+            (or (some-> (try (Integer/parseInt digits radix)
+                             (catch NumberFormatException _ nil))
+                        code-point->str)
+                ;; unparseable / oversized code point: leave the text untouched
+                m))
+          (decode-once [s]
+            (-> s
+                (str/replace #"(?i)&(amp|colon|tab|newline);"
+                             (fn [[m nm]]
+                               ;; Locale/ROOT: str/lower-case uses the JVM default
+                               ;; locale, under which tr/az lowercase "NEWLINE" to
+                               ;; "newlıne" (dotless i), missing the map; the `or`
+                               ;; also nil-guards so a miss leaves the text untouched
+                               ;; rather than NPE-ing str/replace out to a 500.
+                               (or (scheme-relevant-named-entities
+                                    (.toLowerCase ^String nm Locale/ROOT))
+                                   m)))
+                (str/replace #"(?i)&#x([0-9a-f]+);?" (fn [[m d]] (num-ref m d 16)))
+                (str/replace #"&#([0-9]+);?"         (fn [[m d]] (num-ref m d 10)))))]
+    (loop [prev s, budget 8]
+      (let [decoded (decode-once prev)]
+        (if (or (= decoded prev) (zero? budget))
+          decoded
+          (recur decoded (dec budget)))))))
+
+(defn unsafe-url-scheme
+  "When `v` is a string carrying a URL scheme not in `safe-url-schemes`, returns
+   that (lower-cased) scheme; otherwise nil. HTML entities are decoded and
+   control/whitespace/format characters stripped before scheme extraction,
+   because browsers ignore such characters when resolving a URL (so
+   \"java\\tscript:...\", \"&#106;avascript:...\" and \"javascript&colon;...\" all
+   resolve to \"javascript:...\"). The strip class covers ASCII C0 controls and
+   space (\\x00-\\x20, \\x7f) plus the non-ASCII ignorables the decoder can emit --
+   Unicode format chars (\\p{Cf}: ZWSP U+200B, BOM U+FEFF, SOFT HYPHEN U+00AD, ...)
+   and separators (\\p{Z}: NBSP U+00A0, ...) -- so \"java&#8203;script:\" and
+   \"&#65279;javascript:\" are unmasked, not just their ASCII twins.
+
+   Transient references (`transient:...`) are CTIA-internal placeholders callers
+   put in URI-typed fields (e.g. :source_uri) to cross-link entities in a bulk
+   submission. They are exempt because `transient:` is not a browser-executable
+   scheme -- so even an unresolved `transient:<arbitrary>` is inert at the render
+   sink. (CTIA transient IDs are arbitrary client-chosen strings, e.g.
+   \"transient:0\", not necessarily UUIDs, and a plain URI field like :source_uri
+   is not a reference field the flow rewrites, so the exemption cannot rest on
+   rewriting.) This check also runs before transient IDs are resolved (see
+   ctia.flows.crud/validate-entities -> create-ids-from-transient)."
+  [v]
+  (when (and (string? v)
+             (not (schemas/transient-id? v)))
+    (let [normalized (-> v
+                         decode-html-entities
+                         (str/replace #"[\x00-\x20\x7f\p{Cf}\p{Z}]" ""))]
+      (when-let [raw (some-> (re-find url-scheme-re normalized) second)]
+        ;; Locale/ROOT for the same reason as the decoder: str/lower-case would
+        ;; fold under the JVM default locale (tr/az dotted-i). No security impact
+        ;; today (no safe scheme contains an "i"), but keeps the two lower-casings
+        ;; consistent and locale-independent.
+        (let [scheme (.toLowerCase ^String raw Locale/ROOT)]
+          (when-not (contains? safe-url-schemes scheme)
+            scheme))))))
+
+(defn collect-unsafe-url-fields
+  "Recursively walks `x` (maps/vectors/sets) and returns a seq of
+   {:field <key> :scheme <scheme> :value <string>} for every URL-typed field
+   whose value carries a disallowed scheme. Only string values under
+   `url-typed-keys` are checked; non-string values (e.g. a nested Identity map
+   under :identity) are recursed into rather than flagged. `:value` carries the
+   exact offending string so the caller can diff against prev-entity and flag only
+   newly-introduced values."
+  [x]
+  (cond
+    (map? x)
+    (mapcat (fn [[k v]]
+              (concat
+               (when (contains? url-typed-keys k)
+                 ;; unsafe-url-scheme nil-guards non-strings, so a uniform scan
+                 ;; over one-or-many values suffices. Only STRING values under a
+                 ;; URL-typed key are flagged here; a map value (e.g. a nested
+                 ;; Identity under :identity) yields no string here and is
+                 ;; recursed into below -- a dangerous scheme nested under a
+                 ;; NON-URL-typed key (e.g. {:url {:inner "js:.."}}) is
+                 ;; intentionally not flagged, as CTIM URI fields are string-
+                 ;; typed; the recursion only re-flags string values that again
+                 ;; sit directly under a url-typed key.
+                 (for [item (if (coll? v) v [v])
+                       :let [scheme (unsafe-url-scheme item)]
+                       :when scheme]
+                   {:field k :scheme scheme :value item}))
+               (collect-unsafe-url-fields v)))
+            x)
+    (coll? x) (mapcat collect-unsafe-url-fields x)
+    :else nil))

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -11,6 +11,7 @@
    [ctia.domain.access-control :refer [allowed-tlp? allowed-tlps
                                          validate-authorized-groups
                                          validate-authorized-users]]
+   [ctia.domain.url-safety :as url-safety]
    [ctia.entity.event.obj-to-event :refer
     [to-create-event to-delete-event to-update-event]]
    [ctia.lib.collection :as coll]
@@ -167,173 +168,14 @@
        :foreign foreign}
       entity)))
 
-(def ^:private safe-url-schemes
-  "Allowlist of URL schemes permitted in URL-typed fields on ingest. Any other
-   scheme (javascript:, data:, vbscript:, ...) is rejected as defense-in-depth
-   against stored XSS via threat-intel URL fields (XFV-135). A value is
-   scheme-checked only when its prefix matches the RFC 3986 scheme grammar
-   (see `url-scheme-re`); truly scheme-less / relative values (e.g. \"/a/b\",
-   \"example.com/a\") carry no scheme and pass. An ambiguous bare authority such
-   as \"example.com:8080/path\" matches the RFC 3986 scheme grammar with scheme
-   \"example.com\" (java.net.URI/create accepts it as an absolute URI) and is
-   rejected as an unknown scheme, which is acceptable: CTIM URI-typed fields
-   carry absolute http(s) URLs, not bare host:port authorities."
-  #{"http" "https"})
-
-(def ^:private url-typed-keys
-  "Entity keys whose values may be CTIM URI-typed and are rendered as clickable
-   hyperlinks by downstream UIs. Kept in sync with the URI-typed entries across
-   CTIM schemas (:url, :source_uri, :origin_uri, :reason_uri). `:identity` is
-   included defensively: it is URI-typed only in RelatedIdentity (:identity a
-   URI ref) and is a nested map elsewhere (actor.cljc, identity_assertion.cljc);
-   a non-string :identity value is recursed into, not flagged (see
-   `collect-unsafe-url-fields`). This is a cross-schema hand-curation, not the
-   key set of a single schema.
-   These are the render-sinks reachable by an attacker via CTIA writes; free-text
-   fields and observable IOC values (which legitimately carry malicious URLs) are
-   intentionally NOT in this set. Matching is by key name at any nesting depth,
-   which assumes every field so named in a CTIM object is a URI-typed http(s)
-   field; a future same-named free-text field would need adding here."
-  #{:url :source_uri :origin_uri :reason_uri :identity})
-
-;; RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by ":"
-(def ^:private url-scheme-re #"(?i)^([a-z][a-z0-9+.\-]*):")
-
-(defn- code-point->str
-  "Unicode code point -> String, or nil when out of range."
-  [n]
-  (when (<= 0 n 0x10FFFF)
-    (String. (Character/toChars n))))
-
-(def ^:private scheme-relevant-named-entities
-  "The only HTML named character references that can help reconstruct a URL
-   scheme at the render sink, mapped to the character they decode to. No HTML5
-   named reference decodes to a single ASCII letter usable to spell a scheme name
-   (the sole ASCII-letter-producing entity, &fjlig; -> \"fj\", cannot form any
-   executable scheme), so an attacker can only hide the ':' scheme delimiter or
-   insert tab/newline (which the WHATWG URL parser strips from anywhere in a URL)
-   between the letters:
-     javascript&colon;alert(1)   -> javascript:alert(1)
-     java&NewLine;script:alert(1) -> java\\nscript:alert(1) -> javascript:...
-   CR and other C0 controls have no HTML5 named reference (only numeric, handled
-   separately). This closed set is therefore sufficient; matched case-insensitively
-   since over-decoding can only reveal a scheme, never create a false positive."
-  {"colon" ":" "tab" "\t" "newline" "\n"})
-
-(defn- decode-html-entities
-  "Decodes the HTML character references an attacker could use to obfuscate a URL
-   scheme, so the scheme is unmasked before extraction: numeric (&#NN;), hex
-   (&#xHH;), and the scheme-relevant NAMED references (&colon; &Tab; &NewLine;;
-   see `scheme-relevant-named-entities`). Decoding can only *reveal* a scheme
-   (e.g. \"javascript&colon;...\" -> \"javascript:...\"); it never turns a
-   legitimate http(s) URL into a dangerous one, so it adds no false positives.
-   Downstream HTML output-encoding remains the primary XSS control.
-
-   Decoding is iterated to a fixed point (bounded) so a reference that only
-   becomes visible after an *outer* reference is decoded is still unmasked:
-   \"javascript&#38;colon;alert(1)\" -> \"javascript&colon;alert(1)\" ->
-   \"javascript:alert(1)\". Every pass either shortens the string (a decoded
-   entity collapses to a single character) or leaves it byte-identical (an
-   unparseable / oversized numeric entity is left untouched, which is the loop's
-   exit condition), so it always converges; the budget only guards against an
-   unforeseen non-shrinking case."
-  [s]
-  (letfn [(num-ref [m digits radix]
-            (or (some-> (try (Integer/parseInt digits radix)
-                             (catch NumberFormatException _ nil))
-                        code-point->str)
-                ;; unparseable / oversized code point: leave the text untouched
-                m))
-          (decode-once [s]
-            (-> s
-                (str/replace #"(?i)&(colon|tab|newline);"
-                             (fn [[m nm]]
-                               ;; Locale/ROOT: str/lower-case uses the JVM default
-                               ;; locale, under which tr/az lowercase "NEWLINE" to
-                               ;; "newlıne" (dotless i), missing the map; the `or`
-                               ;; also nil-guards so a miss leaves the text untouched
-                               ;; rather than NPE-ing str/replace out to a 500.
-                               (or (scheme-relevant-named-entities
-                                    (.toLowerCase ^String nm java.util.Locale/ROOT))
-                                   m)))
-                (str/replace #"(?i)&#x([0-9a-f]+);?" (fn [[m d]] (num-ref m d 16)))
-                (str/replace #"&#([0-9]+);?"         (fn [[m d]] (num-ref m d 10)))))]
-    (loop [prev s, budget 8]
-      (let [decoded (decode-once prev)]
-        (if (or (= decoded prev) (zero? budget))
-          decoded
-          (recur decoded (dec budget)))))))
-
-(defn- unsafe-url-scheme
-  "When `v` is a string carrying a URL scheme not in `safe-url-schemes`, returns
-   that (lower-cased) scheme; otherwise nil. HTML entities are decoded and
-   control/whitespace/format characters stripped before scheme extraction,
-   because browsers ignore such characters when resolving a URL (so
-   \"java\\tscript:...\", \"&#106;avascript:...\" and \"javascript&colon;...\" all
-   resolve to \"javascript:...\"). The strip class covers ASCII C0 controls and
-   space (\\x00-\\x20, \\x7f) plus the non-ASCII ignorables the decoder can emit --
-   Unicode format chars (\\p{Cf}: ZWSP U+200B, BOM U+FEFF, SOFT HYPHEN U+00AD, ...)
-   and separators (\\p{Z}: NBSP U+00A0, ...) -- so \"java&#8203;script:\" and
-   \"&#65279;javascript:\" are unmasked, not just their ASCII twins.
-
-   Transient references (`transient:...`) are CTIA-internal placeholders callers
-   put in URI-typed fields (e.g. :source_uri) to cross-link entities in a bulk
-   submission. They are exempt because `transient:` is not a browser-executable
-   scheme -- so even an unresolved `transient:<arbitrary>` is inert at the render
-   sink. (CTIA transient IDs are arbitrary client-chosen strings, e.g.
-   \"transient:0\", not necessarily UUIDs, and a plain URI field like :source_uri
-   is not a reference field the flow rewrites, so the exemption cannot rest on
-   rewriting.) This check also runs before transient IDs are resolved (see
-   `validate-entities` -> `create-ids-from-transient`)."
-  [v]
-  (when (and (string? v)
-             (not (schemas/transient-id? v)))
-    (let [normalized (-> v
-                         decode-html-entities
-                         (str/replace #"[\x00-\x20\x7f\p{Cf}\p{Z}]" ""))]
-      (when-let [scheme (some-> (re-find url-scheme-re normalized)
-                                second
-                                str/lower-case)]
-        (when-not (contains? safe-url-schemes scheme)
-          scheme)))))
-
-(defn- collect-unsafe-url-fields
-  "Recursively walks `x` (maps/vectors/sets) and returns a seq of
-   {:field <key> :scheme <scheme> :value <string>} for every URL-typed field
-   whose value carries a disallowed scheme. Only string values under
-   `url-typed-keys` are checked; non-string values (e.g. a nested Identity map
-   under :identity) are recursed into rather than flagged. `:value` carries the
-   exact offending string so `url-scheme-check` can diff against prev-entity and
-   flag only newly-introduced values."
-  [x]
-  (cond
-    (map? x)
-    (mapcat (fn [[k v]]
-              (concat
-               (when (contains? url-typed-keys k)
-                 ;; unsafe-url-scheme nil-guards non-strings, so a uniform scan
-                 ;; over one-or-many values suffices. Only STRING values under a
-                 ;; URL-typed key are flagged here; a map value (e.g. a nested
-                 ;; Identity under :identity) yields no string here and is
-                 ;; recursed into below -- a dangerous scheme nested under a
-                 ;; NON-URL-typed key (e.g. {:url {:inner "js:.."}}) is
-                 ;; intentionally not flagged, as CTIM URI fields are string-
-                 ;; typed; the recursion only re-flags string values that again
-                 ;; sit directly under a url-typed key.
-                 (for [item (if (coll? v) v [v])
-                       :let [scheme (unsafe-url-scheme item)]
-                       :when scheme]
-                   {:field k :scheme scheme :value item}))
-               (collect-unsafe-url-fields v)))
-            x)
-    (coll? x) (mapcat collect-unsafe-url-fields x)
-    :else nil))
-
 (defn url-scheme-check
   "Rejects entities carrying a disallowed URL scheme (javascript:, data:,
    vbscript:, ...) in any URL-typed field. Defense-in-depth against stored XSS
    via threat-intel URL fields (XFV-135). Passes through an entity that a prior
-   check already turned into an error map.
+   check already turned into an error map. The pure predicates live in
+   `ctia.domain.url-safety` (mirroring how `tlp-check`/`authorized-*-check`
+   delegate to `ctia.domain.access-control`); this wrapper adds the prev-entity
+   diff, the error map, and the flow-level short-circuit.
 
    Like `authorized-groups-check`/`authorized-users-check`, this gates only the
    values the caller is *introducing* relative to the stored `prev-entity` (see
@@ -342,16 +184,20 @@
    sends only {:status ...}, but `patch-entities` deep-merges the whole prev-entity
    (including its :source_uri) before this runs, so re-validating the full document
    would 400 a status update that never mentioned the URI on a value predating the
-   gate. On create `prev-entity` is nil, so every value is checked. A dangerous
-   scheme thus can never be *newly* written; a pre-gate value persisting until a
-   data migration cleans it up is the accepted tradeoff (identical to the two
-   authorized_* checks)."
+   gate. On create `prev-entity` is nil, so every value is checked.
+
+   The diff is value-level, not occurrence-level (`set/difference` over
+   {:field :scheme :value}): no dangerous *value* absent from the stored entity can
+   be introduced, but re-writing another copy of a value already stored on the same
+   document is not blocked -- there is no NEW payload, so the render-sink exposure is
+   unchanged. A pre-gate value persisting until a data migration cleans it up is the
+   accepted tradeoff (identical to the two authorized_* checks)."
   [entity prev-entity]
   (if (:error entity)
     entity
     (let [introduced (set/difference
-                      (set (collect-unsafe-url-fields entity))
-                      (set (collect-unsafe-url-fields prev-entity)))
+                      (set (url-safety/collect-unsafe-url-fields entity))
+                      (set (url-safety/collect-unsafe-url-fields prev-entity)))
           ;; dedupe/sort on field+scheme for a stable message (multiple distinct
           ;; offending values in one field collapse to a single "field (scheme:)")
           labels (->> introduced
@@ -362,7 +208,7 @@
       (if (seq labels)
         {:msg (format "Disallowed URL scheme in field(s): %s. Allowed schemes: %s"
                       (str/join ", " labels)
-                      (str/join ", " (sort safe-url-schemes)))
+                      (str/join ", " (sort url-safety/safe-url-schemes)))
          :error "Entity validation Error"
          :type :unsafe-url-scheme-error
          :entity entity}

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -236,9 +236,18 @@
    control/whitespace characters stripped before scheme extraction, because
    browsers ignore such characters when resolving a URL (so \"java\\tscript:...\",
    \"&#106;avascript:...\" and \"javascript&colon;...\" all resolve to
-   \"javascript:...\")."
+   \"javascript:...\").
+
+   Transient references (`transient:<uuid>`) are CTIA-internal placeholders that
+   callers put in URI-typed fields (e.g. :source_uri) to cross-link entities in
+   a bulk submission; the flow rewrites them to real http(s) IDs during ingest,
+   and `transient:` is not a browser-executable scheme, so they are exempt. This
+   check runs before transient IDs are resolved (see `validate-entities` ->
+   `create-ids-from-transient`), so without this exemption every bulk relationship
+   carrying a transient :source_uri would be wrongly rejected."
   [v]
-  (when (string? v)
+  (when (and (string? v)
+             (not (schemas/transient-id? v)))
     (let [normalized (-> v
                          decode-html-entities
                          (str/replace #"[\x00-\x20\x7f]" ""))]

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -186,13 +186,25 @@
    would 400 a status update that never mentioned the URI on a value predating the
    gate. On create `prev-entity` is nil, so every value is checked.
 
-   The diff is value-level, not occurrence-level (`set/difference` over
-   {:field :scheme :value}): no dangerous *value* absent from the stored entity can
-   be introduced, but re-writing another copy of a value already stored on the same
-   document is not blocked -- there is no NEW payload, so the render-sink exposure is
-   unchanged. A pre-gate value persisting until a data migration cleans it up is the
-   accepted tradeoff (identical to the two authorized_* checks)."
-  [entity prev-entity]
+   The diff is value-level, not occurrence- or path-level (`set/difference` over
+   {:field :scheme :value}): no dangerous scheme+value pair absent from the stored
+   entity can be introduced, but re-writing another copy of a pair already stored on
+   the document is not blocked -- including a copy that lands under the same-named
+   url-typed key at a different path (e.g. a top-level :url value also placed in an
+   external_references[].url, which shares the {:field :url ...} diff element). This
+   is an accepted tradeoff, not an oversight: the pair is already stored and therefore
+   already renders at a url-typed sink, so the attacker's payload already fires -- an
+   additional byte-identical sink of an already-renderable value grants no new
+   scheme/value capability, and cannot escalate between url-typed keys, which are all
+   equally render sinks by definition. A path-aware / multiset diff would add
+   complexity for no change to the invariant that matters: no dangerous value renders
+   that was not already renderable. A pre-gate value persisting until a data migration
+   cleans it up is the accepted tradeoff (identical to the two authorized_* checks).
+
+   `ident-map` (threaded from `validate-entities`, as the two authorized_* checks are)
+   is carried into the error map as `:login`/`:groups` so the :warn log lets operators
+   attribute a burst of rejected `javascript:` writes to a caller."
+  [entity prev-entity ident-map]
   (if (:error entity)
     entity
     (let [introduced (set/difference
@@ -211,7 +223,9 @@
                       (str/join ", " (sort url-safety/safe-url-schemes)))
          :error "Entity validation Error"
          :type :unsafe-url-scheme-error
-         :entity entity}
+         :entity entity
+         :login (:login ident-map)
+         :groups (:groups ident-map)}
         entity))))
 
 (s/defn ^:private validate-entities :- FlowMap
@@ -233,7 +247,7 @@
                         (tlp-check get-in-config)
                         (authorized-groups-check prev-entity ident-map)
                         (authorized-users-check prev-entity ident-map)
-                        (url-scheme-check prev-entity))))
+                        (url-scheme-check prev-entity ident-map))))
                 entities))))
 
 (s/defn ^:private create-ids-from-transient :- FlowMap

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -174,17 +174,21 @@
    scheme-checked only when its prefix matches the RFC 3986 scheme grammar
    (see `url-scheme-re`); truly scheme-less / relative values (e.g. \"/a/b\",
    \"example.com/a\") carry no scheme and pass. An ambiguous bare authority such
-   as \"example.com:8080/path\" parses as scheme \"example.com\" and is rejected,
-   which is acceptable: such values are not valid absolute URIs and do not occur
-   in CTIM URI-typed fields."
+   as \"example.com:8080/path\" matches the RFC 3986 scheme grammar with scheme
+   \"example.com\" (java.net.URI/create accepts it as an absolute URI) and is
+   rejected as an unknown scheme, which is acceptable: CTIM URI-typed fields
+   carry absolute http(s) URLs, not bare host:port authorities."
   #{"http" "https"})
 
 (def ^:private url-typed-keys
-  "Entity keys whose values are CTIM URI-typed and are rendered as clickable
+  "Entity keys whose values may be CTIM URI-typed and are rendered as clickable
    hyperlinks by downstream UIs. Kept in sync with the URI-typed entries across
-   CTIM schemas (:url, :source_uri, :origin_uri, :identity in ctim.schemas.common;
-   :reason_uri in ctim.schemas.judgement). This is a cross-schema hand-curation,
-   not the key set of a single schema.
+   CTIM schemas (:url, :source_uri, :origin_uri, :reason_uri). `:identity` is
+   included defensively: it is URI-typed only in RelatedIdentity (:identity a
+   URI ref) and is a nested map elsewhere (actor.cljc, identity_assertion.cljc);
+   a non-string :identity value is recursed into, not flagged (see
+   `collect-unsafe-url-fields`). This is a cross-schema hand-curation, not the
+   key set of a single schema.
    These are the render-sinks reachable by an attacker via CTIA writes; free-text
    fields and observable IOC values (which legitimately carry malicious URLs) are
    intentionally NOT in this set. Matching is by key name at any nesting depth,
@@ -223,41 +227,70 @@
    see `scheme-relevant-named-entities`). Decoding can only *reveal* a scheme
    (e.g. \"javascript&colon;...\" -> \"javascript:...\"); it never turns a
    legitimate http(s) URL into a dangerous one, so it adds no false positives.
-   Downstream HTML output-encoding remains the primary XSS control."
+   Downstream HTML output-encoding remains the primary XSS control.
+
+   Decoding is iterated to a fixed point (bounded) so a reference that only
+   becomes visible after an *outer* reference is decoded is still unmasked:
+   \"javascript&#38;colon;alert(1)\" -> \"javascript&colon;alert(1)\" ->
+   \"javascript:alert(1)\". Every pass either shortens the string (a decoded
+   entity collapses to a single character) or leaves it byte-identical (an
+   unparseable / oversized numeric entity is left untouched, which is the loop's
+   exit condition), so it always converges; the budget only guards against an
+   unforeseen non-shrinking case."
   [s]
   (letfn [(num-ref [m digits radix]
             (or (some-> (try (Integer/parseInt digits radix)
                              (catch NumberFormatException _ nil))
                         code-point->str)
                 ;; unparseable / oversized code point: leave the text untouched
-                m))]
-    (-> s
-        (str/replace #"(?i)&(colon|tab|newline);"
-                     (fn [[_ nm]] (scheme-relevant-named-entities (str/lower-case nm))))
-        (str/replace #"(?i)&#x([0-9a-f]+);?" (fn [[m d]] (num-ref m d 16)))
-        (str/replace #"&#([0-9]+);?"         (fn [[m d]] (num-ref m d 10))))))
+                m))
+          (decode-once [s]
+            (-> s
+                (str/replace #"(?i)&(colon|tab|newline);"
+                             (fn [[m nm]]
+                               ;; Locale/ROOT: str/lower-case uses the JVM default
+                               ;; locale, under which tr/az lowercase "NEWLINE" to
+                               ;; "newlıne" (dotless i), missing the map; the `or`
+                               ;; also nil-guards so a miss leaves the text untouched
+                               ;; rather than NPE-ing str/replace out to a 500.
+                               (or (scheme-relevant-named-entities
+                                    (.toLowerCase ^String nm java.util.Locale/ROOT))
+                                   m)))
+                (str/replace #"(?i)&#x([0-9a-f]+);?" (fn [[m d]] (num-ref m d 16)))
+                (str/replace #"&#([0-9]+);?"         (fn [[m d]] (num-ref m d 10)))))]
+    (loop [prev s, budget 8]
+      (let [decoded (decode-once prev)]
+        (if (or (= decoded prev) (zero? budget))
+          decoded
+          (recur decoded (dec budget)))))))
 
 (defn- unsafe-url-scheme
   "When `v` is a string carrying a URL scheme not in `safe-url-schemes`, returns
-   that (lower-cased) scheme; otherwise nil. HTML entities are decoded and ASCII
-   control/whitespace characters stripped before scheme extraction, because
-   browsers ignore such characters when resolving a URL (so \"java\\tscript:...\",
-   \"&#106;avascript:...\" and \"javascript&colon;...\" all resolve to
-   \"javascript:...\").
+   that (lower-cased) scheme; otherwise nil. HTML entities are decoded and
+   control/whitespace/format characters stripped before scheme extraction,
+   because browsers ignore such characters when resolving a URL (so
+   \"java\\tscript:...\", \"&#106;avascript:...\" and \"javascript&colon;...\" all
+   resolve to \"javascript:...\"). The strip class covers ASCII C0 controls and
+   space (\\x00-\\x20, \\x7f) plus the non-ASCII ignorables the decoder can emit --
+   Unicode format chars (\\p{Cf}: ZWSP U+200B, BOM U+FEFF, SOFT HYPHEN U+00AD, ...)
+   and separators (\\p{Z}: NBSP U+00A0, ...) -- so \"java&#8203;script:\" and
+   \"&#65279;javascript:\" are unmasked, not just their ASCII twins.
 
-   Transient references (`transient:<uuid>`) are CTIA-internal placeholders that
-   callers put in URI-typed fields (e.g. :source_uri) to cross-link entities in
-   a bulk submission; the flow rewrites them to real http(s) IDs during ingest,
-   and `transient:` is not a browser-executable scheme, so they are exempt. This
-   check runs before transient IDs are resolved (see `validate-entities` ->
-   `create-ids-from-transient`), so without this exemption every bulk relationship
-   carrying a transient :source_uri would be wrongly rejected."
+   Transient references (`transient:...`) are CTIA-internal placeholders callers
+   put in URI-typed fields (e.g. :source_uri) to cross-link entities in a bulk
+   submission. They are exempt because `transient:` is not a browser-executable
+   scheme -- so even an unresolved `transient:<arbitrary>` is inert at the render
+   sink. (CTIA transient IDs are arbitrary client-chosen strings, e.g.
+   \"transient:0\", not necessarily UUIDs, and a plain URI field like :source_uri
+   is not a reference field the flow rewrites, so the exemption cannot rest on
+   rewriting.) This check also runs before transient IDs are resolved (see
+   `validate-entities` -> `create-ids-from-transient`)."
   [v]
   (when (and (string? v)
              (not (schemas/transient-id? v)))
     (let [normalized (-> v
                          decode-html-entities
-                         (str/replace #"[\x00-\x20\x7f]" ""))]
+                         (str/replace #"[\x00-\x20\x7f\p{Cf}\p{Z}]" ""))]
       (when-let [scheme (some-> (re-find url-scheme-re normalized)
                                 second
                                 str/lower-case)]
@@ -266,10 +299,12 @@
 
 (defn- collect-unsafe-url-fields
   "Recursively walks `x` (maps/vectors/sets) and returns a seq of
-   {:field <key> :scheme <scheme>} for every URL-typed field whose value carries
-   a disallowed scheme. Only string values under `url-typed-keys` are checked;
-   non-string values (e.g. a nested Identity map under :identity) are recursed
-   into rather than flagged."
+   {:field <key> :scheme <scheme> :value <string>} for every URL-typed field
+   whose value carries a disallowed scheme. Only string values under
+   `url-typed-keys` are checked; non-string values (e.g. a nested Identity map
+   under :identity) are recursed into rather than flagged. `:value` carries the
+   exact offending string so `url-scheme-check` can diff against prev-entity and
+   flag only newly-introduced values."
   [x]
   (cond
     (map? x)
@@ -277,11 +312,18 @@
               (concat
                (when (contains? url-typed-keys k)
                  ;; unsafe-url-scheme nil-guards non-strings, so a uniform scan
-                 ;; over one-or-many values suffices (keep drops the nils). A map
-                 ;; value yields only non-string entries here and is flagged by
-                 ;; the recursion below, never by this branch.
-                 (for [s (keep unsafe-url-scheme (if (coll? v) v [v]))]
-                   {:field k :scheme s}))
+                 ;; over one-or-many values suffices. Only STRING values under a
+                 ;; URL-typed key are flagged here; a map value (e.g. a nested
+                 ;; Identity under :identity) yields no string here and is
+                 ;; recursed into below -- a dangerous scheme nested under a
+                 ;; NON-URL-typed key (e.g. {:url {:inner "js:.."}}) is
+                 ;; intentionally not flagged, as CTIM URI fields are string-
+                 ;; typed; the recursion only re-flags string values that again
+                 ;; sit directly under a url-typed key.
+                 (for [item (if (coll? v) v [v])
+                       :let [scheme (unsafe-url-scheme item)]
+                       :when scheme]
+                   {:field k :scheme scheme :value item}))
                (collect-unsafe-url-fields v)))
             x)
     (coll? x) (mapcat collect-unsafe-url-fields x)
@@ -291,16 +333,35 @@
   "Rejects entities carrying a disallowed URL scheme (javascript:, data:,
    vbscript:, ...) in any URL-typed field. Defense-in-depth against stored XSS
    via threat-intel URL fields (XFV-135). Passes through an entity that a prior
-   check already turned into an error map."
-  [entity]
+   check already turned into an error map.
+
+   Like `authorized-groups-check`/`authorized-users-check`, this gates only the
+   values the caller is *introducing* relative to the stored `prev-entity` (see
+   `introduced-foreign`): a disallowed value byte-identical to one already stored
+   is not re-flagged. This matters on update/patch -- e.g. POST /incident/:id/status
+   sends only {:status ...}, but `patch-entities` deep-merges the whole prev-entity
+   (including its :source_uri) before this runs, so re-validating the full document
+   would 400 a status update that never mentioned the URI on a value predating the
+   gate. On create `prev-entity` is nil, so every value is checked. A dangerous
+   scheme thus can never be *newly* written; a pre-gate value persisting until a
+   data migration cleans it up is the accepted tradeoff (identical to the two
+   authorized_* checks)."
+  [entity prev-entity]
   (if (:error entity)
     entity
-    (let [offending (seq (distinct (collect-unsafe-url-fields entity)))]
-      (if offending
+    (let [introduced (set/difference
+                      (set (collect-unsafe-url-fields entity))
+                      (set (collect-unsafe-url-fields prev-entity)))
+          ;; dedupe/sort on field+scheme for a stable message (multiple distinct
+          ;; offending values in one field collapse to a single "field (scheme:)")
+          labels (->> introduced
+                      (map (fn [{:keys [field scheme]}]
+                             (format "%s (%s:)" (name field) scheme)))
+                      distinct
+                      sort)]
+      (if (seq labels)
         {:msg (format "Disallowed URL scheme in field(s): %s. Allowed schemes: %s"
-                      (str/join ", " (map (fn [{:keys [field scheme]}]
-                                            (format "%s (%s:)" (name field) scheme))
-                                          offending))
+                      (str/join ", " labels)
                       (str/join ", " (sort safe-url-schemes)))
          :error "Entity validation Error"
          :type :unsafe-url-scheme-error
@@ -315,9 +376,10 @@
   (let [ident-map (auth/ident->map identity-obj)]
     (assoc fm :entities
            (map (fn [entity]
-                  ;; On update/patch, validate only the authorized_* values the
-                  ;; caller introduces relative to the stored entity (see CR1);
-                  ;; on create there is no prev-entity so everything is checked.
+                  ;; On update/patch, validate only the values the caller
+                  ;; introduces relative to the stored entity (authorized_* and
+                  ;; URL scheme alike, see CR1); on create there is no prev-entity
+                  ;; so everything is checked.
                   (let [prev-entity (when (and get-prev-entity (:id entity))
                                       (get-prev-entity (:id entity)))]
                     (-> entity
@@ -325,7 +387,7 @@
                         (tlp-check get-in-config)
                         (authorized-groups-check prev-entity ident-map)
                         (authorized-users-check prev-entity ident-map)
-                        url-scheme-check)))
+                        (url-scheme-check prev-entity))))
                 entities))))
 
 (s/defn ^:private create-ids-from-transient :- FlowMap

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -167,6 +167,130 @@
        :foreign foreign}
       entity)))
 
+(def ^:private safe-url-schemes
+  "Allowlist of URL schemes permitted in URL-typed fields on ingest. Any other
+   scheme (javascript:, data:, vbscript:, ...) is rejected as defense-in-depth
+   against stored XSS via threat-intel URL fields (XFV-135). Scheme-less /
+   relative values carry no scheme and are always allowed."
+  #{"http" "https"})
+
+(def ^:private url-typed-keys
+  "Entity keys whose values are CTIM URI-typed and are rendered as clickable
+   hyperlinks by downstream UIs. Kept in sync with the URI-typed entries in
+   ctim.schemas.common (:url, :source_uri, :origin_uri, :reason_uri, :identity).
+   These are the render-sinks reachable by an attacker via CTIA writes; free-text
+   fields and observable IOC values (which legitimately carry malicious URLs) are
+   intentionally NOT in this set. Matching is by key name at any nesting depth,
+   which assumes every field so named in a CTIM object is a URI-typed http(s)
+   field; a future same-named free-text field would need adding here."
+  #{:url :source_uri :origin_uri :reason_uri :identity})
+
+;; RFC 3986 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) followed by ":"
+(def ^:private url-scheme-re #"(?i)^([a-z][a-z0-9+.\-]*):")
+
+(defn- code-point->str
+  "Unicode code point -> String, or nil when out of range."
+  [n]
+  (when (<= 0 n 0x10FFFF)
+    (String. (Character/toChars n))))
+
+(def ^:private scheme-relevant-named-entities
+  "The only HTML named character references that can help reconstruct a URL
+   scheme at the render sink, mapped to the character they decode to. No HTML5
+   named reference decodes to a single ASCII letter usable to spell a scheme name
+   (the sole ASCII-letter-producing entity, &fjlig; -> \"fj\", cannot form any
+   executable scheme), so an attacker can only hide the ':' scheme delimiter or
+   insert tab/newline (which the WHATWG URL parser strips from anywhere in a URL)
+   between the letters:
+     javascript&colon;alert(1)   -> javascript:alert(1)
+     java&NewLine;script:alert(1) -> java\\nscript:alert(1) -> javascript:...
+   CR and other C0 controls have no HTML5 named reference (only numeric, handled
+   separately). This closed set is therefore sufficient; matched case-insensitively
+   since over-decoding can only reveal a scheme, never create a false positive."
+  {"colon" ":" "tab" "\t" "newline" "\n"})
+
+(defn- decode-html-entities
+  "Decodes the HTML character references an attacker could use to obfuscate a URL
+   scheme, so the scheme is unmasked before extraction: numeric (&#NN;), hex
+   (&#xHH;), and the scheme-relevant NAMED references (&colon; &Tab; &NewLine;;
+   see `scheme-relevant-named-entities`). Decoding can only *reveal* a scheme
+   (e.g. \"javascript&colon;...\" -> \"javascript:...\"); it never turns a
+   legitimate http(s) URL into a dangerous one, so it adds no false positives.
+   Downstream HTML output-encoding remains the primary XSS control."
+  [s]
+  (letfn [(num-ref [m digits radix]
+            (or (some-> (try (Integer/parseInt digits radix)
+                             (catch NumberFormatException _ nil))
+                        code-point->str)
+                ;; unparseable / oversized code point: leave the text untouched
+                m))]
+    (-> s
+        (str/replace #"(?i)&(colon|tab|newline);"
+                     (fn [[_ nm]] (scheme-relevant-named-entities (str/lower-case nm))))
+        (str/replace #"(?i)&#x([0-9a-f]+);?" (fn [[m d]] (num-ref m d 16)))
+        (str/replace #"&#([0-9]+);?"         (fn [[m d]] (num-ref m d 10))))))
+
+(defn- unsafe-url-scheme
+  "When `v` is a string carrying a URL scheme not in `safe-url-schemes`, returns
+   that (lower-cased) scheme; otherwise nil. HTML entities are decoded and ASCII
+   control/whitespace characters stripped before scheme extraction, because
+   browsers ignore such characters when resolving a URL (so \"java\\tscript:...\",
+   \"&#106;avascript:...\" and \"javascript&colon;...\" all resolve to
+   \"javascript:...\")."
+  [v]
+  (when (string? v)
+    (let [normalized (-> v
+                         decode-html-entities
+                         (str/replace #"[\x00-\x20\x7f]" ""))]
+      (when-let [scheme (some-> (re-find url-scheme-re normalized)
+                                second
+                                str/lower-case)]
+        (when-not (contains? safe-url-schemes scheme)
+          scheme)))))
+
+(defn- collect-unsafe-url-fields
+  "Recursively walks `x` (maps/vectors/sets) and returns a seq of
+   {:field <key> :scheme <scheme>} for every URL-typed field whose value carries
+   a disallowed scheme. Only string values under `url-typed-keys` are checked;
+   non-string values (e.g. a nested Identity map under :identity) are recursed
+   into rather than flagged."
+  [x]
+  (cond
+    (map? x)
+    (mapcat (fn [[k v]]
+              (concat
+               (when (contains? url-typed-keys k)
+                 (for [s (cond
+                           (string? v)     [(unsafe-url-scheme v)]
+                           (coll? v)       (map unsafe-url-scheme (filter string? v))
+                           :else           nil)
+                       :when s]
+                   {:field k :scheme s}))
+               (collect-unsafe-url-fields v)))
+            x)
+    (coll? x) (mapcat collect-unsafe-url-fields x)
+    :else nil))
+
+(defn url-scheme-check
+  "Rejects entities carrying a disallowed URL scheme (javascript:, data:,
+   vbscript:, ...) in any URL-typed field. Defense-in-depth against stored XSS
+   via threat-intel URL fields (XFV-135). Passes through an entity that a prior
+   check already turned into an error map."
+  [entity]
+  (if (:error entity)
+    entity
+    (let [offending (seq (distinct (collect-unsafe-url-fields entity)))]
+      (if offending
+        {:msg (format "Disallowed URL scheme in field(s): %s. Allowed schemes: %s"
+                      (str/join ", " (map (fn [{:keys [field scheme]}]
+                                            (format "%s (%s:)" (name field) scheme))
+                                          offending))
+                      (str/join ", " (sort safe-url-schemes)))
+         :error "Entity validation Error"
+         :type :unsafe-url-scheme-error
+         :entity entity}
+        entity))))
+
 (s/defn ^:private validate-entities :- FlowMap
   [{{{:keys [get-in-config]} :ConfigService} :services
     identity-obj :identity
@@ -184,7 +308,8 @@
                         (check-spec spec)
                         (tlp-check get-in-config)
                         (authorized-groups-check prev-entity ident-map)
-                        (authorized-users-check prev-entity ident-map))))
+                        (authorized-users-check prev-entity ident-map)
+                        url-scheme-check)))
                 entities))))
 
 (s/defn ^:private create-ids-from-transient :- FlowMap

--- a/src/ctia/flows/crud.clj
+++ b/src/ctia/flows/crud.clj
@@ -170,14 +170,21 @@
 (def ^:private safe-url-schemes
   "Allowlist of URL schemes permitted in URL-typed fields on ingest. Any other
    scheme (javascript:, data:, vbscript:, ...) is rejected as defense-in-depth
-   against stored XSS via threat-intel URL fields (XFV-135). Scheme-less /
-   relative values carry no scheme and are always allowed."
+   against stored XSS via threat-intel URL fields (XFV-135). A value is
+   scheme-checked only when its prefix matches the RFC 3986 scheme grammar
+   (see `url-scheme-re`); truly scheme-less / relative values (e.g. \"/a/b\",
+   \"example.com/a\") carry no scheme and pass. An ambiguous bare authority such
+   as \"example.com:8080/path\" parses as scheme \"example.com\" and is rejected,
+   which is acceptable: such values are not valid absolute URIs and do not occur
+   in CTIM URI-typed fields."
   #{"http" "https"})
 
 (def ^:private url-typed-keys
   "Entity keys whose values are CTIM URI-typed and are rendered as clickable
-   hyperlinks by downstream UIs. Kept in sync with the URI-typed entries in
-   ctim.schemas.common (:url, :source_uri, :origin_uri, :reason_uri, :identity).
+   hyperlinks by downstream UIs. Kept in sync with the URI-typed entries across
+   CTIM schemas (:url, :source_uri, :origin_uri, :identity in ctim.schemas.common;
+   :reason_uri in ctim.schemas.judgement). This is a cross-schema hand-curation,
+   not the key set of a single schema.
    These are the render-sinks reachable by an attacker via CTIA writes; free-text
    fields and observable IOC values (which legitimately carry malicious URLs) are
    intentionally NOT in this set. Matching is by key name at any nesting depth,
@@ -269,11 +276,11 @@
     (mapcat (fn [[k v]]
               (concat
                (when (contains? url-typed-keys k)
-                 (for [s (cond
-                           (string? v)     [(unsafe-url-scheme v)]
-                           (coll? v)       (map unsafe-url-scheme (filter string? v))
-                           :else           nil)
-                       :when s]
+                 ;; unsafe-url-scheme nil-guards non-strings, so a uniform scan
+                 ;; over one-or-many values suffices (keep drops the nils). A map
+                 ;; value yields only non-string entries here and is flagged by
+                 ;; the recursion below, never by this branch.
+                 (for [s (keep unsafe-url-scheme (if (coll? v) v [v]))]
                    {:field k :scheme s}))
                (collect-unsafe-url-fields v)))
             x)

--- a/src/ctia/http/exceptions.clj
+++ b/src/ctia/http/exceptions.clj
@@ -127,6 +127,22 @@
       :entity entity
       :class (.getName (class e))})))
 
+(defn unsafe-url-scheme-error-handler
+  "Handle disallowed-URL-scheme validation error (XFV-135).
+
+  A rejected dangerous URL scheme (javascript:, data:, vbscript:, ...) in a
+  URL-typed field is a security-relevant anomaly (an attempted stored-XSS
+  payload), so it is logged at :warn to help operators correlate a poisoning
+  campaign, and returns 400 rather than surfacing as a 500 server error."
+  [^Exception e _data _request]
+  (logging/log! :warn e (ex-message-and-data e))
+  (bad-request
+   (let [entity (:entity (ex-data e))]
+     {:type "Invalid URL Scheme Error"
+      :message (.getMessage e)
+      :entity entity
+      :class (.getName (class e))})))
+
 (defn realize-entity-error-handler
   "Handle error at the realize step"
   [^Exception e _data _request]

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -113,6 +113,7 @@
    :invalid-tlp-error ex/invalid-tlp-error-handler
    :invalid-authorized-groups-error ex/invalid-authorized-groups-error-handler
    :invalid-authorized-users-error ex/invalid-authorized-users-error-handler
+   :unsafe-url-scheme-error ex/unsafe-url-scheme-error-handler
    :realize-entity-error ex/realize-entity-error-handler
    :spec-validation-error ex/spec-validation-error-handler
    :compojure.api.exception/default ex/default-error-handler})

--- a/test/ctia/domain/url_safety_test.clj
+++ b/test/ctia/domain/url_safety_test.clj
@@ -115,4 +115,27 @@
   (testing "does not flag dangerous-looking values in non-URL-typed fields"
     (is (empty? (sut/collect-unsafe-url-fields
                  {:description "uses javascript:alert(1)"
-                  :value "javascript:alert(1)"})))))
+                  :value "javascript:alert(1)"}))))
+  (testing "flags a value nested more than one list level under a URL-typed key"
+    ;; The prior `(if (coll? v) v [v])` unwrapped exactly one level, so a value
+    ;; nested deeper (a vector-of-vectors under :url) was seen as a non-string,
+    ;; nil-guarded away, then recursed into as a value no longer under a URL-typed
+    ;; key -- and silently passed. Not reachable via the API today (schema coercion
+    ;; rejects a nested vector in a URI-typed field), but the helper must still scan
+    ;; the value at any list depth. Pins the tree-seq flattening.
+    (is (= [{:field :url :scheme "javascript" :value "javascript:a(1)"}]
+           (sut/collect-unsafe-url-fields {:url [["javascript:a(1)"]]})))
+    ;; a set nested below the top level exercises the set? half of the branch
+    ;; predicate at depth (symmetry with the vector-of-vector case above).
+    (is (= [{:field :url :scheme "javascript" :value "javascript:a(1)"}]
+           (sut/collect-unsafe-url-fields {:url [#{"javascript:a(1)"}]}))))
+  (testing "still flags a single-level collection- and set-valued URL field"
+    (is (= [{:field :url :scheme "javascript" :value "javascript:a(1)"}]
+           (sut/collect-unsafe-url-fields {:url ["javascript:a(1)"]})))
+    (is (= [{:field :url :scheme "javascript" :value "javascript:a(1)"}]
+           (sut/collect-unsafe-url-fields {:url #{"javascript:a(1)"}}))))
+  (testing "a nested map under a URL-typed key is recursed, not flagged as a string"
+    ;; tree-seq treats only sequential?/set? as branches, so a map value under a
+    ;; URL-typed key yields no string here; a dangerous scheme under a NON-URL-typed
+    ;; key inside it stays unflagged (CTIM URI fields are string-typed).
+    (is (empty? (sut/collect-unsafe-url-fields {:url {:inner "javascript:a(1)"}})))))

--- a/test/ctia/domain/url_safety_test.clj
+++ b/test/ctia/domain/url_safety_test.clj
@@ -1,0 +1,118 @@
+(ns ctia.domain.url-safety-test
+  "Unit tests for the pure URL-scheme predicates (XFV-135). These live in
+   ctia.domain.url-safety so the security logic is testable directly, without
+   re-implementing private helpers or routing every case through the flow's
+   `url-scheme-check` wrapper (whose flow-level integration is covered in
+   ctia.flows.crud-test)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [ctia.domain.url-safety :as sut]))
+
+(deftest unsafe-url-scheme-basic-test
+  (testing "flags a disallowed scheme, returning it lower-cased"
+    (is (= "javascript" (sut/unsafe-url-scheme "javascript:alert(1)")))
+    (is (= "data" (sut/unsafe-url-scheme "data:text/html;base64,PHN=")))
+    (is (= "vbscript" (sut/unsafe-url-scheme "vbscript:msgbox(1)")))
+    ;; LOW4: scheme lower-cased with Locale/ROOT, so an uppercase disallowed
+    ;; scheme is still recognized as disallowed regardless of the JVM locale.
+    (is (= "javascript" (sut/unsafe-url-scheme "JAVASCRIPT:alert(1)"))))
+  (testing "allows http/https and scheme-less values (nil)"
+    (is (nil? (sut/unsafe-url-scheme "https://example.com/a")))
+    (is (nil? (sut/unsafe-url-scheme "HTTPS://example.com/a")))
+    (is (nil? (sut/unsafe-url-scheme "http://example.org")))
+    (is (nil? (sut/unsafe-url-scheme "/relative/path")))
+    (is (nil? (sut/unsafe-url-scheme "example.com/a"))))
+  (testing "nil-guards non-strings"
+    (is (nil? (sut/unsafe-url-scheme 42)))
+    (is (nil? (sut/unsafe-url-scheme nil)))
+    (is (nil? (sut/unsafe-url-scheme {:a 1}))))
+  (testing "exempts transient: references (CTIA-internal, non-executable)"
+    (is (nil? (sut/unsafe-url-scheme "transient:0")))
+    (is (nil? (sut/unsafe-url-scheme (str "transient:" (random-uuid)))))))
+
+(deftest unsafe-url-scheme-amp-double-encoding-test
+  ;; SEC1: `&amp;` is the canonical encoding of `&`, so `javascript&amp;colon;`
+  ;; HTML-decodes to `javascript&colon;` then `javascript:` at the render sink.
+  ;; Before adding "amp" to scheme-relevant-named-entities the named `&amp;` form
+  ;; slipped through (nil => stored) while its numeric twin `&#38;` was caught --
+  ;; exactly the double-encoding case the fixed-point loop exists to close.
+  (testing "named-ampersand double-encoding is unmasked and flagged"
+    (is (= "javascript" (sut/unsafe-url-scheme "javascript&amp;colon;alert(1)")))
+    (is (= "javascript" (sut/unsafe-url-scheme "javascript&amp;#58;alert(1)"))))
+  (testing "numeric-ampersand twin remains flagged (regression guard)"
+    (is (= "javascript" (sut/unsafe-url-scheme "javascript&#38;colon;alert(1)"))))
+  (testing "a legitimate https URL with an &amp; query separator is NOT flagged"
+    ;; The scheme sits at the front and is extracted first, so decoding `&amp;`
+    ;; in the query string cannot turn a safe URL dangerous (no false positive).
+    (is (nil? (sut/unsafe-url-scheme "https://example.com/q?a=1&amp;b=2")))))
+
+(deftest unsafe-url-scheme-locale-independent-test
+  ;; LOW4: the extracted scheme is lower-cased with Locale/ROOT, not the JVM
+  ;; default locale. Under a Turkish/Azeri default, str/lower-case folds the ASCII
+  ;; "I" in "JAVASCRIPT" to the dotless "ı" ("javascrıpt"); Locale/ROOT keeps it
+  ;; "javascript". Swapping line back to str/lower-case makes this assertion fail
+  ;; (the returned scheme string differs), and keeps the two lower-casings
+  ;; (decoder + extractor) consistent and locale-independent.
+  (let [default (java.util.Locale/getDefault)]
+    (try
+      (java.util.Locale/setDefault (java.util.Locale/forLanguageTag "tr"))
+      (is (= "javascript" (sut/unsafe-url-scheme "JAVASCRIPT:alert(1)")))
+      (is (nil? (sut/unsafe-url-scheme "HTTPS://example.com")))
+      (finally (java.util.Locale/setDefault default)))))
+
+(deftest unsafe-url-scheme-control-and-ignorable-test
+  (testing "strips ASCII controls incl. \\x7f (DEL) before scheme extraction"
+    ;; LOW1: &#127; is DEL; the strip class covers \x00-\x20 AND \x7f. Removing
+    ;; \x7f from the class would let "java<DEL>script:" pass with no failing test.
+    (is (= "javascript" (sut/unsafe-url-scheme "java&#127;script:alert(1)"))))
+  (testing "strips non-ASCII ignorables the decoder can emit"
+    (doseq [v ["java&#8203;script:alert(1)"   ; U+200B ZERO WIDTH SPACE (Cf)
+               "&#65279;javascript:alert(1)"  ; U+FEFF BOM (Cf)
+               "&#160;javascript:alert(1)"    ; U+00A0 NO-BREAK SPACE (Zs)
+               "java&#173;script:alert(1)"]]  ; U+00AD SOFT HYPHEN (Cf)
+      (is (= "javascript" (sut/unsafe-url-scheme v)) (str "must unmask: " v)))))
+
+(deftest decode-html-entities-fixed-point-test
+  (testing "peels multiple stacked encoding layers to reveal the delimiter"
+    ;; LOW3: each pass peels one `&#38;`->`&` layer; the budget bounds the peel
+    ;; depth. A triple-stacked ampersand still converges well within the budget.
+    (is (= "javascript:alert(1)"
+           (sut/decode-html-entities "javascript&#38;#38;#38;colon;alert(1)")))
+    (is (= "javascript"
+           (sut/unsafe-url-scheme "javascript&#38;#38;#38;colon;alert(1)"))))
+  (testing "leaves an unparseable / oversized numeric entity untouched (converges)"
+    (is (= "&#999999999999999999999;oke"
+           (sut/decode-html-entities "&#999999999999999999999;oke"))))
+  (testing "a stack deeper than the budget is left partially-encoded and fails safe"
+    ;; The budget is load-bearing: it caps the peel depth at 8 passes. A value with
+    ;; 10 stacked `&#38;` before the `colon;` cannot fully collapse to `javascript:`
+    ;; within the budget, so the residual `&` sit between the scheme letters and the
+    ;; `:` -- no http(s)-or-dangerous scheme is presented, `unsafe-url-scheme`
+    ;; returns nil (not flagged, no throw), and a browser HTML-decodes only one layer
+    ;; per render so it never reaches `javascript:` in a single hop. A budget-shrink
+    ;; mutation that let this decode fully would flip the nil to "javascript".
+    (let [deep (str "javascript" (apply str (repeat 10 "&#38;")) "colon;alert(1)")]
+      (is (nil? (sut/unsafe-url-scheme deep))))))
+
+(deftest code-point->str-range-guard-test
+  (testing "returns nil past the max Unicode code point rather than throwing"
+    ;; 0x110000 parses as an int but Character/toChars would throw
+    ;; IllegalArgumentException; the (<= 0 n 0x10FFFF) guard must return nil so an
+    ;; oversized numeric entity is left untouched instead of 500-ing.
+    (is (nil? (sut/code-point->str 0x110000)))
+    (is (nil? (sut/code-point->str -1))))
+  (testing "decodes an in-range code point"
+    (is (= "j" (sut/code-point->str 106)))
+    (is (= ":" (sut/code-point->str 58)))))
+
+(deftest collect-unsafe-url-fields-test
+  (testing "returns the field, scheme and exact offending value"
+    (is (= [{:field :source_uri :scheme "javascript" :value "javascript:alert(1)"}]
+           (sut/collect-unsafe-url-fields {:source_uri "javascript:alert(1)"}))))
+  (testing "recurses into nested maps and collections under URL-typed keys"
+    (is (= [{:field :url :scheme "data" :value "data:text/html,x"}]
+           (sut/collect-unsafe-url-fields
+            {:external_references [{:source_name "s" :url "data:text/html,x"}]}))))
+  (testing "does not flag dangerous-looking values in non-URL-typed fields"
+    (is (empty? (sut/collect-unsafe-url-fields
+                 {:description "uses javascript:alert(1)"
+                  :value "javascript:alert(1)"})))))

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -679,6 +679,16 @@
       (let [entity {:source_uri "/relative/path" :url "example.com/a"}]
         (is (= entity (url-scheme-check entity)))))
 
+    (testing "allows transient: references in URL-typed fields (resolved during ingest)"
+      ;; Bulk/bundle submissions cross-link entities with transient IDs before
+      ;; real IDs exist; these land in URI-typed fields (e.g. :source_uri on a
+      ;; relationship) and this check runs before they are resolved. transient:
+      ;; is a CTIA-internal, non-executable scheme, so it must not be flagged.
+      (let [entity {:source_uri "transient:0"
+                    :url (str "transient:" (random-uuid))}]
+        (is (= entity (url-scheme-check entity))
+            "transient references must pass validation unchanged")))
+
     (testing "does not flag dangerous-looking free-text in non-URL fields"
       ;; threat-intel descriptions and observable IOC values legitimately mention
       ;; malicious URLs; only URL-typed fields are gated.

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -600,8 +600,15 @@
     (testing "rejects a javascript: scheme in a URL-typed field"
       (let [result (url-scheme-check {:source_uri "javascript:alert(document.cookie)"})]
         (is (= :unsafe-url-scheme-error (:type result)))
-        (is (re-find #"javascript" (:msg result)))
-        (is (re-find #"source_uri" (:msg result)))))
+        ;; The `:error` key is load-bearing: throw-validation-error selects error
+        ;; maps with (filter :error entities) (crud.clj) and remove-errors drops
+        ;; them, so deleting `:error "Entity validation Error"` from url-scheme-check
+        ;; would silently disable the gate (the payload would be stored) while
+        ;; `:type` still passes. Pin the whole contract, not just `:type`.
+        (is (= "Entity validation Error" (:error result)))
+        ;; LOW2: pin the exact message shape once, not just substrings.
+        (is (= "Disallowed URL scheme in field(s): source_uri (javascript:). Allowed schemes: http, https"
+               (:msg result)))))
 
     (testing "rejects a dangerous scheme under every URL-typed key"
       ;; Loops all five keys in `url-typed-keys` so dropping any one (e.g.
@@ -685,6 +692,15 @@
       ;; set-valued field exercises the same coll? branch
       (let [result (url-scheme-check {:url #{"https://ok.example" "javascript:alert(1)"}})]
         (is (= :unsafe-url-scheme-error (:type result)))))
+
+    (testing "collapses multiple distinct offending values in one field to one label"
+      ;; Pins the `distinct` in url-scheme-check: two different javascript: values
+      ;; under the same :url share field+scheme, so the message lists
+      ;; "url (javascript:)" exactly once. Dropping `distinct` would duplicate it.
+      (let [result (url-scheme-check {:url ["javascript:a(1)" "javascript:b(2)"]})
+            n (count (re-seq #"url \(javascript:\)" (:msg result)))]
+        (is (= :unsafe-url-scheme-error (:type result)))
+        (is (= 1 n) "the field+scheme label must appear exactly once")))
 
     (testing "recurses into a nested map and flags a string :identity value"
       (let [result (url-scheme-check {:sighting {:identity "javascript:alert(1)"}})]
@@ -818,7 +834,12 @@
                             :source_uri "javascript:alert(1)"}]
                 :spec nil}
             validated (first (:entities (validate-entities fm)))]
-        (is (= :unsafe-url-scheme-error (:type validated)))))
+        (is (= :unsafe-url-scheme-error (:type validated)))
+        ;; End-to-end contract: the entity must carry the `:error` key that
+        ;; throw-validation-error/remove-errors act on to actually reject the
+        ;; write. Deleting that key from url-scheme-check leaves `:type` intact but
+        ;; lets the javascript: payload through — this assertion fails the mutation.
+        (is (= "Entity validation Error" (:error validated)))))
 
     (testing "validate-entities allows an https: source_uri on create"
       (let [fm {:services services

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -594,9 +594,10 @@
   ;; Ingest must reject dangerous URL schemes (javascript:, data:, vbscript:)
   ;; in URL-typed fields while allowing http/https and scheme-less values.
   ;; These cases exercise the create path (no prev-entity), so bind a 1-arg
-  ;; wrapper passing prev-entity = nil (everything is checked); the prev-entity
-  ;; diff behavior is covered by url-scheme-check-prev-entity-diff-test below.
-  (let [url-scheme-check #(#'flows.crud/url-scheme-check % nil)]
+  ;; wrapper passing prev-entity = nil (everything is checked) and ident-map = nil;
+  ;; the prev-entity diff behavior is covered by url-scheme-check-prev-entity-diff-test
+  ;; and caller attribution by url-scheme-check-caller-attribution-test below.
+  (let [url-scheme-check #(#'flows.crud/url-scheme-check % nil nil)]
     (testing "rejects a javascript: scheme in a URL-typed field"
       (let [result (url-scheme-check {:source_uri "javascript:alert(document.cookie)"})]
         (is (= :unsafe-url-scheme-error (:type result)))
@@ -793,8 +794,9 @@
   ;; XFV-135 / CR1: on update/patch the gate flags only values the caller
   ;; *introduces* relative to prev-entity (mirroring authorized-groups-check),
   ;; so patch-entities' deep-merge of a pre-gate stored URI does not 400 an
-  ;; unrelated update. Uses the 2-arg url-scheme-check directly.
-  (let [url-scheme-check #'flows.crud/url-scheme-check]
+  ;; unrelated update. Wrapper passes ident-map = nil (attribution is covered by
+  ;; url-scheme-check-caller-attribution-test), so call sites stay (entity prev).
+  (let [url-scheme-check #(#'flows.crud/url-scheme-check %1 %2 nil)]
     (testing "a newly-introduced dangerous scheme is rejected on update"
       (let [prev   {:source_uri "https://old.example"}
             entity {:source_uri "javascript:alert(1)"}]
@@ -820,6 +822,24 @@
       (is (= :unsafe-url-scheme-error
              (:type (url-scheme-check {:source_uri "javascript:alert(1)"} nil)))))))
 
+(deftest url-scheme-check-caller-attribution-test
+  ;; XFV-135: a rejected dangerous-scheme write is a security-relevant anomaly
+  ;; logged at :warn "to help operators correlate a poisoning campaign". Carry the
+  ;; caller's :login/:groups into the error map (threaded via ident-map, as
+  ;; authorized-groups-check/authorized-users-check do) so an operator seeing a
+  ;; burst of rejected javascript: writes can attribute them to a caller. Pins that
+  ;; the two keys are present with the ident-map values.
+  (let [url-scheme-check #'flows.crud/url-scheme-check
+        ident-map {:login "attacker" :groups ["evil-corp"]}]
+    (testing "the error map carries the caller's login and groups"
+      (let [result (url-scheme-check {:source_uri "javascript:alert(1)"} nil ident-map)]
+        (is (= :unsafe-url-scheme-error (:type result)))
+        (is (= "attacker" (:login result)))
+        (is (= ["evil-corp"] (:groups result)))))
+    (testing "a passing entity is returned unchanged (no attribution keys added)"
+      (let [entity {:source_uri "https://example.com/intel"}]
+        (is (= entity (url-scheme-check entity nil ident-map)))))))
+
 (deftest url-scheme-validation-through-validate-entities-test
   ;; End-to-end through the shared write chokepoint used by API writes and
   ;; bundle/bulk import (create-flow/update-flow/patch-flow all call this).
@@ -839,7 +859,13 @@
         ;; throw-validation-error/remove-errors act on to actually reject the
         ;; write. Deleting that key from url-scheme-check leaves `:type` intact but
         ;; lets the javascript: payload through — this assertion fails the mutation.
-        (is (= "Entity validation Error" (:error validated)))))
+        (is (= "Entity validation Error" (:error validated)))
+        ;; Pin the ident-map wiring through the real chokepoint: validate-entities
+        ;; must thread ident-map into url-scheme-check so :login/:groups reach the
+        ;; :warn log for caller attribution. A regression that drops that arg would
+        ;; leave :type/:error green here but silently break audit attribution.
+        (is (= "user" (:login validated)))
+        (is (= ["org-a"] (:groups validated)))))
 
     (testing "validate-entities allows an https: source_uri on create"
       (let [fm {:services services

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -4,6 +4,8 @@
             [ctia.auth.threatgrid :refer [map->Identity]]
             [ctia.entity.sighting.schemas :as ss]
             [ctia.flows.crud :as flows.crud]
+            [ctia.http.exceptions :as exceptions]
+            [ctia.http.handler :as handler]
             [ctia.lib.collection :as coll]
             [ctia.store :refer [query-string-search]]
             [ctia.test-helpers.core :as helpers]
@@ -586,3 +588,152 @@
             "introducing a new foreign authorized_user must be rejected")
         (is (= :invalid-authorized-users-error (:type validated)))
         (is (re-find #"victim" (:msg validated)))))))
+
+(deftest url-scheme-check-test
+  ;; XFV-135: defense-in-depth against stored XSS via threat-intel URL fields.
+  ;; Ingest must reject dangerous URL schemes (javascript:, data:, vbscript:)
+  ;; in URL-typed fields while allowing http/https and scheme-less values.
+  (let [url-scheme-check #'flows.crud/url-scheme-check]
+    (testing "rejects a javascript: scheme in a URL-typed field"
+      (let [result (url-scheme-check {:source_uri "javascript:alert(document.cookie)"})]
+        (is (= :unsafe-url-scheme-error (:type result)))
+        (is (re-find #"javascript" (:msg result)))
+        (is (re-find #"source_uri" (:msg result)))))
+
+    (testing "rejects a data: scheme in an external_reference url (nested)"
+      (let [result (url-scheme-check
+                    {:title "x"
+                     :external_references [{:source_name "s"
+                                            :url "data:text/html;base64,PHNjcmlwdD4="}]})]
+        (is (= :unsafe-url-scheme-error (:type result)))
+        (is (re-find #"data" (:msg result)))))
+
+    (testing "rejects a vbscript: scheme"
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:reason_uri "vbscript:msgbox(1)"})))))
+
+    (testing "rejects control-char-obfuscated javascript scheme (browser strips \\t/\\n)"
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "java\tscript:alert(1)"}))))
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "  JAVASCRIPT:alert(1)"})))))
+
+    (testing "rejects HTML-numeric-entity-obfuscated javascript scheme"
+      ;; &#106; = 'j'; a consumer that HTML-decodes before rendering would
+      ;; otherwise resolve this to javascript:.
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "&#106;avascript:alert(1)"}))))
+      ;; hex entity for the colon: java&#x3a;script -> javascript:
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "javascript&#x3a;alert(1)"}))))
+      ;; entity-encoded control char between letters: java&#9;script:
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "java&#9;script:alert(1)"}))))
+      ;; numeric ref without the optional trailing semicolon: &#106 -> 'j'
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "&#106avascript:alert(1)"})))))
+
+    (testing "rejects HTML-named-entity-obfuscated javascript scheme"
+      ;; &colon; = ':' — the scheme delimiter is the one structural char that
+      ;; HAS a named reference; browsers HTML-decode it at the href sink.
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "javascript&colon;alert(document.domain)"}))))
+      ;; &NewLine; / &Tab; decode to chars the URL parser strips, splitting the
+      ;; scheme letters: java&NewLine;script: -> javascript:
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "java&NewLine;script:alert(1)"}))))
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "java&Tab;script:alert(1)"}))))
+      ;; case-insensitive matching of the named references
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "javascript&COLON;alert(1)"})))))
+
+    (testing "HTML entities appearing after a safe scheme do not cause a false positive"
+      ;; &#39; (apostrophe) and &amp; in a query string must not be flagged.
+      (let [entity {:url "https://example.com/q?a=1&#39;&b=2"}]
+        (is (= entity (url-scheme-check entity)))))
+
+    (testing "an oversized numeric entity does not crash and is not treated as a scheme"
+      (let [entity {:url "&#999999999999999999999;oke"}]
+        (is (= entity (url-scheme-check entity)))))
+
+    (testing "flags a dangerous scheme in a collection-valued URL field"
+      (let [result (url-scheme-check {:url ["https://ok.example" "javascript:alert(1)"]})]
+        (is (= :unsafe-url-scheme-error (:type result))))
+      ;; set-valued field exercises the same coll? branch
+      (let [result (url-scheme-check {:url #{"https://ok.example" "javascript:alert(1)"}})]
+        (is (= :unsafe-url-scheme-error (:type result)))))
+
+    (testing "recurses into a nested :identity map value"
+      (let [result (url-scheme-check {:sighting {:identity "javascript:alert(1)"}})]
+        (is (= :unsafe-url-scheme-error (:type result)))))
+
+    (testing "allows a valid https: URL (control)"
+      (let [entity {:source_uri "https://example.com/intel?q=1"
+                    :external_references [{:source_name "s"
+                                           :url "http://example.org/a"}]}]
+        (is (= entity (url-scheme-check entity))
+            "well-formed http/https URLs must pass unchanged")))
+
+    (testing "allows scheme-less / relative values"
+      (let [entity {:source_uri "/relative/path" :url "example.com/a"}]
+        (is (= entity (url-scheme-check entity)))))
+
+    (testing "does not flag dangerous-looking free-text in non-URL fields"
+      ;; threat-intel descriptions and observable IOC values legitimately mention
+      ;; malicious URLs; only URL-typed fields are gated.
+      (let [entity {:description "Attacker used javascript:alert(1) payload"
+                    :observable {:type "url" :value "javascript:alert(1)"}}]
+        (is (= entity (url-scheme-check entity)))))
+
+    (testing "passes through an entity already marked as an error by a prior check"
+      (let [err {:error "Entity validation Error" :type :invalid-tlp-error
+                 :entity {:source_uri "javascript:alert(1)"}}]
+        (is (= err (url-scheme-check err))
+            "must not clobber a prior validation error")))))
+
+(deftest url-scheme-validation-through-validate-entities-test
+  ;; End-to-end through the shared write chokepoint used by API writes and
+  ;; bundle/bulk import (create-flow/update-flow/patch-flow all call this).
+  (let [get-in-config (helpers/build-get-in-config-fn)
+        services {:ConfigService {:get-in-config get-in-config}}
+        validate-entities #'flows.crud/validate-entities
+        ident (map->Identity {:login "user" :groups ["org-a"] :capabilities #{}})]
+    (testing "validate-entities rejects a javascript: source_uri on create"
+      (let [fm {:services services
+                :identity ident
+                :entities [{:tlp "green" :groups ["org-a"]
+                            :source_uri "javascript:alert(1)"}]
+                :spec nil}
+            validated (first (:entities (validate-entities fm)))]
+        (is (= :unsafe-url-scheme-error (:type validated)))))
+
+    (testing "validate-entities allows an https: source_uri on create"
+      (let [fm {:services services
+                :identity ident
+                :entities [{:tlp "green" :groups ["org-a"]
+                            :source_uri "https://example.com/intel"}]
+                :spec nil}
+            validated (first (:entities (validate-entities fm)))]
+        (is (nil? (:error validated)))))
+
+    (testing "validate-entities rejects a javascript: source_uri on update too"
+      (let [fm {:services services
+                :identity ident
+                :entities [{:tlp "green" :groups ["org-a"]
+                            :source_uri "javascript:alert(1)"}]
+                :get-prev-entity (fn [_] {:tlp "green" :groups ["org-a"]
+                                          :source_uri "https://old.example"})
+                :spec nil}
+            validated (first (:entities (validate-entities fm)))]
+        (is (= :unsafe-url-scheme-error (:type validated))
+            "a newly-introduced dangerous scheme must be rejected on update")))))
+
+(deftest unsafe-url-scheme-error-is-registered-test
+  ;; XFV-135 regression: url-scheme-check emits :type :unsafe-url-scheme-error.
+  ;; If that key is missing from the compojure-api exception handlers, the throw
+  ;; falls through to default-error-handler and surfaces as HTTP 500 instead of
+  ;; 400 (a rejected payload then looks like a server bug). Pin the registration.
+  (testing "the :unsafe-url-scheme-error type maps to the bad-request handler"
+    (is (= exceptions/unsafe-url-scheme-error-handler
+           (:unsafe-url-scheme-error handler/exception-handlers)))))

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -593,12 +593,24 @@
   ;; XFV-135: defense-in-depth against stored XSS via threat-intel URL fields.
   ;; Ingest must reject dangerous URL schemes (javascript:, data:, vbscript:)
   ;; in URL-typed fields while allowing http/https and scheme-less values.
-  (let [url-scheme-check #'flows.crud/url-scheme-check]
+  ;; These cases exercise the create path (no prev-entity), so bind a 1-arg
+  ;; wrapper passing prev-entity = nil (everything is checked); the prev-entity
+  ;; diff behavior is covered by url-scheme-check-prev-entity-diff-test below.
+  (let [url-scheme-check #(#'flows.crud/url-scheme-check % nil)]
     (testing "rejects a javascript: scheme in a URL-typed field"
       (let [result (url-scheme-check {:source_uri "javascript:alert(document.cookie)"})]
         (is (= :unsafe-url-scheme-error (:type result)))
         (is (re-find #"javascript" (:msg result)))
         (is (re-find #"source_uri" (:msg result)))))
+
+    (testing "rejects a dangerous scheme under every URL-typed key"
+      ;; Loops all five keys in `url-typed-keys` so dropping any one (e.g.
+      ;; :origin_uri) from the set breaks a test rather than silently going
+      ;; unchecked.
+      (doseq [k [:url :source_uri :origin_uri :reason_uri :identity]]
+        (is (= :unsafe-url-scheme-error
+               (:type (url-scheme-check {k "javascript:alert(1)"})))
+            (str "must flag a javascript: scheme under " k))))
 
     (testing "rejects a data: scheme in an external_reference url (nested)"
       (let [result (url-scheme-check
@@ -674,7 +686,7 @@
       (let [result (url-scheme-check {:url #{"https://ok.example" "javascript:alert(1)"}})]
         (is (= :unsafe-url-scheme-error (:type result)))))
 
-    (testing "recurses into a nested :identity map value"
+    (testing "recurses into a nested map and flags a string :identity value"
       (let [result (url-scheme-check {:sighting {:identity "javascript:alert(1)"}})]
         (is (= :unsafe-url-scheme-error (:type result)))))
 
@@ -685,14 +697,55 @@
         (is (= entity (url-scheme-check entity))
             "well-formed http/https URLs must pass unchanged")))
 
+    (testing "allows an uppercase safe scheme (schemes are matched case-insensitively)"
+      ;; Pins the `str/lower-case` before the allowlist lookup in unsafe-url-scheme:
+      ;; dropping it would leave scheme "HTTPS"/"Http", miss the http/https set, and
+      ;; 400 every uppercase-scheme URL. The reject-side already has an uppercase
+      ;; case (" JAVASCRIPT:"); this is the safe-side twin.
+      (let [entity {:url "HTTPS://example.com/a" :source_uri "Http://example.org"}]
+        (is (= entity (url-scheme-check entity))
+            "uppercase http/https schemes must pass unchanged")))
+
+    (testing "reveals a double-encoded scheme delimiter (decode iterates to a fixed point)"
+      ;; "javascript&#38;colon;alert(1)": &#38; is '&', so the decimal pass yields
+      ;; "javascript&colon;alert(1)". A single decode pass (named-then-numeric)
+      ;; would stop there and MISS the scheme; iterating re-runs the named pass and
+      ;; unmasks "javascript:". Pins the fixed-point loop in decode-html-entities.
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "javascript&#38;colon;alert(1)"})))))
+
+    (testing "strips non-ASCII ignorable characters emitted by the decoder"
+      ;; The strip class must cover more than ASCII controls: the decoder emits
+      ;; Unicode format/separator chars a browser ignores when resolving a URL.
+      ;; Each of these decodes to an ignorable that splits/prefixes the scheme.
+      (doseq [v ["java&#8203;script:alert(1)"    ; U+200B ZERO WIDTH SPACE (Cf)
+                 "&#65279;javascript:alert(1)"   ; U+FEFF BOM (Cf)
+                 "&#160;javascript:alert(1)"     ; U+00A0 NO-BREAK SPACE (Zs)
+                 "java&#173;script:alert(1)"]]   ; U+00AD SOFT HYPHEN (Cf)
+        (is (= :unsafe-url-scheme-error
+               (:type (url-scheme-check {:url v})))
+            (str "must unmask ignorable-split scheme in: " v))))
+
+    (testing "named-entity decode is locale-independent (no NPE under a tr locale)"
+      ;; str/lower-case uses the JVM default locale; under Turkish/Azeri "NEWLINE"
+      ;; lowercases to "newlıne" (dotless i), which would miss the map and, before
+      ;; the fix, NPE str/replace out to a 500. The decoder uses Locale/ROOT and an
+      ;; `or` fallback, so the scheme is still unmasked here.
+      (let [default (java.util.Locale/getDefault)]
+        (try
+          (java.util.Locale/setDefault (java.util.Locale/forLanguageTag "tr"))
+          (is (= :unsafe-url-scheme-error
+                 (:type (url-scheme-check {:url "java&NEWLINE;script:alert(1)"}))))
+          (finally (java.util.Locale/setDefault default)))))
+
     (testing "allows scheme-less / relative values"
       (let [entity {:source_uri "/relative/path" :url "example.com/a"}]
         (is (= entity (url-scheme-check entity)))))
 
     (testing "an ambiguous bare authority (host:port) parses as a scheme and is rejected"
       ;; Pins the documented behavior in `safe-url-schemes`: "example.com:8080/path"
-      ;; matches url-scheme-re with scheme "example.com" (not allowlisted). Such a
-      ;; value is not a valid absolute URI and does not occur in CTIM URI fields;
+      ;; matches url-scheme-re with scheme "example.com" (not allowlisted). CTIM
+      ;; URI fields carry absolute http(s) URLs, not bare host:port authorities;
       ;; a future change to url-scheme-re must not silently alter this contract.
       (is (= :unsafe-url-scheme-error
              (:type (url-scheme-check {:url "example.com:8080/path"})))))
@@ -720,6 +773,37 @@
         (is (= err (url-scheme-check err))
             "must not clobber a prior validation error")))))
 
+(deftest url-scheme-check-prev-entity-diff-test
+  ;; XFV-135 / CR1: on update/patch the gate flags only values the caller
+  ;; *introduces* relative to prev-entity (mirroring authorized-groups-check),
+  ;; so patch-entities' deep-merge of a pre-gate stored URI does not 400 an
+  ;; unrelated update. Uses the 2-arg url-scheme-check directly.
+  (let [url-scheme-check #'flows.crud/url-scheme-check]
+    (testing "a newly-introduced dangerous scheme is rejected on update"
+      (let [prev   {:source_uri "https://old.example"}
+            entity {:source_uri "javascript:alert(1)"}]
+        (is (= :unsafe-url-scheme-error
+               (:type (url-scheme-check entity prev))))))
+
+    (testing "a pre-existing dangerous value the caller did not change is NOT re-rejected"
+      ;; models POST /incident/:id/status: patch-entities deep-merged the stored
+      ;; source_uri back into the entity; it is byte-identical to prev-entity.
+      (let [prev   {:source_uri "javascript:legacy(1)" :status "New"}
+            entity {:source_uri "javascript:legacy(1)" :status "Closed"}]
+        (is (= entity (url-scheme-check entity prev))
+            "a value identical to the stored one must pass through unchanged")))
+
+    (testing "changing a dangerous value to a different dangerous payload IS rejected"
+      ;; diffing on the exact value (not just the scheme) catches a swapped payload.
+      (let [prev   {:source_uri "javascript:legacy(1)"}
+            entity {:source_uri "javascript:brand_new(1)"}]
+        (is (= :unsafe-url-scheme-error
+               (:type (url-scheme-check entity prev))))))
+
+    (testing "a nil prev-entity (create) checks every value"
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:source_uri "javascript:alert(1)"} nil)))))))
+
 (deftest url-scheme-validation-through-validate-entities-test
   ;; End-to-end through the shared write chokepoint used by API writes and
   ;; bundle/bulk import (create-flow/update-flow/patch-flow all call this).
@@ -745,17 +829,40 @@
             validated (first (:entities (validate-entities fm)))]
         (is (nil? (:error validated)))))
 
-    (testing "validate-entities rejects a javascript: source_uri on update too"
-      (let [fm {:services services
+    (testing "validate-entities rejects a NEWLY-INTRODUCED javascript: source_uri on update"
+      ;; The entity carries an :id, so validate-entities actually invokes
+      ;; get-prev-entity (it only does so when (:id entity) is present); assert
+      ;; the stub fired so this genuinely exercises the update/diff path, not a
+      ;; byte-identical duplicate of the create case.
+      (let [called (atom false)
+            fm {:services services
                 :identity ident
-                :entities [{:tlp "green" :groups ["org-a"]
+                :entities [{:id "x" :tlp "green" :groups ["org-a"]
                             :source_uri "javascript:alert(1)"}]
-                :get-prev-entity (fn [_] {:tlp "green" :groups ["org-a"]
-                                          :source_uri "https://old.example"})
+                :get-prev-entity (fn [_]
+                                   (reset! called true)
+                                   {:tlp "green" :groups ["org-a"]
+                                    :source_uri "https://old.example"})
                 :spec nil}
             validated (first (:entities (validate-entities fm)))]
+        (is (true? @called) "get-prev-entity must be consulted on update")
         (is (= :unsafe-url-scheme-error (:type validated))
-            "a newly-introduced dangerous scheme must be rejected on update")))))
+            "a newly-introduced dangerous scheme must be rejected on update")))
+
+    (testing "validate-entities does NOT re-reject a pre-existing dangerous source_uri on update"
+      ;; CR1: models POST /incident/:id/status — patch-entities deep-merges the
+      ;; stored (pre-gate) :source_uri back into the entity; the caller never
+      ;; touched it, so it must not 400 an unrelated field change.
+      (let [fm {:services services
+                :identity ident
+                :entities [{:id "x" :tlp "green" :groups ["org-a"]
+                            :source_uri "javascript:legacy(1)"}]
+                :get-prev-entity (fn [_] {:tlp "green" :groups ["org-a"]
+                                          :source_uri "javascript:legacy(1)"})
+                :spec nil}
+            validated (first (:entities (validate-entities fm)))]
+        (is (nil? (:error validated))
+            "a pre-existing value the caller did not introduce must pass")))))
 
 (deftest unsafe-url-scheme-error-is-registered-test
   ;; XFV-135 regression: url-scheme-check emits :type :unsafe-url-scheme-error.

--- a/test/ctia/flows/crud_test.clj
+++ b/test/ctia/flows/crud_test.clj
@@ -654,7 +654,17 @@
         (is (= entity (url-scheme-check entity)))))
 
     (testing "an oversized numeric entity does not crash and is not treated as a scheme"
+      ;; 21 digits overflow Integer/parseInt -> NumberFormatException catch.
       (let [entity {:url "&#999999999999999999999;oke"}]
+        (is (= entity (url-scheme-check entity)))))
+
+    (testing "a numeric entity past the max Unicode code point does not crash"
+      ;; &#1114112; = 0x110000, one past Character/MAX_CODE_POINT. It parses as an
+      ;; int (no NumberFormatException) but fails the (<= 0 n 0x10FFFF) range guard
+      ;; in code-point->str, which must return nil rather than let Character/toChars
+      ;; throw IllegalArgumentException (an uncaught throw would surface as HTTP 500).
+      ;; Pins that range guard, which the 21-digit case above never exercises.
+      (let [entity {:url "&#1114112;oke"}]
         (is (= entity (url-scheme-check entity)))))
 
     (testing "flags a dangerous scheme in a collection-valued URL field"
@@ -678,6 +688,14 @@
     (testing "allows scheme-less / relative values"
       (let [entity {:source_uri "/relative/path" :url "example.com/a"}]
         (is (= entity (url-scheme-check entity)))))
+
+    (testing "an ambiguous bare authority (host:port) parses as a scheme and is rejected"
+      ;; Pins the documented behavior in `safe-url-schemes`: "example.com:8080/path"
+      ;; matches url-scheme-re with scheme "example.com" (not allowlisted). Such a
+      ;; value is not a valid absolute URI and does not occur in CTIM URI fields;
+      ;; a future change to url-scheme-re must not silently alter this contract.
+      (is (= :unsafe-url-scheme-error
+             (:type (url-scheme-check {:url "example.com:8080/path"})))))
 
     (testing "allows transient: references in URL-typed fields (resolved during ingest)"
       ;; Bulk/bundle submissions cross-link entities with transient IDs before

--- a/test/ctia/http/exceptions_test.clj
+++ b/test/ctia/http/exceptions_test.clj
@@ -1,6 +1,6 @@
 (ns ctia.http.exceptions-test
   (:require  [ctia.http.exceptions :as sut]
-             [clojure.test :refer [deftest is]]))
+             [clojure.test :refer [deftest is testing]]))
 
 (deftest es-ex-data-test
   (let [exdata {:es "don't like it"}
@@ -14,3 +14,17 @@
             :data data
             :ex-data exdata}
            (sut/es-ex-data exception data request)))))
+
+(deftest unsafe-url-scheme-error-handler-test
+  ;; XFV-135: pin the 400 status and error-type the handler produces. The
+  ;; registration test (crud_test) asserts the :unsafe-url-scheme-error type maps
+  ;; to THIS handler; this asserts the handler returns a 400 (not a 500 or 200).
+  ;; Together they close the chain from url-scheme-check to the HTTP response, so
+  ;; mutating `bad-request` here breaks a test.
+  (testing "returns HTTP 400 with the Invalid URL Scheme Error type"
+    (let [e (ex-info "Disallowed URL scheme in field(s): source_uri (javascript:)"
+                     {:type :unsafe-url-scheme-error
+                      :entity {:source_uri "javascript:alert(1)"}})
+          {:keys [status body]} (sut/unsafe-url-scheme-error-handler e nil nil)]
+      (is (= 400 status))
+      (is (= "Invalid URL Scheme Error" (:type body))))))


### PR DESCRIPTION
## Summary

Defense-in-depth against stored XSS (CWE-79 / CWE-116) via threat-intel URL-typed fields ([XFV-135](https://cisco-sbg.atlassian.net/browse/XFV-135)). Ingest now rejects any value in a URL-typed field whose scheme is not `http`/`https`, so a `javascript:` / `data:` / `vbscript:` payload can never be stored.

The gate is added as the last check in `ctia.flows.crud/validate-entities` — the single write chokepoint that both direct API writes and bundle/bulk import route through (`create-flow` / `update-flow` / `patch-flow`). The pure scheme/normalization predicates live in `ctia.domain.url-safety` (mirroring how `tlp-check`/`authorized-*-check` delegate to `ctia.domain.access-control`); the flow keeps only the thin `url-scheme-check` wrapper.

## What is gated

- **URL-typed keys** (recursively, at any nesting depth): `:url`, `:source_uri`, `:origin_uri`, `:reason_uri`, `:identity`. These are the CTIM `URI`-typed fields a UI renders as clickable `<a href>`.
- **Allowlist**: `http`, `https`. Scheme-less / relative values carry no scheme and pass.
- **Not gated**: free-text fields (e.g. `:description`) and observable IOC `:value` — recording a malicious URL as threat intel is legitimate and must not 400.

## Create vs. update (prev-entity diff)

On **create** (no prev-entity) every value is checked. On **update/patch** the gate flags only the values the caller is *introducing* relative to the stored entity — a value byte-identical to the stored one is not re-flagged. This mirrors `authorized-groups-check`/`authorized-users-check` (`introduced-foreign`), so all three write-gate checks behave consistently. It is required because `patch-entities` deep-merges the whole prev-entity before `validate-entities` runs: POST `/incident/:id/status` sends only `{:status …}`, but the stored `:source_uri` is merged back in, so full re-validation would 400 a status update that never mentioned the URI on a value predating the gate. No dangerous *value* absent from the stored entity can be introduced (create + introduced-on-update are both checked). The diff is value-level, not occurrence-level: re-writing another copy of a value already stored on the same document is not blocked, but that introduces no NEW payload, so the render-sink exposure is unchanged. A pre-gate value persisting until a data migration cleans it up is the accepted tradeoff — identical to the two authorized_* checks.

## Obfuscation handling

A naive scheme check is trivially bypassed by encodings that reconstruct at the HTML render sink. Before extracting the scheme, the value is normalized:

- HTML **numeric/hex** character references decoded (`&#106;`, `&#x3a;`), including the no-trailing-semicolon form.
- The **scheme-relevant named** references decoded: `&amp;` (the entity delimiter `&`, so a double-encoded `javascript&amp;colon;…` is unmasked), `&colon;` (the `:` delimiter), `&Tab;`, `&NewLine;` (whitespace the WHATWG URL parser strips). No HTML5 named reference decodes to a single ASCII *letter* usable to spell a scheme name, so this closed, scheme-relevant set is what the gate decodes; a named reference that decodes to a character the URL parser does not strip (e.g. `&ZeroWidthSpace;` → U+200B) cannot reconstruct an executable scheme and is left encoded.
- Decoding is **iterated to a bounded fixed point**, so a double-encoded delimiter (`javascript&#38;colon;…`) is unmasked. The named-reference lowercasing uses `Locale/ROOT` (locale-independent) with a nil-safe fallback.
- Control/whitespace/**format** characters stripped: `[\x00-\x20\x7f\p{Cf}\p{Z}]` (ASCII C0+space plus the non-ASCII ignorables the decoder can emit — U+200B, U+FEFF, U+00A0, U+00AD), which browsers ignore when resolving a URL.

Decoding can only *reveal* a hidden scheme; it never turns a legitimate `http(s)` URL into a dangerous one — the scheme sits at the front and is extracted before any decoded `&amp;`/`&colon;` in the query or body matters. It can surface a scheme on a *scheme-less* value that encoded a colon (e.g. a filename `report&#58;final.pdf`), which is then rejected as a non-`http(s)` scheme; URI-typed fields are expected to carry absolute `http(s)` URLs, so that rejection is acceptable rather than a false positive on a URL.

## Error surface

A rejected scheme is returned as **HTTP 400** via a dedicated exception handler (`unsafe-url-scheme-error-handler`), logged at `:warn` as a security-relevant anomaly — mirroring the existing `authorized_groups`/`authorized_users` handlers. Without the handler registration the throw would fall through to `default-error-handler` and surface as a misleading 500.

## Scope / ownership

The **primary** XSS control is output-encoding / scheme-filtering at the UI render sink, owned by the **XDR UI team** — this PR is the storage-layer backstop, not a replacement for it.

## Tests

`test/ctia/flows/crud_test.clj` + `test/ctia/http/exceptions_test.clj`, all passing. Coverage: `javascript:`/`data:`/`vbscript:` rejection under every URL-typed key; nested `external_references[].url`; control-char, numeric/hex/named-entity (case-insensitive), double-encoded-delimiter, and non-ASCII-ignorable obfuscation; a locale-independence regression (default Locale = `tr`); oversized/past-max-code-point no-crash; ambiguous bare authority (`example.com:8080/path`); collection- and set-valued fields; nested `:identity` string; uppercase safe scheme; `https`/scheme-less/free-text/`transient:` pass-through; prior-error passthrough; the create/update/patch prev-entity diff (introduced rejected, pre-existing exempt, swapped-payload rejected, `get-prev-entity` actually consulted on update); end-to-end through `validate-entities`; the exception-handler registration and its 400 status + error type.

## Adjudication of the 2026-09-03 re-review (ereteog)

All nine MEDIUM + one LOW findings addressed in the follow-up commit (see the summary comment for the per-finding disposition). CR1 (PATCH re-validation) is **fixed** via the prev-entity diff described above.

## Rejected findings

- **transient exemption — `transient:<uuid>` anchoring (reply, not changed).** The suggestion to anchor the exemption to `transient:<uuid>` does not fit CTIA: transient IDs are arbitrary client-chosen strings (the CTIM spec is `transient:.*`; real bundles use refs like `transient:0`), not necessarily UUIDs, so uuid-anchoring would 400 legitimate bundle cross-links. The exemption is safe because `transient:` is not a browser-executable scheme — an unresolved `transient:<anything>` is inert at the render sink. The docstring was corrected to rest on that (it previously implied the flow rewrites these values, which is not true for a plain URI field like `:source_uri`).
- **B3 — non-executable schemes (`mailto:`/`ftp:`/`urn:`/`s3:`) hard-rejected; make the allowlist config-driven (reply, not changed).** The allowlist stays a hardcoded `http`/`https`: these are the schemes a UI renders as clickable hyperlinks, which is exactly the XSS surface this backstop targets. The concrete pain B3 raised — a legacy non-`http(s)` URI 400-ing an unrelated update — is removed by the prev-entity diff (CR1 fix): a stored value the caller does not touch is no longer re-validated. A config-driven allowlist (à la `allowed-tlps`) can be added as a follow-up if a concrete legitimate `mailto:`/`ftp:` use case in these fields arises.
- **doc — a dangerous scheme nested under a non-URL-typed key (`{:url {:inner "javascript:…"}}`) is not flagged (reply, not changed).** This is intentional: CTIM URI fields are string-typed, and a map value under a URL-typed key does not render as an `href`. The misleading comment claiming such a value "is flagged by the recursion below" was corrected to state accurately what is and is not flagged.

- **CR1 — prev-entity diff is occurrence/path-blind (reply, rebuttal sharpened, code unchanged).** `set/difference` over `{:field :scheme :value}` is value-level, not occurrence- or path-level, so re-writing another copy of a dangerous value already stored on the document is not blocked — including the re-review's sharpened case: a value stored under `:url` copied into an `external_references[].url` (both produce the same `{:field :url …}` diff element, so the copy to the second location passes). This is an accepted tradeoff, not an oversight. The value+scheme pair is already stored and therefore already renders at a `:url` sink, so the attacker's payload already fires; an additional byte-identical sink of an already-renderable value grants no new scheme/value capability, and cannot escalate between URL-typed keys, which are all equally render sinks by definition. The security invariant that matters — *no dangerous value renders that was not already renderable* — holds. A path-aware / multiset diff would add complexity for no change to that invariant. The docstring at `crud.clj:198` was rewritten to state this explicitly rather than claim the render-sink exposure is "unchanged". (The diff still exists so a full-document PUT/patch echoing an already-stored value does not 400 an unrelated update.)
- **CR1 — decode surfaces a scheme on scheme-less encoded-colon values (reply, claim narrowed, code unchanged).** A value like `report&#58;final.pdf` decodes to `report:final.pdf` and is rejected as a non-`http(s)` scheme. The allowlist (reject by absence from http/https) is kept rather than switching to an executable-scheme denylist — a denylist is bypassable by novel schemes and would weaken the gate. URI-typed fields are expected to carry absolute `http(s)` URLs, so this fail-closed rejection is acceptable rather than a false positive on a URL. The "introduces no false positives" claim was reworded to "never turns a legitimate http(s) URL into a dangerous one."

Related: [XFV-135](https://cisco-sbg.atlassian.net/browse/XFV-135)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[XFV-135]: https://cisco-sbg.atlassian.net/browse/XFV-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


