### PR TITLE
fix(judgement): scope verdict calculation to the caller's own org (XFV-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ value does not fail, only newly-introduced foreign values are rejected.
 
 Please note that the `authorized_groups` property may work only if max record visibility is set to `everyone`
 
-##### Verdict carve-out (XFV-20)
+##### Verdict carve-out
 
 The access rules above (TLP visibility and `authorized_users` / `authorized_groups`)
 govern reading and listing individual documents. A Verdict is different: it is a
@@ -278,8 +278,9 @@ public (Green/White) TLP under `everyone` visibility -- is still readable but do
 **not** contribute to the caller's Verdict. This prevents cross-tenant "verdict
 poisoning" while leaving ordinary cross-tenant reads and lists unchanged.
 
-A corollary: a caller with no org of its own -- for example a static-auth
-deployment with `ctia.auth.static.group` unset, or the anonymous identity of
+A corollary: a caller with no org of its own -- a JWT whose `org/id` claim is
+missing (the usual production case), a static-auth deployment with a blank
+`ctia.auth.static.group`, or the anonymous identity of
 `ctia.auth.static.readonly-for-anonymous` -- has no owned Judgements to scope a
 Verdict to and therefore receives no Verdict (HTTP 404) for any Observable,
 including public (Green/White) TLP Observables that a plain document read would

--- a/README.md
+++ b/README.md
@@ -267,6 +267,17 @@ value does not fail, only newly-introduced foreign values are rejected.
 
 Please note that the `authorized_groups` property may work only if max record visibility is set to `everyone`
 
+##### Verdict carve-out (XFV-20)
+
+The access rules above (TLP visibility and `authorized_users` / `authorized_groups`)
+govern reading and listing individual documents. A Verdict is different: it is a
+tenant-local trust decision, so it is derived **only from Judgements owned by the
+querying org** (their stored `groups`). A Judgement that another org merely shares
+with the caller -- whether via `authorized_users` / `authorized_groups` or via a
+public (Green/White) TLP under `everyone` visibility -- is still readable but does
+**not** contribute to the caller's Verdict. This prevents cross-tenant "verdict
+poisoning" while leaving ordinary cross-tenant reads and lists unchanged.
+
 Examples:
 
 The following actor Entity is marked as `Red`, thus allowing only its owner RW access.

--- a/README.md
+++ b/README.md
@@ -271,8 +271,11 @@ Please note that the `authorized_groups` property may work only if max record vi
 
 The access rules above (TLP visibility and `authorized_users` / `authorized_groups`)
 govern reading and listing individual documents. A Verdict is different: it is a
-tenant-local trust decision, so it is derived **only from Judgements owned by the
-querying org** (their stored `groups`). A Judgement that another org merely shares
+tenant-local trust decision, so it is derived **only from Judgements the caller
+can read that are also owned by the querying org** (their stored `groups`). A
+Judgement owned by a different user in the caller's own org that the caller
+cannot read (e.g. a TLP-red judgement without a sharing grant) does not
+contribute either. A Judgement that another org merely shares
 with the caller -- whether via `authorized_users` / `authorized_groups` or via a
 public (Green/White) TLP under `everyone` visibility -- is still readable but does
 **not** contribute to the caller's Verdict. This prevents cross-tenant "verdict

--- a/README.md
+++ b/README.md
@@ -278,6 +278,13 @@ public (Green/White) TLP under `everyone` visibility -- is still readable but do
 **not** contribute to the caller's Verdict. This prevents cross-tenant "verdict
 poisoning" while leaving ordinary cross-tenant reads and lists unchanged.
 
+A corollary: a caller with no org of its own -- for example a static-auth
+deployment with `ctia.auth.static.group` unset, or the anonymous identity of
+`ctia.auth.static.readonly-for-anonymous` -- has no owned Judgements to scope a
+Verdict to and therefore receives no Verdict (HTTP 404) for any Observable,
+including public (Green/White) TLP Observables that a plain document read would
+still return.
+
 Examples:
 
 The following actor Entity is marked as `Red`, thus allowing only its owner RW access.

--- a/resources/ctia/public/doc/design.md
+++ b/resources/ctia/public/doc/design.md
@@ -38,13 +38,15 @@ Practically, that means Judgements related to IPs, Domains, and
 Checksums.  For unshared data, the Pre-Customer Private Cloud model
 would be used.
 
-**Verdict scoping (XFV-20):** while shared documents (Judgements on IPs,
+**Verdict scoping:** while shared documents (Judgements on IPs,
 Domains, and Checksums) remain readable across orgs, a **verdict** is a
 tenant-local trust decision.  A verdict is computed only from judgements
 owned by the querying org, so it is not shared cross-tenant -- independent
 of TLP, of `max-record-visibility`, or of any `authorized_groups` /
 `authorized_users` grant on a foreign-owned judgement.  A caller with no org of
-its own therefore receives no verdict at all.
+its own (a JWT missing `org/id`, static-auth with a blank
+`ctia.auth.static.group`, or the anonymous read-only identity) therefore
+receives no verdict at all.
 
 #### Requirements
 

--- a/resources/ctia/public/doc/design.md
+++ b/resources/ctia/public/doc/design.md
@@ -43,7 +43,8 @@ Domains, and Checksums) remain readable across orgs, a **verdict** is a
 tenant-local trust decision.  A verdict is computed only from judgements
 owned by the querying org, so it is not shared cross-tenant -- independent
 of TLP, of `max-record-visibility`, or of any `authorized_groups` /
-`authorized_users` grant on a foreign-owned judgement.
+`authorized_users` grant on a foreign-owned judgement.  A caller with no org of
+its own therefore receives no verdict at all.
 
 #### Requirements
 

--- a/resources/ctia/public/doc/design.md
+++ b/resources/ctia/public/doc/design.md
@@ -40,10 +40,11 @@ would be used.
 
 **Verdict scoping:** while shared documents (Judgements on IPs,
 Domains, and Checksums) remain readable across orgs, a **verdict** is a
-tenant-local trust decision.  A verdict is computed only from judgements
-owned by the querying org, so it is not shared cross-tenant -- independent
-of TLP, of `max-record-visibility`, or of any `authorized_groups` /
-`authorized_users` grant on a foreign-owned judgement.  A caller with no org of
+tenant-local trust decision.  A verdict is computed only from judgements the
+querying org can read that are also owned by it, so it is not shared
+cross-tenant -- independent of TLP, of `max-record-visibility`, or of any
+`authorized_groups` / `authorized_users` grant on a foreign-owned judgement.  A
+caller with no org of
 its own (a JWT missing `org/id`, static-auth with a blank
 `ctia.auth.static.group`, or the anonymous read-only identity) therefore
 receives no verdict at all.

--- a/resources/ctia/public/doc/design.md
+++ b/resources/ctia/public/doc/design.md
@@ -38,6 +38,13 @@ Practically, that means Judgements related to IPs, Domains, and
 Checksums.  For unshared data, the Pre-Customer Private Cloud model
 would be used.
 
+**Verdict scoping (XFV-20):** while shared documents (Judgements on IPs,
+Domains, and Checksums) remain readable across orgs, a **verdict** is a
+tenant-local trust decision.  A verdict is computed only from judgements
+owned by the querying org, so it is not shared cross-tenant -- independent
+of TLP, of `max-record-visibility`, or of any `authorized_groups` /
+`authorized_users` grant on a foreign-owned judgement.
+
 #### Requirements
 
 * Plug-in authentication and authorization
@@ -58,8 +65,9 @@ Incidents and other data that organizations are not willing to share.
 
 They can configure their devices to query their instance specifically.
 And effectively see an overlay of their data on the global data set
-for Judgements and Verdicts.  This allows the most performance
-critical queries to be made once.  The remainder of the API would
+for Judgements.  The overlay applies to document reads; verdicts are
+computed per-org (see the Verdict scoping note above).  This allows
+the most performance critical queries to be made once.  The remainder of the API would
 require explicit lookups to the global instance.
 
 #### Requiremnts

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -58,11 +58,15 @@
    judgements owned by the caller's own org, regardless of this setting or of
    any =authorized_groups= / =authorized_users= grant on a foreign-owned
    judgement (XFV-20). A consequence is that a caller with no org of its own
-   gets no verdict at all: a static-auth deployment with =ctia.auth.static.group=
-   unset, or =ctia.auth.static.readonly-for-anonymous= = =true= (whose anonymous
-   identity has no real tenant), returns 404 for every =.../verdict= request --
-   including public (Green/White) TLP observables that a document read would
-   still return under =max-record-visibility= = =everyone=.
+   gets no verdict at all. With =ctia.auth.static.group= unset, even the
+   authenticated static write identity is org-less, so every =.../verdict=
+   request returns 404. Under =ctia.auth.static.readonly-for-anonymous= = =true=,
+   a request that does not present =ctia.auth.static.secret= resolves to the
+   org-less read-only identity and returns 404 for =.../verdict= (a request that
+   presents the secret still receives a verdict when =ctia.auth.static.group= is
+   set) -- including public
+   (Green/White) TLP observables that a document read would still return under
+   =max-record-visibility= = =everyone=.
 
 
 ** HTTP

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -54,8 +54,8 @@
 
    Note: =max-record-visibility= governs *document* reads and searches only.
    Verdict computation (the REST =GET .../verdict= endpoint and the GraphQL
-   =verdict= field) is always org-scoped: a verdict is computed solely from
-   judgements owned by the caller's own org, regardless of this setting or of
+   =verdict= field) is always org-scoped: a verdict is computed only from the
+   judgements the caller can read that are also owned by its own org, regardless of this setting or of
    any =authorized_groups= / =authorized_users= grant on a foreign-owned
    judgement. A consequence is that a caller with no org of its own gets no
    verdict at all: the usual production case is a JWT whose =org/id= claim is

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -57,10 +57,11 @@
    =verdict= field) is always org-scoped: a verdict is computed solely from
    judgements owned by the caller's own org, regardless of this setting or of
    any =authorized_groups= / =authorized_users= grant on a foreign-owned
-   judgement (XFV-20). A consequence is that an authenticated caller with no org
-   of its own gets no verdict at all. With =ctia.auth.static.group= unset, even
-   the authenticated static write identity is org-less, so its =.../verdict=
-   requests return 404. Under =ctia.auth.static.readonly-for-anonymous= = =true=,
+   judgement. A consequence is that a caller with no org of its own gets no
+   verdict at all: the usual production case is a JWT whose =org/id= claim is
+   missing. With =ctia.auth.static.group= blank, even the authenticated static
+   write identity is org-less, so its =.../verdict= requests return 404. Under
+   =ctia.auth.static.readonly-for-anonymous= = =true=,
    a request that does not present =ctia.auth.static.secret= resolves to the
    org-less read-only identity and returns 404 for =.../verdict= (a request that
    presents the secret still receives a verdict when =ctia.auth.static.group= is

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -52,6 +52,12 @@
  | ctia.access-control.default-tlp           | set the TLP for a newly posted entity if none is specified | =white= =green= =amber= =red=  |
  | ctia.access-control.max-record-visibility | set the record max visibility for TLP Green/White          | =everyone= =group=             |
 
+   Note: =max-record-visibility= governs *document* reads and searches only.
+   The verdict endpoint (=GET .../verdict=) is always org-scoped: a verdict is
+   computed solely from judgements owned by the caller's own org, regardless of
+   this setting or of any =authorized_groups= / =authorized_users= grant on a
+   foreign-owned judgement (XFV-20).
+
 
 ** HTTP
 

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -53,10 +53,16 @@
  | ctia.access-control.max-record-visibility | set the record max visibility for TLP Green/White          | =everyone= =group=             |
 
    Note: =max-record-visibility= governs *document* reads and searches only.
-   The verdict endpoint (=GET .../verdict=) is always org-scoped: a verdict is
-   computed solely from judgements owned by the caller's own org, regardless of
-   this setting or of any =authorized_groups= / =authorized_users= grant on a
-   foreign-owned judgement (XFV-20).
+   Verdict computation (the REST =GET .../verdict= endpoint and the GraphQL
+   =verdict= field) is always org-scoped: a verdict is computed solely from
+   judgements owned by the caller's own org, regardless of this setting or of
+   any =authorized_groups= / =authorized_users= grant on a foreign-owned
+   judgement (XFV-20). A consequence is that a caller with no org of its own
+   gets no verdict at all: a static-auth deployment with =ctia.auth.static.group=
+   unset, or =ctia.auth.static.readonly-for-anonymous= = =true= (whose anonymous
+   identity has no real tenant), returns 404 for every =.../verdict= request --
+   including public (Green/White) TLP observables that a document read would
+   still return under =max-record-visibility= = =everyone=.
 
 
 ** HTTP

--- a/resources/ctia/public/doc/properties.org
+++ b/resources/ctia/public/doc/properties.org
@@ -57,14 +57,16 @@
    =verdict= field) is always org-scoped: a verdict is computed solely from
    judgements owned by the caller's own org, regardless of this setting or of
    any =authorized_groups= / =authorized_users= grant on a foreign-owned
-   judgement (XFV-20). A consequence is that a caller with no org of its own
-   gets no verdict at all. With =ctia.auth.static.group= unset, even the
-   authenticated static write identity is org-less, so every =.../verdict=
-   request returns 404. Under =ctia.auth.static.readonly-for-anonymous= = =true=,
+   judgement (XFV-20). A consequence is that an authenticated caller with no org
+   of its own gets no verdict at all. With =ctia.auth.static.group= unset, even
+   the authenticated static write identity is org-less, so its =.../verdict=
+   requests return 404. Under =ctia.auth.static.readonly-for-anonymous= = =true=,
    a request that does not present =ctia.auth.static.secret= resolves to the
    org-less read-only identity and returns 404 for =.../verdict= (a request that
    presents the secret still receives a verdict when =ctia.auth.static.group= is
-   set) -- including public
+   set). A request that never authenticates -- =readonly-for-anonymous= off and
+   no valid secret -- is refused earlier by the =:read-verdict= capability gate
+   (401/403), not turned into a 404. The org-less 404 applies even to public
    (Green/White) TLP observables that a document read would still return under
    =max-record-visibility= = =everyone=.
 

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -21,6 +21,18 @@
 
 (def admingroup "Administrators")
 
