### PR TITLE
XDR-59666: push ctia prod images under native prod OIDC role

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,9 +48,10 @@ env:
   # Kept here as env vars rather than repo secrets so the exact role is visible in
   # the workflow.
   #   INT  (372070498991): nonprod build + push to int/test-docker-build/ctia
-  #   PROD (862934447303): release image push to prod-docker-build/ctia
+  #   PROD (862934447303): release image push to prod-docker-build/ctia + SignalFx
+  #         token read in emit-metric (replaces the shared prod github_actions role)
   CI_INT_ROLE_ARN: arn:aws:iam::372070498991:role/IAM_INT_us-east-1_ctia
-  CI_PROD_ECR_PUSH_ROLE_ARN: arn:aws:iam::862934447303:role/IAM_PROD_us-east-1_ctia
+  CI_PROD_ROLE_ARN: arn:aws:iam::862934447303:role/IAM_PROD_us-east-1_ctia
 
 jobs:
   setup:
@@ -464,8 +465,8 @@ jobs:
         if: startsWith(github.ref_name, 'v')
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          # IAM_PROD_us-east-1_ctia: ECR push only, release-branch scoped
-          role-to-assume: ${{ env.CI_PROD_ECR_PUSH_ROLE_ARN }}
+          # IAM_PROD_us-east-1_ctia: ECR push + SignalFx token read, release-branch scoped
+          role-to-assume: ${{ env.CI_PROD_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Push prod images
@@ -504,8 +505,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          # prod role: reads the SignalFx ingest token only (XDR-57773)
-          role-to-assume: ${{ secrets.SRE_AWS_PROD_GITHUB_ACTIONS_ROLE_ARN }}
+          # Per-service prod role reads the token, replacing the shared role. XDR-59666.
+          role-to-assume: ${{ env.CI_PROD_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Emit github.pipeline.run to Splunk o11y

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,16 @@ env:
   DEFAULT_JAVA_VERSION: 21
   ARTIFACTORY_URL: artifactory.devhub-cloud.cisco.com
   ALPINE_VERSION: "3.22"
+  # Per-service GitHub Actions OIDC role ARNs for CI image pushes (XDR-59654 /
+  # XDR-59666). These are plaintext identifiers, not credentials: assuming a role
+  # is IAM-gated by each role's OIDC trust policy (pinned to threatgrid/ctia and,
+  # for the prod role, to release branches), so there is nothing secret to hide.
+  # Kept here as env vars rather than repo secrets so the exact role is visible in
+  # the workflow.
+  #   INT  (372070498991): nonprod build + push to int/test-docker-build/ctia
+  #   PROD (862934447303): release image push to prod-docker-build/ctia
+  CI_INT_ROLE_ARN: arn:aws:iam::372070498991:role/IAM_INT_us-east-1_ctia
+  CI_PROD_ECR_PUSH_ROLE_ARN: arn:aws:iam::862934447303:role/IAM_PROD_us-east-1_ctia
 
 jobs:
   setup:
@@ -422,8 +432,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          # INT_us-east-1_github_actions
-          role-to-assume: ${{ secrets.SRE_AWS_INT_GITHUB_ACTIONS_ROLE_ARN }}
+          # IAM_INT_us-east-1_ctia (nonprod build + int/test-docker-build push)
+          role-to-assume: ${{ env.CI_INT_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Fetch AWS Secrets
@@ -435,13 +445,32 @@ jobs:
           parse-json-secrets: true
 
       - id: deploy
-        run: ./build/deploy-actions.sh
+        name: Build and push nonprod image
+        run: ./build/deploy-actions.sh build
         env:
           # offline to catch issues where `lein warm-ci-deps` doesn't download all
           # dependencies we need to deploy.
           LEIN_OFFLINE: true
           DOCKER_USER: ${{ env.int_us_east_1_xdr_sre_user_jfrog_jfrog_username }}
           DOCKER_PASS: ${{ env.int_us_east_1_xdr_sre_user_jfrog_jfrog_token }}
+
+      # Prod image push runs under a native prod-account role (IAM_PROD_us-east-1_ctia,
+      # account 862934447303) instead of pushing cross-account from the INT role.
+      # This second configure-aws-credentials step re-assumes via OIDC (the prod
+      # role trusts the GitHub OIDC provider, not the INT role, so role-chaining is
+      # not possible), overwriting the INT credentials now that the nonprod push is
+      # done. Release-branch pushes only (vX.Y / vX.Y.Z). XDR-59666.
+      - name: Configure AWS credentials (prod ECR push)
+        if: startsWith(github.ref_name, 'v')
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          # IAM_PROD_us-east-1_ctia: ECR push only, release-branch scoped
+          role-to-assume: ${{ env.CI_PROD_ECR_PUSH_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Push prod images
+        if: startsWith(github.ref_name, 'v')
+        run: ./build/deploy-actions.sh push-prod
 
   # Pushes a github.pipeline.run datapoint to Splunk Observability so release
   # failures alert via the detector in tenzin

--- a/build/deploy-actions.sh
+++ b/build/deploy-actions.sh
@@ -4,7 +4,18 @@
 # Fails if run in non-deployment situations.
 #
 # Assumes awscli is set up with correct credentials for the current user.
+#
+# Deployment mode (first argument, default `build`):
+#   build      Build the uberjar + docker image and push it to the nonprod
+#              (INT account 372070498991) ECR repo. Runs under the INT OIDC role.
+#   push-prod  Re-tag the image produced by `build` and push it to the
+#              prod-account (862934447303) ECR repos in every prod region. Runs
+#              under the native prod OIDC role (IAM_PROD_us-east-1_ctia) rather
+#              than pushing cross-account from the INT role. Release branches
+#              only. XDR-59666.
 set -Eeuxo pipefail
+
+DEPLOY_MODE="${1:-build}"
 
 if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
   echo "./build/build-actions.sh currently supports push deployments only."
@@ -29,6 +40,12 @@ echo "branch: ${CTIA_BRANCH}"
 echo "build number: ${CTIA_BUILD_NUMBER}"
 echo "commit: ${CTIA_COMMIT}"
 
+# Image coordinates shared by the build and push-prod modes. build_version is
+# derived only from the run number and commit, so it is identical across the two
+# workflow steps and the prod push can re-tag the image the build step produced.
+build_version="${CTIA_BUILD_NUMBER}-${CTIA_COMMIT:0:8}"
+int_registry=372070498991.dkr.ecr.us-east-1.amazonaws.com
+
 function build-and-push-docker-image {
   build_type=$1
   if [ "$build_type" == 'int' ]; then
@@ -39,8 +56,7 @@ function build-and-push-docker-image {
     repo_prefix='test'
     echo "Building release docker image"
   fi
-  build_version="${CTIA_BUILD_NUMBER}-${CTIA_COMMIT:0:8}"
-  docker_registry=372070498991.dkr.ecr.us-east-1.amazonaws.com
+  docker_registry=$int_registry
   docker_repository=$repo_prefix-docker-build/ctia
   tempdir=$(mktemp -d)
   cp target/ctia.jar "$tempdir/"
@@ -67,25 +83,33 @@ EOF
   echo "$DOCKER_PASS" | docker login --username "$DOCKER_USER" --password-stdin "$ARTIFACTORY_URL"
   docker build -t "$docker_registry/$docker_repository:$build_version" .
   docker push "$docker_registry/$docker_repository:$build_version"
+}
 
+# Push the already-built release image to the prod-account ECR repos in every
+# prod region. The `build` step built the release image and pushed it to the
+# nonprod `test-docker-build/ctia` repo, so it is still present in this runner's
+# local docker image cache; here we only re-tag and push it. This runs under the
+# prod OIDC role (IAM_PROD_us-east-1_ctia in account 862934447303), so the prod
+# push uses the native prod identity instead of a cross-account push from the
+# INT role. XDR-59666.
+function push-prod-images {
+  source_image=$int_registry/test-docker-build/ctia:$build_version
+  prod_repository=prod-docker-build/ctia
 
-  if [ "$build_type" == 'rel' ]; then
-    prod_repository=prod-docker-build/ctia
-    prod_nam_registry=862934447303.dkr.ecr.us-east-1.amazonaws.com
-    aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "$prod_nam_registry"
-    docker tag "$docker_registry/$docker_repository:$build_version" "$prod_nam_registry/$prod_repository:$build_version"
-    docker push "$prod_nam_registry/$prod_repository:$build_version"
+  prod_nam_registry=862934447303.dkr.ecr.us-east-1.amazonaws.com
+  aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin "$prod_nam_registry"
+  docker tag "$source_image" "$prod_nam_registry/$prod_repository:$build_version"
+  docker push "$prod_nam_registry/$prod_repository:$build_version"
 
-    prod_eu_registry=862934447303.dkr.ecr.eu-west-1.amazonaws.com
-    aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$prod_eu_registry"
-    docker tag "$docker_registry/$docker_repository:$build_version" "$prod_eu_registry/$prod_repository:$build_version"
-    docker push "$prod_eu_registry/$prod_repository:$build_version"
+  prod_eu_registry=862934447303.dkr.ecr.eu-west-1.amazonaws.com
+  aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "$prod_eu_registry"
+  docker tag "$source_image" "$prod_eu_registry/$prod_repository:$build_version"
+  docker push "$prod_eu_registry/$prod_repository:$build_version"
 
-    prod_apjc_registry=862934447303.dkr.ecr.ap-northeast-1.amazonaws.com
-    aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin "$prod_apjc_registry"
-    docker tag "$docker_registry/$docker_repository:$build_version" "$prod_apjc_registry/$prod_repository:$build_version"
-    docker push "$prod_apjc_registry/$prod_repository:$build_version"
-  fi
+  prod_apjc_registry=862934447303.dkr.ecr.ap-northeast-1.amazonaws.com
+  aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin "$prod_apjc_registry"
+  docker tag "$source_image" "$prod_apjc_registry/$prod_repository:$build_version"
+  docker push "$prod_apjc_registry/$prod_repository:$build_version"
 }
 
 function build-and-publish-package {
@@ -105,6 +129,20 @@ function build-and-publish-package {
 
   build-and-push-docker-image "$PKG_TYPE"
 }
+
+if [[ "${DEPLOY_MODE}" == "push-prod" ]]; then
+  # Prod image push (XDR-59666): release branches only. The build step already
+  # produced and pushed the release image to nonprod ECR; here we only re-tag
+  # and push it to prod under the prod OIDC role.
+  if [[ ${CTIA_BRANCH} =~ ^v[0-9]+([.][0-9]+)+$ ]]; then
+    echo "OK: release branch ${CTIA_BRANCH} detected; pushing prod images"
+    push-prod-images
+    exit 0
+  else
+    echo "push-prod requested on non-release branch ${CTIA_BRANCH}; nothing to push."
+    exit 0
+  fi
+fi
 
 if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
   if [[ ${CTIA_BRANCH} == "master" ]]; then


### PR DESCRIPTION
## Summary

Cuts ctia's release image push over to a **native prod-account OIDC role** (XDR-59666), instead of pushing to prod ECR cross-account under the nonprod INT role.

Today the `deploy` job assumes the INT role once and does everything: it builds the release image, pushes it to nonprod ECR, and then tags + pushes the three prod-region images into the prod account (`862934447303`) — relying on the prod ECR repo policy trusting the entire INT account root. This splits that into two credential domains.

## What changed

**`build/deploy-actions.sh`** — now takes a mode argument:
- `build` (default) — build the uberjar + docker image and push it to nonprod (INT `372070498991`) ECR. Unchanged behavior for `master` (int) and release (`test`) builds.
- `push-prod` — re-tag the image the `build` step produced and push it to `prod-docker-build/ctia` in all three prod regions (us-east-1 / eu-west-1 / ap-northeast-1). Release branches (`^v[0-9]+([.][0-9]+)+$`) only; no-ops otherwise. Relies on the built image still being in the runner's local docker cache from the `build` step in the same job (build_version is derived only from run number + commit, so the tag is identical across the two steps).

**`.github/workflows/pr.yml`** (`deploy` job):
- Run `./build/deploy-actions.sh build` under the INT role (as before).
- On release branches only (`if: startsWith(github.ref_name, 'v')`), a second `configure-aws-credentials` step assumes the prod role via OIDC, then runs `./build/deploy-actions.sh push-prod`. Role-chaining isn't possible (the prod role trusts the GitHub OIDC provider, not the INT role), so a second OIDC assume-role is the correct pattern.
- Role ARNs moved from repo secrets to plaintext top-level `env:` vars (`CI_INT_ROLE_ARN`, `CI_PROD_ECR_PUSH_ROLE_ARN`). An ARN is an identifier, not a credential — assume-role is IAM-gated by each role's OIDC trust policy. **The INT build now uses the per-service `IAM_INT_us-east-1_ctia` role** (was the shared `INT_us-east-1_github_actions`). `emit-metric`'s SignalFx role is untouched.

## Why this is safe on non-release branches

The prod push is gated three ways: `on.push.branches` only triggers the workflow for `master` / `v[0-9]+.[0-9]+` / `v[0-9]+.[0-9]+.[0-9]+`; the workflow step `if` limits the prod steps to `v*` refs; and the script re-checks the release regex. The **authoritative** backstop is the prod role's IAM trust policy, pinned to `repository = threatgrid/ctia` AND `sub` `refs/heads/v*.*.*`.

## Prerequisites (ordering matters)

Both roles are created by the tenzin terraform apply tracked in **XDR-59668**. Apply XDR-59668 **before merging this PR**:

- `arn:aws:iam::372070498991:role/IAM_INT_us-east-1_ctia` — assumed on **every push to master** (and release builds), not just releases. If this role does not exist when the first post-merge master push runs, the nonprod build fails at assume-role. (This role already grants int+test ECR push for `ctia`, the `xdr-sre-user-jfrog` secret, and the prod cross-account ECR ARNs — same shape as the in-production `iroh` role.)
- `arn:aws:iam::862934447303:role/IAM_PROD_us-east-1_ctia` — assumed only by the release-branch prod push; needed before the next release cut.

Note: the prod trust is pinned to `refs/heads/v*.*.*` (two dots). Releases are cut as `vX.Y.Z`, so this matches; a two-segment `vX.Y` release branch would be rejected by IAM (out of scope here).

## Validation

- `bash -n build/deploy-actions.sh` — syntax OK
- `./scripts/shellcheck-build.sh` (shellcheck `-S style`) — clean (also runs in this PR's `setup` job)
- `pr.yml` — YAML parses
- Verified against tenzin `int-use1/ci` that `IAM_INT_us-east-1_ctia` grants int+test ECR push, the jfrog secret (no CMK/KMS needed — mirrors the in-production `iroh` role), and trusts `threatgrid/ctia` on any branch push (`refs/heads/*`).

Note: the `deploy`/`push-prod` path only runs on push to master/release, not on PRs, so the cutover itself is first exercised post-merge (next master build → INT role; next release cut → prod push).

Refs: XDR-59666 (workflow cutover), XDR-59668 (prod/int role terraform), XDR-59654 (epic).