+(s/defn anonymous-ident? :- s/Bool
+  "True when the identity represents no real org/tenant: either it carries no
+   groups at all (a JWT missing `org/id`, or static-auth with
+   `ctia.auth.static.group` unset), or it carries only the not-logged-in
+   sentinel group (the `readonly-for-anonymous` ReadOnlyIdentity, which reports
+   `not-logged-in-groups`). Such a caller has no tenant to scope a tenant-local
+   decision (e.g. a verdict) to."
+  [ident]
+  (let [groups (:groups ident)]
+    (boolean (or (empty? groups)
+                 (= (set not-logged-in-groups) (set groups))))))
+
 (defrecord DeniedIdentity []
   IIdentity
   (authenticated? [_]

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -49,29 +49,16 @@
    :groups [s/Str]})
 
 (s/defn orgless-ident? :- s/Bool
-  "True when the identity carries no real org/tenant: either it has no groups at
-   all (a JWT missing `org/id`, or static-auth with `ctia.auth.static.group`
-   unset), or it carries only the not-logged-in sentinel group (the
-   `readonly-for-anonymous` ReadOnlyIdentity, which reports
-   `not-logged-in-groups`). Such a caller has no tenant to scope a tenant-local
-   decision (e.g. a verdict) to.
+  "True when the identity has no real org/tenant to scope a tenant-local
+   decision (a verdict) to: no groups at all (a JWT missing `org/id`, static-auth
+   with a blank `ctia.auth.static.group`), or only the not-logged-in sentinel
+   (the `readonly-for-anonymous` identity). Blank group strings count as absent.
 
-   Takes the map form (`IdentityMap`) rather than an `IIdentity` record on
-   purpose: a plain `:groups` key exists on only SOME implementations. On
-   `ctia.auth.threatgrid/Identity` there is a literal `groups` field, so
-   `(:groups record)` happens to return the real group list and the predicate
-   would answer correctly -- but on the static and JWT identities groups live
-   only behind the `groups` protocol method, so `(:groups record)` is `nil` and
-   the predicate would wrongly answer `true`. A record read is therefore
-   silently correct on threatgrid and silently wrong elsewhere; callers must
-   pass the identity map (`ident->map` / the route `identity-map`) so the answer
-   is uniform across implementations.
-
-   Blank group strings are treated as absent: a JWT with a blank `org/id` claim
-   (or static-auth with a blank `ctia.auth.static.group`) reports `[\"\"]`, which
-   is neither empty nor the sentinel. Dropping blanks here makes one predicate
-   decide the org-less question for every implementation, so no identity slips
-   through to issue a match-nothing `{:terms {\"groups\" [\"\"]}}` verdict filter."
+   Takes the identity *map* (`ident->map`), not an `IIdentity` record: `groups`
+   is a protocol method rather than a field on the static and JWT identities, so
+   `(:groups record)` would read `nil` and the predicate would wrongly answer
+   `true` (it happens to work on `ctia.auth.threatgrid/Identity`, which has a
+   real `groups` field -- silently correct there, silently wrong elsewhere)."
   [ident :- IdentityMap]
   (let [groups (remove str/blank? (:groups ident))]
     (boolean (or (empty? groups)

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -21,18 +21,6 @@
 
 (def admingroup "Administrators")
 
-(s/defn anonymous-ident? :- s/Bool
-  "True when the identity represents no real org/tenant: either it carries no
-   groups at all (a JWT missing `org/id`, or static-auth with
-   `ctia.auth.static.group` unset), or it carries only the not-logged-in
-   sentinel group (the `readonly-for-anonymous` ReadOnlyIdentity, which reports
-   `not-logged-in-groups`). Such a caller has no tenant to scope a tenant-local
-   decision (e.g. a verdict) to."
-  [ident]
-  (let [groups (:groups ident)]
-    (boolean (or (empty? groups)
-                 (= (set not-logged-in-groups) (set groups))))))
-
 (defrecord DeniedIdentity []
   IIdentity
   (authenticated? [_]
@@ -58,6 +46,24 @@
   {:client-id (s/maybe s/Str)
    :login (s/maybe s/Str)
    :groups [s/Str]})
+
+(s/defn orgless-ident? :- s/Bool
+  "True when the identity carries no real org/tenant: either it has no groups at
+   all (a JWT missing `org/id`, or static-auth with `ctia.auth.static.group`
+   unset), or it carries only the not-logged-in sentinel group (the
+   `readonly-for-anonymous` ReadOnlyIdentity, which reports
+   `not-logged-in-groups`). Such a caller has no tenant to scope a tenant-local
+   decision (e.g. a verdict) to.
+
+   Takes the map form (`IdentityMap`) rather than an `IIdentity` record: groups
+   live behind the `groups` protocol method on a record, not a `:groups` key, so
+   `(:groups record)` would be `nil` and the predicate would wrongly answer
+   `true`. Callers must pass the identity map (`ident->map` / the route
+   `identity-map`)."
+  [ident :- IdentityMap]
+  (let [groups (:groups ident)]
+    (boolean (or (empty? groups)
+                 (= (set not-logged-in-groups) (set groups))))))
 
 (s/defn ident->map :- (s/maybe IdentityMap)
   [ident :- (s/maybe AuthIdentity)]

--- a/src/ctia/auth.clj
+++ b/src/ctia/auth.clj
@@ -1,5 +1,6 @@
 (ns ctia.auth
-  (:require [schema.core :as s]))
+  (:require [clojure.string :as str]
+            [schema.core :as s]))
 
 (defprotocol IIdentity
   (authenticated? [this])
@@ -55,13 +56,24 @@
    `not-logged-in-groups`). Such a caller has no tenant to scope a tenant-local
    decision (e.g. a verdict) to.
 
-   Takes the map form (`IdentityMap`) rather than an `IIdentity` record: groups
-   live behind the `groups` protocol method on a record, not a `:groups` key, so
-   `(:groups record)` would be `nil` and the predicate would wrongly answer
-   `true`. Callers must pass the identity map (`ident->map` / the route
-   `identity-map`)."
+   Takes the map form (`IdentityMap`) rather than an `IIdentity` record on
+   purpose: a plain `:groups` key exists on only SOME implementations. On
+   `ctia.auth.threatgrid/Identity` there is a literal `groups` field, so
+   `(:groups record)` happens to return the real group list and the predicate
+   would answer correctly -- but on the static and JWT identities groups live
+   only behind the `groups` protocol method, so `(:groups record)` is `nil` and
+   the predicate would wrongly answer `true`. A record read is therefore
+   silently correct on threatgrid and silently wrong elsewhere; callers must
+   pass the identity map (`ident->map` / the route `identity-map`) so the answer
+   is uniform across implementations.
+
+   Blank group strings are treated as absent: a JWT with a blank `org/id` claim
+   (or static-auth with a blank `ctia.auth.static.group`) reports `[\"\"]`, which
+   is neither empty nor the sentinel. Dropping blanks here makes one predicate
+   decide the org-less question for every implementation, so no identity slips
+   through to issue a match-nothing `{:terms {\"groups\" [\"\"]}}` verdict filter."
   [ident :- IdentityMap]
-  (let [groups (:groups ident)]
+  (let [groups (remove str/blank? (:groups ident))]
     (boolean (or (empty? groups)
                  (= (set not-logged-in-groups) (set groups))))))
 

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -61,19 +61,20 @@
   IAuth
   [[:ConfigService get-in-config]]
   (init [this context]
-        (let [auth-config (get-in-config [:ctia :auth])]
-          ;; XFV-20: a verdict is tenant-local. When `ctia.auth.static.group` is
-          ;; blank, even the authenticated static write identity is org-less, so
-          ;; its `.../verdict` requests 404 (a request that never authenticates
-          ;; is refused earlier by the capability gate, not here). `log/debugf` in
-          ;; the verdict path produces nothing at the shipped `info` root level,
-          ;; so surface the deployment-level cause once here, where it is knowable
-          ;; and a `log/warn` reaches an operator.
-          (when (str/blank? (get-in auth-config [:static :group]))
+        (let [auth-config (get-in-config [:ctia :auth])
+              static-cfg (:static auth-config)]
+          ;; XFV-20: a verdict is tenant-local, so an org-less caller receives
+          ;; none (HTTP 404). Warn once at boot for the two static-auth settings
+          ;; that leave callers org-less -- the per-request signal is only a
+          ;; `log/debugf`, off at the shipped `info` level.
+          (when (str/blank? (:group static-cfg))
             (log/warn (str "ctia.auth.static.group is blank: the authenticated "
                            "static (write) identity has no org, so its verdict "
-                           "requests return 404. Set ctia.auth.static.group to "
-                           "enable verdict computation for static-auth callers.")))
+                           "requests return 404.")))
+          (when (:readonly-for-anonymous static-cfg)
+            (log/warn (str "ctia.auth.static.readonly-for-anonymous is on: "
+                           "anonymous callers have no org, so their verdict "
+                           "requests return 404.")))
           (assoc context :auth-config auth-config)))
   (identity-for-token [this token]
     (let [{:keys [auth-config]} (service-context this)
@@ -81,17 +82,7 @@
           readonly? (get-in auth-config [:static :readonly-for-anonymous])]
       (cond
         (= token secret) (->WriteIdentity (get-in auth-config [:static :name])
-                                          ;; XFV-20: normalize a blank group to
-                                          ;; nil at the source so `orgless-ident?`
-                                          ;; and the boot warning agree. Without
-                                          ;; this, a blank (but non-nil) group
-                                          ;; would make `(groups)` return `[""]`
-                                          ;; -- neither empty nor the sentinel --
-                                          ;; so the verdict guard would be
-                                          ;; bypassed and the request would 404
-                                          ;; via a match-nothing filter instead.
-                                          (let [group (get-in auth-config [:static :group])]
-                                            (when-not (str/blank? group) group)))
+                                          (get-in auth-config [:static :group]))
         ;; Readonly access when the password does not match
         readonly? (->ReadOnlyIdentity)
         :else auth/denied-identity-singleton))))

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -63,16 +63,17 @@
   (init [this context]
         (let [auth-config (get-in-config [:ctia :auth])]
           ;; XFV-20: a verdict is tenant-local. When `ctia.auth.static.group` is
-          ;; unset, even the authenticated static write identity is org-less, so
-          ;; EVERY `.../verdict` request 404s. `log/debugf` in the verdict path
-          ;; produces nothing at the shipped `info` root level, so surface the
-          ;; deployment-level cause once here, where it is knowable and a
-          ;; `log/warn` reaches an operator.
+          ;; blank, even the authenticated static write identity is org-less, so
+          ;; its `.../verdict` requests 404 (a request that never authenticates
+          ;; is refused earlier by the capability gate, not here). `log/debugf` in
+          ;; the verdict path produces nothing at the shipped `info` root level,
+          ;; so surface the deployment-level cause once here, where it is knowable
+          ;; and a `log/warn` reaches an operator.
           (when (str/blank? (get-in auth-config [:static :group]))
-            (log/warn (str "ctia.auth.static.group is unset: the static write "
-                           "identity has no org, so every verdict request will "
-                           "return 404. Set ctia.auth.static.group to enable "
-                           "verdict computation for static-auth callers.")))
+            (log/warn (str "ctia.auth.static.group is blank: the authenticated "
+                           "static (write) identity has no org, so its verdict "
+                           "requests return 404. Set ctia.auth.static.group to "
+                           "enable verdict computation for static-auth callers.")))
           (assoc context :auth-config auth-config)))
   (identity-for-token [this token]
     (let [{:keys [auth-config]} (service-context this)
@@ -80,7 +81,17 @@
           readonly? (get-in auth-config [:static :readonly-for-anonymous])]
       (cond
         (= token secret) (->WriteIdentity (get-in auth-config [:static :name])
-                                          (get-in auth-config [:static :group]))
+                                          ;; XFV-20: normalize a blank group to
+                                          ;; nil at the source so `orgless-ident?`
+                                          ;; and the boot warning agree. Without
+                                          ;; this, a blank (but non-nil) group
+                                          ;; would make `(groups)` return `[""]`
+                                          ;; -- neither empty nor the sentinel --
+                                          ;; so the verdict guard would be
+                                          ;; bypassed and the request would 404
+                                          ;; via a match-nothing filter instead.
+                                          (let [group (get-in auth-config [:static :group])]
+                                            (when-not (str/blank? group) group)))
         ;; Readonly access when the password does not match
         readonly? (->ReadOnlyIdentity)
         :else auth/denied-identity-singleton))))

--- a/src/ctia/auth/static.clj
+++ b/src/ctia/auth/static.clj
@@ -3,6 +3,7 @@
             [clojure
              [set :as set]
              [string :as str]]
+            [clojure.tools.logging :as log]
             [ctia.auth :as auth :refer [IAuth IIdentity]]
             [ctia.auth.capabilities :refer [all-capabilities]]
             [puppetlabs.trapperkeeper.core :as tk]
@@ -60,7 +61,19 @@
   IAuth
   [[:ConfigService get-in-config]]
   (init [this context]
-        (assoc context :auth-config (get-in-config [:ctia :auth])))
+        (let [auth-config (get-in-config [:ctia :auth])]
+          ;; XFV-20: a verdict is tenant-local. When `ctia.auth.static.group` is
+          ;; unset, even the authenticated static write identity is org-less, so
+          ;; EVERY `.../verdict` request 404s. `log/debugf` in the verdict path
+          ;; produces nothing at the shipped `info` root level, so surface the
+          ;; deployment-level cause once here, where it is knowable and a
+          ;; `log/warn` reaches an operator.
+          (when (str/blank? (get-in auth-config [:static :group]))
+            (log/warn (str "ctia.auth.static.group is unset: the static write "
+                           "identity has no org, so every verdict request will "
+                           "return 404. Set ctia.auth.static.group to enable "
+                           "verdict computation for static-auth callers.")))
+          (assoc context :auth-config auth-config)))
   (identity-for-token [this token]
     (let [{:keys [auth-config]} (service-context this)
           secret (get-in auth-config [:static :secret])

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -1,6 +1,7 @@
 (ns ctia.entity.judgement.es-store
   (:require [ductile.document :refer [search-docs]]
             [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [clj-momo.lib.time :as time]
             [ctia.entity.judgement.schemas
              :refer
@@ -52,48 +53,65 @@
   "XFV-20: a verdict is a tenant-local trust decision. Restrict verdict
    candidates to judgements owned by the caller's own org (`groups`), so a
    judgement that merely lists the caller's org in `authorized_groups` /
-   `authorized_users` cannot dominate (poison) the caller's verdict. This
-   neutralizes any pre-existing cross-tenant grant for verdict calculation
-   regardless of the `authorized_*` clauses in `find-restriction-query-part`."
+   `authorized_users` cannot contribute to (poison) the caller's verdict.
+
+   This neutralizes any pre-existing cross-tenant *read* grant for verdict
+   calculation, regardless of the `authorized_*` clauses in
+   `find-restriction-query-part`. It does NOT touch the *write* path: a
+   foreign org listed in a victim-owned document's `authorized_groups` can
+   still update that document (`allow-write?` in
+   `ctia.domain.access-control`), and the stored owner `groups` are preserved
+   on update (`default-realize`), so tightening write-side authority is a
+   separate XFV-20 follow-up out of scope here."
   [{:keys [groups]}]
   {:terms {"groups" (map str/lower-case groups)}})
 
 (defn list-active-by-observable
   [state observable ident get-in-config params]
-  (let [now-str (time/format-date-time (time/timestamp))
-        date-range (select-keys params [:from :to])
-        time-opts {:now-str now-str :date-range date-range}
-        composed-query
-        (-> (find-restriction-query-part ident get-in-config)
-            (assoc-in
-             [:bool :must]
-             (active-judgements-by-observable-query
-              observable
-              time-opts))
-            (assoc-in
-             [:bool :filter]
-             (verdict-owner-filter ident)))
-        es-params
-        {:sort
-         {:priority
-          "desc"
+  ;; XFV-20 (CR1): a verdict is scoped to the caller's own org. A caller with
+  ;; no org (static-auth with `ctia.auth.static.group` unset, or a JWT missing
+  ;; `org/id`) has no tenant to scope to, so there is no verdict to compute.
+  ;; Bail out explicitly and observably rather than issuing a query whose empty
+  ;; `{:terms {"groups" []}}` filter would silently match nothing.
+  (if (empty? (:groups ident))
+    (do (log/warnf "verdict skipped: caller %s has no org; a verdict is tenant-local"
+                   (pr-str (:login ident)))
+        nil)
+    (let [now-str (time/format-date-time (time/timestamp))
+          date-range (select-keys params [:from :to])
+          time-opts {:now-str now-str :date-range date-range}
+          composed-query
+          (-> (find-restriction-query-part ident get-in-config)
+              (assoc-in
+               [:bool :must]
+               (active-judgements-by-observable-query
+                observable
+                time-opts))
+              (update-in
+               [:bool :filter]
+               (fnil conj [])
+               (verdict-owner-filter ident)))
+          es-params
+          {:sort
+           {:priority
+            "desc"
 
-          :disposition
-          "asc"
+            :disposition
+            "asc"
 
-          "valid_time.start_time"
-          {:order "asc"
-           :mode "min"
-           :nested_filter
-           {"range" {"valid_time.start_time" {"lte" now-str}}}}}}]
-    (some->>
-     (search-docs (:conn state)
-                  (:index state)
-                  composed-query
-                  nil
-                  es-params)
-     :data
-     coerce-stored-judgement-list)))
+            "valid_time.start_time"
+            {:order "asc"
+             :mode "min"
+             :nested_filter
+             {"range" {"valid_time.start_time" {"lte" now-str}}}}}}]
+      (some->>
+       (search-docs (:conn state)
+                    (:index state)
+                    composed-query
+                    nil
+                    es-params)
+       :data
+       coerce-stored-judgement-list))))
 
 (s/defn make-verdict :- Verdict
   [judgement :- StoredJudgement]

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -73,14 +73,19 @@
 (defn list-active-by-observable
   [state observable ident get-in-config params]
   ;; XFV-20 (CR1): a verdict is scoped to the caller's own org. A caller with
-  ;; no real tenant (`auth/anonymous-ident?` -- no groups, or only the
+  ;; no real tenant (`auth/orgless-ident?` -- no groups, or only the
   ;; `readonly-for-anonymous` sentinel) has no org to scope to, so there is no
   ;; verdict to compute. Bail out explicitly and observably rather than issuing
   ;; a query whose `{:terms {"groups" ...}}` filter can match no stored doc,
-  ;; silently flipping the response to a 404 with nothing logged.
-  (if (auth/anonymous-ident? ident)
-    (do (log/debugf "verdict skipped: caller %s has no org; a verdict is tenant-local"
-                    (pr-str (:login ident)))
+  ;; silently flipping the response to a 404 with nothing logged. The
+  ;; deployment-level cause (static-auth with `ctia.auth.static.group` unset) is
+  ;; warned once at startup by `static-auth-service`; this per-request line
+  ;; carries the observable so a 404 correlates with the client's request when
+  ;; debug logging is enabled.
+  (if (auth/orgless-ident? ident)
+    (do (log/debugf "verdict skipped: caller %s has no org; a verdict is tenant-local (observable %s)"
+                    (pr-str (:login ident))
+                    (pr-str observable))
         nil)
     (let [now-str (time/format-date-time (time/timestamp))
           date-range (select-keys params [:from :to])

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -77,11 +77,13 @@
   ;; `readonly-for-anonymous` sentinel) has no org to scope to, so there is no
   ;; verdict to compute. Bail out explicitly and observably rather than issuing
   ;; a query whose `{:terms {"groups" ...}}` filter can match no stored doc,
-  ;; silently flipping the response to a 404 with nothing logged. The
-  ;; deployment-level cause (static-auth with `ctia.auth.static.group` unset) is
-  ;; warned once at startup by `static-auth-service`; this per-request line
-  ;; carries the observable so a 404 correlates with the client's request when
-  ;; debug logging is enabled.
+  ;; silently flipping the response to a 404 with nothing logged. Only the
+  ;; static-auth deployment cause (`ctia.auth.static.group` unset) is warned once
+  ;; at startup by `static-auth-service`; the JWT no-`org/id` case is registered
+  ;; via ring middleware regardless of auth type and gets NO boot warning, so for
+  ;; it this per-request `debugf` (off at the shipped `info` root level) is the
+  ;; only signal. It carries the observable so an operator who raises the log
+  ;; level can correlate a 404 with the client's request.
   (if (auth/orgless-ident? ident)
     (do (log/debugf "verdict skipped: caller %s has no org; a verdict is tenant-local (observable %s)"
                     (pr-str (:login ident))

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -59,45 +59,44 @@
    This neutralizes any pre-existing cross-tenant *read* grant for verdict
    calculation, regardless of the `authorized_*` clauses in
    `find-restriction-query-part`. It does NOT touch the *write* path: a
-   foreign org listed in a victim-owned document's `authorized_groups` can
-   still update that document (`allow-write?` in
-   `ctia.domain.access-control`), and the stored owner `groups` are preserved
-   on update (`default-realize`), so tightening write-side authority is a
-   separate XFV-20 follow-up out of scope here."
+   *pre-existing* foreign `authorized_groups` on a victim-owned document still
+   confers write access via `allow-write?` (`ctia.domain.access-control`), and
+   the stored owner `groups` are preserved on update (`default-realize`).
+   Note that a caller can no longer *introduce* a foreign `authorized_groups`
+   at write time -- `authorized-groups-check` (`ctia.flows.crud`) rejects newly
+   added cross-tenant grants -- so this caveat is limited to grants already
+   present in stored data. Tightening write-side authority over such
+   pre-existing grants is a separate XFV-20 follow-up out of scope here."
   [{:keys [groups]}]
   {:terms {"groups" (map str/lower-case groups)}})
 
 (defn list-active-by-observable
   [state observable ident get-in-config params]
   ;; XFV-20 (CR1): a verdict is scoped to the caller's own org. A caller with
-  ;; no org (static-auth with `ctia.auth.static.group` unset, or a JWT missing
-  ;; `org/id`) has no tenant to scope to, so there is no verdict to compute.
-  ;; The anonymous read-only identity (`ctia.auth.type=static` +
-  ;; `readonly-for-anonymous=true`) reports the sentinel
-  ;; `auth/not-logged-in-groups` (`["Unknown Group"]`) rather than an empty
-  ;; group list; it is likewise not a real tenant, so treat it as no-org too.
-  ;; Bail out explicitly and observably rather than issuing a query whose
-  ;; `{:terms {"groups" ...}}` filter can match no stored doc, silently
-  ;; flipping the response to a 404 with nothing logged.
-  (if (or (empty? (:groups ident))
-          (= (set auth/not-logged-in-groups) (set (:groups ident))))
-    (do (log/infof "verdict skipped: caller %s has no org; a verdict is tenant-local"
-                   (pr-str (:login ident)))
+  ;; no real tenant (`auth/anonymous-ident?` -- no groups, or only the
+  ;; `readonly-for-anonymous` sentinel) has no org to scope to, so there is no
+  ;; verdict to compute. Bail out explicitly and observably rather than issuing
+  ;; a query whose `{:terms {"groups" ...}}` filter can match no stored doc,
+  ;; silently flipping the response to a 404 with nothing logged.
+  (if (auth/anonymous-ident? ident)
+    (do (log/debugf "verdict skipped: caller %s has no org; a verdict is tenant-local"
+                    (pr-str (:login ident)))
         nil)
     (let [now-str (time/format-date-time (time/timestamp))
           date-range (select-keys params [:from :to])
           time-opts {:now-str now-str :date-range date-range}
+          ;; Compose the base access-control restriction as one opaque element
+          ;; of the top-level `:filter` (the convention every other caller of
+          ;; `find-restriction-query-part` follows, e.g. `make-search-query` in
+          ;; `ctia.stores.es.crud`), alongside the mandatory owner-org filter,
+          ;; and put the observable/time clauses in `:must`. This avoids reaching
+          ;; into the helper's `[:bool :must]`/`[:bool :filter]` internals, so a
+          ;; future clause added inside `find-restriction-query-part` cannot be
+          ;; silently clobbered.
           composed-query
-          (-> (find-restriction-query-part ident get-in-config)
-              (assoc-in
-               [:bool :must]
-               (active-judgements-by-observable-query
-                observable
-                time-opts))
-              (update-in
-               [:bool :filter]
-               (fnil conj [])
-               (verdict-owner-filter ident)))
+          {:bool {:filter [(find-restriction-query-part ident get-in-config)
+                           (verdict-owner-filter ident)]
+                  :must (active-judgements-by-observable-query observable time-opts)}}
           es-params
           {:sort
            {:priority

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -1,5 +1,6 @@
 (ns ctia.entity.judgement.es-store
   (:require [ductile.document :refer [search-docs]]
+            [clojure.string :as str]
             [clj-momo.lib.time :as time]
             [ctia.entity.judgement.schemas
              :refer
@@ -47,18 +48,31 @@
                       ident
                       params))
 
+(defn- verdict-owner-filter
+  "XFV-20: a verdict is a tenant-local trust decision. Restrict verdict
+   candidates to judgements owned by the caller's own org (`groups`), so a
+   judgement that merely lists the caller's org in `authorized_groups` /
+   `authorized_users` cannot dominate (poison) the caller's verdict. This
+   neutralizes any pre-existing cross-tenant grant for verdict calculation
+   regardless of the `authorized_*` clauses in `find-restriction-query-part`."
+  [{:keys [groups]}]
+  {:terms {"groups" (map str/lower-case groups)}})
+
 (defn list-active-by-observable
   [state observable ident get-in-config params]
   (let [now-str (time/format-date-time (time/timestamp))
         date-range (select-keys params [:from :to])
         time-opts {:now-str now-str :date-range date-range}
         composed-query
-        (assoc-in
-         (find-restriction-query-part ident get-in-config)
-         [:bool :must]
-         (active-judgements-by-observable-query
-          observable
-          time-opts))
+        (-> (find-restriction-query-part ident get-in-config)
+            (assoc-in
+             [:bool :must]
+             (active-judgements-by-observable-query
+              observable
+              time-opts))
+            (assoc-in
+             [:bool :filter]
+             (verdict-owner-filter ident)))
         es-params
         {:sort
          {:priority

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -51,39 +51,23 @@
                       params))
 
 (defn- verdict-owner-filter
-  "XFV-20: a verdict is a tenant-local trust decision. Restrict verdict
-   candidates to judgements owned by the caller's own org (`groups`), so a
-   judgement that merely lists the caller's org in `authorized_groups` /
-   `authorized_users` cannot contribute to (poison) the caller's verdict.
-
-   This neutralizes any pre-existing cross-tenant *read* grant for verdict
-   calculation, regardless of the `authorized_*` clauses in
-   `find-restriction-query-part`. It does NOT touch the *write* path: a
-   *pre-existing* foreign `authorized_groups` on a victim-owned document still
-   confers write access via `allow-write?` (`ctia.domain.access-control`), and
-   the stored owner `groups` are preserved on update (`default-realize`).
-   Note that a caller can no longer *introduce* a foreign `authorized_groups`
-   at write time -- `authorized-groups-check` (`ctia.flows.crud`) rejects newly
-   added cross-tenant grants -- so this caveat is limited to grants already
-   present in stored data. Tightening write-side authority over such
-   pre-existing grants is a separate XFV-20 follow-up out of scope here."
+  "XFV-20: restrict verdict candidates to judgements owned by the caller's own
+   org, so a foreign judgement shared via `authorized_*` cannot contribute to
+   (poison) the verdict. Terms are lower-cased to match the `groups`
+   `lowercase_normalizer` mapping; the arg is the ident *map*."
   [{:keys [groups]}]
   {:terms {"groups" (map str/lower-case groups)}})
 
 (defn list-active-by-observable
   [state observable ident get-in-config params]
-  ;; XFV-20 (CR1): a verdict is scoped to the caller's own org. A caller with
-  ;; no real tenant (`auth/orgless-ident?` -- no groups, or only the
-  ;; `readonly-for-anonymous` sentinel) has no org to scope to, so there is no
-  ;; verdict to compute. Bail out explicitly and observably rather than issuing
-  ;; a query whose `{:terms {"groups" ...}}` filter can match no stored doc,
-  ;; silently flipping the response to a 404 with nothing logged. Only the
-  ;; static-auth deployment cause (`ctia.auth.static.group` unset) is warned once
-  ;; at startup by `static-auth-service`; the JWT no-`org/id` case is registered
-  ;; via ring middleware regardless of auth type and gets NO boot warning, so for
-  ;; it this per-request `debugf` (off at the shipped `info` root level) is the
-  ;; only signal. It carries the observable so an operator who raises the log
-  ;; level can correlate a 404 with the client's request.
+  {:pre [(contains? ident :groups)]}
+  ;; XFV-20: a verdict is scoped to the caller's own org. An org-less caller
+  ;; (`auth/orgless-ident?`) has no org to scope to, so bail out explicitly
+  ;; rather than issue a `{:terms {"groups" ...}}` filter that matches no stored
+  ;; doc and silently 404s. Static-auth org-less settings are warned at boot; a
+  ;; JWT missing `org/id` is not, so for it this per-request `debugf` (off at the
+  ;; shipped `info` level) is the only signal, carrying the observable so an
+  ;; operator who raises the level can correlate the 404 with the request.
   (if (auth/orgless-ident? ident)
     (do (log/debugf "verdict skipped: caller %s has no org; a verdict is tenant-local (observable %s)"
                     (pr-str (:login ident))

--- a/src/ctia/entity/judgement/es_store.clj
+++ b/src/ctia/entity/judgement/es_store.clj
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clj-momo.lib.time :as time]
+            [ctia.auth :as auth]
             [ctia.entity.judgement.schemas
              :refer
              [PartialStoredJudgement StoredJudgement]]
@@ -71,10 +72,16 @@
   ;; XFV-20 (CR1): a verdict is scoped to the caller's own org. A caller with
   ;; no org (static-auth with `ctia.auth.static.group` unset, or a JWT missing
   ;; `org/id`) has no tenant to scope to, so there is no verdict to compute.
-  ;; Bail out explicitly and observably rather than issuing a query whose empty
-  ;; `{:terms {"groups" []}}` filter would silently match nothing.
-  (if (empty? (:groups ident))
-    (do (log/warnf "verdict skipped: caller %s has no org; a verdict is tenant-local"
+  ;; The anonymous read-only identity (`ctia.auth.type=static` +
+  ;; `readonly-for-anonymous=true`) reports the sentinel
+  ;; `auth/not-logged-in-groups` (`["Unknown Group"]`) rather than an empty
+  ;; group list; it is likewise not a real tenant, so treat it as no-org too.
+  ;; Bail out explicitly and observably rather than issuing a query whose
+  ;; `{:terms {"groups" ...}}` filter can match no stored doc, silently
+  ;; flipping the response to a 404 with nothing logged.
+  (if (or (empty? (:groups ident))
+          (= (set auth/not-logged-in-groups) (set (:groups ident))))
+    (do (log/infof "verdict skipped: caller %s has no org; a verdict is tenant-local"
                    (pr-str (:login ident)))
         nil)
     (let [now-str (time/format-date-time (time/timestamp))

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -63,10 +63,11 @@
   * URL -- A minimal form of the URL
 
   The Verdict is derived from the Judgements on that Observable which have not
-  yet expired and are owned by the caller's own org; a verdict is a tenant-local
-  trust decision, so Judgements shared from another org (via `authorized_groups`
-  / `authorized_users`, or visible only through a public TLP) do not contribute
-  to it.  The highest priority Judgement becomes the active verdict.  If there
+  yet expired, that the caller can read and that are owned by the caller's own
+  org; a verdict is a tenant-local trust decision, so Judgements shared from
+  another org (via `authorized_groups` / `authorized_users`, or visible only
+  through a public TLP) do not contribute to it.  The highest priority Judgement
+  becomes the active verdict.  If there
   is more than one Judgement with that priority, than Clean disposition has
   priority over all others, then Malicious disposition, and so on down to
   Unknown.

--- a/src/ctia/http/handler.clj
+++ b/src/ctia/http/handler.clj
@@ -62,11 +62,14 @@
   * SHA1 -- the sha1 checksum of a file, or other data blob
   * URL -- A minimal form of the URL
 
-  The Verdict is derived from all of the Judgements on that Observable which
-  have not yet expired.  The highest priority Judgement becomes the
-  active verdict.  If there is more than one Judgement with that
-  priority, than Clean disposition has priority over all others, then
-  Malicious disposition, and so on down to Unknown.
+  The Verdict is derived from the Judgements on that Observable which have not
+  yet expired and are owned by the caller's own org; a verdict is a tenant-local
+  trust decision, so Judgements shared from another org (via `authorized_groups`
+  / `authorized_users`, or visible only through a public TLP) do not contribute
+  to it.  The highest priority Judgement becomes the active verdict.  If there
+  is more than one Judgement with that priority, than Clean disposition has
+  priority over all others, then Malicious disposition, and so on down to
+  Unknown.
 
   <a href='/doc/README.md'>CTIA Documentation</a>")
 

--- a/src/ctia/observable/graphql/schemas.clj
+++ b/src/ctia/observable/graphql/schemas.clj
@@ -38,9 +38,10 @@
              ;; Customer-visible via introspection: describe the behaviour, keep
              ;; the internal ticket ref (XFV-20) out of the description string.
              :description (str "The tenant-local Verdict for this Observable, "
-                               "computed only from judgements owned by the "
-                               "caller's own org. Null when the caller has no "
-                               "org or no owned judgement contributes.")
+                               "computed only from the judgements the caller can "
+                               "read that are also owned by its own org. Null when "
+                               "the caller has no org or no such judgement "
+                               "contributes.")
              :resolve (s/fn :- AnyRealizeFnResult
                         [context _ _ src]
                         (delayed/fn :- GraphQLValue

--- a/src/ctia/observable/graphql/schemas.clj
+++ b/src/ctia/observable/graphql/schemas.clj
@@ -35,10 +35,12 @@
 
 (def observable-fields
   {:verdict {:type verdict/VerdictType
+             ;; Customer-visible via introspection: describe the behaviour, keep
+             ;; the internal ticket ref (XFV-20) out of the description string.
              :description (str "The tenant-local Verdict for this Observable, "
                                "computed only from judgements owned by the "
-                               "caller's own org (XFV-20). Null when the caller "
-                               "has no org or no owned judgement contributes.")
+                               "caller's own org. Null when the caller has no "
+                               "org or no owned judgement contributes.")
              :resolve (s/fn :- AnyRealizeFnResult
                         [context _ _ src]
                         (delayed/fn :- GraphQLValue

--- a/src/ctia/observable/graphql/schemas.clj
+++ b/src/ctia/observable/graphql/schemas.clj
@@ -35,6 +35,10 @@
 
 (def observable-fields
   {:verdict {:type verdict/VerdictType
+             :description (str "The tenant-local Verdict for this Observable, "
+                               "computed only from judgements owned by the "
+                               "caller's own org (XFV-20). Null when the caller "
+                               "has no org or no owned judgement contributes.")
              :resolve (s/fn :- AnyRealizeFnResult
                         [context _ _ src]
                         (delayed/fn :- GraphQLValue

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -263,6 +263,13 @@
                              :spec-kw-ns ~spec-kw-ns}))
 
 ;; verdict
+;;
+;; NOTE (XFV-20): `vs/Verdict`'s CTIM-sourced description renders into swagger's
+;; `definitions.Verdict.description` and still says a verdict is chosen from
+;; *all* unexpired judgements -- knowingly stale re org-scoping (fixing it needs
+;; a CTIM DDL change). The accurate text lives in the REST `api-description`
+;; (`ctia.http.handler`) and the GraphQL `verdict-description`
+;; (`ctia.verdict.graphql.schemas`).
 
 (def-acl-schema Verdict
   vs/Verdict

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -12,7 +12,6 @@
    [ctim.schemas.vocabularies :as vocs]
    [flanders.schema :as f-schema]
    [flanders.spec :as f-spec]
-   [ring.swagger.json-schema :as rs]
    [schema-tools.core :as st]
    [schema.core :as s :refer [Bool Str]]))
 
@@ -268,25 +267,6 @@
 (def-acl-schema Verdict
   vs/Verdict
   "verdict")
-
-;; XFV-20: a verdict is a tenant-local trust decision. CTIM's entity type carries
-;; a description that says a verdict is chosen from *all* unexpired judgements on
-;; the observable, which flanders renders into swagger.json for the REST
-;; `Verdict` model. That is now false the same way the GraphQL surface was:
-;; override the REST/Swagger description here so both surfaces read consistently
-;; (see `ctia.verdict.graphql.schemas/verdict-description` for the GraphQL one).
-(def Verdict
-  (rs/describe
-   Verdict
-   (str "A Verdict is chosen from the Judgements owned by the caller's own org "
-        "on an Observable which have not yet expired. The highest priority "
-        "Judgement becomes the active verdict. If there is more than one "
-        "Judgement with that priority, then Clean disposition has priority over "
-        "all others, then Malicious disposition, and so on down to Unknown. "
-        "Verdict calculation is tenant-local: judgements owned by another org -- "
-        "even ones shared via authorized_users / authorized_groups or a public "
-        "TLP -- do not contribute, and a caller with no org of its own receives "
-        "no verdict.")))
 
 ;; Bundle
 

--- a/src/ctia/schemas/core.clj
+++ b/src/ctia/schemas/core.clj
@@ -12,6 +12,7 @@
    [ctim.schemas.vocabularies :as vocs]
    [flanders.schema :as f-schema]
    [flanders.spec :as f-spec]
+   [ring.swagger.json-schema :as rs]
    [schema-tools.core :as st]
    [schema.core :as s :refer [Bool Str]]))
 
@@ -267,6 +268,25 @@
 (def-acl-schema Verdict
   vs/Verdict
   "verdict")
+
+;; XFV-20: a verdict is a tenant-local trust decision. CTIM's entity type carries
+;; a description that says a verdict is chosen from *all* unexpired judgements on
+;; the observable, which flanders renders into swagger.json for the REST
+;; `Verdict` model. That is now false the same way the GraphQL surface was:
+;; override the REST/Swagger description here so both surfaces read consistently
+;; (see `ctia.verdict.graphql.schemas/verdict-description` for the GraphQL one).
+(def Verdict
+  (rs/describe
+   Verdict
+   (str "A Verdict is chosen from the Judgements owned by the caller's own org "
+        "on an Observable which have not yet expired. The highest priority "
+        "Judgement becomes the active verdict. If there is more than one "
+        "Judgement with that priority, then Clean disposition has priority over "
+        "all others, then Malicious disposition, and so on down to Unknown. "
+        "Verdict calculation is tenant-local: judgements owned by another org -- "
+        "even ones shared via authorized_users / authorized_groups or a public "
+        "TLP -- do not contribute, and a caller with no org of its own receives "
+        "no verdict.")))
 
 ;; Bundle
 

--- a/src/ctia/verdict/graphql/schemas.clj
+++ b/src/ctia/verdict/graphql/schemas.clj
@@ -18,9 +18,21 @@
                                                     (:ident context)
                                                     field-selection)))}})
 
+;; XFV-20: a verdict is a tenant-local trust decision. Override CTIM's entity
+;; description (which states a verdict is chosen from *all* unexpired judgements
+;; on the observable) so GraphQL introspection reflects the org-scoping: only
+;; judgements owned by the caller's own org contribute, and a caller with no org
+;; of its own gets no verdict (null).
+(def verdict-description
+  (str "A Verdict is chosen from the Judgements owned by the caller's own org on "
+       "an Observable which have not yet expired (XFV-20: verdict calculation is "
+       "tenant-local; judgements owned by another org -- even ones shared via "
+       "authorized_users / authorized_groups or a public TLP -- do not "
+       "contribute). A caller with no org of its own receives no verdict."))
+
 (def VerdictType
-  (let [{:keys [fields name description]}
+  (let [{:keys [fields name]}
         (f/->graphql (fu/optionalize-all ctim-verdict-schema/Verdict)
                      {refs/observable-type-name refs/ObservableTypeRef})]
-    (g/new-object name description [] (into fields
-                                            verdict-fields))))
+    (g/new-object name verdict-description [] (into fields
+                                                    verdict-fields))))

--- a/src/ctia/verdict/graphql/schemas.clj
+++ b/src/ctia/verdict/graphql/schemas.clj
@@ -21,16 +21,17 @@
 ;; XFV-20: a verdict is a tenant-local trust decision. Override CTIM's entity
 ;; description (which states a verdict is chosen from *all* unexpired judgements
 ;; on the observable) so GraphQL introspection reflects the org-scoping: only
-;; judgements owned by the caller's own org contribute, and a caller with no org
-;; of its own gets no verdict (null).
+;; the judgements the caller can read that are also owned by its own org
+;; contribute, and a caller with no org of its own gets no verdict (null).
 ;; Customer-visible via introspection, so it describes the behaviour without an
 ;; internal ticket reference (XFV-20 stays in the source comment above).
 (def verdict-description
-  (str "A Verdict is chosen from the Judgements owned by the caller's own org on "
-       "an Observable which have not yet expired. Verdict calculation is "
-       "tenant-local: judgements owned by another org -- even ones shared via "
-       "authorized_users / authorized_groups or a public TLP -- do not "
-       "contribute. A caller with no org of its own receives no verdict."))
+  (str "A Verdict is chosen from the Judgements on an Observable which have not "
+       "yet expired, that the caller can read and that are owned by the caller's "
+       "own org. Verdict calculation is tenant-local: judgements owned by another "
+       "org -- even ones shared via authorized_users / authorized_groups or a "
+       "public TLP -- do not contribute. A caller with no org of its own receives "
+       "no verdict."))
 
 (def VerdictType
   (let [{:keys [fields name]}

--- a/src/ctia/verdict/graphql/schemas.clj
+++ b/src/ctia/verdict/graphql/schemas.clj
@@ -23,12 +23,14 @@
 ;; on the observable) so GraphQL introspection reflects the org-scoping: only
 ;; judgements owned by the caller's own org contribute, and a caller with no org
 ;; of its own gets no verdict (null).
+;; Customer-visible via introspection, so it describes the behaviour without an
+;; internal ticket reference (XFV-20 stays in the source comment above).
 (def verdict-description
   (str "A Verdict is chosen from the Judgements owned by the caller's own org on "
-       "an Observable which have not yet expired (XFV-20: verdict calculation is "
-       "tenant-local; judgements owned by another org -- even ones shared via "
+       "an Observable which have not yet expired. Verdict calculation is "
+       "tenant-local: judgements owned by another org -- even ones shared via "
        "authorized_users / authorized_groups or a public TLP -- do not "
-       "contribute). A caller with no org of its own receives no verdict."))
+       "contribute. A caller with no org of its own receives no verdict."))
 
 (def VerdictType
   (let [{:keys [fields name]}

--- a/test/ctia/auth_test.clj
+++ b/test/ctia/auth_test.clj
@@ -9,7 +9,7 @@
 (use-fixtures :once validate-schemas)
 
 (deftest orgless-ident?-test
-  ;; XFV-20 (LOW): pin `orgless-ident?` directly. Until now it was exercised only
+  ;; XFV-20: pin `orgless-ident?` directly. Until now it was exercised only
   ;; transitively via `list-active-by-observable`; the mixed case in particular
   ;; (a real org alongside the not-logged-in sentinel) was unpinned.
   (let [ident #(hash-map :client-id "c" :login "l" :groups %)]

--- a/test/ctia/auth_test.clj
+++ b/test/ctia/auth_test.clj
@@ -1,0 +1,31 @@
+(ns ctia.auth-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ctia.auth :as auth]
+            [schema.test :refer [validate-schemas]]))
+
+;; Validate every ident below against `auth/IdentityMap` (`orgless-ident?` is an
+;; `s/defn` taking `IdentityMap`), so a non-conformant shape fails loudly here
+;; rather than silently.
+(use-fixtures :once validate-schemas)
+
+(deftest orgless-ident?-test
+  ;; XFV-20 (LOW): pin `orgless-ident?` directly. Until now it was exercised only
+  ;; transitively via `list-active-by-observable`; the mixed case in particular
+  ;; (a real org alongside the not-logged-in sentinel) was unpinned.
+  (let [ident #(hash-map :client-id "c" :login "l" :groups %)]
+    (testing "no groups at all is org-less (JWT missing org/id, static group unset)"
+      (is (true? (auth/orgless-ident? (ident [])))))
+    (testing "only the not-logged-in sentinel is org-less (readonly-for-anonymous)"
+      (is (true? (auth/orgless-ident? (ident auth/not-logged-in-groups)))))
+    (testing "a blank group string is treated as absent (JWT blank org/id, static blank group)"
+      (is (true? (auth/orgless-ident? (ident [""]))))
+      (is (true? (auth/orgless-ident? (ident ["" ""])))))
+    (testing "a real org is NOT org-less"
+      (is (false? (auth/orgless-ident? (ident ["real-org"])))))
+    (testing "a real org alongside a blank string is NOT org-less"
+      (is (false? (auth/orgless-ident? (ident ["" "real-org"])))))
+    (testing "a real org mixed with the sentinel is NOT org-less"
+      ;; The sentinel-set equality check must not match a superset -- a caller
+      ;; that carries a real org in addition to the sentinel still has a tenant.
+      (is (false? (auth/orgless-ident? (ident (conj (vec auth/not-logged-in-groups)
+                                                    "real-org"))))))))

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -1,0 +1,31 @@
+(ns ctia.entity.judgement.es-store-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ctia.entity.judgement.es-store :as sut]
+            [ductile.document :as ductile]))
+
+(deftest list-active-by-observable-verdict-owner-filter-test
+  ;; XFV-20: a verdict is a tenant-local trust decision. The verdict query must
+  ;; be constrained to judgements owned by the caller's own org (`groups`), so a
+  ;; foreign judgement that merely lists the caller's org in `authorized_groups`
+  ;; (or `authorized_users`) cannot dominate/poison the verdict. This is an
+  ;; ES-free check that the guard clause is composed into the query.
+  (testing "list-active-by-observable adds a mandatory, lower-cased groups filter for the caller's org"
+    (let [captured (atom nil)
+          state {:conn :fake-conn :index "judgement-index"}
+          ident {:login "victim" :groups ["VICTIM-ORG"]}]
+      (with-redefs [ductile/search-docs
+                    (fn [_conn _index query _sort _es-params]
+                      (reset! captured query)
+                      {:data []})]
+        (sut/list-active-by-observable state
+                                       {:type "ip" :value "203.0.113.213"}
+                                       ident
+                                       (constantly nil)
+                                       {}))
+      (is (= {:terms {"groups" ["victim-org"]}}
+             (get-in @captured [:bool :filter]))
+          "the verdict is scoped to the caller's own org, regardless of authorized_* grants")
+      (is (some? (get-in @captured [:bool :must]))
+          "the observable/time query is still applied")
+      (is (some? (get-in @captured [:bool :should]))
+          "the base access-control restriction is still applied"))))

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -24,19 +24,22 @@
                                        (constantly nil)
                                        {}))
       ;; Load-bearing assertion: the owner filter is present and lower-cased.
-      ;; It is conjoined into a vector so a future :filter from
-      ;; find-restriction-query-part is preserved rather than overwritten.
-      (is (= [{:terms {"groups" ["victim-org"]}}]
-             (get-in @captured [:bool :filter]))
+      ;; It is one element of the top-level :filter vector (alongside the opaque
+      ;; access-control restriction), so a revert of the owner filter is
+      ;; detected here.
+      (is (some #{{:terms {"groups" ["victim-org"]}}}
+                (get-in @captured [:bool :filter]))
           "the verdict is scoped to the caller's own org, regardless of authorized_* grants")
       ;; Non-regression assertions: the pre-existing observable/time and
-      ;; access-control clauses must still be composed into the query. These do
-      ;; not, on their own, detect a revert of the owner filter -- the
-      ;; assertion above does.
-      (is (some? (get-in @captured [:bool :must]))
-          "the observable/time query is still applied")
-      (is (some? (get-in @captured [:bool :should]))
-          "the base access-control restriction is still applied")))
+      ;; access-control clauses must still be composed into the query. These are
+      ;; discriminating -- they pin the concrete observable term and the base
+      ;; restriction's shape, not merely that *some* value is present.
+      (is (some #{{:term {"observable.value" "203.0.113.213"}}}
+                (get-in @captured [:bool :must]))
+          "the concrete observable/time query is still applied")
+      (is (some (fn [clause] (get-in clause [:bool :should]))
+                (get-in @captured [:bool :filter]))
+          "the base access-control restriction is still composed in as an opaque filter clause")))
   (testing "a multi-org caller scopes the verdict to ALL of its groups (lower-cased)"
     ;; A caller can legitimately belong to several orgs (e.g. via
     ;; ctia.auth.threatgrid). The owner filter maps over every group, so the
@@ -54,8 +57,8 @@
                                        ident
                                        (constantly nil)
                                        {}))
-      (is (= [{:terms {"groups" ["org-a" "org-b"]}}]
-             (get-in @captured [:bool :filter]))
+      (is (some #{{:terms {"groups" ["org-a" "org-b"]}}}
+                (get-in @captured [:bool :filter]))
           "every one of the caller's groups is included, lower-cased"))))
 
 (deftest list-active-by-observable-empty-groups-test

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -1,8 +1,16 @@
 (ns ctia.entity.judgement.es-store-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ctia.auth :as auth]
             [ctia.entity.judgement.es-store :as sut]
-            [ductile.document :as ductile]))
+            [ductile.document :as ductile]
+            [schema.test :refer [validate-schemas]]))
+
+;; XFV-20 (S1): turn on schema validation so every ident below is checked
+;; against `auth/IdentityMap` -- `list-active-by-observable` reaches
+;; `auth/orgless-ident?` (an `s/defn` taking `IdentityMap`), so this also proves
+;; the guard is exercised with the conformant shape its docstring warns about
+;; (complete `:client-id`/`:login`/`:groups`, groups a real `[s/Str]`).
+(use-fixtures :once validate-schemas)
 
 (deftest list-active-by-observable-verdict-owner-filter-test
   ;; XFV-20: a verdict is a tenant-local trust decision. The verdict query must
@@ -13,7 +21,7 @@
   (testing "list-active-by-observable adds a mandatory, lower-cased groups filter for the caller's org"
     (let [captured (atom nil)
           state {:conn :fake-conn :index "judgement-index"}
-          ident {:login "victim" :groups ["VICTIM-ORG"]}]
+          ident {:client-id "victim-client" :login "victim" :groups ["VICTIM-ORG"]}]
       (with-redefs [ductile/search-docs
                     (fn [_conn _index query _sort _es-params]
                       (reset! captured query)
@@ -57,7 +65,7 @@
     ;; `map` with more than one group.
     (let [captured (atom nil)
           state {:conn :fake-conn :index "judgement-index"}
-          ident {:login "multi" :groups ["ORG-A" "Org-B"]}]
+          ident {:client-id "multi-client" :login "multi" :groups ["ORG-A" "Org-B"]}]
       (with-redefs [ductile/search-docs
                     (fn [_conn _index query _sort _es-params]
                       (reset! captured query)
@@ -78,15 +86,17 @@
   ;; match-nothing {:terms {"groups" ...}} filter. The anonymous read-only
   ;; identity (ctia.auth.type=static + readonly-for-anonymous=true) reports the
   ;; sentinel auth/not-logged-in-groups rather than an empty list, so it must be
-  ;; treated as no-org too.
+  ;; treated as no-org too. Both idents are complete `auth/IdentityMap`s (shapes a
+  ;; real `IIdentity` produces); `:groups nil` is intentionally NOT exercised --
+  ;; no `IIdentity` impl yields nil groups (all `(remove nil? ...)`), and it is
+  ;; rejected by the `[s/Str]` schema now that validation is on.
   (testing "an identity with no real org yields no verdict and issues no query"
     (let [called? (atom false)
           state {:conn :fake-conn :index "judgement-index"}]
       (with-redefs [ductile/search-docs
                     (fn [& _] (reset! called? true) {:data []})]
-        (doseq [ident [{:login "no-org" :groups []}
-                       {:login "no-org" :groups nil}
-                       {:login "anonymous" :groups auth/not-logged-in-groups}]]
+        (doseq [ident [{:client-id "no-org-client" :login "no-org" :groups []}
+                       {:client-id "anon-client" :login "anonymous" :groups auth/not-logged-in-groups}]]
           (is (nil? (sut/list-active-by-observable state
                                                    {:type "ip" :value "203.0.113.213"}
                                                    ident

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -5,19 +5,16 @@
             [ductile.document :as ductile]
             [schema.test :refer [validate-schemas]]))
 
-;; XFV-20 (S1): turn on schema validation so every ident below is checked
-;; against `auth/IdentityMap` -- `list-active-by-observable` reaches
-;; `auth/orgless-ident?` (an `s/defn` taking `IdentityMap`), so this also proves
-;; the guard is exercised with the conformant shape its docstring warns about
-;; (complete `:client-id`/`:login`/`:groups`, groups a real `[s/Str]`).
+;; XFV-20: turn on schema validation so every ident below is checked against
+;; `auth/IdentityMap` -- `list-active-by-observable` reaches `auth/orgless-ident?`
+;; (an `s/defn` taking `IdentityMap`), so this also proves the guard is exercised
+;; with the conformant shape its docstring warns about.
 (use-fixtures :once validate-schemas)
 
-(deftest list-active-by-observable-verdict-owner-filter-test
-  ;; XFV-20: a verdict is a tenant-local trust decision. The verdict query must
-  ;; be constrained to judgements owned by the caller's own org (`groups`), so a
-  ;; foreign judgement that merely lists the caller's org in `authorized_groups`
-  ;; (or `authorized_users`) cannot dominate/poison the verdict. This is an
-  ;; ES-free check that the guard clause is composed into the query.
+(deftest list-active-by-observable-test
+  ;; XFV-20: a verdict is a tenant-local trust decision, so the verdict query is
+  ;; constrained to judgements owned by the caller's own org (`groups`) and an
+  ;; org-less caller gets no verdict. ES-free checks on the composed query.
   (testing "list-active-by-observable adds a mandatory, lower-cased groups filter for the caller's org"
     (let [captured (atom nil)
           state {:conn :fake-conn :index "judgement-index"}
@@ -77,19 +74,10 @@
                                        {}))
       (is (some #{{:terms {"groups" ["org-a" "org-b"]}}}
                 (get-in @captured [:bool :filter]))
-          "every one of the caller's groups is included, lower-cased"))))
-
-(deftest list-active-by-observable-empty-groups-test
-  ;; XFV-20 (CR1): a caller with no org (static-auth with the group unset, or a
-  ;; JWT missing org/id) has no tenant to scope the verdict to. The guard must
-  ;; bail out explicitly -- return nil WITHOUT querying -- rather than issue a
-  ;; match-nothing {:terms {"groups" ...}} filter. The anonymous read-only
-  ;; identity (ctia.auth.type=static + readonly-for-anonymous=true) reports the
-  ;; sentinel auth/not-logged-in-groups rather than an empty list, so it must be
-  ;; treated as no-org too. Both idents are complete `auth/IdentityMap`s (shapes a
-  ;; real `IIdentity` produces); `:groups nil` is intentionally NOT exercised --
-  ;; no `IIdentity` impl yields nil groups (all `(remove nil? ...)`), and it is
-  ;; rejected by the `[s/Str]` schema now that validation is on.
+          "every one of the caller's groups is included, lower-cased")))
+  ;; A caller with no org (static-auth with a blank group, a JWT missing org/id)
+  ;; or one carrying only the `readonly-for-anonymous` sentinel must bail out --
+  ;; return nil WITHOUT querying -- rather than issue a match-nothing filter.
   (testing "an identity with no real org yields no verdict and issues no query"
     (let [called? (atom false)
           state {:conn :fake-conn :index "judgement-index"}]

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -22,10 +22,38 @@
                                        ident
                                        (constantly nil)
                                        {}))
-      (is (= {:terms {"groups" ["victim-org"]}}
+      ;; Load-bearing assertion: the owner filter is present and lower-cased.
+      ;; It is conjoined into a vector so a future :filter from
+      ;; find-restriction-query-part is preserved rather than overwritten.
+      (is (= [{:terms {"groups" ["victim-org"]}}]
              (get-in @captured [:bool :filter]))
           "the verdict is scoped to the caller's own org, regardless of authorized_* grants")
+      ;; Non-regression assertions: the pre-existing observable/time and
+      ;; access-control clauses must still be composed into the query. These do
+      ;; not, on their own, detect a revert of the owner filter -- the
+      ;; assertion above does.
       (is (some? (get-in @captured [:bool :must]))
           "the observable/time query is still applied")
       (is (some? (get-in @captured [:bool :should]))
           "the base access-control restriction is still applied"))))
+
+(deftest list-active-by-observable-empty-groups-test
+  ;; XFV-20 (CR1): a caller with no org (static-auth with the group unset, or a
+  ;; JWT missing org/id) has no tenant to scope the verdict to. The guard must
+  ;; bail out explicitly -- return nil WITHOUT querying -- rather than issue a
+  ;; match-nothing {:terms {"groups" []}} filter.
+  (testing "an identity with no groups yields no verdict and issues no query"
+    (let [called? (atom false)
+          state {:conn :fake-conn :index "judgement-index"}]
+      (with-redefs [ductile/search-docs
+                    (fn [& _] (reset! called? true) {:data []})]
+        (doseq [ident [{:login "no-org" :groups []}
+                       {:login "no-org" :groups nil}]]
+          (is (nil? (sut/list-active-by-observable state
+                                                   {:type "ip" :value "203.0.113.213"}
+                                                   ident
+                                                   (constantly nil)
+                                                   {}))
+              "no org means no tenant-local verdict")))
+      (is (false? @called?)
+          "the store must not be queried when the caller has no org"))))

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -1,5 +1,6 @@
 (ns ctia.entity.judgement.es-store-test
   (:require [clojure.test :refer [deftest is testing]]
+            [ctia.auth :as auth]
             [ctia.entity.judgement.es-store :as sut]
             [ductile.document :as ductile]))
 
@@ -35,20 +36,44 @@
       (is (some? (get-in @captured [:bool :must]))
           "the observable/time query is still applied")
       (is (some? (get-in @captured [:bool :should]))
-          "the base access-control restriction is still applied"))))
+          "the base access-control restriction is still applied")))
+  (testing "a multi-org caller scopes the verdict to ALL of its groups (lower-cased)"
+    ;; A caller can legitimately belong to several orgs (e.g. via
+    ;; ctia.auth.threatgrid). The owner filter maps over every group, so the
+    ;; verdict is scoped to the union of the caller's own orgs -- exercise the
+    ;; `map` with more than one group.
+    (let [captured (atom nil)
+          state {:conn :fake-conn :index "judgement-index"}
+          ident {:login "multi" :groups ["ORG-A" "Org-B"]}]
+      (with-redefs [ductile/search-docs
+                    (fn [_conn _index query _sort _es-params]
+                      (reset! captured query)
+                      {:data []})]
+        (sut/list-active-by-observable state
+                                       {:type "ip" :value "203.0.113.213"}
+                                       ident
+                                       (constantly nil)
+                                       {}))
+      (is (= [{:terms {"groups" ["org-a" "org-b"]}}]
+             (get-in @captured [:bool :filter]))
+          "every one of the caller's groups is included, lower-cased"))))
 
 (deftest list-active-by-observable-empty-groups-test
   ;; XFV-20 (CR1): a caller with no org (static-auth with the group unset, or a
   ;; JWT missing org/id) has no tenant to scope the verdict to. The guard must
   ;; bail out explicitly -- return nil WITHOUT querying -- rather than issue a
-  ;; match-nothing {:terms {"groups" []}} filter.
-  (testing "an identity with no groups yields no verdict and issues no query"
+  ;; match-nothing {:terms {"groups" ...}} filter. The anonymous read-only
+  ;; identity (ctia.auth.type=static + readonly-for-anonymous=true) reports the
+  ;; sentinel auth/not-logged-in-groups rather than an empty list, so it must be
+  ;; treated as no-org too.
+  (testing "an identity with no real org yields no verdict and issues no query"
     (let [called? (atom false)
           state {:conn :fake-conn :index "judgement-index"}]
       (with-redefs [ductile/search-docs
                     (fn [& _] (reset! called? true) {:data []})]
         (doseq [ident [{:login "no-org" :groups []}
-                       {:login "no-org" :groups nil}]]
+                       {:login "no-org" :groups nil}
+                       {:login "anonymous" :groups auth/not-logged-in-groups}]]
           (is (nil? (sut/list-active-by-observable state
                                                    {:type "ip" :value "203.0.113.213"}
                                                    ident

--- a/test/ctia/entity/judgement/es_store_test.clj
+++ b/test/ctia/entity/judgement/es_store_test.clj
@@ -37,9 +37,19 @@
       (is (some #{{:term {"observable.value" "203.0.113.213"}}}
                 (get-in @captured [:bool :must]))
           "the concrete observable/time query is still applied")
-      (is (some (fn [clause] (get-in clause [:bool :should]))
-                (get-in @captured [:bool :filter]))
-          "the base access-control restriction is still composed in as an opaque filter clause")))
+      ;; The base access-control restriction must still be composed in. Pin the
+      ;; CONCRETE authorized_groups should-clause and the minimum_should_match
+      ;; threshold rather than asserting merely that *some* :should is present: a
+      ;; refactor that returned a degenerate restriction (empty :should, or a
+      ;; dropped `:minimum_should_match 1`) would silently drop access control
+      ;; and must fail here.
+      (let [restriction (first (filter #(get-in % [:bool :minimum_should_match])
+                                       (get-in @captured [:bool :filter])))]
+        (is (some #{{:terms {"authorized_groups" ["victim-org"]}}}
+                  (get-in restriction [:bool :should]))
+            "the base access-control restriction is still composed in")
+        (is (= 1 (get-in restriction [:bool :minimum_should_match]))
+            "the restriction still requires at least one should-clause to match"))))
   (testing "a multi-org caller scopes the verdict to ALL of its groups (lower-cased)"
     ;; A caller can legitimately belong to several orgs (e.g. via
     ;; ctia.auth.threatgrid). The owner filter maps over every group, so the

--- a/test/ctia/http/handler/static_auth_anonymous_test.clj
+++ b/test/ctia/http/handler/static_auth_anonymous_test.clj
@@ -1,13 +1,19 @@
 (ns ctia.http.handler.static-auth-anonymous-test
-  (:require [ctia.test-helpers.core :as helpers :refer [GET with-properties]]
+  (:require [ctia.test-helpers.core :as helpers :refer [GET POST with-properties]]
             [ctia.test-helpers.es :as es-helpers]
-            [clojure.test :refer [deftest is use-fixtures]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [schema.test :refer [validate-schemas]]))
 
 (defn fixture-anonymous-readonly-access
   [t]
   (with-properties
-    ["ctia.auth.static.readonly-for-anonymous" true]
+    ["ctia.auth.static.readonly-for-anonymous" true
+     ;; Pin the default so `anonymous-verdict-no-org-404-test` is non-vacuous:
+     ;; the anonymous 404 must be caused by verdict org-scoping, not by the Green
+     ;; judgement being invisible to an anonymous document read. Under `everyone`
+     ;; the document IS anonymously readable, so a 404 can only come from the
+     ;; org-less verdict guard.
+     "ctia.access-control.max-record-visibility" "everyone"]
     (t)))
 
 (use-fixtures :each
@@ -31,3 +37,45 @@
              (str "ctia/judgement/search")
              :query-params {:query "*"})]
     (is (= 200 status))))
+
+(deftest anonymous-verdict-no-org-404-test
+  ;; XFV-20 (route-level): the one path where the fix changes *unauthenticated*
+  ;; behaviour. `ReadOnlyIdentity` keeps `:read-verdict`, so pre-fix an anonymous
+  ;; caller received a verdict for any Green/White judgement under the default
+  ;; `max-record-visibility=everyone`; post-fix the anonymous identity is org-less
+  ;; (`auth/orgless-ident?`) and must get 404. The secret holder (whose static
+  ;; group is set by `fixture-properties:static-auth`) still gets the verdict.
+  ;; This is also the only end-to-end proof the sentinel branch is wired to a real
+  ;; `IIdentity`, not a hand-built map.
+  (let [app (helpers/get-current-app)
+        secret "tearbending"
+        observable {:type "ip" :value "10.0.0.1"}
+        {create-status :status}
+        (POST app
+              "ctia/judgement?wait_for=true"
+              :body {:observable observable
+                     :disposition 2
+                     :disposition_name "Malicious"
+                     :source "static-auth-test"
+                     :priority 99
+                     :severity "High"
+                     :confidence "High"
+                     :tlp "green"
+                     :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
+              :headers {"Authorization" secret})]
+    (is (= 201 create-status)
+        "the secret holder (a static write identity with a group) may create a judgement")
+
+    (testing "the secret holder, whose static identity has an org, gets the verdict"
+      (let [{status :status}
+            (GET app
+                 (str "ctia/" (:type observable) "/" (:value observable) "/verdict")
+                 :headers {"Authorization" secret})]
+        (is (= 200 status))))
+
+    (testing "an anonymous (org-less) caller gets 404 even for a Green judgement under max-record-visibility=everyone"
+      (let [{status :status}
+            (GET app
+                 (str "ctia/" (:type observable) "/" (:value observable) "/verdict"))]
+        (is (= 404 status)
+            "an org-less caller has no tenant to scope a verdict to")))))

--- a/test/ctia/http/handler/static_auth_anonymous_test.clj
+++ b/test/ctia/http/handler/static_auth_anonymous_test.clj
@@ -1,6 +1,7 @@
 (ns ctia.http.handler.static-auth-anonymous-test
   (:require [ctia.test-helpers.core :as helpers :refer [GET POST with-properties]]
             [ctia.test-helpers.es :as es-helpers]
+            [ctim.domain.id :as id]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [schema.test :refer [validate-schemas]]))
 
@@ -50,7 +51,7 @@
   (let [app (helpers/get-current-app)
         secret "tearbending"
         observable {:type "ip" :value "10.0.0.1"}
-        {create-status :status}
+        {create-status :status judgement :parsed-body}
         (POST app
               "ctia/judgement?wait_for=true"
               :body {:observable observable
@@ -62,9 +63,16 @@
                      :confidence "High"
                      :tlp "green"
                      :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
-              :headers {"Authorization" secret})]
+              :headers {"Authorization" secret})
+        judgement-short-id (some-> (:id judgement) id/long-id->id :short-id)]
     (is (= 201 create-status)
         "the secret holder (a static write identity with a group) may create a judgement")
+
+    (testing "the anonymous document read IS allowed (so the verdict 404 below is org-scoping, not an unreadable judgement)"
+      (let [{status :status}
+            (GET app (str "ctia/judgement/" judgement-short-id))]
+        (is (= 200 status)
+            "under max-record-visibility=everyone a Green judgement is anonymously readable as a document")))
 
     (testing "the secret holder, whose static identity has an org, gets the verdict"
       (let [{status :status}

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -520,9 +520,6 @@
              red-observable
              {:type "domain"
               :value "red.com"}
-             auth-observable
-             {:type "domain"
-              :value "auth.com"}
              base-judgement
              {:valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}
               :observable green-observable
@@ -556,15 +553,7 @@
                    :body (assoc base-judgement
                                 :observable red-observable
                                 :tlp "red")
-                   :headers {"Authorization" "foobaruser"})
-             authorized-groups-judgement-post
-             (POST app
-                   "ctia/judgement"
-                   :body (assoc base-judgement
-                                :observable auth-observable
-                                :tlp "red"
-                                :authorized_groups ["bargroup"])
-                   :headers {"Authorization" "baruser"})]
+                   :headers {"Authorization" "foobaruser"})]
 
          (is (= 201 (:status green-judgement-post)))
 
@@ -709,39 +698,17 @@
              (is (= (get-in red-judgement-post [:parsed-body :id])
                     (:judgement_id verdict-3)))))
 
-         (testing "a Judgement with authorized_groups"
-           (let [{status-1 :status
-                  verdict-1 :parsed-body}
-                 (GET app
-                      (str "ctia/"
-                           (:type auth-observable)
-                           "/" (:value auth-observable)
-                           "/verdict")
-                      :headers {"Authorization" "foouser"})
-                 {status-2 :status
-                  verdict-2 :parsed-body}
-                 (GET app
-                      (str "ctia/"
-                           (:type auth-observable)
-                           "/"
-                           (:value auth-observable)
-                           "/verdict")
-                      :headers {"Authorization" "baruser"})
-                 {status-3 :status
-                  verdict-3 :parsed-body}
-                 (GET app
-                      (str "ctia/"
-                           (:type auth-observable)
-                           "/"
-                           (:value auth-observable)
-                           "/verdict")
-                      :headers {"Authorization" "foobaruser"})]
-
-             (is (= 404 status-1))
-             (is (= 200 status-2))
-             (is (= 200 status-3))
-             (is (= (get-in authorized-groups-judgement-post [:parsed-body :id])
-                    (:judgement_id verdict-3))))))))))
+         ;; XFV-20: a subtest that created a Judgement with
+         ;; `authorized_groups ["bargroup"]` as baruser (the caller's OWN group)
+         ;; was removed here: with the owner filter now scoping the verdict to
+         ;; the caller's own org, its outcomes were fully explained by ownership
+         ;; and duplicated the amber subtest above. The property it appeared to
+         ;; test -- a FOREIGN `authorized_groups` grant must not contribute to
+         ;; another org's verdict -- is asserted, with a pre-existing foreign
+         ;; grant injected directly into the store (the write path now rejects
+         ;; introducing one), by
+         ;; `test-observable-verdict-cross-tenant-isolation`.
+         )))))
 
 (deftest with-date-range
   (test-for-each-store-with-app
@@ -848,7 +815,7 @@
   ;; To keep this test discriminating, we run it under BOTH settings and
   ;; separate the two concerns:
   ;;   * the *document* read still follows `max-record-visibility`
-  ;;     (404 under `group`, 200 under `everyone`); this remains the regression
+  ;;     (403 under `group`, 200 under `everyone`); this remains the regression
   ;;     detector for the public-TLP read clause on the document path (also
   ;;     covered by the entity-level access-control tests), and
   ;;   * the *verdict* stays tenant-local (404 for a foreign org under BOTH
@@ -910,8 +877,8 @@
                              (GET app
                                   (str "ctia/judgement/" green-judgement-short-id)
                                   :headers {"Authorization" "baruser"})]
-                         (is (= (if (= "everyone" visibility) 200 404) status)
-                             "cross-tenant document read of a green judgement is allowed only under max-record-visibility=everyone")))))))))]
+                         (is (= (if (= "everyone" visibility) 200 403) status)
+                             "cross-tenant document read of a green judgement is allowed only under max-record-visibility=everyone; otherwise the access-control read denial is a 403")))))))))]
     (run-visibility-test "group")
     (run-visibility-test "everyone")))
 

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -839,84 +839,81 @@
                   verdict))))))))
 
 (deftest test-observable-verdict-access-control-max-record-visibility
-  (helpers/with-properties (into es-helpers/basic-auth-properties
-                                 ["ctia.access-control.max-record-visibility" "group"])
-  (fixture-ctia-with-app
-   (fn [app]
-       (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
-       (helpers/set-capabilities! app "baruser" ["bargroup"] "user" all-capabilities)
-       (helpers/set-capabilities! app "foobaruser" ["bargroup"] "user" all-capabilities)
+  ;; XFV-20: the verdict path is now unconditionally org-scoped (see
+  ;; `ctia.entity.judgement.es-store/verdict-owner-filter`), so a caller in
+  ;; another org gets a 404 verdict for foogroup's green judgement regardless of
+  ;; `max-record-visibility`. That means the verdict route ALONE can no longer
+  ;; detect a revert of the public-TLP clause in
+  ;; `ctia.stores.es.query/find-restriction-query-part` (the `everyone` branch).
+  ;; To keep this test discriminating, we run it under BOTH settings and
+  ;; separate the two concerns:
+  ;;   * the *document* read still follows `max-record-visibility`
+  ;;     (404 under `group`, 200 under `everyone`); this remains the regression
+  ;;     detector for the public-TLP read clause on the document path (also
+  ;;     covered by the entity-level access-control tests), and
+  ;;   * the *verdict* stays tenant-local (404 for a foreign org under BOTH
+  ;;     settings). If the owner filter were reverted, the verdict for baruser
+  ;;     would flip to 200 under `everyone` and this test would fail.
+  (letfn [(run-visibility-test [visibility]
+            (helpers/with-properties (into es-helpers/basic-auth-properties
+                                           ["ctia.access-control.max-record-visibility" visibility])
+              (fixture-ctia-with-app
+               (fn [app]
+                 (helpers/set-capabilities! app "foouser" ["foogroup"] "user" all-capabilities)
+                 (helpers/set-capabilities! app "baruser" ["bargroup"] "user" all-capabilities)
+                 (whoami-helpers/set-whoami-response app "foouser" "foouser" "foogroup" "user")
+                 (whoami-helpers/set-whoami-response app "baruser" "baruser" "bargroup" "user")
+                 (testing (str "verdict route TLP behavior under max-record-visibility=" visibility)
+                   (let [green-observable {:type "domain" :value "green.com"}
+                         base-judgement {:valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}
+                                         :observable green-observable
+                                         :reason_uri "https://example.com/"
+                                         :source "Example"
+                                         :disposition 2
+                                         :disposition_name "Malicious"
+                                         :reason "Example judgement"
+                                         :source_uri "https://example.com/"
+                                         :priority 0
+                                         :severity "None"
+                                         :tlp "green"
+                                         :confidence "None"}
+                         green-judgement-post
+                         (POST app
+                               "ctia/judgement?wait_for=true"
+                               :body (assoc base-judgement
+                                            :observable green-observable
+                                            :tlp "green")
+                               :headers {"Authorization" "foouser"})
+                         green-judgement-id (get-in green-judgement-post [:parsed-body :id])
+                         green-judgement-short-id (some-> green-judgement-id id/long-id->id :short-id)]
+                     (assert (= 201 (:status green-judgement-post))
+                             "the test was not properly initialized")
 
-       (whoami-helpers/set-whoami-response app
-                                           "foouser"
-                                           "foouser"
-                                           "foogroup"
-                                           "user")
+                     (testing "the owning org always gets its own green judgement's verdict"
+                       (let [{status :status verdict :parsed-body}
+                             (GET app
+                                  (str "ctia/" (:type green-observable) "/" (:value green-observable) "/verdict")
+                                  :headers {"Authorization" "foouser"})]
+                         (is (= 200 status))
+                         (is (= green-judgement-id (:judgement_id verdict)))))
 
-       (whoami-helpers/set-whoami-response app
-                                           "baruser"
-                                           "baruser"
-                                           "bargroup"
-                                           "user")
+                     (testing "the verdict is tenant-local: another org gets 404 regardless of max-record-visibility"
+                       (let [{status :status}
+                             (GET app
+                                  (str "ctia/" (:type green-observable) "/" (:value green-observable) "/verdict")
+                                  :headers {"Authorization" "baruser"})]
+                         (is (= 404 status)
+                             "a green judgement owned by another org must not contribute to the caller's verdict, even under max-record-visibility=everyone")))
 
-       (testing "verdict route TLP behavior"
-         (let [green-observable
-               {:type "domain"
-                :value "green.com"}
-               amber-observable
-               {:type "domain"
-                :value "amber.com"}
-               red-observable
-               {:type "domain"
-                :value "red.com"}
-               auth-observable
-               {:type "domain"
-                :value "auth.com"}
-               base-judgement
-               {:valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}
-                :observable green-observable
-                :reason_uri "https://example.com/",
-                :source "Example",
-                :disposition 2,
-                :disposition_name "Malicious"
-                :reason "Example judgement",
-                :source_uri "https://example.com/",
-                :priority 0,
-                :severity "None",
-                :tlp "green",
-                :confidence "None"}
-               green-judgement-post
-               (POST app
-                     "ctia/judgement?wait_for=true"
-                     :body (assoc base-judgement
-                                  :observable green-observable
-                                  :tlp "green")
-                     :headers {"Authorization" "foouser"})]
-           (assert (= 201 (:status green-judgement-post))
-                   "the test was not properly initialized")
-
-           (testing "a green Judgement should only affect verdicts of the group when visibility is set to group."
-             (let [{status-1 :status
-                    verdict-1 :parsed-body}
-                   (GET app
-                        (str "ctia/"
-                             (:type green-observable)
-                             "/" (:value green-observable)
-                             "/verdict")
-                        :headers {"Authorization" "foouser"})
-                   {status-2 :status
-                    verdict-2 :parsed-body}
-                   (GET app
-                        (str "ctia/"
-                             (:type green-observable)
-                             "/"
-                             (:value green-observable)
-                             "/verdict")
-                        :headers {"Authorization" "baruser"})]
-               (is (= 200 status-1))
-               (is (= (get-in green-judgement-post [:parsed-body :id])
-                      (:judgement_id verdict-1)))
-               (is (= 404 status-2))))))))))
+                     (testing "the document read still follows max-record-visibility (the concern the verdict path no longer discriminates)"
+                       (let [{status :status}
+                             (GET app
+                                  (str "ctia/judgement/" green-judgement-short-id)
+                                  :headers {"Authorization" "baruser"})]
+                         (is (= (if (= "everyone" visibility) 200 404) status)
+                             "cross-tenant document read of a green judgement is allowed only under max-record-visibility=everyone")))))))))]
+    (run-visibility-test "group")
+    (run-visibility-test "everyone")))
 
 (deftest test-observable-verdict-cross-tenant-isolation
   ;; XFV-20: a verdict is a tenant-local trust decision. A judgement owned by
@@ -955,19 +952,27 @@
                attacker-short-id (some-> (:id attacker-judgement) id/long-id->id :short-id)]
            (is (= 201 status))
 
-           (testing "simulate pre-fix poisoning: grant the victim org via authorized_groups directly in the store"
+           (testing "simulate pre-fix poisoning: grant the victim org/user via authorized_groups AND authorized_users directly in the store"
+             ;; XFV-20: the owner filter is a pure `groups` filter, so it
+             ;; neutralizes BOTH a foreign `authorized_groups` grant and a
+             ;; foreign `authorized_users` grant identically -- inject both so
+             ;; the end-to-end assertion covers the `authorized_users` carve-out
+             ;; the guard's docstring claims, not only `authorized_groups`.
              (let [stored (store/read-record judgement-store attacker-short-id attacker-ident params)]
                (store/update-record judgement-store
                                     attacker-short-id
-                                    (assoc stored :authorized_groups ["victim-org"])
+                                    (assoc stored
+                                           :authorized_groups ["victim-org"]
+                                           :authorized_users ["victim"])
                                     attacker-ident
                                     params))
-             ;; sanity: confirm the foreign grant actually persisted, otherwise
+             ;; sanity: confirm the foreign grants actually persisted, otherwise
              ;; the isolation assertions below could pass vacuously.
-             (is (contains? (set (:authorized_groups
-                                  (store/read-record judgement-store attacker-short-id attacker-ident params)))
-                            "victim-org")
-                 "the injected foreign authorized_groups grant must be stored"))
+             (let [reread (store/read-record judgement-store attacker-short-id attacker-ident params)]
+               (is (contains? (set (:authorized_groups reread)) "victim-org")
+                   "the injected foreign authorized_groups grant must be stored")
+               (is (contains? (set (:authorized_users reread)) "victim")
+                   "the injected foreign authorized_users grant must be stored")))
 
            (testing "the victim's verdict must NOT be poisoned by the foreign-owned judgement"
              (let [{status :status}
@@ -1052,6 +1057,13 @@
                                   (assoc stored :authorized_groups ["victim-org"])
                                   attacker-ident
                                   params))
+           ;; sanity (mirrors the first sub-test): confirm the foreign grant
+           ;; actually persisted, otherwise this isolation assertion could pass
+           ;; vacuously if `update-record` ever stopped persisting the field.
+           (is (contains? (set (:authorized_groups
+                                (store/read-record judgement-store poison-short-id attacker-ident params)))
+                          "victim-org")
+               "the injected foreign authorized_groups grant must be stored")
            (let [{status :status
                   verdict :parsed-body}
                  (GET app

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -5,6 +5,7 @@
             [clj-time.coerce :as time-coerce]
             [clj-time.format :as time-format]
             [clojure.test :refer [deftest is join-fixtures testing use-fixtures]]
+            [ctia.store :as store]
             [ctia.test-helpers
              [es :as es-helpers]
              [auth :refer [all-capabilities]]
@@ -888,3 +889,137 @@
                (is (= (get-in green-judgement-post [:parsed-body :id])
                       (:judgement_id verdict-1)))
                (is (= 404 status-2))))))))))
+
+(deftest test-observable-verdict-cross-tenant-isolation
+  ;; XFV-20: a verdict is a tenant-local trust decision. A judgement owned by
+  ;; another org that merely lists the caller's org in authorized_groups must
+  ;; not appear in (poison) the caller's verdict. Such a record can only be
+  ;; pre-existing -- the write path now rejects a foreign authorized_groups --
+  ;; so we inject the grant directly in the store to simulate pre-fix data.
+  (test-for-each-store-with-app
+   (fn [app]
+     (helpers/set-capabilities! app "attacker" ["attacker-org"] "user" all-capabilities)
+     (helpers/set-capabilities! app "victim" ["victim-org"] "user" all-capabilities)
+     (whoami-helpers/set-whoami-response app "attacker-key" "attacker" "attacker-org" "user")
+     (whoami-helpers/set-whoami-response app "victim-key" "victim" "victim-org" "user")
+     (let [judgement-store (helpers/get-store app :judgement)
+           params {:refresh "wait_for"}
+           attacker-ident {:login "attacker" :groups ["attacker-org"]}]
+       (testing "attacker creates a Clean judgement it legitimately owns"
+         (let [{status :status
+                attacker-judgement :parsed-body}
+               (POST app
+                     "ctia/judgement"
+                     :body {:observable {:value "203.0.113.213" :type "ip"}
+                            :source "poc-cross-tenant"
+                            :disposition 1
+                            :priority 99
+                            :severity "High"
+                            :confidence "High"
+                            :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
+                     :headers {"Authorization" "attacker-key"})
+               attacker-short-id (some-> (:id attacker-judgement) id/long-id->id :short-id)]
+           (is (= 201 status))
+
+           (testing "simulate pre-fix poisoning: grant the victim org via authorized_groups directly in the store"
+             (let [stored (store/read-record judgement-store attacker-short-id attacker-ident params)]
+               (store/update-record judgement-store
+                                    attacker-short-id
+                                    (assoc stored :authorized_groups ["victim-org"])
+                                    attacker-ident
+                                    params))
+             ;; sanity: confirm the foreign grant actually persisted, otherwise
+             ;; the isolation assertions below could pass vacuously.
+             (is (contains? (set (:authorized_groups
+                                  (store/read-record judgement-store attacker-short-id attacker-ident params)))
+                            "victim-org")
+                 "the injected foreign authorized_groups grant must be stored"))
+
+           (testing "the victim's verdict must NOT be poisoned by the foreign-owned judgement"
+             (let [{status :status}
+                   (GET app
+                        "ctia/ip/203.0.113.213/verdict"
+                        :headers {"Authorization" "victim-key"})]
+               (is (= 404 status)
+                   "a judgement owned by another org must not contribute to the caller's verdict")))
+
+           (testing "the owning (attacker) org still gets its own judgement's verdict"
+             (let [{status :status
+                    verdict :parsed-body}
+                   (GET app
+                        "ctia/ip/203.0.113.213/verdict"
+                        :headers {"Authorization" "attacker-key"})]
+               (is (= 200 status))
+               (is (= (:id attacker-judgement) (:judgement_id verdict)))))))
+
+       (testing "the victim's own judgement still produces a verdict (guard is not over-broad)"
+         (let [{status :status
+                victim-judgement :parsed-body}
+               (POST app
+                     "ctia/judgement"
+                     :body {:observable {:value "198.51.100.7" :type "ip"}
+                            :source "victim-local"
+                            :disposition 2
+                            :priority 99
+                            :severity "High"
+                            :confidence "High"
+                            :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
+                     :headers {"Authorization" "victim-key"})]
+           (is (= 201 status))
+           (let [{status :status
+                  verdict :parsed-body}
+                 (GET app
+                      "ctia/ip/198.51.100.7/verdict"
+                      :headers {"Authorization" "victim-key"})]
+             (is (= 200 status))
+             (is (= (:id victim-judgement) (:judgement_id verdict))))))
+
+       (testing "a higher-priority foreign judgement cannot outrank the victim's own verdict"
+         ;; The attacker owns a high-priority (99) Clean judgement and grants it
+         ;; to the victim via authorized_groups; the victim has its own
+         ;; lower-priority (50) Malicious judgement on the same observable.
+         ;; Pre-fix the attacker's priority-99 Clean would dominate the verdict;
+         ;; post-fix the foreign judgement is excluded entirely, so the victim's
+         ;; own Malicious verdict stands.
+         (let [{astatus :status
+                poison :parsed-body}
+               (POST app
+                     "ctia/judgement"
+                     :body {:observable {:value "203.0.113.220" :type "ip"}
+                            :source "poc-priority"
+                            :disposition 1
+                            :priority 99
+                            :severity "High"
+                            :confidence "High"
+                            :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
+                     :headers {"Authorization" "attacker-key"})
+               poison-short-id (some-> (:id poison) id/long-id->id :short-id)
+               {vstatus :status
+                victim-judgement :parsed-body}
+               (POST app
+                     "ctia/judgement"
+                     :body {:observable {:value "203.0.113.220" :type "ip"}
+                            :source "victim-local"
+                            :disposition 2
+                            :priority 50
+                            :severity "High"
+                            :confidence "High"
+                            :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
+                     :headers {"Authorization" "victim-key"})]
+           (is (= 201 astatus))
+           (is (= 201 vstatus))
+           (let [stored (store/read-record judgement-store poison-short-id attacker-ident params)]
+             (store/update-record judgement-store
+                                  poison-short-id
+                                  (assoc stored :authorized_groups ["victim-org"])
+                                  attacker-ident
+                                  params))
+           (let [{status :status
+                  verdict :parsed-body}
+                 (GET app
+                      "ctia/ip/203.0.113.220/verdict"
+                      :headers {"Authorization" "victim-key"})]
+             (is (= 200 status))
+             (is (= (:id victim-judgement) (:judgement_id verdict))
+                 "the victim's own Malicious judgement must win, not the attacker's higher-priority Clean")
+             (is (= 2 (:disposition verdict))))))))))

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -568,8 +568,28 @@
 
          (is (= 201 (:status green-judgement-post)))
 
-         (testing "a green Judgement implies a verdict readable by everyone"
-           (let [{status-1 :status
+         ;; XFV-20: a verdict is a tenant-local trust decision. Pre-fix, a green
+         ;; Judgement produced a verdict "readable by everyone" -- with the
+         ;; default `max-record-visibility=everyone`, the read filter's public-TLP
+         ;; clause let any green/white record contribute to any org's verdict.
+         ;; That path was itself a cross-tenant poisoning vector: an attacker
+         ;; could set `tlp=green` (visible to all by default) on a high-priority
+         ;; Clean judgement and dominate every tenant's verdict -- the same abuse
+         ;; XFV-20 closes for `authorized_groups`, and NOT closable by only
+         ;; dropping the authorized_* clauses. `list-active-by-observable` now
+         ;; ANDs a mandatory owner-org filter, so a verdict is computed only from
+         ;; the caller's own org's judgements, regardless of TLP. This matches the
+         ;; behavior `test-observable-verdict-access-control-max-record-visibility`
+         ;; already asserts under `max-record-visibility=group` -- the verdict path
+         ;; is now tenant-local unconditionally.
+         ;;
+         ;; Cross-tenant sharing on reads/lists is UNCHANGED: baruser/foobaruser
+         ;; can still read the green judgement directly (asserted below); only the
+         ;; aggregated verdict is scoped to the querying org.
+         (testing "a green Judgement contributes to the owning org's verdict only"
+           (let [green-judgement-id (get-in green-judgement-post [:parsed-body :id])
+                 green-judgement-short-id (some-> green-judgement-id id/long-id->id :short-id)
+                 {status-1 :status
                   verdict-1 :parsed-body}
                  (GET app
                       (str "ctia/"
@@ -577,8 +597,7 @@
                            "/" (:value green-observable)
                            "/verdict")
                       :headers {"Authorization" "foouser"})
-                 {status-2 :status
-                  verdict-2 :parsed-body}
+                 {status-2 :status}
                  (GET app
                       (str "ctia/"
                            (:type green-observable)
@@ -586,8 +605,7 @@
                            (:value green-observable)
                            "/verdict")
                       :headers {"Authorization" "baruser"})
-                 {status-3 :status
-                  verdict-3 :parsed-body}
+                 {status-3 :status}
                  (GET app
                       (str "ctia/"
                            (:type green-observable)
@@ -596,17 +614,27 @@
                            "/verdict")
                       :headers {"Authorization" "foobaruser"})]
 
+             ;; the owning org (foogroup) still gets its own judgement's verdict
              (is (= 200 status-1))
-             (is (= (get-in green-judgement-post [:parsed-body :id])
+             (is (= green-judgement-id
                     (:judgement_id verdict-1)))
 
-             (is (= 200 status-2))
-             (is (= (get-in green-judgement-post [:parsed-body :id])
-                    (:judgement_id verdict-2)))
+             ;; other orgs no longer inherit the green judgement in THEIR verdict
+             (is (= 404 status-2)
+                 "a green judgement owned by another org must not contribute to the caller's verdict")
+             (is (= 404 status-3)
+                 "a green judgement owned by another org must not contribute to the caller's verdict")
 
-             (is (= 200 status-3))
-             (is (= (get-in green-judgement-post [:parsed-body :id])
-                    (:judgement_id verdict-3)))))
+             ;; but cross-tenant READ of the green judgement is unchanged: the
+             ;; guard is scoped to the verdict path, not to reads/lists.
+             (is (= 200 (:status (GET app
+                                      (str "ctia/judgement/" green-judgement-short-id)
+                                      :headers {"Authorization" "baruser"})))
+                 "the green judgement itself remains readable cross-tenant (only the verdict is scoped)")
+             (is (= 200 (:status (GET app
+                                      (str "ctia/judgement/" green-judgement-short-id)
+                                      :headers {"Authorization" "foobaruser"})))
+                 "the green judgement itself remains readable cross-tenant (only the verdict is scoped)")))
 
          (is (= 201 (:status amber-judgement-post)))
 

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -698,17 +698,63 @@
              (is (= (get-in red-judgement-post [:parsed-body :id])
                     (:judgement_id verdict-3)))))
 
-         ;; XFV-20: a subtest that created a Judgement with
-         ;; `authorized_groups ["bargroup"]` as baruser (the caller's OWN group)
-         ;; was removed here: with the owner filter now scoping the verdict to
-         ;; the caller's own org, its outcomes were fully explained by ownership
-         ;; and duplicated the amber subtest above. The property it appeared to
-         ;; test -- a FOREIGN `authorized_groups` grant must not contribute to
-         ;; another org's verdict -- is asserted, with a pre-existing foreign
-         ;; grant injected directly into the store (the write path now rejects
-         ;; introducing one), by
-         ;; `test-observable-verdict-cross-tenant-isolation`.
-         )))))
+         (testing "a same-org authorized_groups grant contributes to a group member's verdict"
+           ;; XFV-20 regression detector for the intra-org sharing path. baruser
+           ;; (bargroup) posts a TLP-red judgement carrying an explicit
+           ;; authorized_groups grant for its OWN org (bargroup). foobaruser is a
+           ;; member of bargroup but NOT the owner, so for foobaruser's verdict:
+           ;;   - the owner-org filter admits the doc (same org, stored groups
+           ;;     ["bargroup"]);
+           ;;   - within the access-control restriction the red clause requires
+           ;;     the owner and the amber/public clauses require a non-red TLP, so
+           ;;     the ONLY should-clause that can admit this red doc is
+           ;;     {:terms {"authorized_groups" groups}} (stores/es/query.clj).
+           ;; A cleanup dropping the authorized_users/authorized_groups should
+           ;; clauses would silently break intra-org verdict sharing of red/amber
+           ;; judgements with no other test failing -- this subtest fails instead.
+           ;; (This is a same-org grant; the FOREIGN-grant non-poisoning property
+           ;; is covered by `test-observable-verdict-cross-tenant-isolation`.)
+           (let [shared-observable {:type "domain" :value "shared-red.com"}
+                 shared-judgement-post
+                 (POST app
+                       "ctia/judgement"
+                       :body (assoc base-judgement
+                                    :observable shared-observable
+                                    :tlp "red"
+                                    :authorized_groups ["bargroup"])
+                       :headers {"Authorization" "baruser"})
+                 _ (is (= 201 (:status shared-judgement-post))
+                       "baruser may grant authorized_groups for its OWN org")
+                 {status-owner :status
+                  verdict-owner :parsed-body}
+                 (GET app
+                      (str "ctia/" (:type shared-observable) "/"
+                           (:value shared-observable) "/verdict")
+                      :headers {"Authorization" "baruser"})
+                 {status-member :status
+                  verdict-member :parsed-body}
+                 (GET app
+                      (str "ctia/" (:type shared-observable) "/"
+                           (:value shared-observable) "/verdict")
+                      :headers {"Authorization" "foobaruser"})
+                 {status-foreign :status}
+                 (GET app
+                      (str "ctia/" (:type shared-observable) "/"
+                           (:value shared-observable) "/verdict")
+                      :headers {"Authorization" "foouser"})]
+             ;; the owner sees its own judgement's verdict
+             (is (= 200 status-owner))
+             (is (= (get-in shared-judgement-post [:parsed-body :id])
+                    (:judgement_id verdict-owner)))
+             ;; a same-org non-owner member sees it only via the
+             ;; authorized_groups should-clause (red TLP blocks every other one)
+             (is (= 200 status-member)
+                 "a same-org group member gets the verdict via the authorized_groups grant")
+             (is (= (get-in shared-judgement-post [:parsed-body :id])
+                    (:judgement_id verdict-member)))
+             ;; a foreign org (foogroup) is still excluded by the owner-org filter
+             (is (= 404 status-foreign)
+                 "a foreign org gets no verdict: the owner-org filter excludes it"))))))))
 
 (deftest with-date-range
   (test-for-each-store-with-app

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -987,14 +987,12 @@
                (is (contains? (set (:authorized_users reread)) "victim")
                    "the injected foreign authorized_users grant must be stored")))
 
-           (testing "the victim's verdict must NOT be poisoned by the foreign-owned judgement"
-             (let [{status :status}
-                   (GET app
-                        "ctia/ip/203.0.113.213/verdict"
-                        :headers {"Authorization" "victim-key"})]
-               (is (= 404 status)
-                   "a judgement owned by another org must not contribute to the caller's verdict")))
-
+           ;; Assert the attacker's own 200 FIRST: it proves the injected
+           ;; judgement is actually searchable, so the victim's 404 below
+           ;; demonstrates isolation rather than passing vacuously on a
+           ;; not-yet-refreshed write (mirrors
+           ;; `test-observable-verdict-access-control`, which binds its 200
+           ;; ahead of its 404s).
            (testing "the owning (attacker) org still gets its own judgement's verdict"
              (let [{status :status
                     verdict :parsed-body}
@@ -1002,7 +1000,15 @@
                         "ctia/ip/203.0.113.213/verdict"
                         :headers {"Authorization" "attacker-key"})]
                (is (= 200 status))
-               (is (= (:id attacker-judgement) (:judgement_id verdict)))))))
+               (is (= (:id attacker-judgement) (:judgement_id verdict)))))
+
+           (testing "the victim's verdict must NOT be poisoned by the foreign-owned judgement"
+             (let [{status :status}
+                   (GET app
+                        "ctia/ip/203.0.113.213/verdict"
+                        :headers {"Authorization" "victim-key"})]
+               (is (= 404 status)
+                   "a judgement owned by another org must not contribute to the caller's verdict")))))
 
        (testing "the victim's own judgement still produces a verdict (guard is not over-broad)"
          (let [{status :status

--- a/test/ctia/http/routes/observable/verdict_test.clj
+++ b/test/ctia/http/routes/observable/verdict_test.clj
@@ -938,12 +938,18 @@
                 attacker-judgement :parsed-body}
                (POST app
                      "ctia/judgement"
+                     ;; tlp "red" so the ONLY clause that could let this
+                     ;; foreign-owned judgement into the victim's verdict is the
+                     ;; injected authorized_groups grant (a green/white default
+                     ;; would already be visible via the public-TLP clause under
+                     ;; max-record-visibility=everyone, masking a partial revert).
                      :body {:observable {:value "203.0.113.213" :type "ip"}
                             :source "poc-cross-tenant"
                             :disposition 1
                             :priority 99
                             :severity "High"
                             :confidence "High"
+                            :tlp "red"
                             :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                      :headers {"Authorization" "attacker-key"})
                attacker-short-id (some-> (:id attacker-judgement) id/long-id->id :short-id)]
@@ -1013,12 +1019,16 @@
                 poison :parsed-body}
                (POST app
                      "ctia/judgement"
+                     ;; tlp "red" (see above): the injected authorized_groups
+                     ;; grant is the only path by which this priority-99 Clean
+                     ;; could reach the victim's verdict pre-fix.
                      :body {:observable {:value "203.0.113.220" :type "ip"}
                             :source "poc-priority"
                             :disposition 1
                             :priority 99
                             :severity "High"
                             :confidence "High"
+                            :tlp "red"
                             :valid_time {:start_time "2016-02-12T00:00:00.000-00:00"}}
                      :headers {"Authorization" "attacker-key"})
                poison-short-id (some-> (:id poison) id/long-id->id :short-id)

--- a/test/ctia/http/routes/swagger_json_test.clj
+++ b/test/ctia/http/routes/swagger_json_test.clj
@@ -11,19 +11,9 @@
   helpers/fixture-ctia)
 
 (deftest test-swagger-json
-  (let [app (helpers/get-current-app)
-        {:keys [status parsed-body]}
-        (helpers/GET app "swagger.json" :accept :json)]
+  (let [app (helpers/get-current-app)]
     (testing "We can get a swagger.json"
-      (is (= 200 status)))
-    (testing "the REST Verdict model description reflects XFV-20 org-scoping"
-      ;; XFV-20 (B3): CTIM's Verdict entity description ("chosen from all of the
-      ;; Judgements on that Observable") is overridden at the `def-acl-schema
-      ;; Verdict` site so the REST/Swagger surface reads consistently with the
-      ;; GraphQL one -- verdict calculation is tenant-local.
-      (let [description (get-in parsed-body [:definitions :Verdict :description])]
-        (is (string? description))
-        (is (re-find #"caller's own org" description)
-            "the swagger Verdict description must state the verdict is org-scoped")
-        (is (not (re-find #"chosen from all" description))
-            "the stale CTIM 'chosen from all ... Judgements' description must not survive")))))
+      (is (= 200
+             (:status (helpers/GET app
+                                   "swagger.json"
+                                   :accept :json)))))))

--- a/test/ctia/http/routes/swagger_json_test.clj
+++ b/test/ctia/http/routes/swagger_json_test.clj
@@ -11,9 +11,19 @@
   helpers/fixture-ctia)
 
 (deftest test-swagger-json
-  (let [app (helpers/get-current-app)]
+  (let [app (helpers/get-current-app)
+        {:keys [status parsed-body]}
+        (helpers/GET app "swagger.json" :accept :json)]
     (testing "We can get a swagger.json"
-      (is (= 200
-             (:status (helpers/GET app
-                                   "swagger.json"
-                                   :accept :json)))))))
+      (is (= 200 status)))
+    (testing "the REST Verdict model description reflects XFV-20 org-scoping"
+      ;; XFV-20 (B3): CTIM's Verdict entity description ("chosen from all of the
+      ;; Judgements on that Observable") is overridden at the `def-acl-schema
+      ;; Verdict` site so the REST/Swagger surface reads consistently with the
+      ;; GraphQL one -- verdict calculation is tenant-local.
+      (let [description (get-in parsed-body [:definitions :Verdict :description])]
+        (is (string? description))
+        (is (re-find #"caller's own org" description)
+            "the swagger Verdict description must state the verdict is org-scoped")
+        (is (not (re-find #"chosen from all" description))
+            "the stale CTIM 'chosen from all ... Judgements' description must not survive")))))


### PR DESCRIPTION
> **Related** XFV-20 -- https://cisco-sbg.atlassian.net/browse/XFV-20

Follow-up to the XFV-20 write-path fix (#1530), closing the read-side gap
flagged during ASIG verification. The write path already rejects new foreign
`authorized_groups`, but the verdict calculation still honoured
`authorized_groups`, so a pre-existing cross-tenant grant could continue to
poison a victim tenant's verdict.

A verdict is a tenant-local trust decision. `list-active-by-observable` (the
verdict path) now ANDs a mandatory `{:terms {"groups" <caller-org>}}` filter
alongside the existing read access-control restriction, so only the judgements
the caller can read that are also owned by its own org contribute to a verdict,
regardless of `authorized_users` / `authorized_groups`. This makes any pre-existing foreign
grant inert for verdicts without requiring a production data cleanup. The change
is scoped to the verdict path only; legitimate cross-tenant sharing on reads/
lists is unchanged.

A caller with no org (static-auth with `ctia.auth.static.group` unset, or a JWT
missing `org/id`) has no tenant to scope a verdict to, so the verdict path bails
out explicitly -- it logs and returns no verdict rather than issuing a
match-nothing filter.

<a name="qa">[§](#qa)</a> QA
============================

No QA is needed; covered by automated tests.

<a name="release-notes">[§](#release-notes)</a> Release Notes
=============================================================

```
Cross-tenant CTIA verdict poisoning (XFV-20): verdict calculation is now scoped
to the querying org. A verdict is computed only from the judgements the caller
can read that are also owned by its own org; a judgement made visible to another
tenant -- whether shared via authorized_users / authorized_groups, or visible
only through a public (Green/White) TLP under max-record-visibility=everyone --
no longer contributes to that tenant's verdict. Reads and lists of individual
judgements are unchanged.

Operational note: a caller with no org of its own -- most commonly a JWT whose
org/id claim is missing, but also a static-auth deployment with a blank
ctia.auth.static.group or the readonly-for-anonymous anonymous identity -- now
receives no verdict (HTTP 404) for any observable, including public (Green/White)
TLP observables that a plain document read still returns.
```

## Testing

- ES-free unit tests: the verdict query composes the mandatory, lower-cased
  `groups` filter (as a conjoined vector) alongside the existing `must`/`should`
  clauses; a caller with no org yields no verdict and issues no query.
- End-to-end two-tenant test (`verdict_test`): a pre-fix poisoned judgement
  (injected directly via the store, since the write path now rejects it; TLP red
  so the injected `authorized_groups` grant is the sole clause that could admit
  it) does not affect the victim's verdict (404), the owning org still sees its
  own verdict, the victim's own judgement resolves, and a higher-priority foreign
  Clean cannot outrank the victim's own Malicious. Runs under Elasticsearch in
  CI.

## Rejected findings

- **SEC1 (write-grant direction) -- out of scope, follow-up.** The reviewer
  correctly noted the verdict-owner filter neutralizes pre-existing cross-tenant
  *read* grants but not *write* grants: `allow-write?` still returns true for a
  foreign org listed in a victim-owned document's `authorized_groups`, and
  `default-realize` preserves the stored owner `groups` on update, so a foreign
  org can still update (and thus dominate) a victim-owned judgement. Closing that
  requires an ACL change on the write path, which is deliberately out of scope
  for this read-path PR. The docstring has been narrowed to the read-grant case
  and this direction is left as an XFV-20 follow-up rather than changed here.
- **Verdict reconstructible via `list-judgements-by-observable` -- consistent
  with scope.** A client can still enumerate individual judgements (with their
  sort fields) via the unguarded list endpoint and reconstruct a ranking. This is
  the documented read/list behavior, which this PR intentionally leaves unchanged;
  it is tracked on the ticket rather than fixed here.
- **GraphQL `Observable.verdict` cross-tenant test -- covered at the store
  layer.** GraphQL's `Observable.verdict` resolves through the same
  `calculate-verdict` / `list-active-by-observable` store function that carries
  the owner filter, so the guard applies to it and is exercised by the store-level
  unit test. A GraphQL-route-level cross-tenant test would be additive coverage,
  not a gap in the guard.
- **Shared `groups` lower-casing helper (query.clj:12-14 duplication) --
  deliberately not shared.** The reviewer noted the verdict-owner filter re-does
  the `(map str/lower-case groups)` normalization that `find-restriction-query-part`
  already performs, and suggested a shared helper. Declined: `find-restriction-query-part`
  carries an open `;; TODO do we really want to discard case on that?`, so
  extracting a shared helper would couple verdict scoping to that unresolved
  decision -- if the TODO is later resolved by dropping the lower-casing there,
  the verdict owner filter must keep its own to match the `groups`
  `lowercase_normalizer` index mapping (`mapping.clj:37-41`). The duplication is
  one line and independently correct; sharing now would be the more fragile
  option, so it is left as-is.
- **B3 (swagger `definitions.Verdict.description` stale) -- addressed via a
  source note; the CTIM DDL fix is out of scope.** The reviewer's follow-up
  correctly noted that updating the REST `api-description` (`:info.description`)
  to the org-scoped text, while `definitions.Verdict.description` still renders
  CTIM's "chosen from all of the Judgements ..." via flanders from
  `def-acl-schema Verdict`, leaves one artifact asserting both. The stale text
  originates in CTIM's `Verdict` DDL (`ctim.schemas.verdict`), a separate repo,
  so making the rendered `:definitions` entry consistent is out of scope for
  this read-path PR. Taking the reviewer's fallback option, a note was added at
  the `def-acl-schema Verdict` site (`src/ctia/schemas/core.clj`) recording that
  the CTIM-sourced description is knowingly stale re org-scoping and pointing to
  the two surfaces that carry the accurate text: the REST `api-description`
  (`ctia.http.handler`) and the GraphQL `verdict-description`
  (`ctia.verdict.graphql.schemas`). An earlier attempt to override the
  `:definitions` text at the `describe` site was reverted last round after CI
  showed it rendered `nil` (a shared swagger definition-name slot resolved
  non-deterministically); that route is not pursued again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




